### PR TITLE
disable CUDA auto tuning

### DIFF
--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -207,7 +207,7 @@ namespace alpaka::onHost
                 T_KernelBundle const& kernelBundle) const
             {
                 auto numThreadBlocks = dataBlocking.getThreadSpec().m_numBlocks;
-#        if 1
+#        if 0
                 using IdxType = typename T_NumBlocks::type;
                 // @todo get this number from device properties
                 static auto const maxBlocks = device.m_properties.m_multiProcessorCount * 16u;


### PR DESCRIPTION
Auto ThreadSpec adjustment was enabled in an older PR silently, this was a left over from some tests and should not be active by default until we are sure it is an improvement.