### PR TITLE
CI: add header include checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  alpaka_cmake_flags: "-Dalpaka_TESTING=ON -Dalpaka_BENCHMARKS=ON -Dalpaka_EXAMPLES=ON -DBUILD_TESTING=ON"
+  alpaka_cmake_flags: "-Dalpaka_TESTING=ON -Dalpaka_BENCHMARKS=ON -Dalpaka_EXAMPLES=ON -DBUILD_TESTING=ON -Dalpaka_HEADERCHECKS=ON"
 
 jobs:
   clang-format:
@@ -90,7 +90,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y hiprand-dev rocrand-dev
-          
+
           export ROCM_PATH=/opt/rocm
           export CMAKE_PREFIX_PATH=$ROCM_PATH:$CMAKE_PREFIX_PATH
           export HIP_PLATFORM="amd"
@@ -98,14 +98,14 @@ jobs:
           export HSA_PATH=$ROCM_PATH
           export PATH=${ROCM_PATH}/bin:$PATH
           export PATH=${ROCM_PATH}/llvm/bin:$PATH
-                  
+
           # Export variables to make them globally visible
           echo "ROCM_PATH=${ROCM_PATH}" >> $GITHUB_ENV
           echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}" >> $GITHUB_ENV
           echo "HIP_PLATFORM=${HIP_PLATFORM}" >> $GITHUB_ENV
           echo "HSA_PATH=${HSA_PATH}" >> $GITHUB_ENV
           echo "PATH=${PATH}" >> $GITHUB_ENV
-          
+
           which clang++
           clang++ --version
           hipconfig --platform
@@ -124,7 +124,7 @@ jobs:
           fi
           cmake -G Ninja \
                 -DCMAKE_BUILD_TYPE=Release \
-                ${alpaka_cmake_flags} \
+                ${alpaka_cmake_flags} -Dalpaka_API_OMP=ON \
                 ${{ matrix.config.cuda != 'no' && '-Dalpaka_API_CUDA=ON' || '' }} \
                 ${{ matrix.config.hip != 'no' && '-DCMAKE_CXX_COMPILER=clang++ -Dalpaka_API_HIP=ON -Dalpaka_API_OMP=OFF \
                    -DCMAKE_HIP_ARCHITECTURES=gfx906 -DAMDGPU_TARGETS=gfx906' || '' }} ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ source_group(TREE "${CMAKE_CURRENT_LIST_DIR}/include/alpaka" FILES ${alpakaSourc
 option(alpaka_TESTING "Enable/Disable testing" OFF)
 option(alpaka_BENCHMARKS "Enable/Disable benchmarks" OFF)
 option(alpaka_EXAMPLES "Enable/Disable examples" OFF)
+option(alpaka_HEADERCHECKS "Enable/Disable header check tests" OFF)
 
 if (alpaka_TESTING)
     include(CTest)
@@ -275,6 +276,10 @@ endif()
 
 if(alpaka_EXAMPLES)
     add_subdirectory(example)
+endif()
+
+if(alpaka_HEADERCHECKS)
+    add_subdirectory(headerCheck)
 endif()
 
 option(alpaka_EXEC_CpuSerial "Enable/Disable serial exeexecutor" ON)

--- a/headerCheck/CMakeLists.txt
+++ b/headerCheck/CMakeLists.txt
@@ -11,12 +11,11 @@
 cmake_minimum_required(VERSION 3.22)
 project(Alpaka2HeaderTest)
 
-
 # Add common functions from alpaka.
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/common.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/addExecutable.cmake)
 
-add_subdirectory(.. ${CMAKE_BINARY_DIR}/alpaka)
+set(_TARGET_NAME "headerCheckTest")
 
 ################################################################################
 # Directory of this file.
@@ -25,42 +24,6 @@ set(ALPAKA_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include/alpaka)
 
 # Normalize the path (e.g. remove ../)
 get_filename_component(ALPAKA_ROOT_DIR "${ALPAKA_ROOT_DIR}" ABSOLUTE)
-
-###############################################################################
-# Language Flags
-###############################################################################
-
-# enforce C++20
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD 20)
-
-set(_TARGET_NAME "headerCheckTest")
-
-###############################################################################
-# Catch2
-###############################################################################
-
-option(alpaka_SYSTEM_CATCH2 "Use the system provided Catch2." OFF)
-if (alpaka_SYSTEM_CATCH2)
-    find_package(Catch2 3.5.3 REQUIRED)
-    include(Catch)
-else()
-    # get Catch2 v3 and build it from source with the same C++ standard as the tests
-    Include(FetchContent)
-    FetchContent_Declare(Catch2 GIT_REPOSITORY https://github.com/catchorg/Catch2.git GIT_TAG v3.5.3)
-    FetchContent_MakeAvailable(Catch2)
-    target_compile_features(Catch2 PUBLIC cxx_std_20)
-    #include(Catch)
-
-    # hide Catch2 cmake variables by default in cmake gui
-    get_cmake_property(variables VARIABLES)
-    foreach (var ${variables})
-        if (var MATCHES "^CATCH_")
-            mark_as_advanced(${var})
-        endif()
-    endforeach()
-endif()
 
 #---------------------------------------------------------------------------
 # Create source files.

--- a/include/alpaka/SimdPtr.hpp
+++ b/include/alpaka/SimdPtr.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/Simd.hpp"
 #include "alpaka/Vec.hpp"
 #include "alpaka/cast.hpp"
 #include "alpaka/core/util.hpp"

--- a/include/alpaka/api/trait.hpp
+++ b/include/alpaka/api/trait.hpp
@@ -5,9 +5,11 @@
 
 #pragma once
 
+#include "alpaka/core/common.hpp"
 #include "alpaka/math/math.hpp"
 
 #include <algorithm>
+#include <cstdint>
 
 namespace alpaka
 {

--- a/include/alpaka/api/unifiedCudaHip/ComputeApi.hpp
+++ b/include/alpaka/api/unifiedCudaHip/ComputeApi.hpp
@@ -9,6 +9,8 @@
 #include "alpaka/onAcc/internal.hpp"
 #include "alpaka/tag.hpp"
 
+#include <cstddef>
+
 #if ALPAKA_LANG_CUDA || ALPAKA_LANG_HIP
 
 #    include "alpaka/core/common.hpp"

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -9,11 +9,6 @@
 #if ALPAKA_LANG_CUDA || ALPAKA_LANG_HIP
 #    include "alpaka/api/unifiedCudaHip/Queue.hpp"
 #    include "alpaka/core/UniformCudaHip.hpp"
-#    include "alpaka/internal.hpp"
-#    include "alpaka/onHost.hpp"
-#    include "alpaka/onHost/Device.hpp"
-#    include "alpaka/onHost/Handle.hpp"
-#    include "alpaka/onHost/Queue.hpp"
 #    include "alpaka/onHost/mem/Data.hpp"
 #    include "alpaka/onHost/mem/View.hpp"
 

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -18,6 +18,7 @@
 #    include "alpaka/core/ApiCudaRt.hpp"
 #    include "alpaka/core/UniformCudaHip.hpp"
 #    include "alpaka/internal.hpp"
+#    include "alpaka/onAcc/Acc.hpp"
 #    include "alpaka/onHost.hpp"
 #    include "alpaka/onHost/FrameSpec.hpp"
 #    include "alpaka/onHost/Handle.hpp"

--- a/include/alpaka/mem/Alignment.hpp
+++ b/include/alpaka/mem/Alignment.hpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <type_traits>
 
 namespace alpaka
 {

--- a/include/alpaka/onHost/mem/stdContainer.hpp
+++ b/include/alpaka/onHost/mem/stdContainer.hpp
@@ -7,6 +7,7 @@
 
 #include "alpaka/CVec.hpp"
 #include "alpaka/Vec.hpp"
+#include "alpaka/api/api.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/onHost/internal.hpp"
 


### PR DESCRIPTION
- add header check to the CI
- refactor header check CMake to be usable as subtree from alpaka
- fix missing includes
- activate API_OMP2 in the CI too