### PR TITLE
fix sliced iteration

### DIFF
--- a/include/alpaka/CVec.hpp
+++ b/include/alpaka/CVec.hpp
@@ -1,0 +1,112 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/Vec.hpp"
+#include "alpaka/core/common.hpp"
+
+#include <array>
+#include <concepts>
+#include <cstdint>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+namespace alpaka
+{
+    template<typename T, T... T_values>
+    using CVec = Vec<T, sizeof...(T_values), detail::CVec<T, T_values...>>;
+
+    namespace detail
+    {
+        template<typename T, T... T_values>
+        constexpr auto integerSequenceToCVec(std::integer_sequence<T, T_values...>)
+        {
+            return alpaka::CVec<T, T_values...>{};
+        };
+
+        template<typename T, T... T_values>
+        constexpr auto toIntegerSequence(alpaka::CVec<T, T_values...>)
+        {
+            return std::integer_sequence<T, T_values...>{};
+        };
+
+        template<typename Int, Int... Is1, Int... Is2>
+        constexpr auto combine(std::integer_sequence<Int, Is1...>, std::integer_sequence<Int, Is2...>)
+        {
+            return std::integer_sequence<Int, Is1..., Is2...>{};
+        };
+
+        template<typename Last>
+        constexpr auto concatenate(Last last)
+        {
+            return last;
+        };
+
+        template<typename First, typename... Rest>
+        constexpr auto concatenate(First first, Rest... rest)
+        {
+            return combine(first, concatenate(rest...));
+        };
+
+        template<bool pred, typename T, T T_v>
+        using selectValue = std::conditional_t<pred, std::integer_sequence<T>, std::integer_sequence<T, T_v>>;
+
+        template<typename T_BinaryOp, typename T, T... T_values>
+        constexpr auto filterValues(T_BinaryOp op, std::integer_sequence<T, T_values...>)
+        {
+            return concatenate(selectValue<op(T_values), T, T_values>{}...);
+        }
+
+        template<typename T_Seq>
+        struct Contains;
+
+        template<typename T, template<typename, T...> typename T_Seq, T... T_values>
+        struct Contains<T_Seq<T, T_values...>>
+        {
+            using argument_type = T;
+
+            constexpr bool operator()(T value) const
+            {
+                return ((value == T_values) || ...);
+            }
+        };
+    } // namespace detail
+
+    template<typename T, uint32_t T_dim>
+    constexpr auto iotaCVec()
+    {
+        using IotaSeq = std::make_integer_sequence<T, T_dim>;
+        return detail::integerSequenceToCVec(IotaSeq{});
+    }
+
+    /** Find all values only exists in the left vector
+     */
+    constexpr auto leftJoin(concepts::CVector auto left, concepts::CVector auto right)
+    {
+        using namespace detail;
+        constexpr auto rightSeq = toIntegerSequence(right);
+
+        return integerSequenceToCVec(filterValues(Contains<ALPAKA_TYPEOF(rightSeq)>{}, toIntegerSequence(left)));
+    }
+
+    constexpr auto rightJoin(concepts::CVector auto left, concepts::CVector auto right)
+    {
+        using namespace detail;
+        constexpr auto leftSeq = toIntegerSequence(left);
+
+        return integerSequenceToCVec(filterValues(Contains<ALPAKA_TYPEOF(leftSeq)>{}, toIntegerSequence(right)));
+    }
+
+    constexpr auto innerJoin(concepts::CVector auto left, concepts::CVector auto right)
+    {
+        using namespace detail;
+        constexpr auto leftSeq = toIntegerSequence(left);
+
+        return integerSequenceToCVec(
+            filterValues(std::not_fn(Contains<ALPAKA_TYPEOF(leftSeq)>{}), toIntegerSequence(right)));
+    }
+
+} // namespace alpaka

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -521,22 +521,6 @@ namespace alpaka
         };
     };
 
-    template<typename T, T... T_values>
-    using CVec = Vec<T, sizeof...(T_values), detail::CVec<T, T_values...>>;
-
-    template<typename T, size_t... T_idx>
-    constexpr auto iotaCVecDo(std::index_sequence<T_idx...>)
-    {
-        return CVec<T, T{T_idx}...>{};
-    }
-
-    template<typename T, uint32_t T_dim>
-    constexpr auto iotaCVec()
-    {
-        using IotaSeq = std::make_integer_sequence<size_t, T_dim>;
-        return iotaCVecDo<T>(IotaSeq{});
-    }
-
     template<std::size_t I, typename T_Type, uint32_t T_dim, typename T_Storage>
     constexpr auto get(Vec<T_Type, T_dim, T_Storage> const& v)
     {

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/CVec.hpp"
 #include "alpaka/Vec.hpp"
 #include "alpaka/api/api.hpp"
 #include "alpaka/api/cpu.hpp"

--- a/include/alpaka/mem/ThreadSpace.hpp
+++ b/include/alpaka/mem/ThreadSpace.hpp
@@ -40,7 +40,85 @@ namespace alpaka
             return stream.str();
         }
 
+        template<concepts::CVector T_CSelect>
+        constexpr ThreadSpace mapTo(T_CSelect selection) const requires(T_ThreadIdx::dim() == T_CSelect::dim())
+        {
+            return *this;
+        }
+
+        template<concepts::CVector T_CSelect>
+        constexpr ThreadSpace mapTo(T_CSelect selection) const requires(T_ThreadIdx::dim() > T_CSelect::dim())
+        {
+            using IdxType = typename T_ThreadIdx::type;
+            constexpr uint32_t dim = T_ThreadIdx::dim();
+
+            auto allElements = iotaCVec<IdxType, dim>();
+            constexpr auto notSelectedDims = leftJoin(allElements, T_CSelect{});
+
+            auto threadIndex = m_threadIdx;
+            auto numThreads = m_threadCount;
+
+            // map not selected dimensions to the slowest selected dimension
+            for(uint32_t x = 0u; x < notSelectedDims.dim(); ++x)
+            {
+                auto d = notSelectedDims[x];
+                auto old = threadIndex[d];
+                threadIndex[d] = 0u;
+                threadIndex[T_CSelect{}[0]] += old * numThreads[T_CSelect{}[0]];
+            }
+
+            for(uint32_t x = 0u; x < notSelectedDims.dim(); ++x)
+            {
+                auto d = notSelectedDims[x];
+                auto old = numThreads[d];
+                numThreads[d] = 1u;
+                numThreads[T_CSelect{}[0]] *= old;
+            }
+
+            return {threadIndex, numThreads};
+        }
+
         T_ThreadIdx m_threadIdx;
         T_ThreadCount m_threadCount;
     };
+
+    template<std::size_t I, typename T_ThreadIdx, typename T_ThreadCount>
+    constexpr auto get(alpaka::ThreadSpace<T_ThreadIdx, T_ThreadCount> const& v) requires(I == 0u)
+    {
+        return v.m_threadIdx;
+    }
+
+    template<std::size_t I, typename T_ThreadIdx, typename T_ThreadCount>
+    constexpr auto& get(alpaka::ThreadSpace<T_ThreadIdx, T_ThreadCount>& v) requires(I == 0u)
+    {
+        return v.m_threadIdx;
+    }
+
+    template<std::size_t I, typename T_ThreadIdx, typename T_ThreadCount>
+    constexpr auto get(alpaka::ThreadSpace<T_ThreadIdx, T_ThreadCount> const& v) requires(I == 1u)
+    {
+        return v.m_threadCount;
+    }
+
+    template<std::size_t I, typename T_ThreadIdx, typename T_ThreadCount>
+    constexpr auto& get(alpaka::ThreadSpace<T_ThreadIdx, T_ThreadCount>& v) requires(I == 1u)
+    {
+        return v.m_threadCount;
+    }
+
 } // namespace alpaka
+
+namespace std
+{
+    template<typename T_ThreadIdx, typename T_ThreadCount>
+    struct tuple_size<alpaka::ThreadSpace<T_ThreadIdx, T_ThreadCount>>
+    {
+        static constexpr std::size_t value = 2u;
+    };
+
+    template<std::size_t I, typename T_ThreadIdx, typename T_ThreadCount>
+    struct tuple_element<I, alpaka::ThreadSpace<T_ThreadIdx, T_ThreadCount>>
+    {
+        using type = std::conditional_t<I == 0u, T_ThreadIdx, T_ThreadCount>;
+    };
+} // namespace std

--- a/include/alpaka/mem/TiledIdxContainer.hpp
+++ b/include/alpaka/mem/TiledIdxContainer.hpp
@@ -247,19 +247,22 @@ namespace alpaka::onAcc
 
         ALPAKA_FN_ACC inline const_iterator begin() const
         {
+            constexpr auto selectedDims = T_CSelect{};
+            auto [threadIdx, numThreads] = m_threadSpace.mapTo(selectedDims);
+
             if constexpr(std::is_same_v<T_IdxMapperFn, layout::Strided>)
             {
                 return const_iterator(
                     m_idxRange.m_begin,
-                    m_threadSpace.m_threadIdx * m_idxRange.m_stride,
+                    threadIdx * m_idxRange.m_stride,
                     m_idxRange.distance(),
-                    m_threadSpace.m_threadCount * m_idxRange.m_stride);
+                    numThreads * m_idxRange.m_stride);
             }
             else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contigious>)
             {
                 auto extent = m_idxRange.distance();
-                auto numElements = core::divCeil(extent, m_idxRange.m_stride * m_threadSpace.m_threadCount);
-                auto first = m_threadSpace.m_threadIdx * numElements * m_idxRange.m_stride;
+                auto numElements = core::divCeil(extent, m_idxRange.m_stride * numThreads);
+                auto first = threadIdx * numElements * m_idxRange.m_stride;
 
                 return const_iterator(
                     m_idxRange.m_begin,
@@ -271,6 +274,9 @@ namespace alpaka::onAcc
 
         ALPAKA_FN_ACC inline const_iterator_end end() const
         {
+            constexpr auto selectedDims = T_CSelect{};
+            auto [threadIdx, numThreads] = m_threadSpace.mapTo(selectedDims);
+
             if constexpr(std::is_same_v<T_IdxMapperFn, layout::Strided>)
             {
                 return const_iterator_end(m_idxRange.m_begin + m_idxRange.distance());
@@ -278,8 +284,8 @@ namespace alpaka::onAcc
             else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contigious>)
             {
                 auto extent = m_idxRange.distance();
-                auto numElements = core::divCeil(extent, m_idxRange.m_stride * m_threadSpace.m_threadCount);
-                auto first = m_threadSpace.m_threadIdx * numElements * m_idxRange.m_stride;
+                auto numElements = core::divCeil(extent, m_idxRange.m_stride * numThreads);
+                auto first = threadIdx * numElements * m_idxRange.m_stride;
 
                 return const_iterator_end(m_idxRange.m_begin + extent.min(first + numElements * m_idxRange.m_stride));
             }

--- a/tests/queue.cpp
+++ b/tests/queue.cpp
@@ -264,15 +264,21 @@ struct IotaKernelNDSelection
         for(auto fameBaseIdx :
             onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, onAcc::range::frameCount)[CVec<uint32_t, 0u>{}])
         {
+            /* fameBaseIdx is unique for each thread block.
+             * Therefor the workgroup for iterating over the frames in other dimensions must be one.
+             */
             for(auto frameIdx : onAcc::makeIdxMap(
                     acc,
-                    onAcc::WorkerGroup{ALPAKA_TYPEOF(acc[layer::block].count())::all(0), acc[layer::block].count()},
+                    onAcc::WorkerGroup{numFrames.all(0), numFrames.all(1)},
                     IdxRange{fameBaseIdx, numFrames})[T_Selection{}])
             {
                 for(auto elemIdx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, onAcc::range::frameExtent))
                     if(linearize(acc[frame::extent], elemIdx) == 1u)
                     {
-                        out[frameIdx] = frameIdx;
+                        // use atomics to detect data races where mre than one thread is updating the result
+                        onAcc::atomicAdd(&(out[frameIdx][0]), frameIdx[0]);
+                        onAcc::atomicAdd(&(out[frameIdx][1]), frameIdx[1]);
+                        onAcc::atomicAdd(&(out[frameIdx][2]), frameIdx[2]);
                     }
             }
         }
@@ -296,6 +302,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
     constexpr Vec numBlocks = Vec{4u, 8u, 16u};
     auto numBlocksReduced = numBlocks;
     numBlocksReduced.ref(CVec<uint32_t, 2u, 1u>{}) = 1u;
+
     std::cout << numBlocksReduced << std::endl;
     std::cout << "exec=" << core::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<Vec<uint32_t, 3u>>(device, numBlocks);
@@ -303,6 +310,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
     Platform cpuPlatform = makePlatform(api::cpu);
     Device cpuDevice = cpuPlatform.makeDevice(0);
     auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    onHost::memset(queue, dBuff, 0u);
 
     wait(queue);
     constexpr auto frameSize = Vec{1u, 1u, 2u};

--- a/tests/vec.cpp
+++ b/tests/vec.cpp
@@ -213,6 +213,20 @@ struct CompileTimeKernel3D
         constexpr auto selectRes2 = vec[selectVec2];
         static_assert(selectRes2 == Vec{7, 5});
 
+        // cvec left and right join, empty result is currently not supported because zero dimensional vector is not
+        // allowed
+        auto m0 = CVec<int, 1, 2, 0>{};
+        auto m1 = CVec<int, 1, 5>{};
+
+        constexpr auto l = leftJoin(m0, m1);
+        static_assert(l == Vec{2, 0});
+
+        constexpr auto r = rightJoin(m0, m1);
+        static_assert(r == Vec{5});
+
+        constexpr auto inner = innerJoin(m0, m1);
+        static_assert(inner == Vec{1});
+
 #if 0
 // add this to runtime etst as soon we add them back
          auto vecRT = Vec{3, 7, 5};


### PR DESCRIPTION
- separate CVec into its own file
  - add join operation for CVec
- for sliced iterations on a index container map worker of not selecte dimensions onto used dimensions
- ThreadSpace: add stl tuple interface