### PR TITLE
refactor data handling

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -123,7 +123,7 @@ struct MultKernel
     template<typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc, auto b, auto const c, auto arraySize) const
     {
-        using T = typename ALPAKA_TYPEOF(b)::element_type;
+        using T = trait::GetValueType_t<ALPAKA_TYPEOF(b)>;
         T const scalar = static_cast<T>(scalarVal);
 
         auto simdGrid = onAcc::SimdForEach{onAcc::worker::threadsInGrid};
@@ -174,7 +174,7 @@ struct TriadKernel
     template<typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc, auto a, auto const b, auto const c, auto arraySize) const
     {
-        using T = typename ALPAKA_TYPEOF(a)::element_type;
+        using T = trait::GetValueType_t<ALPAKA_TYPEOF(a)>;
         T const scalar = static_cast<T>(scalarVal);
 
         auto simdGrid = onAcc::SimdForEach{onAcc::worker::threadsInGrid};
@@ -215,7 +215,7 @@ struct DotKernel
     template<typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const a, auto const b, auto sum, auto arraySize) const
     {
-        using T = typename ALPAKA_TYPEOF(sum)::element_type;
+        using T = trait::GetValueType_t<ALPAKA_TYPEOF(sum)>;
         auto tbSum = onAcc::declareSharedMdArray<T, uniqueId()>(acc, CVec<uint32_t, blockThreadExtentMain>{});
 #if 1
         auto numFrames = acc[frame::count];

--- a/example/tutorial/src/04_views.cpp
+++ b/example/tutorial/src/04_views.cpp
@@ -33,13 +33,13 @@ int example(auto const deviceApi)
 
     // allocate a buffer of floats in host memory
     uint32_t size = 42;
-    auto host_buffer = alpaka::onHost::alloc<float>(host, size);
-    std::cout << "host memory buffer at " << std::data(host_buffer) << "\n\n";
+    std::vector<float> host_data(size);
+    std::cout << "host vector at " << std::data(host_data) << "\n\n";
 
     // fill the host buffers with values
     for(uint32_t i = 0; i < size; ++i)
     {
-        host_buffer[i] = i;
+        host_data[i] = i;
     }
 
     // use the first device
@@ -61,7 +61,7 @@ int example(auto const deviceApi)
         auto view = alpaka::onHost::View(device_buffer);
 
         // copy the contents of the device buffer to the host buffer
-        alpaka::onHost::memcpy(queue, host_buffer, view);
+        alpaka::onHost::memcpy(queue, host_data, view);
 
         // the device buffer goes out of scope, but the memory is freed only
         // once all enqueued operations have completed
@@ -73,7 +73,7 @@ int example(auto const deviceApi)
     // read the content of the host buffer
     for(uint32_t i = 0; i < size; ++i)
     {
-        std::cout << host_buffer[i] << ' ';
+        std::cout << host_data[i] << ' ';
     }
     std::cout << '\n';
 

--- a/include/alpaka/SimdPtr.hpp
+++ b/include/alpaka/SimdPtr.hpp
@@ -33,7 +33,7 @@ namespace alpaka
         alpaka::concepts::CVector T_SimdWidth>
     struct SimdPtr : private T_MdSpan
     {
-        using element_type = typename T_MdSpan::element_type;
+        using value_type = typename T_MdSpan::value_type;
         using IdxType = typename T_IdxType::UniVec;
 
         static consteval uint32_t width()
@@ -56,7 +56,7 @@ namespace alpaka
          */
         constexpr auto operator[](alpaka::concepts::Vector auto const& idx) const
         {
-            constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(element_type));
+            constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(value_type));
             constexpr auto align = Alignment<valueAlignment>{};
             return SimdPtr<T_MdSpan, T_IdxType, ALPAKA_TYPEOF(align), T_SimdWidth>{
                 static_cast<T_MdSpan>(*this),
@@ -67,7 +67,7 @@ namespace alpaka
 
         constexpr auto operator[](alpaka::concepts::Vector auto const& idx)
         {
-            constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(element_type));
+            constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(value_type));
             constexpr auto align = Alignment<valueAlignment>{};
             return SimdPtr<T_MdSpan, T_IdxType, ALPAKA_TYPEOF(align), T_SimdWidth>{
                 static_cast<T_MdSpan>(*this),
@@ -97,7 +97,7 @@ namespace alpaka
          */
         static consteval auto getAlignment()
         {
-            using SpanElemType = typename T_MdSpan::element_type;
+            using SpanElemType = typename T_MdSpan::value_type;
             constexpr uint32_t spanAlignment = T_MdSpan::getAlignment().template get<SpanElemType>();
             using MemoryAlignment = std::conditional_t<
                 std::is_same_v<AutoAligned, T_MemAlignment>,
@@ -113,7 +113,7 @@ namespace alpaka
          * @{
          */
         template<typename T_Storage>
-        constexpr void storeTo(Simd<element_type, SimdPtr::width(), T_Storage> const& rhs)
+        constexpr void storeTo(Simd<value_type, SimdPtr::width(), T_Storage> const& rhs)
         {
             auto* ptr = &T_MdSpan::operator[](m_idx);
 
@@ -121,7 +121,7 @@ namespace alpaka
         }
 
         template<typename T_Storage>
-        constexpr SimdPtr& operator=(Simd<element_type, SimdPtr::width(), T_Storage> const& rhs)
+        constexpr SimdPtr& operator=(Simd<value_type, SimdPtr::width(), T_Storage> const& rhs)
         {
             storeTo(rhs);
             return *this;

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -31,4 +31,5 @@
 #include "alpaka/onHost/Platform.hpp"
 #include "alpaka/onHost/Queue.hpp"
 #include "alpaka/onHost/mem/View.hpp"
+#include "alpaka/onHost/mem/stdContainer.hpp"
 #include "alpaka/tag.hpp"

--- a/include/alpaka/api/cpu/Queue.hpp
+++ b/include/alpaka/api/cpu/Queue.hpp
@@ -138,38 +138,40 @@ namespace alpaka::onHost
         template<typename T_Device, typename T_Dest, typename T_Source, typename T_Extents>
         struct Memcpy::Op<cpu::Queue<T_Device>, T_Dest, T_Source, T_Extents>
         {
-            void operator()(cpu::Queue<T_Device>& queue, T_Dest dest, T_Source const source, T_Extents const& extents)
-                const
+            void operator()(
+                cpu::Queue<T_Device>& queue,
+                T_Dest& dest,
+                T_Source const& source,
+                T_Extents const& extents) const
             {
                 static_assert(std::is_same_v<ALPAKA_TYPEOF(dest), ALPAKA_TYPEOF(source)>);
                 constexpr auto dim = dest.dim();
+
+                /* Get all required properties outside the lambda function to not extend the life-time of the data.
+                 * The life-time is not extended to have some life-time behaviours with all backends.
+                 */
+                auto* destPtr = alpaka::onHost::data(dest);
+                auto const* srcPtr = alpaka::onHost::data(source);
+
                 if constexpr(dim == 1u)
                 {
                     internal::enqueue(
                         queue,
-                        [extents, l_dest = std::move(dest), l_source = std::move(source)]()
-                        {
-                            std::memcpy(
-                                alpaka::onHost::data(l_dest),
-                                alpaka::onHost::data(l_source),
-                                extents.x() * sizeof(typename T_Dest::type));
-                        });
+                        [extents, destPtr, srcPtr]()
+                        { std::memcpy(destPtr, srcPtr, extents.x() * sizeof(typename T_Dest::type)); });
                 }
-
                 else
                 {
+                    // memcpy is implemented as row wise copy therefore the last dimension is not required
+                    auto destPitchBytesWithoutColumn = dest.getPitches().eraseBack();
+                    auto sourcePitchBytesWithoutColumn = source.getPitches().eraseBack();
                     internal::enqueue(
                         queue,
-                        [extents, l_dest = std::move(dest), l_source = std::move(source)]()
+                        [extents, destPtr, srcPtr, destPitchBytesWithoutColumn, sourcePitchBytesWithoutColumn]()
                         {
                             auto const dstExtentWithoutColumn = extents.eraseBack();
                             if(static_cast<std::size_t>(extents.product()) != 0u)
                             {
-                                auto const destPitchBytesWithoutColumn = l_dest.getPitches().eraseBack();
-                                auto* destPtr = data(l_dest);
-                                auto const sourcePitchBytesWithoutColumn = l_source.getPitches().eraseBack();
-                                auto* sourcePtr = data(l_source);
-
                                 meta::ndLoopIncIdx(
                                     dstExtentWithoutColumn,
                                     [&](auto const& idx)
@@ -177,7 +179,7 @@ namespace alpaka::onHost
                                         std::memcpy(
                                             reinterpret_cast<std::uint8_t*>(destPtr)
                                                 + (idx * destPitchBytesWithoutColumn).sum(),
-                                            reinterpret_cast<std::uint8_t*>(sourcePtr)
+                                            reinterpret_cast<std::uint8_t const*>(srcPtr)
                                                 + (idx * sourcePitchBytesWithoutColumn).sum(),
                                             static_cast<size_t>(extents.back()) * sizeof(typename T_Dest::type));
                                     });
@@ -190,34 +192,31 @@ namespace alpaka::onHost
         template<typename T_Device, typename T_Dest, typename T_Extents>
         struct Memset::Op<cpu::Queue<T_Device>, T_Dest, T_Extents>
         {
-            void operator()(cpu::Queue<T_Device>& queue, T_Dest dest, uint8_t byteValue, T_Extents const& extents)
+            void operator()(cpu::Queue<T_Device>& queue, T_Dest& dest, uint8_t byteValue, T_Extents const& extents)
                 const
             {
                 constexpr auto dim = dest.dim();
+
+                auto* destPtr = alpaka::onHost::data(dest);
+
                 if constexpr(dim == 1u)
                 {
                     internal::enqueue(
                         queue,
-                        [extents, l_dest = std::move(dest), byteValue]() {
-                            std::memset(
-                                alpaka::onHost::data(l_dest),
-                                byteValue,
-                                extents.x() * sizeof(typename T_Dest::type));
-                        });
+                        [extents, destPtr, byteValue]()
+                        { std::memset(destPtr, byteValue, extents.x() * sizeof(typename T_Dest::type)); });
                 }
-
                 else
                 {
+                    // memset is implemented as row wise memset therefore the last dimension is not required
+                    auto destPitchBytesWithoutColumn = dest.getPitches().eraseBack();
                     internal::enqueue(
                         queue,
-                        [extents, l_dest = std::move(dest), byteValue]()
+                        [extents, destPtr, destPitchBytesWithoutColumn, byteValue]()
                         {
                             auto const dstExtentWithoutColumn = extents.eraseBack();
                             if(static_cast<std::size_t>(extents.product()) != 0u)
                             {
-                                auto const destPitchBytesWithoutColumn = l_dest.getPitches().eraseBack();
-                                auto* destPtr = data(l_dest);
-
                                 meta::ndLoopIncIdx(
                                     dstExtentWithoutColumn,
                                     [&](auto const& idx)

--- a/include/alpaka/api/cpu/Queue.hpp
+++ b/include/alpaka/api/cpu/Queue.hpp
@@ -144,8 +144,7 @@ namespace alpaka::onHost
                 T_Source const& source,
                 T_Extents const& extents) const
             {
-                static_assert(std::is_same_v<ALPAKA_TYPEOF(dest), ALPAKA_TYPEOF(source)>);
-                constexpr auto dim = dest.dim();
+                constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
 
                 /* Get all required properties outside the lambda function to not extend the life-time of the data.
                  * The life-time is not extended to have some life-time behaviours with all backends.
@@ -157,8 +156,9 @@ namespace alpaka::onHost
                 {
                     internal::enqueue(
                         queue,
-                        [extents, destPtr, srcPtr]()
-                        { std::memcpy(destPtr, srcPtr, extents.x() * sizeof(typename T_Dest::type)); });
+                        [extents, destPtr, srcPtr]() {
+                            std::memcpy(destPtr, srcPtr, extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
+                        });
                 }
                 else
                 {
@@ -181,7 +181,8 @@ namespace alpaka::onHost
                                                 + (idx * destPitchBytesWithoutColumn).sum(),
                                             reinterpret_cast<std::uint8_t const*>(srcPtr)
                                                 + (idx * sourcePitchBytesWithoutColumn).sum(),
-                                            static_cast<size_t>(extents.back()) * sizeof(typename T_Dest::type));
+                                            static_cast<size_t>(extents.back())
+                                                * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
                                     });
                             }
                         });
@@ -195,7 +196,7 @@ namespace alpaka::onHost
             void operator()(cpu::Queue<T_Device>& queue, T_Dest& dest, uint8_t byteValue, T_Extents const& extents)
                 const
             {
-                constexpr auto dim = dest.dim();
+                constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
 
                 auto* destPtr = alpaka::onHost::data(dest);
 
@@ -203,8 +204,12 @@ namespace alpaka::onHost
                 {
                     internal::enqueue(
                         queue,
-                        [extents, destPtr, byteValue]()
-                        { std::memset(destPtr, byteValue, extents.x() * sizeof(typename T_Dest::type)); });
+                        [extents, destPtr, byteValue]() {
+                            std::memset(
+                                destPtr,
+                                byteValue,
+                                extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
+                        });
                 }
                 else
                 {
@@ -225,7 +230,8 @@ namespace alpaka::onHost
                                             reinterpret_cast<std::uint8_t*>(destPtr)
                                                 + (idx * destPitchBytesWithoutColumn).sum(),
                                             byteValue,
-                                            static_cast<size_t>(extents.back()) * sizeof(typename T_Dest::type));
+                                            static_cast<size_t>(extents.back())
+                                                * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
                                     });
                             }
                         });

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -292,7 +292,7 @@ namespace alpaka::onHost
                     ALPAKA_TYPEOF(alpaka::internal::getApi(dest)),
                     ALPAKA_TYPEOF(alpaka::internal::getApi(source))>::kind;
 
-                constexpr auto dim = T_Extents::dim();
+                constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
                 if constexpr(dim == 1u)
                 {
                     // Initiate the memory copy.
@@ -301,7 +301,7 @@ namespace alpaka::onHost
                         ApiInterface::memcpyAsync(
                             destPtr,
                             srcPtr,
-                            extents.x() * sizeof(typename T_Dest::type),
+                            extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
                             copyKind,
                             internal::getNativeHandle(queue)));
                 }
@@ -314,7 +314,7 @@ namespace alpaka::onHost
                             dest.getPitches().y(),
                             srcPtr,
                             source.getPitches().y(),
-                            extents.x() * sizeof(typename T_Dest::type),
+                            extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
                             extents.y(),
                             copyKind,
                             internal::getNativeHandle(queue)));
@@ -335,7 +335,7 @@ namespace alpaka::onHost
                         dest.getExtents().x(),
                         dest.getExtents().y());
                     memCpy3DParms.extent = ApiInterface::makeExtent(
-                        extents.x() * sizeof(typename T_Dest::type),
+                        extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
                         extents.y(),
                         extents.z());
                     memCpy3DParms.kind = copyKind;
@@ -364,7 +364,7 @@ namespace alpaka::onHost
 
                 auto* destPtr = (void*) onHost::data(dest);
 
-                constexpr auto dim = T_Extents::dim();
+                constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
                 if constexpr(dim == 1u)
                 {
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
@@ -372,7 +372,7 @@ namespace alpaka::onHost
                         ApiInterface::memsetAsync(
                             destPtr,
                             static_cast<int>(byteValue),
-                            extents.x() * sizeof(typename T_Dest::type),
+                            extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
                             internal::getNativeHandle(queue)));
                 }
                 else if constexpr(dim == 2u)
@@ -383,7 +383,7 @@ namespace alpaka::onHost
                             destPtr,
                             dest.getPitches().y(),
                             static_cast<int>(byteValue),
-                            extents.x() * sizeof(typename T_Dest::type),
+                            extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
                             extents.y(),
                             internal::getNativeHandle(queue)));
                 }
@@ -396,7 +396,7 @@ namespace alpaka::onHost
                         dest.getExtents().y());
 
                     typename ApiInterface::Extent_t const extentVal = ApiInterface::makeExtent(
-                        extents.x() * sizeof(typename T_Dest::type),
+                        extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
                         extents.y(),
                         extents.z());
 

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -274,8 +274,8 @@ namespace alpaka::onHost
         {
             void operator()(
                 unifiedCudaHip::Queue<T_Device>& queue,
-                T_Dest dest,
-                T_Source const source,
+                T_Dest& dest,
+                T_Source const& source,
                 T_Extents const& extents) const
             {
                 using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
@@ -352,7 +352,7 @@ namespace alpaka::onHost
         {
             void operator()(
                 unifiedCudaHip::Queue<T_Device>& queue,
-                T_Dest dest,
+                T_Dest& dest,
                 uint8_t byteValue,
                 T_Extents const& extents) const
             {

--- a/include/alpaka/mem/DataPitches.hpp
+++ b/include/alpaka/mem/DataPitches.hpp
@@ -1,0 +1,80 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/CVec.hpp"
+#include "alpaka/Vec.hpp"
+#include "alpaka/core/config.hpp"
+#include "alpaka/mem/Alignment.hpp"
+
+#include <type_traits>
+
+namespace alpaka
+{
+
+    template<typename T_Type, concepts::Vector T_Pitches>
+    struct DataPitches
+    {
+        using element_type = T_Type;
+        using index_type = typename T_Pitches::type;
+
+        static consteval uint32_t dim()
+        {
+            return T_Pitches::dim();
+        }
+
+        constexpr DataPitches(T_Pitches const& pitchBytes) : m_pitch(pitchBytes.eraseBack())
+        {
+            assert(pitchBytes.back() == sizeof(element_type));
+        }
+
+        /*Object must init by copy a valid instance*/
+        constexpr DataPitches() = default;
+
+        constexpr auto getPitches() const
+        {
+            Vec<index_type, dim()> result;
+            for(uint32_t d = 0u; d < dim() - 1u; ++d)
+            {
+                result[d] = m_pitch[d];
+            }
+            result.back() = static_cast<index_type>(sizeof(element_type));
+            return m_pitch;
+        }
+
+        constexpr index_type operator[](std::integral auto idx) const
+        {
+            return getPitches()[idx];
+        }
+
+    private:
+        decltype(std::declval<T_Pitches>().eraseBack()) m_pitch;
+    };
+
+    template<typename T_Type, typename T_IndexType>
+    struct DataPitches<T_Type, Vec<T_IndexType, 1u>>
+    {
+        using element_type = T_Type;
+        using index_type = T_IndexType;
+
+        static consteval uint32_t dim()
+        {
+            return 1u;
+        }
+
+        constexpr DataPitches([[maybe_unused]] Vec<T_IndexType, 1u> const& pitchBytes)
+        {
+            assert(pitchBytes.back() == sizeof(element_type));
+        }
+
+        /*Object must init by copy a valid instance*/
+        constexpr DataPitches() = default;
+
+        constexpr auto getPitches() const
+        {
+            return Vec{static_cast<index_type>(sizeof(element_type))};
+        }
+    };
+} // namespace alpaka

--- a/include/alpaka/mem/DataPitches.hpp
+++ b/include/alpaka/mem/DataPitches.hpp
@@ -17,7 +17,7 @@ namespace alpaka
     template<typename T_Type, concepts::Vector T_Pitches>
     struct DataPitches
     {
-        using element_type = T_Type;
+        using value_type = T_Type;
         using index_type = typename T_Pitches::type;
 
         static consteval uint32_t dim()
@@ -27,7 +27,7 @@ namespace alpaka
 
         constexpr DataPitches(T_Pitches const& pitchBytes) : m_pitch(pitchBytes.eraseBack())
         {
-            assert(pitchBytes.back() == sizeof(element_type));
+            assert(pitchBytes.back() == sizeof(value_type));
         }
 
         /*Object must init by copy a valid instance*/
@@ -40,7 +40,7 @@ namespace alpaka
             {
                 result[d] = m_pitch[d];
             }
-            result.back() = static_cast<index_type>(sizeof(element_type));
+            result.back() = static_cast<index_type>(sizeof(value_type));
             return m_pitch;
         }
 
@@ -56,7 +56,7 @@ namespace alpaka
     template<typename T_Type, typename T_IndexType>
     struct DataPitches<T_Type, Vec<T_IndexType, 1u>>
     {
-        using element_type = T_Type;
+        using value_type = T_Type;
         using index_type = T_IndexType;
 
         static consteval uint32_t dim()
@@ -66,7 +66,7 @@ namespace alpaka
 
         constexpr DataPitches([[maybe_unused]] Vec<T_IndexType, 1u> const& pitchBytes)
         {
-            assert(pitchBytes.back() == sizeof(element_type));
+            assert(pitchBytes.back() == sizeof(value_type));
         }
 
         /*Object must init by copy a valid instance*/
@@ -74,7 +74,7 @@ namespace alpaka
 
         constexpr auto getPitches() const
         {
-            return Vec{static_cast<index_type>(sizeof(element_type))};
+            return Vec{static_cast<index_type>(sizeof(value_type))};
         }
     };
 } // namespace alpaka

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -8,6 +8,7 @@
 #include "alpaka/Vec.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/mem/Alignment.hpp"
+#include "alpaka/mem/DataPitches.hpp"
 
 #include <type_traits>
 
@@ -25,16 +26,6 @@ namespace alpaka
         concepts::Vector auto const& extents,
         concepts::Vector auto const& pitchBytes,
         concepts::Alignment auto const& memAlignment = Alignment{})
-    {
-        return MdSpan{pointer, extents, pitchBytes.eraseBack(), memAlignment};
-    }
-
-    inline constexpr auto makeMdSpan(
-        auto* pointer,
-        concepts::Vector auto const& extents,
-        concepts::Vector auto const& pitchBytes,
-        concepts::Alignment auto const& memAlignment = Alignment{})
-        requires(ALPAKA_TYPEOF(pitchBytes)::dim() == 1u && ALPAKA_TYPEOF(extents)::dim() == 1u)
     {
         return MdSpan{pointer, extents, pitchBytes, memAlignment};
     }
@@ -97,7 +88,6 @@ namespace alpaka
             T_Extents extents,
             T_Pitches const& pitchBytes,
             [[maybe_unused]] T_MemAlignment const& memAlignmentInByte = T_MemAlignment{})
-            requires(ALPAKA_TYPEOF(pitchBytes)::dim() + 1u == T_Extents::dim())
             : m_ptr(pointer)
             , m_extent(extents)
             , m_pitch(pitchBytes)
@@ -130,6 +120,16 @@ namespace alpaka
 
         /** }@ */
 
+        constexpr element_type operator[](std::integral auto const& idx) const requires(dim() == 1u)
+        {
+            return *ptr(Vec{idx});
+        }
+
+        constexpr reference operator[](std::integral auto const& idx) requires(dim() == 1u)
+        {
+            return *ptr(Vec{idx});
+        }
+
         constexpr auto getExtents() const
         {
             return m_extent;
@@ -141,7 +141,7 @@ namespace alpaka
          * @param idx n-dimensional offset
          * @return pointer to value
          */
-        constexpr element_type const* ptr(concepts::Vector auto const& idx) const
+        constexpr element_type const* ptr(concepts::Vector auto const& idx) const requires(dim() >= 2u)
         {
             /** offset in bytes
              *
@@ -156,7 +156,7 @@ namespace alpaka
             return reinterpret_cast<element_type const*>(reinterpret_cast<char const*>(this->m_ptr) + offset);
         }
 
-        constexpr element_type* ptr(concepts::Vector auto const& idx)
+        constexpr element_type* ptr(concepts::Vector auto const& idx) requires(dim() >= 2u)
         {
             /** offset in bytes
              *
@@ -171,139 +171,19 @@ namespace alpaka
             return reinterpret_cast<element_type*>(reinterpret_cast<char*>(this->m_ptr) + offset);
         }
 
+        constexpr element_type* ptr(concepts::Vector auto const& idx) const requires(dim() == 1u)
+        {
+            return this->m_ptr + idx.x();
+        }
+
+        constexpr element_type* ptr(concepts::Vector auto const& idx) requires(dim() == 1u)
+        {
+            return this->m_ptr + idx.x();
+        }
+
         element_type* m_ptr;
         T_Extents m_extent;
-        T_Pitches m_pitch;
-    };
-
-    template<
-        typename T_Type,
-        concepts::Vector T_Extents,
-        concepts::Vector T_Pitches,
-        concepts::Alignment T_MemAlignment>
-    ALPAKA_FN_HOST_ACC MdSpan(
-        T_Type* pointer,
-        T_Extents const&,
-        T_Pitches const&,
-        [[maybe_unused]] T_MemAlignment const&) -> MdSpan<T_Type, T_Extents, T_Pitches, T_MemAlignment>;
-
-    template<
-        typename T_Type,
-        concepts::Vector T_Extents,
-        concepts::Vector T_Pitches,
-        concepts::Alignment T_MemAlignment>
-    requires(T_Pitches::dim() == 1u && T_Extents::dim() == 1u)
-    struct MdSpan<T_Type, T_Extents, T_Pitches, T_MemAlignment>
-    {
-        using element_type = T_Type;
-        using reference = element_type&;
-        using index_type = typename T_Pitches::type;
-
-        static_assert(std::is_convertible_v<index_type, typename T_Extents::type>);
-
-        static consteval uint32_t dim()
-        {
-            return 1u;
-        }
-
-        /** return value the origin pointer is pointing to
-         *
-         * @return value at the current location
-         */
-        constexpr reference operator*()
-        {
-            return *this->m_ptr;
-        }
-
-        /** get origin pointer
-         *
-         * @{
-         */
-        constexpr element_type const* data() const
-        {
-            return this->m_ptr;
-        }
-
-        constexpr element_type* data()
-        {
-            return this->m_ptr;
-        }
-
-        /** @} */
-
-        /*Object must init by copy a valid instance*/
-        constexpr MdSpan() = default;
-
-        /** Constructor
-         *
-         * @param pointer pointer to the memory
-         * @param extents number of elements
-         * @param pitchBytes pitch in bytes per dimension
-         * @param memAlignmentInByte alignment in bytes (zero will set alignment to element alignment)
-         */
-        constexpr MdSpan(
-            T_Type* pointer,
-            T_Extents const& extents,
-            [[maybe_unused]] T_Pitches const& pitchBytes,
-            [[maybe_unused]] T_MemAlignment const& memAlignmentInByte = T_MemAlignment{})
-            : m_ptr(pointer)
-            , m_extent(extents)
-        {
-        }
-
-        constexpr MdSpan(element_type* pointer) : m_ptr(pointer)
-        {
-        }
-
-        static consteval auto getAlignment()
-        {
-            return T_MemAlignment{};
-        }
-
-        constexpr MdSpan(MdSpan const&) = default;
-        constexpr MdSpan(MdSpan&&) = default;
-
-        /** get value at the given index
-         *
-         * @param idx offset relative to the origin pointer
-         * @return reference to the value
-         * @{
-         */
-        constexpr element_type const& operator[](concepts::Vector auto const& idx) const
-        {
-            return *(m_ptr + idx.x());
-        }
-
-        constexpr reference operator[](concepts::Vector auto const& idx)
-        {
-            return *(m_ptr + idx.x());
-        }
-
-        constexpr element_type const& operator[](std::integral auto const& idx) const
-        {
-            return *(m_ptr + idx);
-        }
-
-        constexpr reference operator[](std::integral auto const& idx)
-        {
-            return *(m_ptr + idx);
-        }
-
-        constexpr bool operator==(MdSpan const other) const
-        {
-            return m_ptr == other.m_ptr && m_extent == other.m_extent;
-        }
-
-        /** @} */
-
-        constexpr auto getExtents() const
-        {
-            return m_extent;
-        }
-
-    protected:
-        element_type* m_ptr;
-        T_Extents m_extent;
+        DataPitches<element_type, T_Pitches> m_pitch;
     };
 
     /** access a C array with compile time extents via a runtime md index. */

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -37,8 +37,8 @@ namespace alpaka
         concepts::Alignment T_MemAlignment>
     struct MdSpan
     {
-        using element_type = T_Type;
-        using reference = element_type&;
+        using value_type = T_Type;
+        using reference = value_type&;
         using index_type = typename T_Pitches::type;
 
         static_assert(std::is_convertible_v<index_type, typename T_Extents::type>);
@@ -61,12 +61,12 @@ namespace alpaka
          *
          * @{
          */
-        constexpr element_type const* data() const
+        constexpr value_type const* data() const
         {
             return this->m_ptr;
         }
 
-        constexpr element_type* data()
+        constexpr value_type* data()
         {
             return this->m_ptr;
         }
@@ -108,19 +108,19 @@ namespace alpaka
          * @return reference to the value
          * @{
          */
-        constexpr element_type const& operator[](concepts::Vector auto const& idx) const
+        constexpr value_type const& operator[](concepts::Vector auto const& idx) const
         {
             return *ptr(idx);
         }
 
         constexpr reference operator[](concepts::Vector auto const& idx)
         {
-            return *const_cast<element_type*>(ptr(idx));
+            return *const_cast<value_type*>(ptr(idx));
         }
 
         /** }@ */
 
-        constexpr element_type operator[](std::integral auto const& idx) const requires(dim() == 1u)
+        constexpr value_type operator[](std::integral auto const& idx) const requires(dim() == 1u)
         {
             return *ptr(Vec{idx});
         }
@@ -141,49 +141,49 @@ namespace alpaka
          * @param idx n-dimensional offset
          * @return pointer to value
          */
-        constexpr element_type const* ptr(concepts::Vector auto const& idx) const requires(dim() >= 2u)
+        constexpr value_type const* ptr(concepts::Vector auto const& idx) const requires(dim() >= 2u)
         {
             /** offset in bytes
              *
              * We calculate the complete offset in bytes even if it would be possible to change the x-dimension
-             * with the native element_types pointer, this is reducing the register footprint.
+             * with the native value_types pointer, this is reducing the register footprint.
              */
-            index_type offset = sizeof(element_type) * idx.back();
+            index_type offset = sizeof(value_type) * idx.back();
             for(uint32_t d = 0u; d < dim() - 1u; ++d)
             {
                 offset += m_pitch[d] * idx[d];
             }
-            return reinterpret_cast<element_type const*>(reinterpret_cast<char const*>(this->m_ptr) + offset);
+            return reinterpret_cast<value_type const*>(reinterpret_cast<char const*>(this->m_ptr) + offset);
         }
 
-        constexpr element_type* ptr(concepts::Vector auto const& idx) requires(dim() >= 2u)
+        constexpr value_type* ptr(concepts::Vector auto const& idx) requires(dim() >= 2u)
         {
             /** offset in bytes
              *
              * We calculate the complete offset in bytes even if it would be possible to change the x-dimension
-             * with the native element_types pointer, this is reducing the register footprint.
+             * with the native value_types pointer, this is reducing the register footprint.
              */
-            index_type offset = sizeof(element_type) * idx.back();
+            index_type offset = sizeof(value_type) * idx.back();
             for(uint32_t d = 0u; d < dim() - 1u; ++d)
             {
                 offset += m_pitch[d] * idx[d];
             }
-            return reinterpret_cast<element_type*>(reinterpret_cast<char*>(this->m_ptr) + offset);
+            return reinterpret_cast<value_type*>(reinterpret_cast<char*>(this->m_ptr) + offset);
         }
 
-        constexpr element_type* ptr(concepts::Vector auto const& idx) const requires(dim() == 1u)
+        constexpr value_type* ptr(concepts::Vector auto const& idx) const requires(dim() == 1u)
         {
             return this->m_ptr + idx.x();
         }
 
-        constexpr element_type* ptr(concepts::Vector auto const& idx) requires(dim() == 1u)
+        constexpr value_type* ptr(concepts::Vector auto const& idx) requires(dim() == 1u)
         {
             return this->m_ptr + idx.x();
         }
 
-        element_type* m_ptr;
+        value_type* m_ptr;
         T_Extents m_extent;
-        DataPitches<element_type, T_Pitches> m_pitch;
+        DataPitches<value_type, T_Pitches> m_pitch;
     };
 
     /** access a C array with compile time extents via a runtime md index. */
@@ -231,8 +231,8 @@ namespace alpaka
     struct MdSpanArray<T_ArrayType, T_MemAlignment>
     {
         using extentType = std::extent<T_ArrayType, std::rank_v<T_ArrayType>>;
-        using element_type = std::remove_all_extents_t<T_ArrayType>;
-        using reference = element_type&;
+        using value_type = std::remove_all_extents_t<T_ArrayType>;
+        using reference = value_type&;
         using index_type = typename extentType::value_type;
 
         static consteval uint32_t dim()
@@ -253,12 +253,12 @@ namespace alpaka
          *
          * @{
          */
-        constexpr element_type const* data() const
+        constexpr value_type const* data() const
         {
             return this->m_ptr;
         }
 
-        constexpr element_type* data()
+        constexpr value_type* data()
         {
             return this->m_ptr;
         }
@@ -290,7 +290,7 @@ namespace alpaka
          * @return reference to the value
          * @{
          */
-        constexpr element_type const& operator[](concepts::Vector auto const& idx) const
+        constexpr value_type const& operator[](concepts::Vector auto const& idx) const
         {
             return ResolveArrayAccess<dim()>{}(*m_ptr, idx);
         }
@@ -300,7 +300,7 @@ namespace alpaka
             return ResolveArrayAccess<dim()>{}(*m_ptr, idx);
         }
 
-        constexpr element_type const& operator[](index_type const& idx) const
+        constexpr value_type const& operator[](index_type const& idx) const
         {
             return (*m_ptr)[idx];
         }

--- a/include/alpaka/onHost.hpp
+++ b/include/alpaka/onHost.hpp
@@ -180,6 +180,10 @@ namespace alpaka::onHost
 
     /** copy data byte wise from one to another container
      *
+     * @attention For dest and source the caller should ensure that the memory is valid until the operation is
+     * completed not until the execution handle is given back because alpaka is not extending the life-time until the
+     * operation is finished.
+     *
      * @param queue the copy will be executed after all previous work in this queue is finished
      * @param dest can be a container/view where the data should be written to
      * @param source can be a container/view from which the data will be copied
@@ -212,6 +216,9 @@ namespace alpaka::onHost
      *
      * @param queue memset will be executed after all previous work in this queue is finished
      * @param dest can be a container/view where the data should be written to
+     *             The caller should ensure that the memory is valid until the operation is completed not until the
+     *             execution handle is given back because alpaka is not extending the life-time until the operation is
+     *             finished.
      * @param byteValue value to be written to each byte
      *
      * @{

--- a/include/alpaka/onHost.hpp
+++ b/include/alpaka/onHost.hpp
@@ -8,9 +8,48 @@
 #include "alpaka/concepts.hpp"
 #include "alpaka/onHost/DeviceProperties.hpp"
 #include "alpaka/onHost/concepts.hpp"
+#include "alpaka/trait.hpp"
 
 namespace alpaka::onHost
 {
+    /** Get extents of an object
+     *
+     * @param any can be a view, a data
+     * @return the extents of the object
+     *
+     * @{
+     */
+    inline decltype(auto) getExtents(auto&& any)
+    {
+        return internal::getExtents(ALPAKA_FORWARD(any));
+    }
+
+    inline decltype(auto) getExtents(alpaka::concepts::HasGet auto&& any)
+    {
+        return internal::getExtents(*any.get());
+    }
+
+    /** @} */
+
+    /** Get the number of elements of an object
+     *
+     * @param any can be a view, a data
+     * @return the number of elements of the object
+     *
+     * @{
+     */
+    inline decltype(auto) getPitches(auto&& any)
+    {
+        return internal::getPitches(ALPAKA_FORWARD(any));
+    }
+
+    inline decltype(auto) getPitches(alpaka::concepts::HasGet auto&& any)
+    {
+        return internal::getPitches(*any.get());
+    }
+
+    /** @} */
+
     /** create a platform to get access to devices */
     inline concepts::PlatformHandle auto makePlatform(alpaka::concepts::Api auto&& api)
     {
@@ -175,7 +214,7 @@ namespace alpaka::onHost
      */
     inline auto allocMirror(auto const& device, auto const& view)
     {
-        return alloc<typename ALPAKA_TYPEOF(view)::type>(device, view.getExtents());
+        return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, getExtents(view));
     }
 
     /** copy data byte wise from one to another container
@@ -192,7 +231,7 @@ namespace alpaka::onHost
      */
     inline void memcpy(concepts::QueueHandle auto& queue, auto& dest, auto const& source)
     {
-        return memcpy(queue, dest, source, dest.getExtents());
+        return memcpy(queue, dest, source, getExtents(dest));
     }
 
     /** @param extents M-dimensional data extents in elements, can be smaller than the container capacity */
@@ -225,7 +264,7 @@ namespace alpaka::onHost
      */
     inline auto memset(concepts::QueueHandle auto& queue, auto& dest, uint8_t byteValue)
     {
-        return memset(queue, dest, byteValue, dest.getExtents());
+        return memset(queue, dest, byteValue, getExtents(dest));
     }
 
     /** @param extents M-dimensional data extents in elements, can be smaller than the container capacity */

--- a/include/alpaka/onHost/internal.hpp
+++ b/include/alpaka/onHost/internal.hpp
@@ -180,11 +180,11 @@ namespace alpaka::onHost
             {
                 decltype(auto) operator()(auto&& any) const
                 {
-                    return any.data();
+                    return std::data(any);
                 }
             };
 
-            static auto data(auto&& any)
+            static decltype(auto) data(auto&& any)
             {
                 return Op<std::decay_t<decltype(any)>>{}(any);
             }
@@ -227,5 +227,39 @@ namespace alpaka::onHost
                 DeviceProperties operator()(auto const& device) const;
             };
         };
+
+        struct GetExtents
+        {
+            template<typename T_Any>
+            struct Op
+            {
+                decltype(auto) operator()(auto&& any) const
+                {
+                    return any.getExtents();
+                }
+            };
+        };
+
+        inline auto getExtents(auto&& any)
+        {
+            return GetExtents::Op<std::decay_t<decltype(any)>>{}(any);
+        }
+
+        struct GetPitches
+        {
+            template<typename T_Any>
+            struct Op
+            {
+                decltype(auto) operator()(auto&& any) const
+                {
+                    return any.getPitches();
+                }
+            };
+        };
+
+        inline auto getPitches(auto&& any)
+        {
+            return GetPitches::Op<std::decay_t<decltype(any)>>{}(any);
+        }
     } // namespace internal
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/mem/Data.hpp
+++ b/include/alpaka/onHost/mem/Data.hpp
@@ -86,7 +86,7 @@ namespace alpaka::onHost
             m_deleter(m_data);
         }
 
-        using type = T_Type;
+        using value_type = T_Type;
         using ExtentType = T_Extents;
 
         // private:
@@ -134,6 +134,8 @@ namespace alpaka::onHost
         }
 
         friend struct alpaka::internal::GetApi;
+        friend struct alpaka::onHost::internal::GetExtents;
+        friend struct alpaka::onHost::internal::GetPitches;
     };
 } // namespace alpaka::onHost
 

--- a/include/alpaka/onHost/mem/View.hpp
+++ b/include/alpaka/onHost/mem/View.hpp
@@ -60,7 +60,7 @@ namespace alpaka::onHost
             return T_Extents::dim();
         }
 
-        using type = typename T_Datahandle::element_type::type;
+        using value_type = alpaka::trait::GetValueType_t<T_Datahandle>;
         using index_type = typename T_Extents::type;
 
         /** get the number of elements for each dimension */

--- a/include/alpaka/onHost/mem/stdContainer.hpp
+++ b/include/alpaka/onHost/mem/stdContainer.hpp
@@ -1,0 +1,106 @@
+/* Copyright 2024 René Widera, Bernhard Manfred Gruber
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+#pragma once
+
+#include "alpaka/CVec.hpp"
+#include "alpaka/Vec.hpp"
+#include "alpaka/core/config.hpp"
+#include "alpaka/onHost/internal.hpp"
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace alpaka
+{
+    namespace internal
+    {
+        template<typename T_Type, typename T_Allocator>
+        struct GetApi::Op<std::vector<T_Type, T_Allocator>>
+        {
+            decltype(auto) operator()(auto&& platform) const
+            {
+                return api::Cpu{};
+            }
+        };
+
+        /** The Api is the Api of the caller scope */
+        template<typename T_Type, size_t T_size>
+        struct GetApi::Op<std::array<T_Type, T_size>>
+        {
+            decltype(auto) operator()(auto&& platform) const
+            {
+                return thisApi();
+            }
+        };
+    } // namespace internal
+
+    namespace onHost::internal
+    {
+        template<typename T_Type, typename T_Allocator>
+        struct GetExtents::Op<std::vector<T_Type, T_Allocator>>
+        {
+            decltype(auto) operator()(auto&& stdVector) const
+            {
+                return Vec{stdVector.size()};
+            }
+        };
+
+        template<typename T_Type, size_t T_size>
+        struct GetExtents::Op<std::array<T_Type, T_size>>
+        {
+            decltype(auto) operator()(auto&& stdVector) const
+            {
+                return CVec<size_t, T_size>{};
+            }
+        };
+
+        template<typename T_Type, typename T_Allocator>
+        struct GetPitches::Op<std::vector<T_Type, T_Allocator>>
+        {
+            decltype(auto) operator()(auto&& stdVector) const
+            {
+                return Vec{sizeof(T_Type)};
+            }
+        };
+
+        template<typename T_Type, size_t T_size>
+        struct GetPitches::Op<std::array<T_Type, T_size>>
+        {
+            decltype(auto) operator()(auto&& stdVector) const
+            {
+                return CVec<size_t, sizeof(T_Type)>{};
+            }
+        };
+    } // namespace onHost::internal
+
+    namespace trait
+    {
+        template<typename T_Type, typename T_Allocator>
+        struct GetValueType<std::vector<T_Type, T_Allocator>>
+        {
+            using type = T_Type;
+        };
+
+        template<typename T_Type, size_t T_size>
+        struct GetValueType<std::array<T_Type, T_size>>
+        {
+            using type = T_Type;
+        };
+
+        template<typename T_Type, typename T_Allocator>
+        struct GetDim<std::vector<T_Type, T_Allocator>>
+        {
+            static constexpr uint32_t value = 1u;
+        };
+
+        template<typename T_Type, size_t T_size>
+        struct GetDim<std::array<T_Type, T_size>>
+        {
+            static constexpr uint32_t value = 1u;
+        };
+    } // namespace trait
+} // namespace alpaka

--- a/include/alpaka/trait.hpp
+++ b/include/alpaka/trait.hpp
@@ -27,10 +27,35 @@ namespace alpaka
 
         template<typename T>
         constexpr uint32_t getDim_v = GetDim<T>::value;
+
+        template<typename T>
+        struct GetValueType
+        {
+            using type = typename T::value_type;
+        };
+
+        template<typename T>
+        requires(std::is_fundamental_v<T>)
+        struct GetValueType<T>
+        {
+            using type = T;
+        };
+
+        // resolve handles
+        template<typename T>
+        requires requires() { typename T::element_type; }
+        struct GetValueType<T>
+        {
+            using type = typename GetValueType<typename T::element_type>::type;
+        };
+
+        template<typename T>
+        using GetValueType_t = typename GetValueType<T>::type;
+
     } // namespace trait
 
     template<typename T>
-    consteval uint32_t getDim(T const& any)
+    consteval uint32_t getDim([[maybe_unused]] T const& any)
     {
         return trait::getDim_v<T>;
     }

--- a/tests/unit/precision/precision.cpp
+++ b/tests/unit/precision/precision.cpp
@@ -32,7 +32,7 @@ struct IotaKernelND
 {
     ALPAKA_FN_ACC void operator()(auto const& acc, auto out, auto outSize) const
     {
-        using MemScalarType = typename ALPAKA_TYPEOF(out)::element_type::type;
+        using MemScalarType = typename alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>::type;
         for(auto i : onAcc::makeIdxMap<T_LoopIdxType>(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
         {
             out[i] = pCast<MemScalarType>(i);


### PR DESCRIPTION
- add class with optimized memory footprint to store pitches
- refactor memset/memcpy to guarantee equal life-time handling for all backends
- add trait `GetValueType`
- rename `element_type` into `value`type` in data objects
- use `getDim_v` of the extent to get the dimensionallity for memcpy and memset
- - support for data container `std::vector` and `std::array`