### PR TITLE
remove id from global variables

### DIFF
--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -96,7 +96,7 @@ namespace alpaka::onHost
 
             void wait() const
             {
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface,ApiInterface::streamSynchronize(getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::streamSynchronize(getNativeHandle()));
             }
 
             friend struct alpaka::internal::GetApi;

--- a/include/alpaka/api/unifiedCudaHip/atomicBuiltIn.hpp
+++ b/include/alpaka/api/unifiedCudaHip/atomicBuiltIn.hpp
@@ -6,8 +6,8 @@
 
 #include "alpaka/core/Utility.hpp"
 #include "alpaka/core/config.hpp"
-#include "alpaka/onAcc/atomicOp.hpp"
 #include "alpaka/onAcc/atomicHierarchy.hpp"
+#include "alpaka/onAcc/atomicOp.hpp"
 
 #include <type_traits>
 

--- a/include/alpaka/core/Assert.hpp
+++ b/include/alpaka/core/Assert.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "alpaka/core/config.hpp"
 #include "alpaka/core/common.hpp"
+#include "alpaka/core/config.hpp"
 
 #include <cassert>
 #include <type_traits>

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "alpaka/Vec.hpp"
 #include "alpaka/CVec.hpp"
+#include "alpaka/Vec.hpp"
 #include "alpaka/core/config.hpp"
 
 #include <type_traits>
@@ -266,7 +266,7 @@ namespace alpaka
     {
         static_assert(
             sizeof(T_ArrayType) && false,
-            "MdSpanArray can only be used if std::is_array_v<T> is true for teh given type.");
+            "MdSpanArray can only be used if std::is_array_v<T> is true for the given type.");
     };
 
     template<typename T_ArrayType>


### PR DESCRIPTION
The id is not required because each variable name is unqiue.