### PR TITLE
fix math default impl trait and refactor atomics

### DIFF
--- a/include/alpaka/api/cpu/atomic.hpp
+++ b/include/alpaka/api/cpu/atomic.hpp
@@ -6,8 +6,9 @@
 
 #include "alpaka/api/cpu/tag.hpp"
 #include "alpaka/core/config.hpp"
-#include "alpaka/onAcc/atomic.hpp"
+#include "alpaka/onAcc/atomicHierarchy.hpp"
 #include "alpaka/onAcc/atomicOp.hpp"
+#include "alpaka/onAcc/internal.hpp"
 
 #include <array>
 #include <atomic>
@@ -49,11 +50,11 @@ namespace alpaka::onAcc
             "ALPAKA_DISABLE_ATOMIC_ATOMICREF.");
     }
 
-    namespace trait
+    namespace internalCompute
     {
         //! The CPU accelerators AtomicAdd.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicAdd, internal::StlAtomic, T, THierarchy>
+        struct Atomic::Op<AtomicAdd, internal::StlAtomic, T, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -65,7 +66,7 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicSub.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicSub, internal::StlAtomic, T, THierarchy>
+        struct Atomic::Op<AtomicSub, internal::StlAtomic, T, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -77,7 +78,7 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicMin.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicMin, internal::StlAtomic, T, THierarchy>
+        struct Atomic::Op<AtomicMin, internal::StlAtomic, T, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -97,7 +98,7 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicMax.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicMax, internal::StlAtomic, T, THierarchy>
+        struct Atomic::Op<AtomicMax, internal::StlAtomic, T, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -117,7 +118,7 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicExch.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicExch, internal::StlAtomic, T, THierarchy>
+        struct Atomic::Op<AtomicExch, internal::StlAtomic, T, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -135,7 +136,7 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicInc.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicInc, internal::StlAtomic, T, THierarchy>
+        struct Atomic::Op<AtomicInc, internal::StlAtomic, T, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -153,7 +154,7 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicDec.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicDec, internal::StlAtomic, T, THierarchy>
+        struct Atomic::Op<AtomicDec, internal::StlAtomic, T, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -171,7 +172,7 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicAnd.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicAnd, internal::StlAtomic, T, THierarchy>
+        struct Atomic::Op<AtomicAnd, internal::StlAtomic, T, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -183,7 +184,7 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicOr.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicOr, internal::StlAtomic, T, THierarchy>
+        struct Atomic::Op<AtomicOr, internal::StlAtomic, T, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -195,7 +196,7 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicXor.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicXor, internal::StlAtomic, T, THierarchy>
+        struct Atomic::Op<AtomicXor, internal::StlAtomic, T, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -207,7 +208,7 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicCas.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicCas, internal::StlAtomic, T, THierarchy>
+        struct Atomic::Op<AtomicCas, internal::StlAtomic, T, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(
                 internal::StlAtomic const&,
@@ -233,7 +234,7 @@ namespace alpaka::onAcc
                 return old;
             }
         };
-    } // namespace trait
+    } // namespace internalCompute
 } // namespace alpaka::onAcc
 
 #endif

--- a/include/alpaka/api/cpu/atomic.hpp
+++ b/include/alpaka/api/cpu/atomic.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/api/cpu/tag.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/onAcc/atomic.hpp"
 #include "alpaka/onAcc/atomicOp.hpp"
@@ -52,9 +53,9 @@ namespace alpaka::onAcc
     {
         //! The CPU accelerators AtomicAdd.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicAdd, api::Cpu, T, THierarchy>
+        struct AtomicOp<AtomicAdd, internal::StlAtomic, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(api::Cpu const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 detail::atomic_ref<T> ref(*addr);
@@ -64,9 +65,9 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicSub.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicSub, api::Cpu, T, THierarchy>
+        struct AtomicOp<AtomicSub, internal::StlAtomic, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(api::Cpu const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 detail::atomic_ref<T> ref(*addr);
@@ -76,9 +77,9 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicMin.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicMin, api::Cpu, T, THierarchy>
+        struct AtomicOp<AtomicMin, internal::StlAtomic, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(api::Cpu const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 detail::atomic_ref<T> ref(*addr);
@@ -96,9 +97,9 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicMax.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicMax, api::Cpu, T, THierarchy>
+        struct AtomicOp<AtomicMax, internal::StlAtomic, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(api::Cpu const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 detail::atomic_ref<T> ref(*addr);
@@ -116,9 +117,9 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicExch.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicExch, api::Cpu, T, THierarchy>
+        struct AtomicOp<AtomicExch, internal::StlAtomic, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(api::Cpu const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 detail::atomic_ref<T> ref(*addr);
@@ -134,9 +135,9 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicInc.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicInc, api::Cpu, T, THierarchy>
+        struct AtomicOp<AtomicInc, internal::StlAtomic, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(api::Cpu const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 detail::atomic_ref<T> ref(*addr);
@@ -152,9 +153,9 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicDec.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicDec, api::Cpu, T, THierarchy>
+        struct AtomicOp<AtomicDec, internal::StlAtomic, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(api::Cpu const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 detail::atomic_ref<T> ref(*addr);
@@ -170,9 +171,9 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicAnd.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicAnd, api::Cpu, T, THierarchy>
+        struct AtomicOp<AtomicAnd, internal::StlAtomic, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(api::Cpu const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 detail::atomic_ref<T> ref(*addr);
@@ -182,9 +183,9 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicOr.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicOr, api::Cpu, T, THierarchy>
+        struct AtomicOp<AtomicOr, internal::StlAtomic, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(api::Cpu const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 detail::atomic_ref<T> ref(*addr);
@@ -194,9 +195,9 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicXor.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicXor, api::Cpu, T, THierarchy>
+        struct AtomicOp<AtomicXor, internal::StlAtomic, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(api::Cpu const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 detail::atomic_ref<T> ref(*addr);
@@ -206,9 +207,13 @@ namespace alpaka::onAcc
 
         //! The CPU accelerators AtomicCas.
         template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicCas, api::Cpu, T, THierarchy>
+        struct AtomicOp<AtomicCas, internal::StlAtomic, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(api::Cpu const&, T* const addr, T const& compare, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(
+                internal::StlAtomic const&,
+                T* const addr,
+                T const& compare,
+                T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 detail::atomic_ref<T> ref(*addr);

--- a/include/alpaka/api/cpu/executor.hpp
+++ b/include/alpaka/api/cpu/executor.hpp
@@ -1,0 +1,76 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/cpu/tag.hpp"
+#include "alpaka/api/trait.hpp"
+#include "alpaka/tag.hpp"
+
+#include <cassert>
+#include <tuple>
+
+namespace alpaka::exec
+{
+    struct CpuSerial
+    {
+    };
+
+    constexpr CpuSerial cpuSerial;
+
+    struct CpuOmpBlocks
+    {
+    };
+
+    constexpr CpuOmpBlocks cpuOmpBlocks;
+
+    struct CpuOmpBlocksAndThreads
+    {
+    };
+
+    constexpr CpuOmpBlocksAndThreads cpuOmpBlocksAndThreads;
+
+    namespace traits
+    {
+        template<>
+        struct IsSeqExecutor<CpuSerial> : std::true_type
+        {
+        };
+
+        template<>
+        struct IsSeqExecutor<CpuOmpBlocks> : std::true_type
+        {
+        };
+    } // namespace traits
+} // namespace alpaka::exec
+
+namespace alpaka::onAcc::trait
+{
+    template<>
+    struct GetAtomicImpl::Op<alpaka::exec::CpuSerial>
+    {
+        constexpr decltype(auto) operator()(alpaka::exec::CpuSerial const) const
+        {
+            return alpaka::onAcc::internal::stlAtomic;
+        }
+    };
+
+    template<>
+    struct GetAtomicImpl::Op<alpaka::exec::CpuOmpBlocks>
+    {
+        constexpr decltype(auto) operator()(alpaka::exec::CpuOmpBlocks const) const
+        {
+            return alpaka::onAcc::internal::stlAtomic;
+        }
+    };
+
+    template<>
+    struct GetAtomicImpl::Op<alpaka::exec::CpuOmpBlocksAndThreads>
+    {
+        constexpr decltype(auto) operator()(alpaka::exec::CpuOmpBlocksAndThreads const) const
+        {
+            return alpaka::onAcc::internal::stlAtomic;
+        }
+    };
+} // namespace alpaka::onAcc::trait

--- a/include/alpaka/api/cpu/tag.hpp
+++ b/include/alpaka/api/cpu/tag.hpp
@@ -1,0 +1,17 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+namespace alpaka::onAcc
+{
+    namespace internal
+    {
+        struct StlAtomic
+        {
+        };
+
+        constexpr auto stlAtomic = StlAtomic{};
+    } // namespace internal
+} // namespace alpaka::onAcc

--- a/include/alpaka/api/cuda/executor.hpp
+++ b/include/alpaka/api/cuda/executor.hpp
@@ -1,0 +1,32 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/cuda/tag.hpp"
+#include "alpaka/api/trait.hpp"
+
+#include <cassert>
+#include <tuple>
+
+namespace alpaka::exec
+{
+    struct GpuCuda
+    {
+    };
+
+    constexpr GpuCuda gpuCuda;
+} // namespace alpaka::exec
+
+namespace alpaka::onAcc::trait
+{
+    template<>
+    struct GetAtomicImpl::Op<alpaka::exec::GpuCuda>
+    {
+        constexpr decltype(auto) operator()(alpaka::exec::GpuCuda const) const
+        {
+            return internal::cudaHipAtomic;
+        }
+    };
+} // namespace alpaka::onAcc::trait

--- a/include/alpaka/api/cuda/tag.hpp
+++ b/include/alpaka/api/cuda/tag.hpp
@@ -1,0 +1,14 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+namespace alpaka::onAcc::internal
+{
+    struct CudaHipAtomic
+    {
+    };
+
+    constexpr auto cudaHipAtomic = CudaHipAtomic{};
+} // namespace alpaka::onAcc::internal

--- a/include/alpaka/api/executor.hpp
+++ b/include/alpaka/api/executor.hpp
@@ -1,0 +1,30 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/cpu/executor.hpp"
+#include "alpaka/api/cuda/executor.hpp"
+
+namespace alpaka::exec
+{
+    constexpr auto availableMappings = std::make_tuple(ALPAKA_PP_REMOVE_FIRST_COMMA(
+#ifndef ALPAKA_DISABLE_EXEC_CpuSerial
+        ,
+        cpuSerial
+#endif
+#ifndef ALPAKA_DISABLE_EXEC_CpuOmpBlocks
+        ,
+        cpuOmpBlocks
+#endif
+#ifndef ALPAKA_DISABLE_EXEC_CpuOmpBlocksAndThreads
+        ,
+        cpuOmpBlocksAndThreads
+#endif
+#ifndef ALPAKA_DISABLE_EXEC_GpuCuda
+        ,
+        gpuCuda
+#endif
+        ));
+} // namespace alpaka::exec

--- a/include/alpaka/api/trait.hpp
+++ b/include/alpaka/api/trait.hpp
@@ -18,7 +18,7 @@ namespace alpaka::trait
         template<typename T_Api>
         struct Op
         {
-            constexpr decltype(auto) operator()(alpaka::api::Cpu const) const
+            constexpr decltype(auto) operator()(T_Api const) const
             {
                 return alpaka::math::internal::stlMath;
             }
@@ -31,3 +31,28 @@ namespace alpaka::trait
         return GetMathImpl::Op<T_Api>{}(api);
     }
 } // namespace alpaka::trait
+
+namespace alpaka::onAcc::trait
+{
+    /** Defines the implementation used for atomic operations toghether with the used executor */
+    struct GetAtomicImpl
+    {
+        template<typename T_Executor>
+        struct Op
+        {
+            constexpr decltype(auto) operator()(T_Executor const) const
+            {
+                static_assert(
+                    sizeof(T_Executor) && false,
+                    "Atomic implementation for the current used executor is not defined.");
+                return 0;
+            }
+        };
+    };
+
+    template<typename T_Executor>
+    constexpr decltype(auto) getAtomicImpl(T_Executor const executor)
+    {
+        return GetAtomicImpl::Op<T_Executor>{}(executor);
+    }
+} // namespace alpaka::onAcc::trait

--- a/include/alpaka/onAcc/atomic.hpp
+++ b/include/alpaka/onAcc/atomic.hpp
@@ -7,42 +7,14 @@
 #include "alpaka/api/api.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/core/common.hpp"
+#include "alpaka/onAcc/atomicHierarchy.hpp"
 #include "alpaka/onAcc/atomicOp.hpp"
+#include "alpaka/onAcc/internal.hpp"
 
 #include <type_traits>
 
 namespace alpaka::onAcc
 {
-    //! Defines the parallelism hierarchy levels of alpaka
-    namespace hierarchy
-    {
-        struct Grids
-        {
-        };
-
-        constexpr auto grids = Grids{};
-
-        struct Blocks
-        {
-        };
-
-        constexpr auto blocks = Blocks{};
-
-        struct Threads
-        {
-        };
-
-        constexpr auto threads = Threads{};
-    } // namespace hierarchy
-
-    //! The atomic operation trait.
-    namespace trait
-    {
-        //! The atomic operation trait.
-        template<typename TOp, typename TAtomic, typename T, typename THierarchy, typename TSfinae = void>
-        struct AtomicOp;
-    } // namespace trait
-
     //! Executes the given operation atomically.
     //!
     //! \tparam TOp The operation type.
@@ -53,7 +25,10 @@ namespace alpaka::onAcc
     constexpr auto atomicOp(auto const& acc, T* const addr, T const& value, THierarchy const = THierarchy()) -> T
     {
         auto atomicImpl = trait::getAtomicImpl(acc[object::exec]);
-        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(atomicImpl), T, THierarchy>::atomicOp(atomicImpl, addr, value);
+        return internalCompute::Atomic::Op<TOp, ALPAKA_TYPEOF(atomicImpl), T, THierarchy>::atomicOp(
+            atomicImpl,
+            addr,
+            value);
     }
 
     //! Executes the given operation atomically.
@@ -72,7 +47,7 @@ namespace alpaka::onAcc
         THierarchy const = THierarchy()) -> T
     {
         auto atomicImpl = trait::getAtomicImpl(acc[object::exec]);
-        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(atomicImpl), T, THierarchy>::atomicOp(
+        return internalCompute::Atomic::Op<TOp, ALPAKA_TYPEOF(atomicImpl), T, THierarchy>::atomicOp(
             atomicImpl,
             addr,
             compare,

--- a/include/alpaka/onAcc/atomic.hpp
+++ b/include/alpaka/onAcc/atomic.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/api/api.hpp"
+#include "alpaka/api/trait.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/onAcc/atomicOp.hpp"
 
@@ -19,13 +20,19 @@ namespace alpaka::onAcc
         {
         };
 
+        constexpr auto grids = Grids{};
+
         struct Blocks
         {
         };
 
+        constexpr auto blocks = Blocks{};
+
         struct Threads
         {
         };
+
+        constexpr auto threads = Threads{};
     } // namespace hierarchy
 
     //! The atomic operation trait.
@@ -43,9 +50,10 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename TOp, typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicOp(T* const addr, T const& value, THierarchy const& = THierarchy()) -> T
+    constexpr auto atomicOp(auto const& acc, T* const addr, T const& value, THierarchy const = THierarchy()) -> T
     {
-        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(thisApi()), T, THierarchy>::atomicOp(thisApi(), addr, value);
+        auto atomicImpl = trait::getAtomicImpl(acc[object::exec]);
+        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(atomicImpl), T, THierarchy>::atomicOp(atomicImpl, addr, value);
     }
 
     //! Executes the given operation atomically.
@@ -56,10 +64,16 @@ namespace alpaka::onAcc
     //! \param compare The comparison value used in the atomic operation.
     //! \param value The value used in the atomic operation.
     template<typename TOp, typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicOp(T* const addr, T const& compare, T const& value, THierarchy const& = THierarchy()) -> T
+    constexpr auto atomicOp(
+        auto const& acc,
+        T* const addr,
+        T const& compare,
+        T const& value,
+        THierarchy const = THierarchy()) -> T
     {
-        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(thisApi()), T, THierarchy>::atomicOp(
-            thisApi(),
+        auto atomicImpl = trait::getAtomicImpl(acc[object::exec]);
+        return trait::AtomicOp<TOp, ALPAKA_TYPEOF(atomicImpl), T, THierarchy>::atomicOp(
+            atomicImpl,
             addr,
             compare,
             value);
@@ -71,9 +85,9 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicAdd(T* const addr, T const& value, THierarchy const& hier = THierarchy()) -> T
+    constexpr auto atomicAdd(auto const& acc, T* const addr, T const& value, THierarchy const hier = THierarchy()) -> T
     {
-        return atomicOp<AtomicAdd>(addr, value, hier);
+        return atomicOp<AtomicAdd>(acc, addr, value, hier);
     }
 
     //! Executes an atomic sub operation.
@@ -82,9 +96,9 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicSub(T* const addr, T const& value, THierarchy const& hier = THierarchy()) -> T
+    constexpr auto atomicSub(auto const& acc, T* const addr, T const& value, THierarchy const hier = THierarchy()) -> T
     {
-        return atomicOp<AtomicSub>(addr, value, hier);
+        return atomicOp<AtomicSub>(acc, addr, value, hier);
     }
 
     //! Executes an atomic min operation.
@@ -93,9 +107,9 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicMin(T* const addr, T const& value, THierarchy const& hier = THierarchy()) -> T
+    constexpr auto atomicMin(auto const& acc, T* const addr, T const& value, THierarchy const hier = THierarchy()) -> T
     {
-        return atomicOp<AtomicMin>(addr, value, hier);
+        return atomicOp<AtomicMin>(acc, addr, value, hier);
     }
 
     //! Executes an atomic max operation.
@@ -104,9 +118,9 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicMax(T* const addr, T const& value, THierarchy const& hier = THierarchy()) -> T
+    constexpr auto atomicMax(auto const& acc, T* const addr, T const& value, THierarchy const hier = THierarchy()) -> T
     {
-        return atomicOp<AtomicMax>(addr, value, hier);
+        return atomicOp<AtomicMax>(acc, addr, value, hier);
     }
 
     //! Executes an atomic exchange operation.
@@ -115,9 +129,10 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicExch(T* const addr, T const& value, THierarchy const& hier = THierarchy()) -> T
+    constexpr auto atomicExch(auto const& acc, T* const addr, T const& value, THierarchy const hier = THierarchy())
+        -> T
     {
-        return atomicOp<AtomicExch>(addr, value, hier);
+        return atomicOp<AtomicExch>(acc, addr, value, hier);
     }
 
     //! Executes an atomic increment operation.
@@ -126,9 +141,9 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicInc(T* const addr, T const& value, THierarchy const& hier = THierarchy()) -> T
+    constexpr auto atomicInc(auto const& acc, T* const addr, T const& value, THierarchy const hier = THierarchy()) -> T
     {
-        return atomicOp<AtomicInc>(addr, value, hier);
+        return atomicOp<AtomicInc>(acc, addr, value, hier);
     }
 
     //! Executes an atomic decrement operation.
@@ -137,9 +152,9 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicDec(T* const addr, T const& value, THierarchy const& hier = THierarchy()) -> T
+    constexpr auto atomicDec(auto const& acc, T* const addr, T const& value, THierarchy const hier = THierarchy()) -> T
     {
-        return atomicOp<AtomicDec>(addr, value, hier);
+        return atomicOp<AtomicDec>(acc, addr, value, hier);
     }
 
     //! Executes an atomic and operation.
@@ -148,9 +163,9 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicAnd(T* const addr, T const& value, THierarchy const& hier = THierarchy()) -> T
+    constexpr auto atomicAnd(auto const& acc, T* const addr, T const& value, THierarchy const hier = THierarchy()) -> T
     {
-        return atomicOp<AtomicAnd>(addr, value, hier);
+        return atomicOp<AtomicAnd>(acc, addr, value, hier);
     }
 
     //! Executes an atomic or operation.
@@ -159,9 +174,9 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicOr(T* const addr, T const& value, THierarchy const& hier = THierarchy()) -> T
+    constexpr auto atomicOr(auto const& acc, T* const addr, T const& value, THierarchy const hier = THierarchy()) -> T
     {
-        return atomicOp<AtomicOr>(addr, value, hier);
+        return atomicOp<AtomicOr>(acc, addr, value, hier);
     }
 
     //! Executes an atomic xor operation.
@@ -170,9 +185,9 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicXor(T* const addr, T const& value, THierarchy const& hier = THierarchy()) -> T
+    constexpr auto atomicXor(auto const& acc, T* const addr, T const& value, THierarchy const hier = THierarchy()) -> T
     {
-        return atomicOp<AtomicXor>(addr, value, hier);
+        return atomicOp<AtomicXor>(acc, addr, value, hier);
     }
 
     //! Executes an atomic compare-and-swap operation.
@@ -182,9 +197,13 @@ namespace alpaka::onAcc
     //! \param compare The comparison value used in the atomic operation.
     //! \param value The value used in the atomic operation.
     template<typename T, typename THierarchy = hierarchy::Grids>
-    constexpr auto atomicCas(T* const addr, T const& compare, T const& value, THierarchy const& hier = THierarchy())
-        -> T
+    constexpr auto atomicCas(
+        auto const& acc,
+        T* const addr,
+        T const& compare,
+        T const& value,
+        THierarchy const hier = THierarchy()) -> T
     {
-        return atomicOp<AtomicCas>(addr, compare, value, hier);
+        return atomicOp<AtomicCas>(acc, addr, compare, value, hier);
     }
 } // namespace alpaka::onAcc

--- a/include/alpaka/onAcc/atomicHierarchy.hpp
+++ b/include/alpaka/onAcc/atomicHierarchy.hpp
@@ -1,0 +1,30 @@
+/* Copyright 2022 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+namespace alpaka::onAcc
+{
+    //! Defines the parallelism hierarchy levels of alpaka
+    namespace hierarchy
+    {
+        struct Grids
+        {
+        };
+
+        constexpr auto grids = Grids{};
+
+        struct Blocks
+        {
+        };
+
+        constexpr auto blocks = Blocks{};
+
+        struct Threads
+        {
+        };
+
+        constexpr auto threads = Threads{};
+    } // namespace hierarchy
+} // namespace alpaka::onAcc

--- a/include/alpaka/onAcc/internal.hpp
+++ b/include/alpaka/onAcc/internal.hpp
@@ -46,5 +46,11 @@ namespace alpaka::onAcc
             return DeclareSharedVar::Op<T, std::decay_t<decltype(acc)>>{}(acc);
         }
 
+        struct Atomic
+        {
+            /** Implements a atomic operation */
+            template<typename TOp, typename TAtomicImpl, typename T, typename THierarchy, typename TSfinae = void>
+            struct Op;
+        };
     } // namespace internalCompute
 } // namespace alpaka::onAcc

--- a/include/alpaka/onHost/trait.hpp
+++ b/include/alpaka/onHost/trait.hpp
@@ -6,6 +6,7 @@
 
 #include "Handle.hpp"
 #include "alpaka/KernelBundle.hpp"
+#include "alpaka/api/executor.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/meta/filter.hpp"
 #include "alpaka/onHost/concepts.hpp"

--- a/include/alpaka/tag.hpp
+++ b/include/alpaka/tag.hpp
@@ -48,63 +48,12 @@ namespace alpaka
 
     namespace exec
     {
-        struct CpuSerial
-        {
-        };
 
-        constexpr CpuSerial cpuSerial;
-
-        struct CpuOmpBlocks
-        {
-        };
-
-        constexpr CpuOmpBlocks cpuOmpBlocks;
-
-        struct CpuOmpBlocksAndThreads
-        {
-        };
-
-        constexpr CpuOmpBlocksAndThreads cpuOmpBlocksAndThreads;
-
-        struct GpuCuda
-        {
-        };
-
-        constexpr GpuCuda gpuCuda;
-
-        constexpr auto availableMappings = std::make_tuple(ALPAKA_PP_REMOVE_FIRST_COMMA(
-#ifndef ALPAKA_DISABLE_EXEC_CpuSerial
-            ,
-            cpuSerial
-#endif
-#ifndef ALPAKA_DISABLE_EXEC_CpuOmpBlocks
-            ,
-            cpuOmpBlocks
-#endif
-#ifndef ALPAKA_DISABLE_EXEC_CpuOmpBlocksAndThreads
-            ,
-            cpuOmpBlocksAndThreads
-#endif
-#ifndef ALPAKA_DISABLE_EXEC_GpuCuda
-            ,
-            gpuCuda
-#endif
-            ));
 
         namespace traits
         {
             template<typename T_Mapping>
             struct IsSeqExecutor : std::false_type
-            {
-            };
-
-            template<>
-            struct IsSeqExecutor<CpuSerial> : std::true_type
-            {
-            };
-
-            template<>
-            struct IsSeqExecutor<CpuOmpBlocks> : std::true_type
             {
             };
 

--- a/tests/queue.cpp
+++ b/tests/queue.cpp
@@ -276,9 +276,9 @@ struct IotaKernelNDSelection
                     if(linearize(acc[frame::extent], elemIdx) == 1u)
                     {
                         // use atomics to detect data races where mre than one thread is updating the result
-                        onAcc::atomicAdd(&(out[frameIdx][0]), frameIdx[0]);
-                        onAcc::atomicAdd(&(out[frameIdx][1]), frameIdx[1]);
-                        onAcc::atomicAdd(&(out[frameIdx][2]), frameIdx[2]);
+                        onAcc::atomicAdd(acc, &(out[frameIdx][0]), frameIdx[0]);
+                        onAcc::atomicAdd(acc, &(out[frameIdx][1]), frameIdx[1]);
+                        onAcc::atomicAdd(acc, &(out[frameIdx][2]), frameIdx[2]);
                     }
             }
         }


### PR DESCRIPTION
- silently fix that the default math trait was wrong
- atomic function refactoring
   - require accelerator to derive the executor to select atomic implementation
   - same as math implementation allows mapping of different executors to the same atomic implementations