### PR TITLE
2D shared mem, compile time array propagation into the kernel

### DIFF
--- a/example/heatEquation2D/src/BoundaryKernel.hpp
+++ b/example/heatEquation2D/src/BoundaryKernel.hpp
@@ -23,12 +23,12 @@
 //! \param dt step in t
 struct BoundaryKernel
 {
-    template<typename TAcc, typename TChunk>
+    template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(
         TAcc const& acc,
         double* const uBuf,
-        TChunk const chunkSize,
-        TChunk const pitch,
+        alpaka::concepts::Vector auto const chunkSize,
+        alpaka::concepts::Vector auto const pitch,
         uint32_t step,
         double const dx,
         double const dy,

--- a/example/heatEquation2D/src/StencilKernel.hpp
+++ b/example/heatEquation2D/src/StencilKernel.hpp
@@ -42,7 +42,7 @@ struct StencilKernel
         auto const gridBlockIdx = acc[alpaka::layer::block].idx();
         auto const blockStartIdx = gridBlockIdx * chunkSize;
 
-        for(auto idx2d : alpaka::makeIter(acc, alpaka::iter::withinDataFrame, sharedMemExtents + 0u))
+        for(auto idx2d : alpaka::makeIter(acc, alpaka::iter::withinDataFrame, sharedMemExtents))
         {
             auto bufIdx = idx2d + blockStartIdx;
             sdata[idx2d] = uCurrBuf[bufIdx];

--- a/example/heatEquation2D/src/StencilKernel.hpp
+++ b/example/heatEquation2D/src/StencilKernel.hpp
@@ -42,7 +42,7 @@ struct StencilKernel
         double const dy,
         double const dt) const -> void
     {
-        auto sdata = alpaka::onAcc::declareSharedArray<double[T_SharedMemSize{}[0]][T_SharedMemSize{}[1]]>(acc);
+        auto sdata = alpaka::onAcc::declareSharedMdArray<double>(acc, T_SharedMemSize{});
 
         // Get indexes
         auto const gridBlockIdx = acc[alpaka::layer::block].idx();

--- a/example/heatEquation2D/src/StencilKernel.hpp
+++ b/example/heatEquation2D/src/StencilKernel.hpp
@@ -25,12 +25,12 @@
 //! \param dt step in t
 struct StencilKernel
 {
-    template<typename TAcc, typename TIdx>
+    template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(
         TAcc const& acc,
         auto const uCurrBuf,
         auto uNextBuf,
-        alpaka::Vec<TIdx, 2u> const chunkSize,
+        alpaka::concepts::Vector auto const chunkSize,
         alpaka::concepts::CVector auto sharedMemExtents,
         double const dx,
         double const dy,
@@ -62,7 +62,7 @@ struct StencilKernel
         // go over only core cells
         // alpaka::Vec{1, 1}; offset for halo above and to the left
         for(auto idx2D :
-            alpaka::makeIter(acc, alpaka::iter::withinDataFrame, alpaka::Vec{1u, 1u}, alpaka::Vec{16u, 16u}))
+            alpaka::makeIter(acc, alpaka::iter::withinThreadBlock, alpaka::Vec{1u, 1u}, alpaka::Vec{16u, 16u}))
         {
             auto bufIdx = idx2D + blockStartIdx;
 

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -109,7 +109,6 @@ auto example(T_Cfg const& cfg) -> int
     constexpr Idx ySize = 16u;
     constexpr Idx halo = 2u;
     constexpr IdxVec chunkSize{ySize, xSize};
-    constexpr auto sharedMemSize = (ySize + halo) * (xSize + halo);
 
     constexpr IdxVec numChunks{
         alpaka::core::divCeil(numNodes[0], chunkSize[0]),
@@ -120,7 +119,7 @@ auto example(T_Cfg const& cfg) -> int
         numNodes[0] % chunkSize[0] == 0 && numNodes[1] % chunkSize[1] == 0
         && "Domain must be divisible by chunk size");
 
-    StencilKernel<sharedMemSize> stencilKernel;
+    StencilKernel<CVec<uint32_t, ySize + halo, xSize + halo>> stencilKernel;
     BoundaryKernel boundaryKernel;
 
     auto dataBlocking = alpaka::DataBlocking{numChunks, chunkSize};
@@ -137,8 +136,8 @@ auto example(T_Cfg const& cfg) -> int
             dataBlocking,
             KernelBundle{
                 stencilKernel,
-                uCurrBufAcc.data(),
-                uNextBufAcc.data(),
+                uCurrBufAcc.getMdSpan(),
+                uNextBufAcc.getMdSpan(),
                 chunkSize,
                 pitchCurrAcc,
                 pitchNextAcc,

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -119,7 +119,8 @@ auto example(T_Cfg const& cfg) -> int
         numNodes[0] % chunkSize[0] == 0 && numNodes[1] % chunkSize[1] == 0
         && "Domain must be divisible by chunk size");
 
-    StencilKernel<CVec<uint32_t, ySize + halo, xSize + halo>> stencilKernel;
+    auto sharedMemExtents = CVec<uint32_t, ySize + halo, xSize + halo>{};
+    StencilKernel stencilKernel;
     BoundaryKernel boundaryKernel;
 
     auto dataBlocking = alpaka::DataBlocking{numChunks, chunkSize};
@@ -139,8 +140,7 @@ auto example(T_Cfg const& cfg) -> int
                 uCurrBufAcc.getMdSpan(),
                 uNextBufAcc.getMdSpan(),
                 chunkSize,
-                pitchCurrAcc,
-                pitchNextAcc,
+                sharedMemExtents,
                 dx,
                 dy,
                 dt});

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -108,7 +108,7 @@ auto example(T_Cfg const& cfg) -> int
     constexpr Idx xSize = 16u;
     constexpr Idx ySize = 16u;
     constexpr Idx halo = 2u;
-    constexpr IdxVec chunkSize{ySize, xSize};
+    constexpr auto chunkSize = CVec<Idx, ySize, xSize>{};
 
     constexpr IdxVec numChunks{
         alpaka::core::divCeil(numNodes[0], chunkSize[0]),

--- a/include/alpaka/Blocking.hpp
+++ b/include/alpaka/Blocking.hpp
@@ -11,19 +11,20 @@
 
 namespace alpaka
 {
-    template<typename T_NumBlocks, typename T_NumThreads>
+    template<alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_NumThreads>
     struct ThreadBlocking
     {
         using type = typename T_NumBlocks::type;
-        using vecType = T_NumBlocks;
+        using NumBlocksVecType = typename T_NumBlocks::UniVec;
+        using NumThreadsVecType = typename T_NumThreads::UniVec;
 
         consteval uint32_t dim() const
         {
             return T_NumThreads::dim();
         }
 
-        T_NumBlocks m_numBlocks;
-        T_NumThreads m_numThreads;
+        NumBlocksVecType m_numBlocks;
+        NumThreadsVecType m_numThreads;
 
         ThreadBlocking(T_NumBlocks const& numBlocks, T_NumThreads const& numThreads)
             : m_numBlocks(numBlocks)
@@ -32,7 +33,10 @@ namespace alpaka
         }
     };
 
-    template<typename T_NumBlocks, typename T_BlockSize>
+    template<alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_NumThreads>
+    ThreadBlocking(T_NumBlocks const&, T_NumThreads const&) -> ThreadBlocking<T_NumBlocks, T_NumThreads>;
+
+    template<alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_BlockSize>
     struct DataBlocking
     {
         using type = typename T_NumBlocks::type;
@@ -61,7 +65,7 @@ namespace alpaka
         }
     };
 
-    template<typename T_NumBlocks, typename T_BlockSize>
+    template<alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_BlockSize>
     std::ostream& operator<<(std::ostream& s, DataBlocking<T_NumBlocks, T_BlockSize> const& d)
     {
         return s << "blocks=" << d.m_numBlocks << " blockSize=" << d.m_blockSize;

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -744,12 +744,28 @@ namespace alpaka
     };
 
     template<typename T>
+    struct IsCVector : std::false_type
+    {
+    };
+
+    template<typename T_Type, uint32_t T_dim, T_Type... T_values>
+    struct IsCVector<Vec<T_Type, T_dim, detail::CVec<T_Type, T_values...>>> : std::true_type
+    {
+    };
+
+    template<typename T>
     constexpr bool isVector_v = IsVector<T>::value;
+
+    template<typename T>
+    constexpr bool isCVector_v = IsCVector<T>::value;
 
     namespace concepts
     {
         template<typename T>
         concept Vector = isVector_v<T>;
+
+        template<typename T>
+        concept CVector = isCVector_v<T>;
 
         template<typename T, typename T_RequiredComponent>
         concept TypeOrVector = (isVector_v<T> || std::is_same_v<T, T_RequiredComponent>);

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -299,12 +299,12 @@ namespace alpaka
          */
 #define ALPAKA_NAMED_ARRAY_ACCESS(functionName, dimValue)                                                             \
     template<uint32_t T_deferDim = T_dim, std::enable_if_t<T_deferDim >= dimValue + 1u, int> = 0>                     \
-    constexpr type& functionName()                                                                                    \
+    constexpr decltype(auto) functionName()                                                                           \
     {                                                                                                                 \
         return (*this)[T_dim - 1u - dimValue];                                                                        \
     }                                                                                                                 \
     template<uint32_t T_deferDim = T_dim, std::enable_if_t<T_deferDim >= dimValue + 1u, int> = 0>                     \
-    constexpr type const& functionName() const                                                                        \
+    constexpr decltype(auto) functionName() const                                                                     \
     {                                                                                                                 \
         return (*this)[T_dim - 1u - dimValue];                                                                        \
     }

--- a/include/alpaka/api/cpu/Queue.hpp
+++ b/include/alpaka/api/cpu/Queue.hpp
@@ -76,7 +76,7 @@ namespace alpaka::onHost
 
             friend struct internal::Enqueue;
 
-            template<typename T_NumBlocks, typename T_NumThreads>
+            template<alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_NumThreads>
             void enqueue(
                 auto const executor,
                 ThreadBlocking<T_NumBlocks, T_NumThreads> const& threadBlocking,
@@ -90,7 +90,7 @@ namespace alpaka::onHost
                     });
             }
 
-            template<typename T_Mapping, typename T_NumBlocks, typename T_BlockSize>
+            template<typename T_Mapping, alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_BlockSize>
             void enqueue(
                 T_Mapping const executor,
                 DataBlocking<T_NumBlocks, T_BlockSize> dataBlocking,

--- a/include/alpaka/api/cpu/exec/OmpThreads.hpp
+++ b/include/alpaka/api/cpu/exec/OmpThreads.hpp
@@ -28,9 +28,6 @@ namespace alpaka::onHost
         template<typename T_NumBlocks, typename T_NumThreads>
         struct OmpThreads
         {
-            using IndexVecType = typename ThreadBlocking<T_NumBlocks, T_NumThreads>::vecType;
-            using IndexType = typename IndexVecType::type;
-
             constexpr OmpThreads(ThreadBlocking<T_NumBlocks, T_NumThreads> threadBlocking)
                 : m_threadBlocking{std::move(threadBlocking)}
             {
@@ -67,14 +64,17 @@ namespace alpaka::onHost
                         auto const blockSharedMemEntry = DictEntry{layer::shared, std::ref(blockSharedMem)};
                         auto const blockSyncEntry = DictEntry{action::sync, onAcc::cpu::OmpSync{}};
 
+                        using NumThreadsVecType =
+                            typename ThreadBlocking<T_NumBlocks, T_NumThreads>::NumThreadsVecType;
+                        using ThreadIdxType = typename NumThreadsVecType::type;
 #    pragma omp for
-                        for(IndexType i = 0; i < blockCountND.product(); ++i)
+                        for(ThreadIdxType i = 0; i < blockCountND.product(); ++i)
                         {
                             blockIdx = mapToND(blockCountND, i);
 #    pragma omp parallel num_threads(threadCount)
                             {
                                 int x = omp_get_thread_num();
-                                IndexVecType threadIdx = mapToND(threadCountND, static_cast<IndexType>(x));
+                                NumThreadsVecType threadIdx = mapToND(threadCountND, static_cast<ThreadIdxType>(x));
 
 
                                 // usleep(100 * x * i);

--- a/include/alpaka/api/cpu/exec/Serial.hpp
+++ b/include/alpaka/api/cpu/exec/Serial.hpp
@@ -24,7 +24,7 @@ namespace alpaka::onHost
         template<typename T_NumBlocks, typename T_NumThreads>
         struct Serial
         {
-            using IndexVecType = typename ThreadBlocking<T_NumBlocks, T_NumThreads>::vecType;
+            using NumThreadsVecType = typename ThreadBlocking<T_NumBlocks, T_NumThreads>::NumThreadsVecType;
 
             constexpr Serial(ThreadBlocking<T_NumBlocks, T_NumThreads> threadBlocking)
                 : m_threadBlocking{std::move(threadBlocking)}
@@ -45,7 +45,7 @@ namespace alpaka::onHost
                 auto const blockLayerEntry = DictEntry{
                     layer::block,
                     onAcc::cpu::GenericLayer{std::cref(blockIdx), std::cref(m_threadBlocking.m_numBlocks)}};
-                auto const threadLayerEntry = DictEntry{layer::thread, onAcc::cpu::OneLayer<IndexVecType>{}};
+                auto const threadLayerEntry = DictEntry{layer::thread, onAcc::cpu::OneLayer<NumThreadsVecType>{}};
                 auto const blockSharedMemEntry = DictEntry{layer::shared, std::ref(blockSharedMem)};
                 auto const blockSyncEntry = DictEntry{action::sync, onAcc::cpu::NoOp{}};
 

--- a/include/alpaka/api/cuda/Device.hpp
+++ b/include/alpaka/api/cuda/Device.hpp
@@ -120,14 +120,14 @@ namespace alpaka::onHost
 {
     namespace internal
     {
-        template<typename T_Type, typename T_Platform, typename T_Extents>
+        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
         struct Alloc::Op<T_Type, cuda::Device<T_Platform>, T_Extents>
         {
             auto operator()(cuda::Device<T_Platform>& device, T_Extents const& extents) const
             {
                 using TApi = typename cuda::Device<T_Platform>::TApi;
                 T_Type* ptr = nullptr;
-                auto pitches = T_Extents::all(sizeof(T_Type));
+                auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
 
                 using Idx = typename T_Extents::type;
 
@@ -164,7 +164,8 @@ namespace alpaka::onHost
                 }
 
                 auto deleter = [](T_Type* ptr) { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::free(ptr)); };
-                auto data = std::make_shared<onHost::Data<Handle<std::decay_t<decltype(device)>>, T_Type, T_Extents>>(
+                auto data = std::make_shared<
+                    onHost::Data<Handle<std::decay_t<decltype(device)>>, T_Type, T_Extents, ALPAKA_TYPE(pitches)>>(
                     device.getSharedPtr(),
                     ptr,
                     extents,

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -223,6 +223,7 @@ namespace alpaka
         T_Extents m_extent;
     };
 
+    /** access a C array with compile time extents via a runtime md index. */
     template<std::integral auto T_numDims, uint32_t T_dim = 0u>
     struct ResolveArrayAccess
     {
@@ -239,6 +240,19 @@ namespace alpaka
         {
             return arrayPtr[idx[T_dim]];
         }
+    };
+
+    /** build C array type with compile time extents from a scalar value based on the compile time extents vector */
+    template<typename T, concepts::CVector T_Extent, uint32_t T_numDims = T_Extent::dim(), uint32_t T_dim = 0u>
+    struct CArrayType
+    {
+        using type = typename CArrayType<T[T_Extent{}[T_dim]], T_Extent, T_numDims - 1u, T_dim + 1u>::type;
+    };
+
+    template<typename T, concepts::CVector T_Extent, uint32_t T_dim>
+    struct CArrayType<T, T_Extent, 1u, T_dim>
+    {
+        using type = T[T_Extent{}[T_dim]];
     };
 
     template<typename T_ArrayType>

--- a/include/alpaka/onAcc.hpp
+++ b/include/alpaka/onAcc.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/mem/MdSpan.hpp"
 #include "alpaka/onAcc/internal.hpp"
 
 namespace alpaka::onAcc
@@ -18,4 +19,11 @@ namespace alpaka::onAcc
     {
         return internalCompute::declareSharedVar<T>(acc);
     }
+
+    template<typename T_Array>
+    constexpr decltype(auto) declareSharedArray(auto const& acc)
+    {
+        return MdSpanArray<T_Array>{internalCompute::declareSharedVar<T_Array>(acc)};
+    }
+
 } // namespace alpaka::onAcc

--- a/include/alpaka/onAcc.hpp
+++ b/include/alpaka/onAcc.hpp
@@ -20,10 +20,11 @@ namespace alpaka::onAcc
         return internalCompute::declareSharedVar<T>(acc);
     }
 
-    template<typename T_Array>
-    constexpr decltype(auto) declareSharedArray(auto const& acc)
+    template<typename T, concepts::CVector T_Extent>
+    constexpr decltype(auto) declareSharedMdArray(auto const& acc, T_Extent const& extent)
     {
-        return MdSpanArray<T_Array>{internalCompute::declareSharedVar<T_Array>(acc)};
+        using CArrayType = typename CArrayType<T, T_Extent>::type;
+        return MdSpanArray<CArrayType>{internalCompute::declareSharedVar<CArrayType>(acc)};
     }
 
 } // namespace alpaka::onAcc

--- a/include/alpaka/onHost.hpp
+++ b/include/alpaka/onHost.hpp
@@ -90,7 +90,7 @@ namespace alpaka::onHost
     template<typename T_Type>
     inline auto alloc(auto const& any, auto const& extents)
     {
-        return internal::Alloc::Op<T_Type, std::decay_t<decltype(*any.get())>, std::decay_t<decltype(extents)>>{}(
+        return internal::Alloc::Op<T_Type, std::decay_t<decltype(*any.get())>, ALPAKA_TYPE(extents)>{}(
             *any.get(),
             extents);
     }

--- a/include/alpaka/onHost/internal.hpp
+++ b/include/alpaka/onHost/internal.hpp
@@ -165,8 +165,8 @@ namespace alpaka::onHost
             KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
         {
             return AdjustThreadBlocking::Op<
-                std::decay_t<decltype(device)>,
-                std::decay_t<decltype(executor)>,
+                ALPAKA_TYPE(device),
+                ALPAKA_TYPE(executor),
                 DataBlocking<T_NumBlocks, T_NumThreads>,
                 KernelBundle<TKernelFn, TArgs...>>{}(device, executor, dataBlocking, kernelBundle);
         }

--- a/include/alpaka/onHost/mem/Data.hpp
+++ b/include/alpaka/onHost/mem/Data.hpp
@@ -21,47 +21,51 @@ namespace alpaka::onHost
     namespace mem
     {
         //! Calculate the pitches purely from the extents.
-        template<typename T_Elem, typename T_Idx, uint32_t T_dim>
-        constexpr auto calculatePitchesFromExtents(Vec<T_Idx, T_dim> const& extent)
+        template<typename T_Elem, alpaka::concepts::Vector T_Vec>
+        constexpr auto calculatePitchesFromExtents(T_Vec const& extent)
         {
-            using VecType = Vec<T_Idx, T_dim>;
-            VecType pitchBytes{};
-            constexpr auto dim = VecType::dim();
+            constexpr auto dim = T_Vec::dim();
+            using type = typename T_Vec::type;
+            auto pitchBytes = typename T_Vec::UniVec{};
             if constexpr(dim > 0)
-                pitchBytes.back() = static_cast<T_Idx>(sizeof(T_Elem));
+                pitchBytes.back() = static_cast<type>(sizeof(T_Elem));
             if constexpr(dim > 1)
-                for(T_Idx i = dim - 1; i > 0; i--)
+                for(type i = dim - 1; i > 0; i--)
                     pitchBytes[i - 1] = extent[i] * pitchBytes[i];
             return pitchBytes;
         }
 
         //! Calculate the pitches purely from the extents.
-        template<typename T_Elem, typename T_Idx, uint32_t T_dim>
-        requires(T_dim >= 2)
-        constexpr auto calculatePitches(Vec<T_Idx, T_dim> const& extent, T_Idx const& rowPitchBytes)
+        template<typename T_Elem, alpaka::concepts::Vector T_Vec>
+        requires(T_Vec::dim() >= 2)
+        constexpr auto calculatePitches(T_Vec const& extent, typename T_Vec::type const& rowPitchBytes)
         {
-            using VecType = Vec<T_Idx, T_dim>;
-            VecType pitchBytes{};
-            constexpr auto dim = VecType::dim();
-            pitchBytes.back() = static_cast<T_Idx>(sizeof(T_Elem));
+            constexpr auto dim = T_Vec::dim();
+            using type = typename T_Vec::type;
+            auto pitchBytes = typename T_Vec::UniVec{};
+            pitchBytes.back() = static_cast<type>(sizeof(T_Elem));
             if constexpr(dim > 1)
-                pitchBytes[T_dim - 2u] = rowPitchBytes;
+                pitchBytes[dim - 2u] = rowPitchBytes;
             if constexpr(dim > 2)
-                for(T_Idx i = dim - 2; i > 0; i--)
+                for(type i = dim - 2; i > 0; i--)
                     pitchBytes[i - 1] = extent[i] * pitchBytes[i];
             return pitchBytes;
         }
     } // namespace mem
 
-    template<typename T_BaseHandle, typename T_Type, typename T_Extents>
-    struct Data : std::enable_shared_from_this<Data<T_BaseHandle, T_Type, T_Extents>>
+    template<
+        typename T_BaseHandle,
+        typename T_Type,
+        alpaka::concepts::Vector T_Extents,
+        alpaka::concepts::Vector T_Pitches>
+    struct Data : std::enable_shared_from_this<Data<T_BaseHandle, T_Type, T_Extents, T_Pitches>>
     {
     public:
         Data(
             T_BaseHandle base,
             T_Type* data,
             T_Extents const& extents,
-            T_Extents const& pitches,
+            T_Pitches const& pitches,
             std::function<void(T_Type*)> deleter)
             : m_base(std::move(base))
             , m_data(data)
@@ -92,7 +96,7 @@ namespace alpaka::onHost
         T_BaseHandle m_base;
         T_Type* m_data;
         T_Extents m_extents;
-        T_Extents m_pitches;
+        T_Pitches m_pitches;
         std::function<void(T_Type*)> m_deleter;
 
         std::shared_ptr<Data> getSharedPtr()
@@ -102,7 +106,7 @@ namespace alpaka::onHost
 
         friend struct internal::Data;
 
-        T_Extents getPitches() const
+        T_Pitches getPitches() const
         {
             return m_pitches;
         }
@@ -129,8 +133,8 @@ namespace alpaka::onHost
 namespace alpaka::internal
 {
 
-    template<typename T_BaseHandle, typename T_Type, typename T_Extents>
-    struct GetApi::Op<onHost::Data<T_BaseHandle, T_Type, T_Extents>>
+    template<typename T_BaseHandle, typename T_Type, typename T_Extents, typename T_Pitches>
+    struct GetApi::Op<onHost::Data<T_BaseHandle, T_Type, T_Extents, T_Pitches>>
     {
         decltype(auto) operator()(auto&& data) const
         {

--- a/tests/vec.cpp
+++ b/tests/vec.cpp
@@ -120,6 +120,10 @@ struct CompileTimeKernel2D
         constexpr auto iota2 = iotaCVec<int, 2u>();
         static_assert(iota2 == Vec{0, 1});
 
+        // CVec fallback to Vec for different operations
+        constexpr auto allVec = CVec<int, 2u, 2u>::all(1u);
+        static_assert(allVec == Vec{1, 1});
+
         constexpr auto typeLambda = [](auto const typeDummy) constexpr
         {
             using type = std::decay_t<decltype(typeDummy)>;


### PR DESCRIPTION
- keep CVec as long as possible if we do not need to perform operations on it.
- add possibility to use 2D shared memory