### PR TITLE
allow using scalar values instead of `Vec{value`}

### DIFF
--- a/example/tutorial/src/03_memory.cpp
+++ b/example/tutorial/src/03_memory.cpp
@@ -33,7 +33,7 @@ int example(auto const deviceApi)
 
     // allocate a buffer of floats in host memory
     uint32_t size = 42;
-    auto host_buffer = alpaka::onHost::alloc<float>(host, alpaka::Vec{size});
+    auto host_buffer = alpaka::onHost::alloc<float>(host, size);
     std::cout << "host memory buffer at " << std::data(host_buffer) << "\n\n";
 
     // fill the host buffers with values
@@ -51,7 +51,7 @@ int example(auto const deviceApi)
 
     {
         // allocate a buffer of floats in global device memory
-        auto device_buffer = alpaka::onHost::alloc<float>(device, Vec1D{size});
+        auto device_buffer = alpaka::onHost::alloc<float>(device, size);
         std::cout << "memory buffer on " << alpaka::onHost::getStaticName(alpaka::onHost::getApi(device_buffer))
                   << " at " << std::data(device_buffer) << "\n\n";
 

--- a/example/tutorial/src/04_views.cpp
+++ b/example/tutorial/src/04_views.cpp
@@ -33,7 +33,7 @@ int example(auto const deviceApi)
 
     // allocate a buffer of floats in host memory
     uint32_t size = 42;
-    auto host_buffer = alpaka::onHost::alloc<float>(host, alpaka::Vec{size});
+    auto host_buffer = alpaka::onHost::alloc<float>(host, size);
     std::cout << "host memory buffer at " << std::data(host_buffer) << "\n\n";
 
     // fill the host buffers with values
@@ -50,7 +50,7 @@ int example(auto const deviceApi)
     alpaka::onHost::Queue queue = device.makeQueue();
     {
         // allocate a buffer of floats in global device memory
-        auto device_buffer = alpaka::onHost::alloc<float>(device, Vec1D{size});
+        auto device_buffer = alpaka::onHost::alloc<float>(device, size);
         std::cout << "memory buffer on " << alpaka::onHost::getStaticName(alpaka::onHost::getApi(device_buffer))
                   << " at " << std::data(device_buffer) << "\n\n";
 

--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -16,7 +16,7 @@ struct VectorAddKernel
     ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const in1, auto const in2, auto out, uint32_t size) const
     {
         for(auto [index] :
-            alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{Vec1D{size}}))
+            alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))
         {
             out[index] = in1[index] + in2[index];
         }
@@ -66,7 +66,7 @@ void testVectorAddKernel(
     constexpr uint32_t size = 1024 * 1024;
 
     // allocate input and output host buffers in pinned memory accessible by the Platform devices
-    auto in1_h = alpaka::onHost::alloc<float>(host, Vec1D{size});
+    auto in1_h = alpaka::onHost::alloc<float>(host, size);
     auto in2_h = alpaka::onHost::allocMirror(host, in1_h);
     auto out_h = alpaka::onHost::allocMirror(host, in1_h);
 
@@ -94,7 +94,7 @@ void testVectorAddKernel(
     alpaka::onHost::memset(queue, out_d, 0x00);
 
     // launch the 1-dimensional kernel with scalar size
-    auto frameSpec = alpaka::onHost::FrameSpec{Vec1D{32u}, Vec1D{32u}};
+    auto frameSpec = alpaka::onHost::FrameSpec{32u, 32u};
 
     std::cout << "Testing VectorAddKernel with scalar indices with a grid of " << frameSpec << "\n";
     queue.enqueue(

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -111,7 +111,7 @@ void testVectorAddKernel(
      * In contrast to frame specification where the number of threads and blocks will be adjusted by alpaka to be
      * optimal.
      */
-    auto threadSpec = alpaka::onHost::ThreadSpec{Vec1D{32u}, Vec1D{32u}};
+    auto threadSpec = alpaka::onHost::ThreadSpec{32u, 32u};
 
     // launch the 1-dimensional kernel with scalar size
     if constexpr(alpaka::isSeqExecutor(computeExec))
@@ -119,7 +119,7 @@ void testVectorAddKernel(
         /* Some executors allow only a single thread for the block.
          * You must write your kernel independent of the number of threads per block.
          */
-        threadSpec.m_numThreads = Vec1D{1u};
+        threadSpec.m_numThreads = 1u;
     }
 
     // fill the output buffer with zeros; the size is known from the buffer objects

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -162,7 +162,7 @@ void testVectorAddKernel(
     constexpr uint32_t size = 1024 * 1024;
 
     // allocate input and output host buffers in pinned memory accessible by the Platform devices
-    auto in1_h = alpaka::onHost::alloc<float>(host, Vec1D{size});
+    auto in1_h = alpaka::onHost::alloc<float>(host, size);
     auto in2_h = alpaka::onHost::allocMirror(host, in1_h);
     auto out_h = alpaka::onHost::allocMirror(host, in1_h);
 
@@ -191,9 +191,9 @@ void testVectorAddKernel(
 
     // launch the 1-dimensional kernel
     constexpr auto frameExtent = 32u;
-    auto numFrames = Vec1D{size} / frameExtent;
+    auto numFrames = size / frameExtent;
     // The kernel assumes that the problem size is a multiple of the frame size.
-    assert((numFrames * frameExtent).x() == size);
+    assert((numFrames * frameExtent) == size);
 
     auto frameSpec = alpaka::onHost::FrameSpec{numFrames, alpaka::CVec<uint32_t, frameExtent>{}};
 

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -6,6 +6,7 @@
 
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/util.hpp"
+#include "alpaka/trait.hpp"
 
 #include <array>
 #include <concepts>
@@ -777,6 +778,9 @@ namespace alpaka
         concept Vector = isVector_v<T>;
 
         template<typename T>
+        concept VectorOrScalar = (isVector_v<T> || std::integral<T>);
+
+        template<typename T>
         concept CVector = isCVector_v<T>;
 
         template<typename T, typename T_RequiredComponent>
@@ -785,6 +789,39 @@ namespace alpaka
         template<typename T, typename T_RequiredComponent>
         concept VectorOrConvertableType = (isVector_v<T> || std::is_convertible_v<T, T_RequiredComponent>);
     } // namespace concepts
+
+    namespace trait
+    {
+        template<typename T_Type, uint32_t T_dim, typename T_Storage>
+        struct GetDim<alpaka::Vec<T_Type, T_dim, T_Storage>>
+        {
+            static constexpr uint32_t value = T_dim;
+        };
+
+        template<typename T>
+        struct GetVec;
+
+        template<std::integral T>
+        struct GetVec<T>
+        {
+            using type = Vec<T, 1u>;
+        };
+
+        template<typename T_Type, uint32_t T_dim, typename T_Storage>
+        struct GetVec<alpaka::Vec<T_Type, T_dim, T_Storage>>
+        {
+            using type = alpaka::Vec<T_Type, T_dim, T_Storage>;
+        };
+
+        template<typename T>
+        using getVec_t = typename GetVec<T>::type;
+    } // namespace trait
+
+    template<typename T>
+    consteval auto getVec(T const& any)
+    {
+        return trait::getVec_t<T>{any};
+    }
 }; // namespace alpaka
 
 namespace std

--- a/include/alpaka/core/Tag.hpp
+++ b/include/alpaka/core/Tag.hpp
@@ -33,7 +33,7 @@ namespace alpaka
         };
 
         template<typename T_Id>
-        bool isTag_v = IsTag<T_Id>::value;
+        constexpr bool isTag_v = IsTag<T_Id>::value;
 
     } // namespace trait
 

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -98,4 +98,18 @@ namespace alpaka
         T_End m_end;
         T_Stride m_stride;
     };
+
+    template<concepts::VectorOrScalar T_Extent>
+    IdxRange(T_Extent const&) -> IdxRange<typename trait::getVec_t<T_Extent>::UniVec>;
+
+    template<concepts::VectorOrScalar T_Begin, concepts::VectorOrScalar T_End>
+    IdxRange(T_Begin const&, T_End const&)
+        -> IdxRange<typename trait::getVec_t<T_Begin>::UniVec, typename trait::getVec_t<T_End>::UniVec>;
+
+    template<concepts::VectorOrScalar T_Begin, concepts::VectorOrScalar T_End, concepts::VectorOrScalar T_Stride>
+    IdxRange(T_Begin const&, T_End const&, T_Stride const&) -> IdxRange<
+        typename trait::getVec_t<T_Begin>::UniVec,
+        typename trait::getVec_t<T_End>::UniVec,
+        typename trait::getVec_t<T_Stride>::UniVec>;
+
 } // namespace alpaka

--- a/include/alpaka/onHost.hpp
+++ b/include/alpaka/onHost.hpp
@@ -155,11 +155,12 @@ namespace alpaka::onHost
      * @return memory owning view to the allocated memory
      */
     template<typename T_Type>
-    inline auto alloc(auto const& device, alpaka::concepts::Vector auto const& extents)
+    inline auto alloc(auto const& device, alpaka::concepts::VectorOrScalar auto const& extents)
     {
-        return internal::Alloc::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extents)>{}(
+        Vec const extentsVec = extents;
+        return internal::Alloc::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
             *device.get(),
-            extents);
+            extentsVec);
     }
 
     /** allocate memory on the given device based on a view
@@ -191,13 +192,18 @@ namespace alpaka::onHost
     }
 
     /** @param extents M-dimensional data extents in elements, can be smaller than the container capacity */
-    inline void memcpy(concepts::QueueHandle auto& queue, auto& dest, auto const& source, auto const& extents)
+    inline void memcpy(
+        concepts::QueueHandle auto& queue,
+        auto& dest,
+        auto const& source,
+        alpaka::concepts::VectorOrScalar auto const& extents)
     {
+        Vec const extentsVec = extents;
         return internal::Memcpy::Op<
             std::decay_t<decltype(*queue.get())>,
             std::decay_t<decltype(dest)>,
             std::decay_t<decltype(source)>,
-            std::decay_t<decltype(extents)>>{}(*queue.get(), dest, source, extents);
+            std::decay_t<decltype(extentsVec)>>{}(*queue.get(), dest, source, extentsVec);
     }
 
     /** @} */
@@ -216,22 +222,25 @@ namespace alpaka::onHost
     }
 
     /** @param extents M-dimensional data extents in elements, can be smaller than the container capacity */
-    inline auto memset(concepts::QueueHandle auto& queue, auto& dest, uint8_t byteValue, auto const& extents)
+    inline auto memset(
+        concepts::QueueHandle auto& queue,
+        auto& dest,
+        uint8_t byteValue,
+        alpaka::concepts::VectorOrScalar auto const& extents)
     {
-        return internal::Memset::
-            Op<std::decay_t<decltype(*queue.get())>, std::decay_t<decltype(dest)>, std::decay_t<decltype(extents)>>{}(
-                *queue.get(),
-                dest,
-                byteValue,
-                extents);
+        Vec const extentsVec = extents;
+        return internal::Memset::Op<
+            std::decay_t<decltype(*queue.get())>,
+            std::decay_t<decltype(dest)>,
+            std::decay_t<decltype(extentsVec)>>{}(*queue.get(), dest, byteValue, extentsVec);
     }
 
     /** @} */
 
     /** Properties of a given device
      *
-     * @attention Currently only a handful of entries is available. The object will be refactored soon and will become
-     * most likely a compile time dictionary tu support optional entries.
+     * @attention Currently only a handful of entries is available. The object will be refactored soon and will
+     * become most likely a compile time dictionary tu support optional entries.
      *
      * @{
      */

--- a/include/alpaka/onHost/FrameSpec.hpp
+++ b/include/alpaka/onHost/FrameSpec.hpp
@@ -59,6 +59,18 @@ namespace alpaka::onHost
         }
     };
 
+    template<concepts::VectorOrScalar T_NumFrames, concepts::VectorOrScalar T_FrameExtent>
+    FrameSpec(T_NumFrames const&, T_FrameExtent const&)
+        -> FrameSpec<trait::getVec_t<T_NumFrames>, trait::getVec_t<T_FrameExtent>>;
+
+    template<concepts::VectorOrScalar T_NumFrames, concepts::VectorOrScalar T_FrameExtent>
+    FrameSpec(T_NumFrames const&, T_FrameExtent const&, T_FrameExtent const&)
+        -> FrameSpec<trait::getVec_t<T_NumFrames>, trait::getVec_t<T_FrameExtent>>;
+
+    template<concepts::VectorOrScalar T_NumFrames, concepts::VectorOrScalar T_FrameExtent>
+    FrameSpec(T_NumFrames const&, T_FrameExtent const&, T_NumFrames const&, T_FrameExtent const&)
+        -> FrameSpec<trait::getVec_t<T_NumFrames>, trait::getVec_t<T_FrameExtent>>;
+
     template<alpaka::concepts::Vector T_NumFrames, alpaka::concepts::Vector T_FrameExtent>
     std::ostream& operator<<(std::ostream& s, FrameSpec<T_NumFrames, T_FrameExtent> const& d)
     {

--- a/include/alpaka/onHost/ThreadSpec.hpp
+++ b/include/alpaka/onHost/ThreadSpec.hpp
@@ -35,6 +35,8 @@ namespace alpaka::onHost
         }
     };
 
-    template<alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_NumThreads>
-    ThreadSpec(T_NumBlocks const&, T_NumThreads const&) -> ThreadSpec<T_NumBlocks, T_NumThreads>;
+    template<concepts::VectorOrScalar T_NumBlocks, concepts::VectorOrScalar T_NumThreads>
+    ThreadSpec(T_NumBlocks const&, T_NumThreads const&)
+        -> ThreadSpec<trait::getVec_t<T_NumBlocks>, trait::getVec_t<T_NumThreads>>;
+
 } // namespace alpaka::onHost

--- a/include/alpaka/trait.hpp
+++ b/include/alpaka/trait.hpp
@@ -1,0 +1,36 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <concepts>
+#include <cstdint>
+
+namespace alpaka
+{
+    namespace trait
+    {
+        template<typename T>
+        struct GetDim
+        {
+            static constexpr uint32_t value = T::dim();
+        };
+
+        template<std::integral T>
+        struct GetDim<T>
+        {
+            static constexpr uint32_t value = 1u;
+        };
+
+        template<typename T>
+        constexpr uint32_t getDim_v = GetDim<T>::value;
+    } // namespace trait
+
+    template<typename T>
+    consteval uint32_t getDim(T const& any)
+    {
+        return trait::getDim_v<T>;
+    }
+
+} // namespace alpaka


### PR DESCRIPTION
This change simplifies using interfaces where a 1-dimensional vector is required.
The user can now pass a scalar value instead of a 1-dimension vector.

Maybe I missed updating some interfaces, if so please notify me.
