### PR TITLE
fix iterators

### DIFF
--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -123,6 +123,7 @@ auto example(T_Cfg const& cfg) -> int
     StencilKernel stencilKernel;
     BoundaryKernel boundaryKernel;
 
+    auto dataBlockingStancil = alpaka::DataBlocking{numChunks, chunkSize};
     auto dataBlocking = alpaka::DataBlocking{numChunks, chunkSize};
 
     auto startTime = std::chrono::high_resolution_clock::now();
@@ -134,16 +135,19 @@ auto example(T_Cfg const& cfg) -> int
         alpaka::onHost::enqueue(
             computeQueue,
             exec,
-            dataBlocking,
+            dataBlockingStancil,
             KernelBundle{
                 stencilKernel,
                 uCurrBufAcc.getMdSpan(),
                 uNextBufAcc.getMdSpan(),
                 chunkSize,
                 sharedMemExtents,
+                numNodes,
                 dx,
                 dy,
                 dt});
+
+        // std::cout<<"_--"<<std::endl;
         // Apply boundaries
         alpaka::onHost::enqueue(
             computeQueue,

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -33,8 +33,7 @@ public:
 
         // The uniformElements range for loop takes care automatically of the blocks, threads and elements in the
         // kernel launch grid.
-        for(auto i :
-            onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{numElements}))
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{numElements}))
         {
             C[i] = A[i] + B[i];
         }

--- a/include/alpaka/mem/layout.hpp
+++ b/include/alpaka/mem/layout.hpp
@@ -1,0 +1,28 @@
+/* Copyright 2024 Andrea Bocci, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+namespace alpaka::onAcc::iter
+{
+    namespace layout
+    {
+        struct Strided
+        {
+        };
+
+        struct Contigious
+        {
+        };
+
+        struct Optimized
+        {
+        };
+
+        constexpr auto strided = Strided{};
+        constexpr auto contigious = Contigious{};
+        constexpr auto optimized = Optimized{};
+
+    } // namespace layout
+} // namespace alpaka::onAcc::iter

--- a/include/alpaka/onAcc.hpp
+++ b/include/alpaka/onAcc.hpp
@@ -34,7 +34,7 @@ namespace alpaka::onAcc
      */
     template<
         iter::concepts::IdxTraversing T_Traverse = iter::traverse::Flat,
-        iter::concepts::IdxMapping T_IdxMapping = iter::idxLayout::Optimized>
+        iter::concepts::IdxMapping T_IdxMapping = iter::layout::Optimized>
     ALPAKA_FN_HOST_ACC constexpr auto makeIdxMap(
         auto const& acc,
         auto const workGroup,

--- a/tests/queue.cpp
+++ b/tests/queue.cpp
@@ -109,6 +109,7 @@ struct IotaKernel
         static_assert(alpaka::concepts::CVector<ALPAKA_TYPE(acc[frame::extent])>);
         for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, onAcc::range::dataExtent))
         {
+            //            std::cout<<i<<std::endl;
             out[i.x()] = i.x();
         }
     }
@@ -128,7 +129,7 @@ TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
     std::cout << getName(platform) << " " << device.getName() << std::endl;
 
     Queue queue = device.makeQueue();
-    constexpr Vec extent = Vec{128u};
+    constexpr Vec extent = Vec{12u};
     std::cout << "exec=" << core::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<uint32_t>(device, extent);
 


### PR DESCRIPTION
The index flattening was wrong in cases a stride for the index range was
used. Move the implementation into the index container.

Note: The code contains many code duplications, this will be refactored
soon.

Heat equation: Use block loop to support any number of blocks.
For the stencil kernel number of blocks and number and framesize is not
freely choosable.