### PR TITLE
replace assert() with self written verify() in the tutorial examples

### DIFF
--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -6,7 +6,6 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include <cassert>
 #include <cstdio>
 #include <random>
 
@@ -116,8 +115,8 @@ void testVectorAddKernel(
     for(uint32_t i = 0; i < size; ++i)
     {
         float sum = in1_h[i] + in2_h[i];
-        assert(out_h[i] < sum + epsilon);
-        assert(out_h[i] > sum - epsilon);
+        verify(out_h[i] < sum + epsilon);
+        verify(out_h[i] > sum - epsilon);
     }
     std::cout << "success\n";
 
@@ -145,8 +144,8 @@ void testVectorAddKernel(
     for(uint32_t i = 0; i < size; ++i)
     {
         float sum = in1_h[i] + in2_h[i];
-        assert(out_h[i] < sum + epsilon);
-        assert(out_h[i] > sum - epsilon);
+        verify(out_h[i] < sum + epsilon);
+        verify(out_h[i] > sum - epsilon);
     }
     std::cout << "success\n";
 }
@@ -221,8 +220,8 @@ void testVectorAddKernel3D(
     {
         auto lIdx = alpaka::mapToND(ndsize, i);
         float sum = in1_h[lIdx] + in2_h[lIdx];
-        assert(out_h[lIdx] < sum + epsilon);
-        assert(out_h[lIdx] > sum - epsilon);
+        verify(out_h[lIdx] < sum + epsilon);
+        verify(out_h[lIdx] > sum - epsilon);
     }
     std::cout << "success\n";
 }

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -6,7 +6,6 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include <cassert>
 #include <cstdio>
 #include <random>
 
@@ -146,8 +145,8 @@ void testVectorAddKernel(
     for(uint32_t i = 0; i < size; ++i)
     {
         float sum = in1_h[i] + in2_h[i];
-        assert(out_h[i] < sum + epsilon);
-        assert(out_h[i] > sum - epsilon);
+        verify(out_h[i] < sum + epsilon);
+        verify(out_h[i] > sum - epsilon);
     }
     std::cout << "success\n";
 }
@@ -241,8 +240,8 @@ void testVectorAddKernel3D(
     {
         auto lIdx = alpaka::mapToND(ndsize, i);
         float sum = in1_h[lIdx] + in2_h[lIdx];
-        assert(out_h[lIdx] < sum + epsilon);
-        assert(out_h[lIdx] > sum - epsilon);
+        verify(out_h[lIdx] < sum + epsilon);
+        verify(out_h[lIdx] > sum - epsilon);
     }
     std::cout << "success\n";
 }

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -6,7 +6,6 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include <cassert>
 #include <cstdio>
 #include <random>
 
@@ -193,7 +192,7 @@ void testVectorAddKernel(
     constexpr auto frameExtent = 32u;
     auto numFrames = size / frameExtent;
     // The kernel assumes that the problem size is a multiple of the frame size.
-    assert((numFrames * frameExtent) == size);
+    verify((numFrames * frameExtent) == size);
 
     auto frameSpec = alpaka::onHost::FrameSpec{numFrames, alpaka::CVec<uint32_t, frameExtent>{}};
 
@@ -214,8 +213,8 @@ void testVectorAddKernel(
     for(uint32_t i = 0; i < size; ++i)
     {
         float sum = in1_h[i] + in2_h[i];
-        assert(out_h[i] < sum + epsilon);
-        assert(out_h[i] > sum - epsilon);
+        verify(out_h[i] < sum + epsilon);
+        verify(out_h[i] > sum - epsilon);
     }
     std::cout << "success\n";
 }
@@ -271,7 +270,7 @@ void testVectorAddKernel3D(
     auto frameExtent = alpaka::CVec<uint32_t, 4, 4, 2>{};
     auto numFrames = ndsize / frameExtent;
     // The kernel assumes that the problem size is a multiple of the frame size.
-    assert((numFrames * frameExtent).product() == size);
+    verify((numFrames * frameExtent).product() == size);
 
     auto frameSpec = alpaka::onHost::FrameSpec{numFrames, frameExtent};
 
@@ -291,8 +290,8 @@ void testVectorAddKernel3D(
     {
         auto lIdx = alpaka::mapToND(ndsize, i);
         float sum = in1_h[lIdx] + in2_h[lIdx];
-        assert(out_h[lIdx] < sum + epsilon);
-        assert(out_h[lIdx] > sum - epsilon);
+        verify(out_h[lIdx] < sum + epsilon);
+        verify(out_h[lIdx] > sum - epsilon);
     }
     std::cout << "success\n";
 }

--- a/example/tutorial/src/config.h
+++ b/example/tutorial/src/config.h
@@ -8,6 +8,24 @@
 #include <alpaka/example/executors.hpp>
 
 #include <cstdint>
+#include <iostream>
+
+#define verify(expr) verify_func(expr, #expr)
+
+/// Same behavior like assert() on host, but independent of the compiler define -DNDEBUG
+void verify_func(
+    bool const value,
+    char const* const expr_string,
+    std::source_location const location = std::source_location::current())
+{
+    if(!value)
+    {
+        std::cerr << "file: " << location.file_name() << '(' << location.line() << ':' << location.column() << ") `"
+                  << location.function_name() << "`: "
+                  << "Assertion '" << expr_string << "' failed\n";
+        std::abort();
+    }
+}
 
 // index type
 using Idx = uint32_t;
@@ -19,8 +37,3 @@ using Vec = alpaka::Vec<uint32_t, T_dim>;
 using Vec1D = Vec<1u>;
 using Vec2D = Vec<2u>;
 using Vec3D = Vec<3u>;
-
-// remove NDEBUG to activate asserts
-#ifdef NDEBUG
-#    undef NDEBUG
-#endif


### PR DESCRIPTION
`verify()` does the same like `assert()` but is independent of the compiler define `NDEBUG`.

Looks like undefine the define `NDEBUG` in source code is undefined behavior. The Intel icpx compiler has problems, if the define was removed in source code. 