### PR TITLE
refactor math functions

### DIFF
--- a/include/alpaka/api/api.hpp
+++ b/include/alpaka/api/api.hpp
@@ -14,11 +14,19 @@
 
 namespace alpaka
 {
+    /** provides the API used during the execution of the current code path
+     *
+     * @attention if api::cpu os returned it can also mena that this method was called within the host controlling
+     * workflow and not within a kernel running on a CPU device.
+     */
+    constexpr auto thisApi()
+    {
 #if ALPAKA_LANG_CUDA && (ALPAKA_COMP_CLANG_CUDA || ALPAKA_COMP_NVCC) && __CUDA_ARCH__
-    constexpr auto apiCtx = api::cuda;
+        return api::cuda;
 #else
-    constexpr auto apiCtx = api::cpu;
+        return api::cpu;
 #endif
+    }
 
     namespace onHost
     {

--- a/include/alpaka/api/cuda.hpp
+++ b/include/alpaka/api/cuda.hpp
@@ -9,3 +9,4 @@
 #include "alpaka/api/cuda/Platform.hpp"
 #include "alpaka/api/cuda/Queue.hpp"
 #include "alpaka/api/cuda/atomic.hpp"
+#include "alpaka/api/cuda/math.hpp"

--- a/include/alpaka/api/trait.hpp
+++ b/include/alpaka/api/trait.hpp
@@ -1,0 +1,33 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+#pragma once
+
+#include "alpaka/api/cpu/Api.hpp"
+#include "alpaka/math/math.hpp"
+
+#include <algorithm>
+
+namespace alpaka::trait
+{
+    /** Map's all API's by default to stl math functions. */
+    struct GetMathImpl
+    {
+        template<typename T_Api>
+        struct Op
+        {
+            constexpr decltype(auto) operator()(alpaka::api::Cpu const) const
+            {
+                return alpaka::math::internal::stlMath;
+            }
+        };
+    };
+
+    template<typename T_Api>
+    constexpr decltype(auto) getMathImpl(T_Api const api)
+    {
+        return GetMathImpl::Op<T_Api>{}(api);
+    }
+} // namespace alpaka::trait

--- a/include/alpaka/math.hpp
+++ b/include/alpaka/math.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/api/trait.hpp"
 #include "alpaka/math/math.hpp"
 
 #include <cmath>
@@ -12,11 +13,13 @@ namespace alpaka::math
 {
     constexpr auto sin(auto const& arg)
     {
-        return internal::Sin::Op<ALPAKA_TYPEOF(apiCtx), ALPAKA_TYPEOF(arg)>{}(apiCtx, arg);
+        auto const mathImpl = trait::getMathImpl(thisApi());
+        return internal::Sin::Op<ALPAKA_TYPEOF(mathImpl), ALPAKA_TYPEOF(arg)>{}(mathImpl, arg);
     }
 
     constexpr auto exp(auto const& arg)
     {
-        return internal::Exp::Op<ALPAKA_TYPEOF(apiCtx), ALPAKA_TYPEOF(arg)>{}(apiCtx, arg);
+        auto const mathImpl = trait::getMathImpl(thisApi());
+        return internal::Exp::Op<ALPAKA_TYPEOF(mathImpl), ALPAKA_TYPEOF(arg)>{}(mathImpl, arg);
     }
 } // namespace alpaka::math

--- a/include/alpaka/math/math.hpp
+++ b/include/alpaka/math/math.hpp
@@ -9,12 +9,18 @@
 
 namespace alpaka::math::internal
 {
+    struct StlMath
+    {
+    };
+
+    constexpr auto stlMath = StlMath{};
+
     struct Sin
     {
-        template<typename T_Api, typename T_Arg>
+        template<typename T_MathImpl, typename T_Arg>
         struct Op
         {
-            constexpr auto operator()(T_Api, T_Arg const& arg) const
+            constexpr auto operator()(T_MathImpl, T_Arg const& arg) const
             {
                 using std::sin;
                 return sin(arg);
@@ -24,10 +30,10 @@ namespace alpaka::math::internal
 
     struct Exp
     {
-        template<typename T_Api, typename T_Arg>
+        template<typename T_MathImpl, typename T_Arg>
         struct Op
         {
-            constexpr auto operator()(T_Api, T_Arg const& arg) const
+            constexpr auto operator()(T_MathImpl, T_Arg const& arg) const
             {
                 using std::exp;
                 return exp(arg);

--- a/include/alpaka/onAcc/atomic.hpp
+++ b/include/alpaka/onAcc/atomic.hpp
@@ -45,7 +45,7 @@ namespace alpaka::onAcc
     template<typename TOp, typename T, typename THierarchy = hierarchy::Grids>
     constexpr auto atomicOp(T* const addr, T const& value, THierarchy const& = THierarchy()) -> T
     {
-        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(apiCtx), T, THierarchy>::atomicOp(apiCtx, addr, value);
+        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(thisApi()), T, THierarchy>::atomicOp(thisApi(), addr, value);
     }
 
     //! Executes the given operation atomically.
@@ -58,7 +58,11 @@ namespace alpaka::onAcc
     template<typename TOp, typename T, typename THierarchy = hierarchy::Grids>
     constexpr auto atomicOp(T* const addr, T const& compare, T const& value, THierarchy const& = THierarchy()) -> T
     {
-        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(apiCtx), T, THierarchy>::atomicOp(apiCtx, addr, compare, value);
+        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(thisApi()), T, THierarchy>::atomicOp(
+            thisApi(),
+            addr,
+            compare,
+            value);
     }
 
     //! Executes an atomic add operation.


### PR DESCRIPTION
- provide `thisApi()` instead of a global variable
- add trait `GetMathImpl()` to map different API's to the same math implementation