### PR TITLE
support for different pressions kernel, makeIdxMap and memory

### DIFF
--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -844,6 +844,18 @@ namespace alpaka
             }
         };
     } // namespace internal
+
+    namespace core
+    {
+        /** @todo the function for intergral values is defined in Utils.hpp
+         * move this to a better place, e.g. math and expose this for the user too
+         */
+        template<concepts::Vector Vector>
+        [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto divCeil(Vector a, Vector b) -> Vector
+        {
+            return (a + b - Vector::all(1)) / b;
+        }
+    } // namespace core
 }; // namespace alpaka
 
 namespace std

--- a/include/alpaka/api/cpu/Device.hpp
+++ b/include/alpaka/api/cpu/Device.hpp
@@ -145,7 +145,7 @@ namespace alpaka::onHost
                 constexpr uint32_t simdPackBytes
                     = getArchSimdWidth<T_Type>(ALPAKA_TYPEOF(getApi(device)){}) * sizeof(T_Type);
                 constexpr uint32_t bestSimdPackBytes = highestPowerOfTwo(simdPackBytes);
-                constexpr uint32_t alignment = std::max(bestSimdPackBytes, typeAlignmentBytes);
+                constexpr IdxType alignment = std::max(bestSimdPackBytes, typeAlignmentBytes);
 
                 constexpr auto dim = T_Extents::dim();
                 if constexpr(dim == 1u)
@@ -164,12 +164,12 @@ namespace alpaka::onHost
                 }
                 else
                 {
-                    auto rowExtentInBytes = extents.x() * static_cast<IdxType>(sizeof(T_Type));
-                    auto rowPitchInBytes = core::divCeil(rowExtentInBytes, alignment) * alignment;
+                    IdxType rowExtentInBytes = extents.x() * static_cast<IdxType>(sizeof(T_Type));
+                    IdxType rowPitchInBytes = core::divCeil(rowExtentInBytes, alignment) * alignment;
                     auto pitches = mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
 
                     // product of pitches does contain the size for the first dimension
-                    size_t memSizeInByte = lpCast<size_t>(pitches).product() * extents[0];
+                    size_t memSizeInByte = pCast<size_t>(pitches).product() * static_cast<size_t>(extents[0]);
                     auto* ptr = reinterpret_cast<T_Type*>(alpaka::core::alignedAlloc(alignment, memSizeInByte));
                     auto deleter = [](T_Type* ptr) { alpaka::core::alignedFree(alignment, ptr); };
 
@@ -264,7 +264,7 @@ namespace alpaka::onHost
                 // universal vector type that both return produce the same result type.
                 using UniVec = typename ALPAKA_TYPEOF(dataBlocking.getThreadSpec().m_numBlocks)::UniVec;
 
-                if(dataBlocking.getThreadSpec().m_numThreads.product() > 4u)
+                if(dataBlocking.getThreadSpec().m_numThreads.product() > typename UniVec::type{4u})
                 {
                     auto const numThreads = UniVec::all(1);
                     return ThreadSpec{UniVec{dataBlocking.getThreadSpec().m_numBlocks}, numThreads};

--- a/include/alpaka/core/Utility.hpp
+++ b/include/alpaka/core/Utility.hpp
@@ -23,10 +23,10 @@ namespace alpaka::core
 #endif
 
     /// Returns the ceiling of a / b, as integer.
-    template<typename Integral>
+    template<std::integral Integral>
     [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto divCeil(Integral a, Integral b) -> Integral
     {
-        return (a + b - 1u) / b;
+        return (a + b - Integral{1}) / b;
     }
 
     /// Computes the nth power of base, in integers.

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -97,7 +97,28 @@ namespace alpaka
         T_Begin m_begin;
         T_End m_end;
         T_Stride m_stride;
+
+        using type = typename T_Begin::type;
     };
+
+    namespace internal
+    {
+        template<typename T_To, concepts::Vector T_End, concepts::Vector T_Begin, concepts::Vector T_Stride>
+        struct PCast::Op<T_To, IdxRange<T_End, T_Begin, T_Stride>>
+        {
+            constexpr decltype(auto) operator()(auto&& input) const
+                requires std::convertible_to<typename T_End::type, T_To> && (!std::same_as<T_To, typename T_End::type>)
+            {
+                return IdxRange{pCast<T_To>(input.m_begin), pCast<T_To>(input.m_end), pCast<T_To>(input.m_stride)};
+            }
+
+            constexpr decltype(auto) operator()(auto&& input) const requires std::same_as<T_To, typename T_End::type>
+            {
+                return input;
+            }
+        };
+
+    } // namespace internal
 
     template<concepts::VectorOrScalar T_Extent>
     ALPAKA_FN_HOST_ACC IdxRange(T_Extent const&) -> IdxRange<typename trait::getVec_t<T_Extent>::UniVec>;

--- a/include/alpaka/mem/Iter.hpp
+++ b/include/alpaka/mem/Iter.hpp
@@ -255,7 +255,12 @@ namespace alpaka::onAcc
              * ALPAKA_FN_HOST_ACC is required for cuda else __host__ function called from __host__ __device__
              * warning is popping up and generated code is wrong.
              */
-            template<typename T_Acc, typename T_DomainSpec, typename T_Traverse, typename T_IdxMapping>
+            template<
+                typename T_ScalarIdxType,
+                typename T_Acc,
+                typename T_DomainSpec,
+                typename T_Traverse,
+                typename T_IdxMapping>
             struct Op
             {
                 ALPAKA_FN_HOST_ACC constexpr auto operator()(
@@ -268,9 +273,14 @@ namespace alpaka::onAcc
                     auto adjIdxMapping = adjustMapping(acc, acc[object::api]);
                     auto const idxRange = domainSpec.getIdxRange(acc);
                     auto const threadSpace = domainSpec.getThreadSpace(acc);
+
+                    using IdxType = std::conditional_t<
+                        std::is_same_v<void, T_ScalarIdxType>,
+                        typename ALPAKA_TYPEOF(idxRange)::IdxType,
+                        T_ScalarIdxType>;
                     return T_Traverse::make(
-                        idxRange,
-                        threadSpace,
+                        pCast<IdxType>(idxRange),
+                        pCast<IdxType>(threadSpace),
                         adjIdxMapping,
                         iotaCVec<
                             typename ALPAKA_TYPEOF(idxRange.distance())::type,
@@ -285,9 +295,14 @@ namespace alpaka::onAcc
                 {
                     auto const idxRange = domainSpec.getIdxRange(acc);
                     auto const threadSpace = domainSpec.getThreadSpace(acc);
+
+                    using IdxType = std::conditional_t<
+                        std::is_same_v<void, T_ScalarIdxType>,
+                        typename ALPAKA_TYPEOF(idxRange)::IdxType,
+                        T_ScalarIdxType>;
                     return T_Traverse::make(
-                        idxRange,
-                        threadSpace,
+                        pCast<IdxType>(idxRange),
+                        pCast<IdxType>(threadSpace),
                         idxMapping,
                         iotaCVec<
                             typename ALPAKA_TYPEOF(idxRange.distance())::type,

--- a/include/alpaka/mem/ThreadSpace.hpp
+++ b/include/alpaka/mem/ThreadSpace.hpp
@@ -86,7 +86,29 @@ namespace alpaka
 
         T_ThreadIdx m_threadIdx;
         T_ThreadCount m_threadCount;
+
+        using type = typename T_ThreadIdx::type;
     };
+
+    namespace internal
+    {
+        template<typename T_To, typename T_ThreadIdx, typename T_ThreadCount>
+        struct PCast::Op<T_To, ThreadSpace<T_ThreadIdx, T_ThreadCount>>
+        {
+            constexpr decltype(auto) operator()(auto&& input) const
+                requires std::convertible_to<typename T_ThreadIdx::type, T_To>
+                         && (!std::same_as<T_To, typename T_ThreadIdx::type>)
+            {
+                return ThreadSpace{pCast<T_To>(input.m_threadIdx), pCast<T_To>(input.m_threadCount)};
+            }
+
+            constexpr decltype(auto) operator()(auto&& input) const
+                requires std::same_as<T_To, typename T_ThreadIdx::type>
+            {
+                return input;
+            }
+        };
+    } // namespace internal
 
     template<std::size_t I, typename T_ThreadIdx, typename T_ThreadCount>
     constexpr auto get(alpaka::ThreadSpace<T_ThreadIdx, T_ThreadCount> const& v) requires(I == 0u)

--- a/include/alpaka/onAcc.hpp
+++ b/include/alpaka/onAcc.hpp
@@ -109,11 +109,30 @@ namespace alpaka::onAcc
         T_IdxLayout idxLayout = T_IdxLayout{})
     {
         return internal::MakeIter::
-            Op<ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(DomainSpec{workGroup, range}), T_Traverse, T_IdxLayout>{}(
+            Op<void, ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(DomainSpec{workGroup, range}), T_Traverse, T_IdxLayout>{}(
                 acc,
                 DomainSpec{workGroup, range},
                 traverse,
                 idxLayout);
+    }
+
+    template<
+        typename T_ScalarIdxType,
+        concepts::IdxTraversing T_Traverse = traverse::Flat,
+        concepts::IdxMapping T_IdxLayout = layout::Optimized>
+    ALPAKA_FN_HOST_ACC constexpr auto makeIdxMap(
+        auto const& acc,
+        auto const workGroup,
+        auto const range,
+        T_Traverse traverse = T_Traverse{},
+        T_IdxLayout idxLayout = T_IdxLayout{})
+    {
+        return internal::MakeIter::Op<
+            T_ScalarIdxType,
+            ALPAKA_TYPEOF(acc),
+            ALPAKA_TYPEOF(DomainSpec{workGroup, range}),
+            T_Traverse,
+            T_IdxLayout>{}(acc, DomainSpec{workGroup, range}, traverse, idxLayout);
     }
 
     /** specialization for 1-dimensional ranges
@@ -132,11 +151,34 @@ namespace alpaka::onAcc
         T_IdxLayout idxLayout = T_IdxLayout{}) requires(ALPAKA_TYPEOF(range)::dim() == 1u)
     {
         return internal::MakeIter::
-            Op<ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(DomainSpec{workGroup, range}), T_Traverse, T_IdxLayout>{}(
+            Op<void, ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(DomainSpec{workGroup, range}), T_Traverse, T_IdxLayout>{}(
                 acc,
                 DomainSpec{workGroup, range},
                 traverse,
                 idxLayout);
+    }
+
+    /**
+     * @tparam T_ScalarIdxType The type of the indices used within the index container. If `void` the index type will
+     * be derived from the range
+     */
+    template<
+        typename T_ScalarIdxType,
+        concepts::IdxTraversing T_Traverse = traverse::Tiled,
+        concepts::IdxMapping T_IdxLayout = layout::Optimized>
+    ALPAKA_FN_HOST_ACC constexpr auto makeIdxMap(
+        auto const& acc,
+        auto const workGroup,
+        alpaka::concepts::HasStaticDim auto const range,
+        T_Traverse traverse = T_Traverse{},
+        T_IdxLayout idxLayout = T_IdxLayout{}) requires(ALPAKA_TYPEOF(range)::dim() == 1u)
+    {
+        return internal::MakeIter::Op<
+            T_ScalarIdxType,
+            ALPAKA_TYPEOF(acc),
+            ALPAKA_TYPEOF(DomainSpec{workGroup, range}),
+            T_Traverse,
+            T_IdxLayout>{}(acc, DomainSpec{workGroup, range}, traverse, idxLayout);
     }
 
     /**

--- a/tests/unit/precision/precision.cpp
+++ b/tests/unit/precision/precision.cpp
@@ -1,0 +1,186 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include "alpaka/meta/NdLoop.hpp"
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executeForEach.hpp>
+#include <alpaka/example/executors.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <functional>
+#include <iostream>
+
+/** @file Test if we can execute a kernel with different precisions for kernel start parameters, in kernel index loop
+ * and memory index types.
+ *
+ * Since vectors used in alpaka not perform implicit type conversion, except for operators where left or right hand
+ * side is a scalar and if we do not lose precision or signedness, the tests guard against mistakes within alpaka due
+ * to `auto` usage.
+ */
+
+using namespace alpaka;
+using namespace alpaka::onHost;
+
+using TestApis = std::decay_t<decltype(allExecutorsAndApis(enabledApis))>;
+
+template<typename T_LoopIdxType>
+struct IotaKernelND
+{
+    ALPAKA_FN_ACC void operator()(auto const& acc, auto out, auto outSize) const
+    {
+        using MemScalarType = typename ALPAKA_TYPEOF(out)::element_type::type;
+        for(auto i : onAcc::makeIdxMap<T_LoopIdxType>(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
+        {
+            out[i] = pCast<MemScalarType>(i);
+        }
+
+        // rerun the tests with automatic derived loop index type
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
+        {
+            out[i] = pCast<MemScalarType>(i);
+        }
+    }
+};
+
+template<typename T_MemIdxType, typename T_LoopIdxType>
+void iotaTest(auto cfg, auto const extents, auto frameSize)
+{
+    using KenelIdxScalarType = typename ALPAKA_TYPEOF(frameSize)::type;
+    auto api = cfg[object::api];
+    auto exec = cfg[object::exec];
+
+    std::cout << api.getName() << std::endl;
+
+    Platform platform = makePlatform(api);
+    Device device = platform.makeDevice(0);
+
+    std::cout << getName(platform) << " " << device.getName() << std::endl;
+
+    Queue queue = device.makeQueue();
+
+    std::cout << "exec=" << core::demangledName(exec) << std::endl;
+    auto dBuff = onHost::alloc<Vec<T_MemIdxType, ALPAKA_TYPEOF(extents)::dim()>>(device, extents);
+
+    Platform cpuPlatform = makePlatform(api::cpu);
+    Device cpuDevice = cpuPlatform.makeDevice(0);
+    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+
+    wait(queue);
+    onHost::enqueue(
+        queue,
+        exec,
+        FrameSpec{pCast<KenelIdxScalarType>(extents) / frameSize, frameSize},
+        KernelBundle{IotaKernelND<T_LoopIdxType>{}, dBuff.getMdSpan(), extents});
+    onHost::memcpy(queue, hBuff, dBuff);
+    wait(queue);
+
+
+    auto mdSpan = hBuff.getMdSpan();
+
+    meta::ndLoopIncIdx(extents, [&](auto idx) { CHECK(idx == pCast<T_MemIdxType>(mdSpan[idx])); });
+}
+
+#if 1
+
+template<bool T_signedMemIdx, bool T_signedLoopIdx, bool T_signedKernelIdx>
+void callTests(auto cfg)
+{
+    {
+        using MemIdxType = std::conditional_t<T_signedMemIdx, std::make_signed_t<uint32_t>, uint32_t>;
+        using LoopIdxType = std::conditional_t<T_signedLoopIdx, std::make_signed_t<uint32_t>, uint32_t>;
+        using KenelIdxType = std::conditional_t<T_signedKernelIdx, std::make_signed_t<uint32_t>, uint32_t>;
+
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 1u>{15u}, Vec<KenelIdxType, 1u>{7u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 2u>{8u, 16u}, Vec<KenelIdxType, 2u>{2u, 4u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 3u>{3u, 8u, 16u}, Vec<KenelIdxType, 3u>{2u, 2u, 4u});
+    }
+
+    {
+        using MemIdxType = std::conditional_t<T_signedMemIdx, std::make_signed_t<uint64_t>, uint64_t>;
+        using LoopIdxType = std::conditional_t<T_signedLoopIdx, std::make_signed_t<uint32_t>, uint32_t>;
+        using KenelIdxType = std::conditional_t<T_signedKernelIdx, std::make_signed_t<uint32_t>, uint32_t>;
+
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 1u>{15u}, Vec<KenelIdxType, 1u>{7u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 2u>{8u, 16u}, Vec<KenelIdxType, 2u>{2u, 4u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 3u>{3u, 8u, 16u}, Vec<KenelIdxType, 3u>{2u, 2u, 4u});
+    }
+
+    {
+        using MemIdxType = std::conditional_t<T_signedMemIdx, std::make_signed_t<uint32_t>, uint32_t>;
+        using LoopIdxType = std::conditional_t<T_signedLoopIdx, std::make_signed_t<uint64_t>, uint64_t>;
+        using KenelIdxType = std::conditional_t<T_signedKernelIdx, std::make_signed_t<uint32_t>, uint32_t>;
+
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 1u>{15u}, Vec<KenelIdxType, 1u>{7u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 2u>{8u, 16u}, Vec<KenelIdxType, 2u>{2u, 4u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 3u>{3u, 8u, 16u}, Vec<KenelIdxType, 3u>{2u, 2u, 4u});
+    }
+
+    {
+        using MemIdxType = std::conditional_t<T_signedMemIdx, std::make_signed_t<uint64_t>, uint64_t>;
+        using LoopIdxType = std::conditional_t<T_signedLoopIdx, std::make_signed_t<uint64_t>, uint64_t>;
+        using KenelIdxType = std::conditional_t<T_signedKernelIdx, std::make_signed_t<uint32_t>, uint32_t>;
+
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 1u>{15u}, Vec<KenelIdxType, 1u>{7u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 2u>{8u, 16u}, Vec<KenelIdxType, 2u>{2u, 4u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 3u>{3u, 8u, 16u}, Vec<KenelIdxType, 3u>{2u, 2u, 4u});
+    }
+    // half of the combinations
+    {
+        using MemIdxType = std::conditional_t<T_signedMemIdx, std::make_signed_t<uint32_t>, uint32_t>;
+        using LoopIdxType = std::conditional_t<T_signedLoopIdx, std::make_signed_t<uint32_t>, uint32_t>;
+        using KenelIdxType = std::conditional_t<T_signedKernelIdx, std::make_signed_t<uint64_t>, uint64_t>;
+
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 1u>{15u}, Vec<KenelIdxType, 1u>{7u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 2u>{8u, 16u}, Vec<KenelIdxType, 2u>{2u, 4u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 3u>{3u, 8u, 16u}, Vec<KenelIdxType, 3u>{2u, 2u, 4u});
+    }
+
+    {
+        using MemIdxType = std::conditional_t<T_signedMemIdx, std::make_signed_t<uint64_t>, uint64_t>;
+        using LoopIdxType = std::conditional_t<T_signedLoopIdx, std::make_signed_t<uint32_t>, uint32_t>;
+        using KenelIdxType = std::conditional_t<T_signedKernelIdx, std::make_signed_t<uint64_t>, uint64_t>;
+
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 1u>{15u}, Vec<KenelIdxType, 1u>{7u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 2u>{8u, 16u}, Vec<KenelIdxType, 2u>{2u, 4u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 3u>{3u, 8u, 16u}, Vec<KenelIdxType, 3u>{2u, 2u, 4u});
+    }
+
+    {
+        using MemIdxType = std::conditional_t<T_signedMemIdx, std::make_signed_t<uint32_t>, uint32_t>;
+        using LoopIdxType = std::conditional_t<T_signedLoopIdx, std::make_signed_t<uint64_t>, uint64_t>;
+        using KenelIdxType = std::conditional_t<T_signedKernelIdx, std::make_signed_t<uint64_t>, uint64_t>;
+
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 1u>{15u}, Vec<KenelIdxType, 1u>{7u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 2u>{8u, 16u}, Vec<KenelIdxType, 2u>{2u, 4u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 3u>{3u, 8u, 16u}, Vec<KenelIdxType, 3u>{2u, 2u, 4u});
+    }
+
+    {
+        using MemIdxType = std::conditional_t<T_signedMemIdx, std::make_signed_t<uint64_t>, uint64_t>;
+        using LoopIdxType = std::conditional_t<T_signedLoopIdx, std::make_signed_t<uint64_t>, uint64_t>;
+        using KenelIdxType = std::conditional_t<T_signedKernelIdx, std::make_signed_t<uint64_t>, uint64_t>;
+
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 1u>{15u}, Vec<KenelIdxType, 1u>{7u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 2u>{8u, 16u}, Vec<KenelIdxType, 2u>{2u, 4u});
+        iotaTest<MemIdxType, LoopIdxType>(cfg, Vec<MemIdxType, 3u>{3u, 8u, 16u}, Vec<KenelIdxType, 3u>{2u, 2u, 4u});
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("kernel_precision_iotaNd", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    // test signed-ness
+    callTests<false, false, false>(cfg);
+    callTests<true, false, false>(cfg);
+    callTests<false, true, false>(cfg);
+    callTests<true, true, false>(cfg);
+    callTests<false, false, true>(cfg);
+    callTests<true, false, true>(cfg);
+    callTests<false, true, true>(cfg);
+    callTests<true, true, true>(cfg);
+}
+#endif


### PR DESCRIPTION
- support precision selection for makeIdxMap()
- add unit test to check if the precision for kernel, makeIdxMap and
  memory can be different
- fix parts which broke usage of different presisions and signedness