### PR TITLE
benchmark: optimize bableStream

### DIFF
--- a/benchmark/babelstream/src/babelStreamCommon.hpp
+++ b/benchmark/babelstream/src/babelStreamCommon.hpp
@@ -31,8 +31,10 @@ namespace
     [[maybe_unused]] constexpr double scalarVal = 0.4;
 
     // Block thread extent for DotKernel test work division parameters.
-    [[maybe_unused]] constexpr auto blockThreadExtentMain = 1024;
-    [[maybe_unused]] constexpr auto dotGridBlockExtent = 256;
+    [[maybe_unused]] constexpr auto blockThreadExtentMain = 512;
+    // If we use to many blocks the single precision result will be wrong due to the long summation with atomics per
+    // thread block.
+    [[maybe_unused]] constexpr auto dotGridBlockExtent = 1024;
 
     // Number of runs for each kernel, can be changed by command line arguments.
     // At least 100 runs are recommended for good benchmarking.

--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -352,7 +352,7 @@ void testKernels(auto cfg)
      * a kernel can reflect the concurrency bytes used for the `SimdForEach::concurrent()` back to the host, e.g. some
      * as we use for dynamic shared memory.
      */
-    constexpr uint32_t elementsPerFrameItem = 64u;
+    constexpr uint32_t elementsPerFrameItem = 16u;
 
     auto numFrames = core::divCeil(arraySize, static_cast<Idx>(blockThreadExtentMain) * elementsPerFrameItem);
     auto dataBlocking = onHost::FrameSpec{numFrames, static_cast<Idx>(blockThreadExtentMain)};
@@ -487,8 +487,14 @@ void testKernels(auto cfg)
         }
         if(kernelsToBeExecuted == KernelsToRun::All)
         {
-            auto dataBlockingDot
-                = onHost::FrameSpec{static_cast<Idx>(dotGridBlockExtent), static_cast<Idx>(blockThreadExtentMain)};
+            constexpr uint32_t elementsPerFrameItem = 16u;
+            auto numFrames = std::max(
+                Idx{1},
+                std::min(
+                    static_cast<Idx>(dotGridBlockExtent),
+                    arraySize / (static_cast<Idx>(blockThreadExtentMain) * elementsPerFrameItem)));
+
+            auto dataBlockingDot = onHost::FrameSpec{numFrames, static_cast<Idx>(blockThreadExtentMain)};
 
             // Vector of sums of each block
             auto bufAccSumPerBlock = onHost::alloc<DataType>(devAcc, 1u);


### PR DESCRIPTION
- ensure for the dot kernel that we can use SIMD by reducing the number of used frames
- adjust `dotGridBlockExtent` to allow up to 1024 threadblocks/frames
- set default thread-block/frame extent to 512 instead of 1024.