### PR TITLE
support compile-time number of threads per block

### DIFF
--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -79,6 +79,22 @@ namespace alpaka
                     Values{});
                 return result;
             }
+
+            template<T T_value>
+            static constexpr auto all()
+            {
+                using IotaSeq = std::make_integer_sequence<T, dim()>;
+                return integerSequenceToCVec(IotaSeq{}, [](auto&&) constexpr { return T_value; });
+            }
+
+        private:
+            template<T... T_indecies>
+            static constexpr auto integerSequenceToCVec(
+                std::integer_sequence<T, T_indecies...>,
+                auto const op = std::identity{})
+            {
+                return CVec<T, op(T_indecies)...>{};
+            };
         };
 
         template<typename T>
@@ -212,6 +228,12 @@ namespace alpaka
                 Vec result([=](uint32_t const) { return value; });
                 return result;
             }
+        }
+
+        template<T_Type T_v>
+        static constexpr auto all() requires requires { T_Storage::template all<T_v>(); }
+        {
+            return Vec<T_Type, T_dim, ALPAKA_TYPEOF(T_Storage::template all<T_v>())>{};
         }
 
         constexpr Vec toRT() const

--- a/include/alpaka/api/cpu/Device.hpp
+++ b/include/alpaka/api/cpu/Device.hpp
@@ -176,6 +176,16 @@ namespace alpaka::onHost
                 cpu::Device<T_Platform> const& device,
                 T_Mapping const& executor,
                 FrameSpec<T_NumBlocks, T_NumThreads> const& dataBlocking,
+                T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_NumThreads>
+            {
+                auto numThreadBlocks = dataBlocking.getThreadSpec().m_numBlocks;
+                return ThreadSpec{numThreadBlocks, T_NumThreads::template all<1u>()};
+            }
+
+            auto operator()(
+                cpu::Device<T_Platform> const& device,
+                T_Mapping const& executor,
+                FrameSpec<T_NumBlocks, T_NumThreads> const& dataBlocking,
                 T_KernelBundle const& kernelBundle) const
             {
                 auto numThreadBlocks = dataBlocking.getThreadSpec().m_numBlocks;
@@ -212,6 +222,17 @@ namespace alpaka::onHost
             FrameSpec<T_NumBlocks, T_NumThreads>,
             T_KernelBundle>
         {
+            auto operator()(
+                cpu::Device<T_Platform> const& device,
+                exec::CpuOmpBlocksAndThreads const& executor,
+                FrameSpec<T_NumBlocks, T_NumThreads> const& dataBlocking,
+                T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_NumThreads>
+            {
+                auto numThreadBlocks = dataBlocking.getThreadSpec().m_numBlocks;
+
+                return ThreadSpec{numThreadBlocks, T_NumThreads::template all<1u>()};
+            }
+
             auto operator()(
                 cpu::Device<T_Platform> const& device,
                 exec::CpuOmpBlocksAndThreads const& executor,

--- a/include/alpaka/api/cpu/IdxLayer.hpp
+++ b/include/alpaka/api/cpu/IdxLayer.hpp
@@ -24,9 +24,19 @@ namespace alpaka::onAcc
                 return IndexVecType::all(0);
             }
 
+            constexpr auto idx() const requires alpaka::concepts::CVector<IndexVecType>
+            {
+                return IndexVecType::template all<0>();
+            }
+
             constexpr auto count() const
             {
                 return IndexVecType::all(1);
+            }
+
+            constexpr auto count() const requires alpaka::concepts::CVector<IndexVecType>
+            {
+                return IndexVecType::template all<1u>();
             }
         };
 

--- a/include/alpaka/api/cpu/exec/OmpThreads.hpp
+++ b/include/alpaka/api/cpu/exec/OmpThreads.hpp
@@ -84,7 +84,7 @@ namespace alpaka::onHost
                         auto const blockSharedMemEntry = DictEntry{layer::shared, std::ref(blockSharedMem)};
                         auto const blockSyncEntry = DictEntry{action::sync, onAcc::cpu::OmpSync{}};
 
-                        using NumThreadsVecType = typename ThreadSpecType::NumThreadsVecType;
+                        using NumThreadsVecType = typename ThreadSpecType::NumThreadsVecType::UniVec;
                         using ThreadIdxType = typename NumThreadsVecType::type;
 #    pragma omp for
                         for(ThreadIdxType i = 0; i < blockCountND.product(); ++i)

--- a/include/alpaka/api/cuda/IdxLayer.hpp
+++ b/include/alpaka/api/cuda/IdxLayer.hpp
@@ -14,31 +14,40 @@ namespace alpaka::onAcc
 {
     namespace unifiedCudaHip
     {
-        template<typename T_IdxType, uint32_t T_dim>
+        template<typename T_NumBlocksType>
         struct BlockLayer
         {
             constexpr auto idx() const
             {
-                return Vec<T_IdxType, 3u>{::blockIdx.z, ::blockIdx.y, ::blockIdx.x}.template rshrink<T_dim>();
+                return Vec<typename T_NumBlocksType::type, 3u>{::blockIdx.z, ::blockIdx.y, ::blockIdx.x}
+                    .template rshrink<T_NumBlocksType::dim()>();
             }
 
             constexpr auto count() const
             {
-                return Vec<T_IdxType, 3u>{::gridDim.z, ::gridDim.y, ::gridDim.x}.template rshrink<T_dim>();
+                return Vec<typename T_NumBlocksType::type, 3u>{::gridDim.z, ::gridDim.y, ::gridDim.x}
+                    .template rshrink<T_NumBlocksType::dim()>();
             }
         };
 
-        template<typename T_IdxType, uint32_t T_dim>
+        template<typename T_NumThreadsType>
         struct ThreadLayer
         {
             constexpr auto idx() const
             {
-                return Vec<T_IdxType, 3u>{::threadIdx.z, ::threadIdx.y, ::threadIdx.x}.template rshrink<T_dim>();
+                return Vec<typename T_NumThreadsType::type, 3u>{::threadIdx.z, ::threadIdx.y, ::threadIdx.x}
+                    .template rshrink<T_NumThreadsType::dim()>();
             }
 
             constexpr auto count() const
             {
-                return Vec<T_IdxType, 3u>{::blockDim.z, ::blockDim.y, ::blockDim.x}.template rshrink<T_dim>();
+                return Vec<typename T_NumThreadsType::type, 3u>{::threadIdx.z, ::threadIdx.y, ::threadIdx.x}
+                    .template rshrink<T_NumThreadsType::dim()>();
+            }
+
+            constexpr auto count() const requires alpaka::concepts::CVector<T_NumThreadsType>
+            {
+                return T_NumThreadsType{};
             }
         };
     } // namespace unifiedCudaHip

--- a/include/alpaka/api/hip/IdxLayer.hpp
+++ b/include/alpaka/api/hip/IdxLayer.hpp
@@ -14,31 +14,40 @@ namespace alpaka::onAcc
 {
     namespace unifiedCudaHip
     {
-        template<typename T_IdxType, uint32_t T_dim>
+        template<typename T_NumBlocksType>
         struct BlockLayer
         {
             constexpr auto idx() const
             {
-                return Vec<T_IdxType, 3u>{hipBlockIdx_z, hipBlockIdx_y, hipBlockIdx_x}.template rshrink<T_dim>();
+                return Vec<typename T_NumBlocksType::type, 3u>{hipBlockIdx_z, hipBlockIdx_y, hipBlockIdx_x}
+                    .template rshrink<T_NumBlocksType::dim()>();
             }
 
             constexpr auto count() const
             {
-                return Vec<T_IdxType, 3u>{hipGridDim_z, hipGridDim_y, hipGridDim_x}.template rshrink<T_dim>();
+                return Vec<typename T_NumBlocksType::type, 3u>{hipGridDim_z, hipGridDim_y, hipGridDim_x}
+                    .template rshrink<T_NumBlocksType::dim()>();
             }
         };
 
-        template<typename T_IdxType, uint32_t T_dim>
+        template<typename T_NumThreadsType>
         struct ThreadLayer
         {
             constexpr auto idx() const
             {
-                return Vec<T_IdxType, 3u>{hipThreadIdx_z, hipThreadIdx_y, hipThreadIdx_x}.template rshrink<T_dim>();
+                return Vec<typename T_NumThreadsType::type, 3u>{hipThreadIdx_z, hipThreadIdx_y, hipThreadIdx_x}
+                    .template rshrink<T_NumThreadsType::dim()>();
             }
 
             constexpr auto count() const
             {
-                return Vec<T_IdxType, 3u>{hipBlockDim_z, hipBlockDim_y, hipBlockDim_x}.template rshrink<T_dim>();
+                return Vec<typename T_NumThreadsType::type, 3u>{hipBlockDim_z, hipBlockDim_y, hipBlockDim_x}
+                    .template rshrink<T_NumThreadsType::dim()>();
+            }
+
+            constexpr auto count() const requires alpaka::concepts::CVector<T_NumThreadsType>
+            {
+                return T_NumThreadsType{};
             }
         };
     } // namespace unifiedCudaHip

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -204,6 +204,15 @@ namespace alpaka::onHost
                 unifiedCudaHip::Device<T_Platform> const& device,
                 T_Mapping const& executor,
                 FrameSpec<T_NumBlocks, T_NumThreads> const& dataBlocking,
+                T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_NumThreads>
+            {
+                return dataBlocking.getThreadSpec();
+            }
+
+            auto operator()(
+                unifiedCudaHip::Device<T_Platform> const& device,
+                T_Mapping const& executor,
+                FrameSpec<T_NumBlocks, T_NumThreads> const& dataBlocking,
                 T_KernelBundle const& kernelBundle) const
             {
                 auto numThreadBlocks = dataBlocking.getThreadSpec().m_numBlocks;

--- a/include/alpaka/onHost/ThreadSpec.hpp
+++ b/include/alpaka/onHost/ThreadSpec.hpp
@@ -18,7 +18,7 @@ namespace alpaka::onHost
     {
         using type = typename T_NumBlocks::type;
         using NumBlocksVecType = typename T_NumBlocks::UniVec;
-        using NumThreadsVecType = typename T_NumThreads::UniVec;
+        using NumThreadsVecType = T_NumThreads;
 
         consteval uint32_t dim() const
         {

--- a/tests/cvecKernelCall.cpp
+++ b/tests/cvecKernelCall.cpp
@@ -1,0 +1,119 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executeForEach.hpp>
+#include <alpaka/example/executors.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <thread>
+
+/** @file In this file we test if the a compile time thread extent for number of threads within a block is forwarded
+ * correctly into the kernel without silent conversions into a runtime value.
+ */
+
+using namespace alpaka;
+using namespace alpaka::onHost;
+
+using TestApis = std::decay_t<decltype(allExecutorsAndApis(enabledApis))>;
+
+struct KernelCVecFrameExtents
+{
+    template<typename T>
+    ALPAKA_FN_ACC void operator()(T const& acc, auto result) const
+    {
+        alpaka::concepts::CVector auto frameExtent = acc[alpaka::frame::extent];
+        // compile will fail if the type is silently cast to non CVec type
+        [[maybe_unused]] alpaka::concepts::CVector auto blockThreadCount = acc[alpaka::layer::thread].count();
+        static_assert(frameExtent.x() == 43u);
+        result[0] = frameExtent.x() == 43u;
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("CVec frame extent kernel call", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto api = cfg[object::api];
+    auto exec = cfg[object::exec];
+
+    std::cout << api.getName() << std::endl;
+
+    Platform platform = makePlatform(api);
+    Device device = platform.makeDevice(0);
+
+    std::cout << getName(platform) << " " << device.getName() << std::endl;
+
+    Queue queue = device.makeQueue();
+
+
+    auto dBuff = onHost::alloc<bool>(device, Vec{1u});
+
+    Platform cpuPlatform = makePlatform(api::cpu);
+    Device cpuDevice = cpuPlatform.makeDevice(0);
+    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    wait(queue);
+    {
+        onHost::enqueue(
+            queue,
+            exec,
+            FrameSpec{Vec{1u}, CVec<uint32_t, 43u>{}},
+            KernelBundle{KernelCVecFrameExtents{}, dBuff.getMdSpan()});
+        onHost::memcpy(queue, hBuff, dBuff);
+        wait(queue);
+        CHECK(hBuff[0] == true);
+    }
+}
+
+struct KernelCVecThreadExtents
+{
+    template<typename T>
+    ALPAKA_FN_ACC void operator()(T const& acc, auto result) const
+    {
+        // compile will fail if the type is silently cast to non CVec type
+        alpaka::concepts::CVector auto blockThreadCount = acc[alpaka::layer::thread].count();
+        static_assert(blockThreadCount.x() == 1u);
+        result[0] = blockThreadCount.x() == 1u;
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("CVec thread extent kernel call", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto api = cfg[object::api];
+    auto exec = cfg[object::exec];
+
+    std::cout << api.getName() << std::endl;
+
+    Platform platform = makePlatform(api);
+    Device device = platform.makeDevice(0);
+
+    std::cout << getName(platform) << " " << device.getName() << std::endl;
+
+    Queue queue = device.makeQueue();
+
+
+    auto dBuff = onHost::alloc<bool>(device, Vec{1u});
+
+    Platform cpuPlatform = makePlatform(api::cpu);
+    Device cpuDevice = cpuPlatform.makeDevice(0);
+    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    wait(queue);
+    {
+        onHost::enqueue(
+            queue,
+            exec,
+            // we need to use one thread per thread block because serial executors will reduce the number of threads to
+            // a single thread
+            ThreadSpec{Vec{1u}, CVec<uint32_t, 1u>{}},
+            KernelBundle{KernelCVecThreadExtents{}, dBuff.getMdSpan()});
+        onHost::memcpy(queue, hBuff, dBuff);
+        wait(queue);
+        CHECK(hBuff[0] == true);
+    }
+}


### PR DESCRIPTION
- take care that a compile time definition of frame extents reults into compile-time number of threads per block
- ensure that compile time number of threads is propergated as compile time value into the kernel
- add test to check that number of threads per block is compile time if required
- implement method `all<N>()` for CVector
- automatic adjustment for number of threads within a threadblock is required to handle compile time thread extents for a block