### PR TITLE
some renamings

### DIFF
--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -31,7 +31,7 @@ public:
         -> void
     {
         using namespace alpaka;
-        static_assert(ALPAKA_TYPE(numElements)::dim() == 1, "The VectorAddKernel expects 1-dimensional indices!");
+        static_assert(ALPAKA_TYPEOF(numElements)::dim() == 1, "The VectorAddKernel expects 1-dimensional indices!");
 
         // The uniformElements range for loop takes care automatically of the blocks, threads and elements in the
         // kernel launch grid.

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -496,8 +496,9 @@ namespace alpaka
             return stream.str();
         }
 
+        /** swizzle operator */
         template<typename T, T... T_values>
-        constexpr auto select(Vec<T, sizeof...(T_values), detail::CVec<T, T_values...>> const v) const
+        constexpr auto operator[](Vec<T, sizeof...(T_values), detail::CVec<T, T_values...>> const v) const
         {
             using InType = ALPAKA_TYPEOF(v);
             return Vec<T_Type, InType::dim()>{(*this)[T_values]...};

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -65,7 +65,7 @@ namespace alpaka
             constexpr T operator[](std::integral auto const idx) const
             {
                 T result;
-                using IdxType = ALPAKA_TYPE(idx);
+                using IdxType = ALPAKA_TYPEOF(idx);
                 std::apply(
                     [&result, idx](auto const&... v)
                     {
@@ -73,7 +73,7 @@ namespace alpaka
                         /**
                          *  sizeof() is required to return a bool which is deferred in the evaluation
                          */
-                        (void) (((idx == i++) && (result = ALPAKA_TYPE(v)::value, sizeof(IdxType))) || ...);
+                        (void) (((idx == i++) && (result = ALPAKA_TYPEOF(v)::value, sizeof(IdxType))) || ...);
                     },
                     Values{});
                 return result;
@@ -499,24 +499,24 @@ namespace alpaka
         template<typename T, T... T_values>
         constexpr auto select(Vec<T, sizeof...(T_values), detail::CVec<T, T_values...>> const v) const
         {
-            using InType = ALPAKA_TYPE(v);
+            using InType = ALPAKA_TYPEOF(v);
             return Vec<T_Type, InType::dim()>{(*this)[T_values]...};
         }
 
         template<typename T, T... T_values>
         constexpr auto ref(Vec<T, sizeof...(T_values), detail::CVec<T, T_values...>> const v)
         {
-            using InType = ALPAKA_TYPE(v);
+            using InType = ALPAKA_TYPEOF(v);
             auto array = std::array{std::ref((*this)[T_values])...};
-            return Vec<T_Type, InType::dim(), ALPAKA_TYPE(array)>{array};
+            return Vec<T_Type, InType::dim(), ALPAKA_TYPEOF(array)>{array};
         };
 
         template<typename T, T... T_values>
         constexpr auto ref(Vec<T, sizeof...(T_values), detail::CVec<T, T_values...>> const v) const
         {
-            using InType = ALPAKA_TYPE(v);
+            using InType = ALPAKA_TYPEOF(v);
             auto array = std::array{std::ref((*this)[T_values])...};
-            return Vec<T_Type, InType::dim(), ALPAKA_TYPE(array)>{array};
+            return Vec<T_Type, InType::dim(), ALPAKA_TYPEOF(array)>{array};
         };
     };
 

--- a/include/alpaka/api/cpu/Device.hpp
+++ b/include/alpaka/api/cpu/Device.hpp
@@ -136,7 +136,8 @@ namespace alpaka::onHost
                     auto deleter = [](T_Type* ptr) { delete[](ptr); };
                     auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
                     auto data = std::make_shared<
-                        onHost::Data<Handle<std::decay_t<decltype(device)>>, T_Type, T_Extents, ALPAKA_TYPE(pitches)>>(
+                        onHost::
+                            Data<Handle<std::decay_t<decltype(device)>>, T_Type, T_Extents, ALPAKA_TYPEOF(pitches)>>(
                         device.getSharedPtr(),
                         ptr,
                         extents,
@@ -150,7 +151,8 @@ namespace alpaka::onHost
                     auto deleter = [](T_Type* ptr) { delete[](ptr); };
                     auto pitches = mem::calculatePitchesFromExtents<T_Type>(extents);
                     auto data = std::make_shared<
-                        onHost::Data<Handle<std::decay_t<decltype(device)>>, T_Type, T_Extents, ALPAKA_TYPE(pitches)>>(
+                        onHost::
+                            Data<Handle<std::decay_t<decltype(device)>>, T_Type, T_Extents, ALPAKA_TYPEOF(pitches)>>(
                         device.getSharedPtr(),
                         ptr,
                         extents,
@@ -218,7 +220,7 @@ namespace alpaka::onHost
                 T_KernelBundle const& kernelBundle) const
             {
                 // universal vector type that both return produce the same result type.
-                using UniVec = typename ALPAKA_TYPE(dataBlocking.getThreadSpec().m_numBlocks)::UniVec;
+                using UniVec = typename ALPAKA_TYPEOF(dataBlocking.getThreadSpec().m_numBlocks)::UniVec;
 
                 if(dataBlocking.getThreadSpec().m_numThreads.product() > 4u)
                 {

--- a/include/alpaka/api/cpu/Queue.hpp
+++ b/include/alpaka/api/cpu/Queue.hpp
@@ -141,7 +141,7 @@ namespace alpaka::onHost
             void operator()(cpu::Queue<T_Device>& queue, T_Dest dest, T_Source const source, T_Extents const& extents)
                 const
             {
-                static_assert(std::is_same_v<ALPAKA_TYPE(dest), ALPAKA_TYPE(source)>);
+                static_assert(std::is_same_v<ALPAKA_TYPEOF(dest), ALPAKA_TYPEOF(source)>);
                 constexpr auto dim = dest.dim();
                 if constexpr(dim == 1u)
                 {

--- a/include/alpaka/api/cuda/Device.hpp
+++ b/include/alpaka/api/cuda/Device.hpp
@@ -170,7 +170,7 @@ namespace alpaka::onHost
 
                 auto deleter = [](T_Type* ptr) { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::free(ptr)); };
                 auto data = std::make_shared<
-                    onHost::Data<Handle<std::decay_t<decltype(device)>>, T_Type, T_Extents, ALPAKA_TYPE(pitches)>>(
+                    onHost::Data<Handle<std::decay_t<decltype(device)>>, T_Type, T_Extents, ALPAKA_TYPEOF(pitches)>>(
                     device.getSharedPtr(),
                     ptr,
                     extents,

--- a/include/alpaka/api/cuda/Queue.hpp
+++ b/include/alpaka/api/cuda/Queue.hpp
@@ -250,8 +250,8 @@ namespace alpaka::onHost
                 auto* const srcPtr = (void*) onHost::data(source);
 
                 auto copyKind = cuda::MemcpyKind<
-                    ALPAKA_TYPE(alpaka::internal::getApi(dest)),
-                    ALPAKA_TYPE(alpaka::internal::getApi(source))>::kind;
+                    ALPAKA_TYPEOF(alpaka::internal::getApi(dest)),
+                    ALPAKA_TYPEOF(alpaka::internal::getApi(source))>::kind;
 
                 constexpr auto dim = extents.dim();
                 if constexpr(dim == 1u)

--- a/include/alpaka/core/common.hpp
+++ b/include/alpaka/core/common.hpp
@@ -221,4 +221,4 @@
 
 #define ALPAKA_FORWARD(instance) std::forward<decltype(instance)>(instance)
 
-#define ALPAKA_TYPE(...) std::decay_t<decltype(__VA_ARGS__)>
+#define ALPAKA_TYPEOF(...) std::decay_t<decltype(__VA_ARGS__)>

--- a/include/alpaka/math.hpp
+++ b/include/alpaka/math.hpp
@@ -12,11 +12,11 @@ namespace alpaka::math
 {
     constexpr auto sin(auto const& arg)
     {
-        return internal::Sin::Op<ALPAKA_TYPE(apiCtx), ALPAKA_TYPE(arg)>{}(apiCtx, arg);
+        return internal::Sin::Op<ALPAKA_TYPEOF(apiCtx), ALPAKA_TYPEOF(arg)>{}(apiCtx, arg);
     }
 
     constexpr auto exp(auto const& arg)
     {
-        return internal::Exp::Op<ALPAKA_TYPE(apiCtx), ALPAKA_TYPE(arg)>{}(apiCtx, arg);
+        return internal::Exp::Op<ALPAKA_TYPEOF(apiCtx), ALPAKA_TYPEOF(arg)>{}(apiCtx, arg);
     }
 } // namespace alpaka::math

--- a/include/alpaka/mem/FlatIdxContainer.hpp
+++ b/include/alpaka/mem/FlatIdxContainer.hpp
@@ -200,35 +200,33 @@ namespace alpaka::onAcc
             if constexpr(std::is_same_v<T_IdxMapperFn, layout::Strided>)
             {
                 auto groupOffset = m_threadSpace.m_threadIdx * m_idxRange.m_stride;
-                groupOffset.ref(T_CSelect{}) -= groupOffset.select(T_CSelect{});
+                groupOffset.ref(T_CSelect{}) -= groupOffset[T_CSelect{}];
 
                 auto begin = m_idxRange.m_begin + groupOffset;
 
-                auto linearCurrent = linearize(
-                    m_threadSpace.m_threadCount.select(T_CSelect{}),
-                    m_threadSpace.m_threadIdx.select(T_CSelect{}));
-                auto linearStride = m_threadSpace.m_threadCount.select(T_CSelect{}).product();
-                auto strideMD = m_idxRange.m_stride.select(T_CSelect{});
-                auto extentMD = core::divCeil(m_idxRange.distance().select(T_CSelect{}), strideMD);
+                auto linearCurrent
+                    = linearize(m_threadSpace.m_threadCount[T_CSelect{}], m_threadSpace.m_threadIdx[T_CSelect{}]);
+                auto linearStride = m_threadSpace.m_threadCount[T_CSelect{}].product();
+                auto strideMD = m_idxRange.m_stride[T_CSelect{}];
+                auto extentMD = core::divCeil(m_idxRange.distance()[T_CSelect{}], strideMD);
 
                 return const_iterator(begin, linearCurrent, linearStride, extentMD.product(), extentMD, strideMD);
             }
             else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contigious>)
             {
                 auto groupOffset = m_threadSpace.m_threadIdx * m_idxRange.m_stride;
-                groupOffset.ref(T_CSelect{}) -= groupOffset.select(T_CSelect{});
+                groupOffset.ref(T_CSelect{}) -= groupOffset[T_CSelect{}];
 
                 auto begin = m_idxRange.m_begin + groupOffset;
 
-                auto strideMD = m_idxRange.m_stride.select(T_CSelect{});
+                auto strideMD = m_idxRange.m_stride[T_CSelect{}];
                 auto numElements = core::divCeil(
-                    m_idxRange.distance().select(T_CSelect{}).product(),
-                    (m_threadSpace.m_threadCount.select(T_CSelect{}).product() * strideMD.product()));
-                auto linearCurrent = linearize(
-                                         m_threadSpace.m_threadCount.select(T_CSelect{}),
-                                         m_threadSpace.m_threadIdx.select(T_CSelect{}))
-                                     * numElements;
-                auto extentMD = core::divCeil(m_idxRange.distance().select(T_CSelect{}), strideMD);
+                    m_idxRange.distance()[T_CSelect{}].product(),
+                    (m_threadSpace.m_threadCount[T_CSelect{}].product() * strideMD.product()));
+                auto linearCurrent
+                    = linearize(m_threadSpace.m_threadCount[T_CSelect{}], m_threadSpace.m_threadIdx[T_CSelect{}])
+                      * numElements;
+                auto extentMD = core::divCeil(m_idxRange.distance()[T_CSelect{}], strideMD);
                 return const_iterator(
                     begin,
                     linearCurrent,
@@ -243,22 +241,19 @@ namespace alpaka::onAcc
         {
             if constexpr(std::is_same_v<T_IdxMapperFn, layout::Strided>)
             {
-                auto extentMD = core::divCeil(
-                    m_idxRange.distance().select(T_CSelect{}),
-                    m_idxRange.m_stride.select(T_CSelect{}));
+                auto extentMD = core::divCeil(m_idxRange.distance()[T_CSelect{}], m_idxRange.m_stride[T_CSelect{}]);
                 return const_iterator_end(extentMD.product());
             }
             else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contigious>)
             {
-                auto strideMD = m_idxRange.m_stride.select(T_CSelect{});
+                auto strideMD = m_idxRange.m_stride[T_CSelect{}];
                 auto numElements = core::divCeil(
-                    m_idxRange.distance().select(T_CSelect{}).product(),
-                    (m_threadSpace.m_threadCount.select(T_CSelect{}).product() * strideMD.product()));
-                auto linearCurrent = linearize(
-                                         m_threadSpace.m_threadCount.select(T_CSelect{}),
-                                         m_threadSpace.m_threadIdx.select(T_CSelect{}))
-                                     * numElements;
-                auto extentMD = core::divCeil(m_idxRange.distance().select(T_CSelect{}), strideMD);
+                    m_idxRange.distance()[T_CSelect{}].product(),
+                    (m_threadSpace.m_threadCount[T_CSelect{}].product() * strideMD.product()));
+                auto linearCurrent
+                    = linearize(m_threadSpace.m_threadCount[T_CSelect{}], m_threadSpace.m_threadIdx[T_CSelect{}])
+                      * numElements;
+                auto extentMD = core::divCeil(m_idxRange.distance()[T_CSelect{}], strideMD);
                 return const_iterator_end(std::min(linearCurrent + numElements, extentMD.product()));
             }
         }

--- a/include/alpaka/mem/FlatIdxContainer.hpp
+++ b/include/alpaka/mem/FlatIdxContainer.hpp
@@ -265,7 +265,7 @@ namespace alpaka::onAcc
 
         ALPAKA_FN_HOST_ACC constexpr auto operator[](concepts::CVector auto const iterDir) const
         {
-            return FlatIdxContainer<T_IdxRange, T_ThreadSpace, T_IdxMapperFn, ALPAKA_TYPE(iterDir)>(
+            return FlatIdxContainer<T_IdxRange, T_ThreadSpace, T_IdxMapperFn, ALPAKA_TYPEOF(iterDir)>(
                 m_idxRange,
                 m_threadSpace,
                 T_IdxMapperFn{});

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -48,13 +48,13 @@ namespace alpaka
         template<concepts::TypeOrVector<typename T_End::type> T_OpType>
         ALPAKA_FN_HOST_ACC constexpr auto operator%(T_OpType const& rhs) const
         {
-            return IdxRange<T_End, T_Begin, ALPAKA_TYPE(m_stride * rhs)>{m_begin, m_end, m_stride * rhs};
+            return IdxRange<T_End, T_Begin, ALPAKA_TYPEOF(m_stride * rhs)>{m_begin, m_end, m_stride * rhs};
         }
 
         template<concepts::TypeOrVector<typename T_End::type> T_OpType>
         ALPAKA_FN_HOST_ACC constexpr auto operator>>(T_OpType const& rhs) const
         {
-            return IdxRange<ALPAKA_TYPE(m_end + rhs), ALPAKA_TYPE(m_begin + rhs), ALPAKA_TYPE(m_stride)>{
+            return IdxRange<ALPAKA_TYPEOF(m_end + rhs), ALPAKA_TYPEOF(m_begin + rhs), ALPAKA_TYPEOF(m_stride)>{
                 m_begin + rhs,
                 m_end + rhs,
                 m_stride};
@@ -63,7 +63,7 @@ namespace alpaka
         template<concepts::TypeOrVector<typename T_End::type> T_OpType>
         ALPAKA_FN_HOST_ACC constexpr auto operator<<(T_OpType const& rhs) const
         {
-            return IdxRange<ALPAKA_TYPE(m_end - rhs), ALPAKA_TYPE(m_begin - rhs), T_Stride>{
+            return IdxRange<ALPAKA_TYPEOF(m_end - rhs), ALPAKA_TYPEOF(m_begin - rhs), T_Stride>{
                 m_begin - rhs,
                 m_end - rhs,
                 m_stride};

--- a/include/alpaka/mem/Iter.hpp
+++ b/include/alpaka/mem/Iter.hpp
@@ -277,7 +277,7 @@ namespace alpaka::onAcc
 
         constexpr auto adjustMapping(auto const& acc, auto api)
         {
-            return internal::AutoIndexMapping::Op<ALPAKA_TYPE(acc), ALPAKA_TYPE(api)>{}(acc, api);
+            return internal::AutoIndexMapping::Op<ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(api)>{}(acc, api);
         }
 
         struct MakeIter
@@ -294,7 +294,8 @@ namespace alpaka::onAcc
                     T_Acc const& acc,
                     T_DomainSpec const& domainSpec,
                     [[maybe_unused]] T_Traverse traverse,
-                    T_IdxMapping idxMapping) const requires std::is_same_v<ALPAKA_TYPE(idxMapping), layout::Optimized>
+                    T_IdxMapping idxMapping) const
+                    requires std::is_same_v<ALPAKA_TYPEOF(idxMapping), layout::Optimized>
                 {
                     auto adjIdxMapping = adjustMapping(acc, acc[object::api]);
                     auto const idxRange = domainSpec.getIdxRange(acc);
@@ -304,8 +305,8 @@ namespace alpaka::onAcc
                         threadSpace,
                         adjIdxMapping,
                         iotaCVec<
-                            typename ALPAKA_TYPE(idxRange.distance())::type,
-                            ALPAKA_TYPE(idxRange.distance())::dim()>());
+                            typename ALPAKA_TYPEOF(idxRange.distance())::type,
+                            ALPAKA_TYPEOF(idxRange.distance())::dim()>());
                 }
 
                 ALPAKA_FN_HOST_ACC constexpr auto operator()(
@@ -321,8 +322,8 @@ namespace alpaka::onAcc
                         threadSpace,
                         idxMapping,
                         iotaCVec<
-                            typename ALPAKA_TYPE(idxRange.distance())::type,
-                            ALPAKA_TYPE(idxRange.distance())::dim()>());
+                            typename ALPAKA_TYPEOF(idxRange.distance())::type,
+                            ALPAKA_TYPEOF(idxRange.distance())::dim()>());
                 }
             };
         };

--- a/include/alpaka/mem/TiledIdxContainer.hpp
+++ b/include/alpaka/mem/TiledIdxContainer.hpp
@@ -287,7 +287,7 @@ namespace alpaka::onAcc
 
         ALPAKA_FN_HOST_ACC constexpr auto operator[](concepts::CVector auto const iterDir) const
         {
-            return TiledIdxContainer<T_IdxRange, T_ThreadSpace, T_IdxMapperFn, ALPAKA_TYPE(iterDir)>(
+            return TiledIdxContainer<T_IdxRange, T_ThreadSpace, T_IdxMapperFn, ALPAKA_TYPEOF(iterDir)>(
                 m_idxRange,
                 m_threadSpace,
                 T_IdxMapperFn{});

--- a/include/alpaka/mem/TiledIdxContainer.hpp
+++ b/include/alpaka/mem/TiledIdxContainer.hpp
@@ -105,7 +105,7 @@ namespace alpaka::onAcc
             }
 
             ALPAKA_FN_ACC inline const_iterator_end(concepts::Vector auto const& extent)
-                : m_extentSlowDim{extent.select(T_CSelect{})[0]}
+                : m_extentSlowDim{extent[T_CSelect{}][0]}
             {
             }
 
@@ -159,9 +159,9 @@ namespace alpaka::onAcc
                 concepts::Vector auto const extent,
                 concepts::Vector auto const stride)
                 : m_current{first + offset}
-                , m_stride{stride.select(T_CSelect{})}
-                , m_extent{(extent + offset).select(T_CSelect{})}
-                , m_first((m_current).select(T_CSelect{}))
+                , m_stride{stride[T_CSelect{}]}
+                , m_extent{(extent + offset)[T_CSelect{}]}
+                , m_first((m_current)[T_CSelect{}])
             {
                 // range check required for 1 dimensional iterators
                 if constexpr(iterDim > 1u)

--- a/include/alpaka/onAcc.hpp
+++ b/include/alpaka/onAcc.hpp
@@ -43,7 +43,7 @@ namespace alpaka::onAcc
         T_IdxMapping idxMapping = T_IdxMapping{})
     {
         return internal::MakeIter::
-            Op<ALPAKA_TYPE(acc), ALPAKA_TYPE(DomainSpec{workGroup, range}), T_Traverse, T_IdxMapping>{}(
+            Op<ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(DomainSpec{workGroup, range}), T_Traverse, T_IdxMapping>{}(
                 acc,
                 DomainSpec{workGroup, range},
                 traverse,
@@ -58,10 +58,10 @@ namespace alpaka::onAcc
         auto const workGroup,
         alpaka::concepts::HasStaticDim auto const range,
         T_Traverse traverse = T_Traverse{},
-        T_IdxMapping idxMapping = T_IdxMapping{}) requires(ALPAKA_TYPE(range)::dim() == 1u)
+        T_IdxMapping idxMapping = T_IdxMapping{}) requires(ALPAKA_TYPEOF(range)::dim() == 1u)
     {
         return internal::MakeIter::
-            Op<ALPAKA_TYPE(acc), ALPAKA_TYPE(DomainSpec{workGroup, range}), T_Traverse, T_IdxMapping>{}(
+            Op<ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(DomainSpec{workGroup, range}), T_Traverse, T_IdxMapping>{}(
                 acc,
                 DomainSpec{workGroup, range},
                 traverse,

--- a/include/alpaka/onAcc/atomic.hpp
+++ b/include/alpaka/onAcc/atomic.hpp
@@ -45,7 +45,7 @@ namespace alpaka::onAcc
     template<typename TOp, typename T, typename THierarchy = hierarchy::Grids>
     constexpr auto atomicOp(T* const addr, T const& value, THierarchy const& = THierarchy()) -> T
     {
-        return trait::AtomicOp<TOp, ALPAKA_TYPE(apiCtx), T, THierarchy>::atomicOp(apiCtx, addr, value);
+        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(apiCtx), T, THierarchy>::atomicOp(apiCtx, addr, value);
     }
 
     //! Executes the given operation atomically.
@@ -58,7 +58,7 @@ namespace alpaka::onAcc
     template<typename TOp, typename T, typename THierarchy = hierarchy::Grids>
     constexpr auto atomicOp(T* const addr, T const& compare, T const& value, THierarchy const& = THierarchy()) -> T
     {
-        return trait::AtomicOp<TOp, ALPAKA_TYPE(apiCtx), T, THierarchy>::atomicOp(apiCtx, addr, compare, value);
+        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(apiCtx), T, THierarchy>::atomicOp(apiCtx, addr, compare, value);
     }
 
     //! Executes an atomic add operation.

--- a/include/alpaka/onHost.hpp
+++ b/include/alpaka/onHost.hpp
@@ -97,7 +97,7 @@ namespace alpaka::onHost
     template<typename T_Type>
     inline auto alloc(auto const& device, alpaka::concepts::Vector auto const& extents)
     {
-        return internal::Alloc::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPE(extents)>{}(
+        return internal::Alloc::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extents)>{}(
             *device.get(),
             extents);
     }
@@ -114,7 +114,7 @@ namespace alpaka::onHost
      */
     inline auto allocMirror(auto const& device, auto const& view)
     {
-        return alloc<typename ALPAKA_TYPE(view)::type>(device, view.getExtents());
+        return alloc<typename ALPAKA_TYPEOF(view)::type>(device, view.getExtents());
     }
 
     inline auto memcpy(concepts::QueueHandle auto& queue, auto& dest, auto const& source, auto const& extents)
@@ -148,11 +148,11 @@ namespace alpaka::onHost
 
     inline auto getDeviceProperties(concepts::PlatformHandle auto const& platform, uint32_t idx)
     {
-        return internal::GetDeviceProperties::Op<ALPAKA_TYPE(*platform.get())>{}(*platform.get(), idx);
+        return internal::GetDeviceProperties::Op<ALPAKA_TYPEOF(*platform.get())>{}(*platform.get(), idx);
     }
 
     inline auto getDeviceProperties(concepts::DeviceHandle auto const& device)
     {
-        return internal::GetDeviceProperties::Op<ALPAKA_TYPE(*device.get())>{}(*device.get());
+        return internal::GetDeviceProperties::Op<ALPAKA_TYPEOF(*device.get())>{}(*device.get());
     }
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/internal.hpp
+++ b/include/alpaka/onHost/internal.hpp
@@ -168,8 +168,8 @@ namespace alpaka::onHost
             KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
         {
             return AdjustThreadSpec::Op<
-                ALPAKA_TYPE(device),
-                ALPAKA_TYPE(executor),
+                ALPAKA_TYPEOF(device),
+                ALPAKA_TYPEOF(executor),
                 FrameSpec<T_NumBlocks, T_NumThreads>,
                 KernelBundle<TKernelFn, TArgs...>>{}(device, executor, dataBlocking, kernelBundle);
         }

--- a/tests/block.cpp
+++ b/tests/block.cpp
@@ -28,7 +28,7 @@ struct BlockIotaKernel
         for(auto blockIdx : onAcc::makeIdxMap(
                 acc,
                 onAcc::worker::blocksInGrid,
-                IdxRange{ALPAKA_TYPE(numBlocks)::all(0), numBlocks * numDataElemInBlock, numDataElemInBlock},
+                IdxRange{ALPAKA_TYPEOF(numBlocks)::all(0), numBlocks * numDataElemInBlock, numDataElemInBlock},
                 onAcc::traverse::tiled,
                 onAcc::layout::contigious))
         {

--- a/tests/queue.cpp
+++ b/tests/queue.cpp
@@ -106,7 +106,7 @@ struct IotaKernel
     ALPAKA_FN_ACC void operator()(auto const& acc, auto out, uint32_t outSize) const
     {
         // check that frame extent keeps compile time const-ness
-        static_assert(alpaka::concepts::CVector<ALPAKA_TYPE(acc[frame::extent])>);
+        static_assert(alpaka::concepts::CVector<ALPAKA_TYPEOF(acc[frame::extent])>);
         for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, onAcc::range::dataExtent))
         {
             //            std::cout<<i<<std::endl;
@@ -313,7 +313,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
         queue,
         exec,
         FrameSpec{numBlocksReduced, frameSize},
-        KernelBundle{IotaKernelNDSelection<ALPAKA_TYPE(selection)>{}, dBuff.getMdSpan(), numBlocks});
+        KernelBundle{IotaKernelNDSelection<ALPAKA_TYPEOF(selection)>{}, dBuff.getMdSpan(), numBlocks});
     onHost::memcpy(queue, hBuff, dBuff);
     wait(queue);
 #if 1

--- a/tests/vec.cpp
+++ b/tests/vec.cpp
@@ -37,7 +37,7 @@ struct CompileTimeKernel1D
         static_assert(cvec[0] == 23);
 
         auto selectVec = CVec<int, 0>{};
-        constexpr auto selectRes = vec.select(selectVec);
+        constexpr auto selectRes = vec[selectVec];
         static_assert(selectRes == Vec{3});
 
         constexpr auto typeLambda = [](auto const typeDummy) constexpr
@@ -114,7 +114,7 @@ struct CompileTimeKernel2D
         static_assert(linearize(cvec, Vec{0, 1}) == 1);
 
         auto selectVec = CVec<int, 1, 0>{};
-        constexpr auto selectRes = vec.select(selectVec);
+        constexpr auto selectRes = vec[selectVec];
         static_assert(selectRes == Vec{7, 3});
 
         constexpr auto iota2 = iotaCVec<int, 2u>();
@@ -206,11 +206,11 @@ struct CompileTimeKernel3D
         static_assert(linearize(cvec, Vec{0, 0, 1}) == 1);
 
         auto selectVec = CVec<int, 1, 2, 0>{};
-        constexpr auto selectRes = vec.select(selectVec);
+        constexpr auto selectRes = vec[selectVec];
         static_assert(selectRes == Vec{7, 5, 3});
 
         auto selectVec2 = CVec<int, 1, 2>{};
-        constexpr auto selectRes2 = vec.select(selectVec2);
+        constexpr auto selectRes2 = vec[selectVec2];
         static_assert(selectRes2 == Vec{7, 5});
 
 #if 0


### PR DESCRIPTION
- rename ALPAKA_TYPE to ALPAKA_TYPEOF
- rename Vec swizzle operator
  - `.select` is now `operator[](Vec)`