### PR TITLE
precision cast

### DIFF
--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -85,7 +85,7 @@ auto example(T_Cfg const& cfg) -> int
     std::default_random_engine eng{rd()};
     std::uniform_int_distribution<Data> dist(1, 42);
 
-    for(auto i(0); i < extent; ++i)
+    for(auto i(0u); i < extent; ++i)
     {
         bufHostA.getMdSpan()[i] = dist(eng);
         bufHostB.getMdSpan()[i] = dist(eng);

--- a/include/alpaka/cast.hpp
+++ b/include/alpaka/cast.hpp
@@ -1,0 +1,63 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/common.hpp"
+#include "alpaka/trait.hpp"
+
+namespace alpaka
+{
+    namespace internal
+    {
+        struct PCast
+        {
+            template<typename T_To, typename T_Input>
+            struct Op
+            {
+                decltype(auto) operator()(auto&& any) const;
+            };
+        };
+
+        struct LPCast
+        {
+            template<typename T_To, typename T_Input>
+            struct Op
+            {
+                decltype(auto) operator()(auto&& any) const
+                {
+                    return PCast::Op<T_To, T_Input>{}(any);
+                }
+            };
+        };
+    } // namespace internal
+
+    /** Performs a precision of the value type to another.
+     *
+     * @tparam T_To The target type to which the input is cast.
+     * @param input The input value to be cast. value_type must be cast able to `T_To`.
+     * @return input with exchanged value_type
+     */
+    template<typename T_To>
+    constexpr decltype(auto) pCast(auto&& input) requires(isConvertible_v<typename ALPAKA_TYPEOF(input)::type, T_To>)
+    {
+        return internal::PCast::Op<T_To, ALPAKA_TYPEOF(input)>{}(input);
+    }
+
+    /** Performs a precision of the value type to another.
+     *
+     * It ensures that the conversion is lossless by requiring that the value_type of the input is lossless convertible
+     * to the target type `T_To`.
+     *
+     * @tparam T_To The target type to which the input is cast.
+     * @param input The input value to be cast. value_type must be cast able to `T_To`.
+     * @return input with exchanged value_type
+     */
+    template<typename T_To>
+    constexpr decltype(auto) lpCast(auto&& input)
+        requires(isLosslessConvertible_v<typename ALPAKA_TYPEOF(input)::type, T_To>)
+    {
+        return internal::LPCast::Op<T_To, ALPAKA_TYPEOF(input)>{}(input);
+    }
+} // namespace alpaka

--- a/include/alpaka/core/common.hpp
+++ b/include/alpaka/core/common.hpp
@@ -6,6 +6,8 @@
 
 #include "alpaka/core/config.hpp"
 
+#include <type_traits>
+
 // Boost.Uuid errors with VS2017 when intrin.h is not included
 #if defined(_MSC_VER) && _MSC_VER >= 1910
 #    include <intrin.h>

--- a/include/alpaka/trait.hpp
+++ b/include/alpaka/trait.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "alpaka/vecConcepts.hpp"
+
 #include <concepts>
 #include <cstdint>
 
@@ -32,5 +34,11 @@ namespace alpaka
     {
         return trait::getDim_v<T>;
     }
+
+    template<typename T_From, typename T_To>
+    constexpr bool isLosslessConvertible_v = concepts::IsLosslessConvertible<T_From, T_To>;
+
+    template<typename T_From, typename T_To>
+    constexpr bool isConvertible_v = concepts::IsConvertible<T_From, T_To>;
 
 } // namespace alpaka

--- a/include/alpaka/vecConcepts.hpp
+++ b/include/alpaka/vecConcepts.hpp
@@ -1,0 +1,48 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <concepts>
+#include <string>
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace concepts
+    {
+        /** Concept to check if a type can be lossless converted to another type.
+         *
+         * This concept ensures that a type `T_From` can be converted to a type `T_To` without any loss of information.
+         * It checks for implicit convertibility, signedness compatibility, and precision preservation for both integer
+         * and floating-point types.
+         *
+         * @tparam T_From The source type to be converted.
+         * @tparam T_To The target type to which the source type is converted.
+         */
+        template<typename T_From, typename T_To>
+        concept IsLosslessConvertible =
+            // Ensure T_From can be implicitly converted to T_To
+            std::convertible_to<T_From, T_To> &&
+
+            // Check for potential signedness change issues
+            (std::is_signed_v<T_From> == std::is_signed_v<T_To>) &&
+
+            // Prevent precision loss for integer types
+            (std::is_integral_v<T_From> && std::is_integral_v<T_To>
+                 ? (std::numeric_limits<T_From>::digits <= std::numeric_limits<T_To>::digits)
+                 : true)
+            &&
+
+            // For floating-point types, ensure no precision loss
+            (std::is_floating_point_v<T_From> && std::is_floating_point_v<T_To>
+                 ? (std::numeric_limits<T_From>::radix == std::numeric_limits<T_To>::radix
+                    && std::numeric_limits<T_From>::digits <= std::numeric_limits<T_To>::digits
+                    && std::numeric_limits<T_From>::max_exponent <= std::numeric_limits<T_To>::max_exponent)
+                 : true);
+
+        template<typename T_From, typename T_To>
+        concept IsConvertible = requires { std::is_convertible_v<T_From, T_To>; };
+    }; // namespace concepts
+} // namespace alpaka


### PR DESCRIPTION
- add precision cast
- add lossless precision cast
- add concepts
  - IsLosslessConvertible
  - IsConvertible
- refactor Vec
  - to allow up-castable types for scalar values in operations
  - remove explicit constructor for vector type changes (pCast, lpCast should be used)