### PR TITLE
aligned host memory

### DIFF
--- a/example/heatEquation2D/src/analyticalSolution.hpp
+++ b/example/heatEquation2D/src/analyticalSolution.hpp
@@ -27,9 +27,9 @@ ALPAKA_FN_HOST_ACC auto exactSolution(double const x, double const y, double con
 //! \param dx
 //! \param dy
 //! \param tMax time at simulation end
-template<typename T_Buffer, typename T_Extent>
+template<typename T_MdSpan, typename T_Extent>
 auto validateSolution(
-    T_Buffer const& buffer,
+    T_MdSpan const dataMdSpan,
     T_Extent const& extent,
     double const dx,
     double const dy,
@@ -41,7 +41,12 @@ auto validateSolution(
     {
         for(uint32_t i = 1; i < extent[1] - 1; ++i)
         {
-            auto const error = std::abs(buffer.data()[j * extent[1] + i] - exactSolution(i * dx, j * dy, tMax));
+            auto const error = std::abs(
+                dataMdSpan[alpaka::Vec{
+                    j,
+                    i,
+                }]
+                - exactSolution(i * dx, j * dy, tMax));
             maxError = std::max(maxError, error);
         }
     }
@@ -56,16 +61,19 @@ auto validateSolution(
 //! \param extent extents of the buffer
 //! \param dx
 //! \param dy
-template<typename TBuffer>
-auto initalizeBuffer(TBuffer& buffer, double const dx, double const dy) -> void
+template<typename T_MdSpan>
+auto initalizeBuffer(T_MdSpan dataMdSpan, double const dx, double const dy) -> void
 {
-    auto extents = buffer.getExtents();
+    auto extents = dataMdSpan.getExtents();
     // Apply initial conditions for the test problem
     for(uint32_t j = 0; j < extents[0]; ++j)
     {
         for(uint32_t i = 0; i < extents[1]; ++i)
         {
-            buffer.data()[j * extents[1] + i] = exactSolution(i * dx, j * dy, 0.0);
+            dataMdSpan[alpaka::Vec{
+                j,
+                i,
+            }] = exactSolution(i * dx, j * dy, 0.0);
         }
     }
 }

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -94,7 +94,7 @@ auto example(T_Cfg const& cfg) -> int
     auto const pitchNextAcc{uNextBufAcc.getPitches()};
 
     // Set buffer to initial conditions
-    initalizeBuffer(uBufHost, dx, dy);
+    initalizeBuffer(uBufHost.getMdSpan(), dx, dy);
 
     // Select queue
     Queue dumpQueue = devAcc.makeQueue();
@@ -163,7 +163,7 @@ auto example(T_Cfg const& cfg) -> int
             alpaka::wait(computeQueue);
             alpaka::memcpy(dumpQueue, uBufHost, uCurrBufAcc);
             alpaka::wait(dumpQueue);
-            writeImage(step - 1, uBufHost);
+            writeImage(step - 1, uBufHost.getMdSpan());
         }
 #endif
 
@@ -183,7 +183,7 @@ auto example(T_Cfg const& cfg) -> int
     alpaka::onHost::wait(dumpQueue);
 
     // Validate
-    auto const [resultIsCorrect, maxError] = validateSolution(uBufHost, extent, dx, dy, tMax);
+    auto const [resultIsCorrect, maxError] = validateSolution(uBufHost.getMdSpan(), extent, dx, dy, tMax);
 
     if(resultIsCorrect)
     {

--- a/example/heatEquation2D/src/writeImage.hpp
+++ b/example/heatEquation2D/src/writeImage.hpp
@@ -17,13 +17,13 @@
 //!
 //! \param currentStep the current step of the simulation
 //! \param buffer the buffer to write to the file
-template<typename T_Buffer>
-auto writeImage(uint32_t const currentStep, T_Buffer const& buffer) -> void
+template<typename T_MdSpan>
+auto writeImage(uint32_t const currentStep, T_MdSpan const& dataMdSpan) -> void
 {
     std::stringstream step;
     step << std::setw(6) << std::setfill('0') << currentStep;
     std::string filename("heat_" + step.str() + ".png");
-    auto extents = buffer.getExtents();
+    auto extents = dataMdSpan.getExtents();
     pngwriter png{static_cast<int>(extents[1]), static_cast<int>(extents[0]), 0, filename.c_str()};
     png.setcompressionlevel(9);
 
@@ -31,7 +31,7 @@ auto writeImage(uint32_t const currentStep, T_Buffer const& buffer) -> void
     {
         for(uint32_t x = 0; x < extents[1]; ++x)
         {
-            auto p = buffer.data()[y * extents[1] + x];
+            auto p = dataMdSpan[alpaka::Vec{y, x}];
             png.plot(
                 x + 1,
                 extents[0] - y,

--- a/include/alpaka/api/cpu/Api.hpp
+++ b/include/alpaka/api/cpu/Api.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/api/trait.hpp"
 #include "alpaka/concepts.hpp"
 #include "alpaka/onHost/trait.hpp"
 
@@ -44,4 +45,62 @@ namespace alpaka
         {
         };
     } // namespace onHost::trait
+
+    namespace trait
+    {
+
+        template<typename T_Type>
+        struct GetArchSimdWidth::Op<T_Type, api::Cpu>
+        {
+            constexpr uint32_t operator()(api::Cpu const) const
+            {
+                constexpr std::size_t simdWidthInByte =
+#if defined(__AVX512BW__)
+                    // addition (AVX512BW): vpaddb / _mm512_mask_add_epi8
+                    // subtraction (AVX512BW): vpsubb / _mm512_sub_epi8
+                    // multiplication: -
+                    64u;
+#elif defined(__AVX2__)
+                    // addition (AVX2): vpaddb / _mm256_add_epi8
+                    // subtraction (AVX2): vpsubb / _mm256_sub_epi8
+                    // multiplication: -
+                    32u;
+#elif defined(__SSE2__)
+                    // addition (SSE2): paddb / _mm_add_epi8
+                    // subtraction (SSE2): psubb / _mm_sub_epi8
+                    // multiplication: -
+                    16u;
+#elif defined(__ARM_NEON__)
+                    16u;
+#elif defined(__ALTIVEC__)
+                    16u;
+#elif defined(__CUDA_ARCH__)
+                    // addition: __vadd4
+                    // subtraction: __vsub4
+                    // multiplication: -
+                    4u;
+#else
+                    1u;
+#endif
+                return simdWidthInByte / sizeof(T_Type);
+            }
+        };
+
+        template<>
+        struct GetCachelineSize::Op<api::Cpu>
+        {
+            constexpr uint32_t operator()(api::Cpu const) const
+            {
+                constexpr uint32_t cachlineBytes =
+#ifdef __cpp_lib_hardware_interference_size
+                    std::hardware_constructive_interference_size;
+
+#else
+                    // Fallback value, typically 64 bytes
+                    64;
+#endif
+                return cachlineBytes;
+            }
+        };
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/api/cpu/Device.hpp
+++ b/include/alpaka/api/cpu/Device.hpp
@@ -8,6 +8,7 @@
 #include "alpaka/api/cpu/Queue.hpp"
 #include "alpaka/api/cpu/sysInfo.hpp"
 #include "alpaka/core/Utility.hpp"
+#include "alpaka/core/alignedAlloc.hpp"
 #include "alpaka/internal.hpp"
 #include "alpaka/onHost.hpp"
 #include "alpaka/onHost/Device.hpp"
@@ -128,11 +129,15 @@ namespace alpaka::onHost
         {
             auto operator()(cpu::Device<T_Platform>& device, T_Extents const& extents) const
             {
+                using IdxType = typename T_Extents::type;
+                constexpr uint32_t alignment
+                    = getArchSimdWidth<T_Type>(ALPAKA_TYPEOF(getApi(device)){}) * alignof(T_Type);
                 constexpr auto dim = T_Extents::dim();
                 if constexpr(dim == 1u)
                 {
-                    auto* ptr = new T_Type[extents.x()];
-                    auto deleter = [](T_Type* ptr) { delete[](ptr); };
+                    auto* ptr = reinterpret_cast<T_Type*>(
+                        alpaka::core::alignedAlloc(alignment, extents.x() * sizeof(T_Type)));
+                    auto deleter = [](T_Type* ptr) { alpaka::core::alignedFree(alignment, ptr); };
                     auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
                     auto data = std::make_shared<
                         onHost::
@@ -146,9 +151,15 @@ namespace alpaka::onHost
                 }
                 else
                 {
-                    auto* ptr = new T_Type[extents.product()];
-                    auto deleter = [](T_Type* ptr) { delete[](ptr); };
-                    auto pitches = mem::calculatePitchesFromExtents<T_Type>(extents);
+                    auto rowExtentInBytes = extents.x() * static_cast<IdxType>(sizeof(T_Type));
+                    auto rowPitchInBytes = core::divCeil(rowExtentInBytes, alignment) * alignment;
+                    auto pitches = mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
+
+                    // product of pitches does contain the size for the first dimension
+                    size_t memSizeInByte = lpCast<size_t>(pitches).product() * extents[0];
+                    auto* ptr = reinterpret_cast<T_Type*>(alpaka::core::alignedAlloc(alignment, memSizeInByte));
+                    auto deleter = [](T_Type* ptr) { alpaka::core::alignedFree(alignment, ptr); };
+
                     auto data = std::make_shared<
                         onHost::
                             Data<Handle<std::decay_t<decltype(device)>>, T_Type, T_Extents, ALPAKA_TYPEOF(pitches)>>(
@@ -190,25 +201,25 @@ namespace alpaka::onHost
             {
                 auto numThreadBlocks = dataBlocking.getThreadSpec().m_numBlocks;
 #if 0
-                using IdxType = typename T_NumBlocks::type;
-                // @todo get this number from device properties
-                static auto const maxBlocks = device.m_properties.m_multiProcessorCount;
+               using IdxType = typename T_NumBlocks::type;
+               // @todo get this number from device properties
+               static auto const maxBlocks = device.m_properties.m_multiProcessorCount;
 
 
-                while(numThreadBlocks.product() > maxBlocks)
-                {
-                    uint32_t maxIdx = 0u;
-                    auto maxValue = numThreadBlocks[0];
-                    for(auto i = 0u; i < T_NumBlocks::dim(); ++i)
-                        if(maxValue < numThreadBlocks[i])
-                        {
-                            maxIdx = i;
-                            maxValue = numThreadBlocks[i];
-                        }
-                    if(numThreadBlocks.product() > maxBlocks)
-                        numThreadBlocks[maxIdx] = core::divCeil(numThreadBlocks[maxIdx], IdxType{2u});
+               while(numThreadBlocks.product() > maxBlocks)
+               {
+                   uint32_t maxIdx = 0u;
+                   auto maxValue = numThreadBlocks[0];
+                   for(auto i = 0u; i < T_NumBlocks::dim(); ++i)
+                       if(maxValue < numThreadBlocks[i])
+                       {
+                           maxIdx = i;
+                           maxValue = numThreadBlocks[i];
+                       }
+                   if(numThreadBlocks.product() > maxBlocks)
+                       numThreadBlocks[maxIdx] = core::divCeil(numThreadBlocks[maxIdx], IdxType{2u});
 
-                }
+               }
 #endif
                 auto const numThreads = Vec<typename T_NumThreads::type, T_NumThreads::dim()>::all(1);
                 return ThreadSpec{numThreadBlocks, numThreads};

--- a/include/alpaka/api/cuda/Api.hpp
+++ b/include/alpaka/api/cuda/Api.hpp
@@ -58,4 +58,28 @@ namespace alpaka
         {
         };
     } // namespace unifiedCudaHip::trait
+
+    namespace trait
+    {
+        template<typename T_Type>
+        struct GetArchSimdWidth::Op<T_Type, api::Cuda>
+        {
+            constexpr uint32_t operator()(api::Cuda const) const
+            {
+                /** vector load and store width in bytes */
+                constexpr std::size_t simdWidthInByte = 16u;
+                return simdWidthInByte / sizeof(T_Type);
+            }
+        };
+
+        template<>
+        struct GetCachelineSize::Op<api::Cuda>
+        {
+            constexpr uint32_t operator()(api::Cuda const) const
+            {
+                // loading 16 byte per thread will result in optimal memory bandwith
+                return 16u;
+            }
+        };
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/api/hip/Api.hpp
+++ b/include/alpaka/api/hip/Api.hpp
@@ -57,4 +57,28 @@ namespace alpaka
         {
         };
     } // namespace unifiedCudaHip::trait
+
+    namespace trait
+    {
+        template<typename T_Type>
+        struct GetArchSimdWidth::Op<T_Type, api::Hip>
+        {
+            constexpr uint32_t operator()(api::Hip const) const
+            {
+                /** vector load/store width in bytes */
+                constexpr std::size_t simdWidthInByte = 16u;
+                return simdWidthInByte / sizeof(T_Type);
+            }
+        };
+
+        template<>
+        struct GetCachelineSize::Op<api::Hip>
+        {
+            constexpr uint32_t operator()(api::Hip const) const
+            {
+                // loading 16 byte per thread will result in optimal memory bandwith
+                return 16u;
+            }
+        };
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/api/trait.hpp
+++ b/include/alpaka/api/trait.hpp
@@ -9,49 +9,100 @@
 
 #include <algorithm>
 
-namespace alpaka::trait
+namespace alpaka
 {
-    /** Map's all API's by default to stl math functions. */
-    struct GetMathImpl
+    namespace trait
     {
+        /** Map's all API's by default to stl math functions. */
+        struct GetMathImpl
+        {
+            template<typename T_Api>
+            struct Op
+            {
+                constexpr decltype(auto) operator()(T_Api const) const
+                {
+                    return alpaka::math::internal::stlMath;
+                }
+            };
+        };
+
         template<typename T_Api>
-        struct Op
+        constexpr decltype(auto) getMathImpl(T_Api const api)
         {
-            constexpr decltype(auto) operator()(T_Api const) const
+            return GetMathImpl::Op<T_Api>{}(api);
+        }
+
+        struct GetArchSimdWidth
+        {
+            template<typename T_Type, typename T_Api>
+            struct Op
             {
-                return alpaka::math::internal::stlMath;
-            }
+                consteval uint32_t operator()(T_Api const) const
+                {
+                    static_assert(sizeof(T_Api) && false, "GetArchSimdWidth for the current used API is not defined.");
+                    return 1u;
+                }
+            };
         };
-    };
 
-    template<typename T_Api>
-    constexpr decltype(auto) getMathImpl(T_Api const api)
+        struct GetCachelineSize
+        {
+            template<typename T_Api>
+            struct Op
+            {
+                consteval uint32_t operator()(T_Api const) const
+                {
+                    static_assert(sizeof(T_Api) && false, "GetCachelineSize for the current used API is not defined.");
+                    return 42u;
+                }
+            };
+        };
+    } // namespace trait
+
+    /** get SIMD with in bytes for the
+     *
+     * @tparam T_Type data type
+     * @return number of elements that can be processed in parallel in a vector register
+     */
+    template<typename T_Type>
+    consteval uint32_t getArchSimdWidth(auto const api)
     {
-        return GetMathImpl::Op<T_Api>{}(api);
+        return trait::GetArchSimdWidth::Op<T_Type, ALPAKA_TYPEOF(api)>{}(api);
     }
-} // namespace alpaka::trait
 
-namespace alpaka::onAcc::trait
-{
-    /** Defines the implementation used for atomic operations toghether with the used executor */
-    struct GetAtomicImpl
+    /** get the cacheline size in bytes
+     *
+     * Cache line size is the distance between two memory address that guarantees to be false sharing free.
+     *
+     * @return cacheline size in bytes
+     */
+    consteval uint32_t getCachelineSize(auto const api)
     {
+        return trait::GetCachelineSize::Op<ALPAKA_TYPEOF(api)>{}(api);
+    }
+
+    namespace onAcc::trait
+    {
+        /** Defines the implementation used for atomic operations toghether with the used executor */
+        struct GetAtomicImpl
+        {
+            template<typename T_Executor>
+            struct Op
+            {
+                constexpr decltype(auto) operator()(T_Executor const) const
+                {
+                    static_assert(
+                        sizeof(T_Executor) && false,
+                        "Atomic implementation for the current used executor is not defined.");
+                    return 0;
+                }
+            };
+        };
+
         template<typename T_Executor>
-        struct Op
+        constexpr decltype(auto) getAtomicImpl(T_Executor const executor)
         {
-            constexpr decltype(auto) operator()(T_Executor const) const
-            {
-                static_assert(
-                    sizeof(T_Executor) && false,
-                    "Atomic implementation for the current used executor is not defined.");
-                return 0;
-            }
-        };
-    };
-
-    template<typename T_Executor>
-    constexpr decltype(auto) getAtomicImpl(T_Executor const executor)
-    {
-        return GetAtomicImpl::Op<T_Executor>{}(executor);
-    }
-} // namespace alpaka::onAcc::trait
+            return GetAtomicImpl::Op<T_Executor>{}(executor);
+        }
+    } // namespace onAcc::trait
+} // namespace alpaka

--- a/include/alpaka/core/alignedAlloc.hpp
+++ b/include/alpaka/core/alignedAlloc.hpp
@@ -1,0 +1,32 @@
+/* Copyright 2022 René Widera, Bernhard Manfred Gruber
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/common.hpp"
+#include "alpaka/core/config.hpp"
+
+#include <cstddef>
+#include <new>
+
+namespace alpaka::core
+{
+    ALPAKA_FN_INLINE ALPAKA_FN_HOST auto alignedAlloc(size_t alignment, size_t size) -> void*
+    {
+        if(size == 0u)
+        {
+            return nullptr;
+        }
+        else
+        {
+            return ::operator new(size, std::align_val_t{alignment});
+        }
+    }
+
+    ALPAKA_FN_INLINE ALPAKA_FN_HOST void alignedFree(size_t alignment, void* ptr)
+    {
+        if(ptr != nullptr)
+            ::operator delete(ptr, std::align_val_t{alignment});
+    }
+} // namespace alpaka::core


### PR DESCRIPTION
- allocate always row-aligned host memory
- add traits `GetArchSimdWidth` and `GetCachelineSize`
- example heat equation: Use MdSpan instead of a pointer to support M-dimensional aligned memory.