### PR TITLE
mdSpan support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,66 @@ if(alpaka_API_CUDA)
     endif()
 endif()
 
+#-------------------------------------------------------------------------------
+# Include mdspan
+
+set(alpaka_USE_MDSPAN "FETCH" CACHE STRING "Use std::mdspan with alpaka")
+set_property(CACHE alpaka_USE_MDSPAN PROPERTY STRINGS "SYSTEM;FETCH;OFF")
+
+if (alpaka_USE_MDSPAN STREQUAL "SYSTEM")
+    find_package(mdspan REQUIRED)
+    target_link_libraries(alpaka INTERFACE std::mdspan)
+    target_compile_definitions(alpaka INTERFACE ALPAKA_USE_MDSPAN)
+elseif (alpaka_USE_MDSPAN STREQUAL "FETCH")
+    include(FetchContent)
+    FetchContent_Declare(
+            mdspan
+            GIT_REPOSITORY https://github.com/kokkos/mdspan.git
+            GIT_TAG 973ef6415a6396e5f0a55cb4c99afd1d1d541681
+    )
+    # we don't use FetchContent_MakeAvailable(mdspan) since it would also install mdspan
+    # see also: https://stackoverflow.com/questions/65527126/how-to-disable-installation-a-fetchcontent-dependency
+    FetchContent_GetProperties(mdspan)
+    if(NOT mdspan_POPULATED)
+        FetchContent_Populate(mdspan)
+        if(${CMAKE_VERSION} VERSION_LESS "3.25.0")
+            add_subdirectory(${mdspan_SOURCE_DIR} ${mdspan_BINARY_DIR} EXCLUDE_FROM_ALL)
+        else()
+            add_subdirectory(${mdspan_SOURCE_DIR} ${mdspan_BINARY_DIR} EXCLUDE_FROM_ALL SYSTEM)
+        endif()
+    endif()
+    if(${CMAKE_VERSION} VERSION_LESS "3.25.0")
+        get_target_property(mdspan_include_dir std::mdspan INTERFACE_INCLUDE_DIRECTORIES)
+        target_include_directories(alpaka SYSTEM INTERFACE ${mdspan_include_dir})
+    else()
+        target_link_libraries(alpaka INTERFACE std::mdspan)
+    endif()
+    target_compile_definitions(alpaka INTERFACE ALPAKA_USE_MDSPAN)
+elseif (alpaka_USE_MDSPAN STREQUAL "OFF")
+else()
+    message(FATAL_ERROR "Invalid option for alpaka_USE_MDSPAN")
+endif()
+
+if (NOT alpaka_USE_MDSPAN STREQUAL "OFF")
+    if (MSVC AND (alpaka_CXX_STANDARD LESS 20))
+        message(WARNING "std::mdspan on MSVC requires C++20. Please enable C++20 via alpaka_CXX_STANDARD. Use of std::mdspan has been disabled.")
+        set(alpaka_USE_MDSPAN "OFF" CACHE STRING "Use std::mdspan with alpaka" FORCE)
+    endif ()
+
+    if (alpaka_ACC_GPU_CUDA_ENABLE AND (CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA") AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+        # this issue actually only occurs when the host compiler (not the CXX compiler) is clang, but cmake does not let us query the host compiler id
+        # see: https://gitlab.kitware.com/cmake/cmake/-/issues/20901
+        message(WARNING "std::mdspan does not work with nvcc and clang as host compiler. Use of std::mdspan has been disabled.")
+        set(alpaka_USE_MDSPAN "OFF" CACHE STRING "Use std::mdspan with alpaka" FORCE)
+    endif ()
+
+    if (alpaka_API_CUDA AND (NOT alpaka_CUDA_EXPT_EXTENDED_LAMBDA STREQUAL ON))
+        message(WARNING "std::mdspan requires nvcc's extended lambdas. Use of std::mdspan has been disabled.")
+        set(alpaka_USE_MDSPAN "OFF" CACHE STRING "Use std::mdspan with alpaka" FORCE)
+    endif()
+endif()
+
+
 
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -21,7 +21,7 @@ namespace alpaka
      * array as default storage without this wrapper.
      */
     template<typename T_Type, uint32_t T_dim>
-    struct ArrayStorage : private std::array<T_Type, T_dim>
+    struct ArrayStorage : protected std::array<T_Type, T_dim>
     {
         using BaseType = std::array<T_Type, T_dim>;
         using BaseType::operator[];
@@ -42,6 +42,15 @@ namespace alpaka
         using Storage = T_Storage;
         using type = T_Type;
         using ParamType = type;
+
+        using index_type = T_Type;
+        using size_type = uint32_t;
+        using rank_type = uint32_t;
+
+        constexpr auto toStdArray() const requires std::same_as<ArrayStorage<T_Type, T_dim>, T_Storage>
+        {
+            return static_cast<std::array<T_Type, T_dim>>(*this);
+        }
 
         /*Vecs without elements are not allowed*/
         static_assert(T_dim > 0u);

--- a/include/alpaka/mem/Buffer.hpp
+++ b/include/alpaka/mem/Buffer.hpp
@@ -1,13 +1,13 @@
-/* Copyright 2024 René Widera
+/* Copyright 2024 Bernhard Manfred Gruber, René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
-
 
 #pragma once
 
 #include "alpaka/core/Handle.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/hostApi.hpp"
+#include "alpaka/mem/MdSpan.hpp"
 
 #include <cstdint>
 #include <functional>
@@ -41,6 +41,28 @@ namespace alpaka
         auto getExtent() const
         {
             return m_extents;
+        }
+
+        auto getMdSpan() const
+        {
+            // import mdspan into alpaka::experimental namespace. see: https://eel.is/c++draft/mdspan.syn
+            using std::experimental::default_accessor;
+            using std::experimental::dextents;
+            using std::experimental::extents;
+            using std::experimental::layout_left;
+            using std::experimental::layout_right;
+            using std::experimental::layout_stride;
+            using std::experimental::mdspan;
+            // import submdspan as well, which is not standardized yet
+            using std::experimental::full_extent;
+            using std::experimental::submdspan;
+
+            auto* ptr = reinterpret_cast<std::byte*>(data(m_data));
+            auto ex = detail::makeExtents(m_extents, std::make_index_sequence<T_Extents::dim()>{});
+            auto const strides = m_data->m_pitch;
+            layout_stride::mapping<decltype(ex)> m{ex, strides.toStdArray()};
+            return alpaka::MdSpan{
+                mdspan<type, decltype(ex), layout_stride, detail::ByteIndexedAccessor<type>>{ptr, m}};
         }
 
     private:

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -1,0 +1,73 @@
+/* Copyright 2024 Bernhard Manfred Gruber, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+#pragma once
+
+#include "alpaka/Vec.hpp"
+#include "alpaka/core/config.hpp"
+
+#include <experimental/mdspan>
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace detail
+    {
+        template<typename ElementType>
+        struct ByteIndexedAccessor
+        {
+            using offset_policy = ByteIndexedAccessor;
+            using element_type = ElementType;
+            using reference = ElementType&;
+
+            using data_handle_type = std::conditional_t<std::is_const_v<ElementType>, std::byte const*, std::byte*>;
+
+            constexpr ByteIndexedAccessor() noexcept = default;
+
+            constexpr data_handle_type offset(data_handle_type p, size_t i) const noexcept
+            {
+                return p + i;
+            }
+
+            constexpr reference access(data_handle_type p, size_t i) const noexcept
+            {
+                assert(i % alignof(ElementType) == 0);
+#if ALPAKA_COMP_GNUC
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wcast-align"
+#endif
+                return *reinterpret_cast<ElementType*>(p + i);
+#if ALPAKA_COMP_GNUC
+#    pragma GCC diagnostic pop
+#endif
+            }
+        };
+
+        template<typename T_Extnets, std::size_t... Is>
+        constexpr auto makeExtents(T_Extnets const& extent, std::index_sequence<Is...>)
+        {
+            auto const ex = extent;
+            return std::experimental::dextents<typename T_Extnets::type, T_Extnets::dim()>{ex[Is]...};
+        }
+
+    } // namespace detail
+
+    template<typename T>
+    struct MdSpan : T
+    {
+        template<typename T_Type, uint32_t T_dim>
+        constexpr decltype(auto) operator[](Vec<T_Type, T_dim> const& vec) const
+        {
+            return T::operator()(vec.toStdArray());
+        }
+
+        template<typename T_Type>
+        requires(std::is_integral_v<T_Type> && T::rank() == 1u)
+        constexpr decltype(auto) operator[](T_Type const& value) const
+        {
+            return T::operator()(value);
+        }
+    };
+} // namespace alpaka

--- a/tests/queue.cpp
+++ b/tests/queue.cpp
@@ -95,7 +95,7 @@ TEST_CASE("enqueue hallo idx", "")
 
 struct IotaKernel
 {
-    ALPAKA_FN_ACC void operator()(auto const& acc, auto* out, uint32_t outSize) const
+    ALPAKA_FN_ACC void operator()(auto const& acc, auto out, uint32_t outSize) const
     {
 #if 0
         auto globalIdx = (acc[layer::thread].count() * acc[layer::block].idx() + acc[layer::thread].idx()).x();
@@ -128,7 +128,7 @@ void runIota(auto mapping, auto device)
         queue,
         mapping,
         alpaka::DataBlocking{extent / frameSize, Vec{frameSize}},
-        KernelBundle{IotaKernel{}, alpaka::data(dBuff), extent.x()});
+        KernelBundle{IotaKernel{}, dBuff.getMdSpan(), extent.x()});
     alpaka::memcpy(queue, hBuff, dBuff);
     wait(queue);
     auto* ptr = alpaka::data(hBuff);


### PR DESCRIPTION
- implement own MdSpan over original mdSpan to support `operator[]`
- switch example to MdSpan