### PR TITLE
add `GetNumPipelines` `divExZero()`

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -102,7 +102,7 @@ struct CopyKernel
     ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const a, auto c, auto arraySize) const
     {
         auto simdGrid = onAcc::SimdForEach{onAcc::worker::threadsInGrid};
-        simdGrid.concurrent<64>(
+        simdGrid.concurrent(
             acc,
             alpaka::Vec{arraySize},
             [](auto const&, auto const in, auto out) constexpr { out = in.load(); },
@@ -127,7 +127,7 @@ struct MultKernel
         T const scalar = static_cast<T>(scalarVal);
 
         auto simdGrid = onAcc::SimdForEach{onAcc::worker::threadsInGrid};
-        simdGrid.concurrent<64>(
+        simdGrid.concurrent(
             acc,
             alpaka::Vec{arraySize},
             [&](auto const&, auto out, auto const& in) constexpr { out = scalar * in.load(); },
@@ -150,7 +150,7 @@ struct AddKernel
     ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const a, auto const b, auto c, auto arraySize) const
     {
         auto simdGrid = onAcc::SimdForEach{onAcc::worker::threadsInGrid};
-        simdGrid.concurrent<64>(
+        simdGrid.concurrent(
             acc,
             alpaka::Vec{arraySize},
             [&](auto const&, auto const& simdA, auto const& simdB, auto simdC) constexpr
@@ -178,7 +178,7 @@ struct TriadKernel
         T const scalar = static_cast<T>(scalarVal);
 
         auto simdGrid = onAcc::SimdForEach{onAcc::worker::threadsInGrid};
-        simdGrid.concurrent<64>(
+        simdGrid.concurrent(
             acc,
             [&](auto const&, auto&& simdA, auto&& simdB, auto&& simdC) constexpr
             { simdA = simdB.load() + scalar * simdC.load(); },
@@ -242,7 +242,7 @@ struct DotKernel
             for(auto elemIdxInFrame : traverseInFrame)
             {
                 auto allThreads = onAcc::SimdForEach{onAcc::WorkerGroup{frameIdx + elemIdxInFrame, frameDataExtent}};
-                allThreads.template concurrent<64>(
+                allThreads.concurrent(
                     acc,
                     alpaka::Vec{arraySize},
                     [&](auto const&, auto&& simdA, auto&& simdB) constexpr
@@ -352,9 +352,9 @@ void testKernels(auto cfg)
      * a kernel can reflect the concurrency bytes used for the `SimdForEach::concurrent()` back to the host, e.g. some
      * as we use for dynamic shared memory.
      */
-    constexpr uint32_t elementsPerFrameItem = 16u;
+    uint32_t elementsPerFrameItem = alpaka::getNumElemPerThread<DataType>(alpaka::onHost::getApi(queue));
 
-    auto numFrames = core::divCeil(arraySize, static_cast<Idx>(blockThreadExtentMain) * elementsPerFrameItem);
+    auto numFrames = divExZero(arraySize, static_cast<Idx>(blockThreadExtentMain) * elementsPerFrameItem);
     auto dataBlocking = onHost::FrameSpec{numFrames, static_cast<Idx>(blockThreadExtentMain)};
 
     // To record runtime data generated while running the kernels
@@ -487,12 +487,10 @@ void testKernels(auto cfg)
         }
         if(kernelsToBeExecuted == KernelsToRun::All)
         {
-            constexpr uint32_t elementsPerFrameItem = 16u;
-            auto numFrames = std::max(
-                Idx{1},
-                std::min(
-                    static_cast<Idx>(dotGridBlockExtent),
-                    arraySize / (static_cast<Idx>(blockThreadExtentMain) * elementsPerFrameItem)));
+            uint32_t elementsPerFrameItem = alpaka::getNumElemPerThread<DataType>(alpaka::onHost::getApi(queue));
+            auto numFrames = std::min(
+                static_cast<Idx>(dotGridBlockExtent),
+                alpaka::divExZero(arraySize, (static_cast<Idx>(blockThreadExtentMain) * elementsPerFrameItem)));
 
             auto dataBlockingDot = onHost::FrameSpec{numFrames, static_cast<Idx>(blockThreadExtentMain)};
 

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -112,8 +112,8 @@ auto example(T_Cfg const& cfg) -> int
     constexpr auto numNodesWithHalo = numNodes + halo;
 
     constexpr IdxVec numChunks{
-        alpaka::core::divCeil(numNodes[0], chunkSize[0]),
-        alpaka::core::divCeil(numNodes[1], chunkSize[1]),
+        alpaka::divCeil(numNodes[0], chunkSize[0]),
+        alpaka::divCeil(numNodes[1], chunkSize[1]),
     };
 
     assert(

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -34,7 +34,7 @@ public:
         static_assert(ALPAKA_TYPEOF(numElements)::dim() == 1, "The VectorAddKernel expects 1-dimensional indices!");
 
         auto simdGrid = onAcc::SimdForEach{onAcc::worker::threadsInGrid};
-        simdGrid.concurrent<64>(
+        simdGrid.concurrent(
             acc,
             numElements,
             [&](auto const&, auto&& simdA, auto&& simdB, auto&& simdC) constexpr
@@ -112,8 +112,8 @@ auto example(T_Cfg const& cfg) -> int
 
     Vec<size_t, 1u> chunkSize = 256u;
     // how many elements one worker should compute to ensure vectorization or instruction parallelism
-    constexpr size_t elementsPerWorker = 16u;
-    auto dataBlocking = onHost::FrameSpec{core::divCeil(extent, chunkSize * elementsPerWorker), chunkSize};
+    uint32_t elementsPerWorker = alpaka::getNumElemPerThread<Data>(alpaka::onHost::getApi(queue));
+    auto dataBlocking = onHost::FrameSpec{divCeil(extent, chunkSize * elementsPerWorker), chunkSize};
 
     // Enqueue the kernel execution task
     {

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -845,17 +845,23 @@ namespace alpaka
         };
     } // namespace internal
 
-    namespace core
+    /** @todo the function for intergral values is defined in Utils.hpp
+     * move this to a better place, e.g. math and expose this for the user too
+     */
+    template<concepts::Vector Vector>
+    [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto divCeil(Vector a, Vector b) -> Vector
     {
-        /** @todo the function for intergral values is defined in Utils.hpp
-         * move this to a better place, e.g. math and expose this for the user too
-         */
-        template<concepts::Vector Vector>
-        [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto divCeil(Vector a, Vector b) -> Vector
-        {
-            return (a + b - Vector::all(1)) / b;
-        }
-    } // namespace core
+        return (a + b - Vector::all(1)) / b;
+    }
+
+    template<concepts::Vector Vector>
+    [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto divExZero(Vector a, Vector b) -> Vector
+    {
+        auto tmp = a / b;
+        using ValueType = alpaka::trait::GetValueType_t<Vector>;
+        for(uint32_t d = 0u; d < Vector::dim(); ++d)
+            tmp[d] = std::min(tmp[d], ValueType{1u});
+    }
 }; // namespace alpaka
 
 namespace std

--- a/include/alpaka/api/cpu/Api.hpp
+++ b/include/alpaka/api/cpu/Api.hpp
@@ -6,6 +6,7 @@
 
 #include "alpaka/api/trait.hpp"
 #include "alpaka/concepts.hpp"
+#include "alpaka/core/Utility.hpp"
 #include "alpaka/onHost/trait.hpp"
 
 #include <memory>
@@ -54,7 +55,7 @@ namespace alpaka
         {
             constexpr uint32_t operator()(api::Cpu const) const
             {
-                constexpr uint32_t simdWidthInByte =
+                constexpr size_t simdWidthInByte =
 #if defined(__AVX512BW__) || defined(__AVX512F__) || defined(__AVX512DQ__) || defined(__AVX512VL__)
                     64u;
 #elif defined(__riscv_vector)
@@ -73,7 +74,23 @@ namespace alpaka
 #else
                     sizeof(T_Type);
 #endif
-                return std::max(static_cast<uint32_t>(simdWidthInByte / sizeof(T_Type)), 1u);
+                return alpaka::divExZero(simdWidthInByte, sizeof(T_Type));
+            }
+        };
+
+        template<>
+        struct GetNumPipelines::Op<api::Cpu>
+        {
+            constexpr uint32_t operator()(api::Cpu const) const
+            {
+                /* INTEL can issue 4 commands and AMD typically 2, since we can not distinguish between both we use
+                 * the higher value.
+                 * ARM SVE can typically issue 4 commands too.
+                 *
+                 * Therefor we use at the moment as default 4.
+                 */
+                constexpr uint32_t numPipes = 4u;
+                return numPipes;
             }
         };
 

--- a/include/alpaka/api/cpu/Device.hpp
+++ b/include/alpaka/api/cpu/Device.hpp
@@ -165,7 +165,7 @@ namespace alpaka::onHost
                 else
                 {
                     IdxType rowExtentInBytes = extents.x() * static_cast<IdxType>(sizeof(T_Type));
-                    IdxType rowPitchInBytes = core::divCeil(rowExtentInBytes, alignment) * alignment;
+                    IdxType rowPitchInBytes = divCeil(rowExtentInBytes, alignment) * alignment;
                     auto pitches = mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
 
                     // product of pitches does contain the size for the first dimension
@@ -228,7 +228,7 @@ namespace alpaka::onHost
                            maxValue = numThreadBlocks[i];
                        }
                    if(numThreadBlocks.product() > maxBlocks)
-                       numThreadBlocks[maxIdx] = core::divCeil(numThreadBlocks[maxIdx], IdxType{2u});
+                       numThreadBlocks[maxIdx] = divCeil(numThreadBlocks[maxIdx], IdxType{2u});
 
                }
 #endif
@@ -294,7 +294,7 @@ namespace alpaka::internal
     template<typename T_Platform>
     struct GetApi::Op<onHost::cpu::Device<T_Platform>>
     {
-        decltype(auto) operator()(auto&& device) const
+        inline constexpr auto operator()(auto&& device) const
         {
             return onHost::getApi(device.m_platform);
         }

--- a/include/alpaka/api/cpu/Platform.hpp
+++ b/include/alpaka/api/cpu/Platform.hpp
@@ -113,7 +113,7 @@ namespace alpaka::internal
     template<>
     struct GetApi::Op<onHost::cpu::Platform>
     {
-        decltype(auto) operator()(auto&& platform) const
+        inline constexpr auto operator()(auto&& platform) const
         {
             return api::Cpu{};
         }

--- a/include/alpaka/api/cpu/Queue.hpp
+++ b/include/alpaka/api/cpu/Queue.hpp
@@ -248,7 +248,7 @@ namespace alpaka::internal
     template<typename T_Device>
     struct GetApi::Op<onHost::cpu::Queue<T_Device>>
     {
-        decltype(auto) operator()(auto&& queue) const
+        inline constexpr auto operator()(auto&& queue) const
         {
             return onHost::getApi(queue.m_device);
         }

--- a/include/alpaka/api/cuda/Api.hpp
+++ b/include/alpaka/api/cuda/Api.hpp
@@ -7,6 +7,7 @@
 
 #include "alpaka/api/unifiedCudaHip/trait.hpp"
 #include "alpaka/concepts.hpp"
+#include "alpaka/core/Utility.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/onHost/trait.hpp"
 
@@ -67,8 +68,22 @@ namespace alpaka
             constexpr uint32_t operator()(api::Cuda const) const
             {
                 /** vector load and store width in bytes */
-                constexpr std::size_t simdWidthInByte = 16u;
-                return std::max(static_cast<uint32_t>(simdWidthInByte / sizeof(T_Type)), 1u);
+                constexpr size_t simdWidthInByte = 16u;
+                return alpaka::divExZero(simdWidthInByte, sizeof(T_Type));
+            }
+        };
+
+        template<>
+        struct GetNumPipelines::Op<api::Cuda>
+        {
+            constexpr uint32_t operator()(api::Cuda const) const
+            {
+                /* NVIDIA GPUs have two scheduler what we interpreted as pipelines.
+                 * Therefore, the value should normally be 2 but for current tests where the default is used it looks
+                 * like 4 is a better value.
+                 */
+                constexpr uint32_t numPipes = 4u;
+                return numPipes;
             }
         };
 

--- a/include/alpaka/api/cuda/Platform.hpp
+++ b/include/alpaka/api/cuda/Platform.hpp
@@ -35,7 +35,7 @@ namespace alpaka::internal
     template<>
     struct GetApi::Op<onHost::unifiedCudaHip::Platform<ApiCudaRt>>
     {
-        decltype(auto) operator()(auto&& platform) const
+        inline constexpr auto operator()(auto&& platform) const
         {
             return api::Cuda{};
         }

--- a/include/alpaka/api/hip/Api.hpp
+++ b/include/alpaka/api/hip/Api.hpp
@@ -7,6 +7,7 @@
 
 #include "alpaka/api/unifiedCudaHip/trait.hpp"
 #include "alpaka/concepts.hpp"
+#include "alpaka/core/Utility.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/onHost/trait.hpp"
 
@@ -66,8 +67,19 @@ namespace alpaka
             constexpr uint32_t operator()(api::Hip const) const
             {
                 /** vector load/store width in bytes */
-                constexpr std::size_t simdWidthInByte = 16u;
-                return std::max(static_cast<uint32_t>(simdWidthInByte / sizeof(T_Type)), 1u);
+                constexpr size_t simdWidthInByte = 16u;
+                return alpaka::divExZero(simdWidthInByte, sizeof(T_Type));
+            }
+        };
+
+        template<>
+        struct GetNumPipelines::Op<api::Hip>
+        {
+            constexpr uint32_t operator()(api::Hip const) const
+            {
+                /* AMD GPUs SIMD units will be interpreted as pipelines */
+                constexpr uint32_t numPipes = 4u;
+                return numPipes;
             }
         };
 

--- a/include/alpaka/api/hip/Platform.hpp
+++ b/include/alpaka/api/hip/Platform.hpp
@@ -36,7 +36,7 @@ namespace alpaka::internal
     template<>
     struct GetApi::Op<onHost::unifiedCudaHip::Platform<ApiHipRt>>
     {
-        decltype(auto) operator()(auto&& platform) const
+        inline constexpr auto operator()(auto&& platform) const
         {
             return api::Hip{};
         }

--- a/include/alpaka/api/trait.hpp
+++ b/include/alpaka/api/trait.hpp
@@ -41,7 +41,22 @@ namespace alpaka
             {
                 consteval uint32_t operator()(T_Api const) const
                 {
-                    static_assert(sizeof(T_Api) && false, "GetArchSimdWidth for the current used API is not defined.");
+                    static_assert(sizeof(T_Api) && false, "Missing definition of GetArchSimdWidth for API.");
+                    return 1u;
+                }
+            };
+        };
+
+        /** Number of commands a CPU can issue at the same time. */
+        struct GetNumPipelines
+        {
+            template<typename T_Api>
+            struct Op
+            {
+                /** @return the return value must be >= 1 */
+                consteval uint32_t operator()(T_Api const) const
+                {
+                    static_assert(sizeof(T_Api) && false, "Missing definition of GetNumPipelines for API.");
                     return 1u;
                 }
             };
@@ -70,6 +85,26 @@ namespace alpaka
     consteval uint32_t getArchSimdWidth(auto const api)
     {
         return trait::GetArchSimdWidth::Op<T_Type, ALPAKA_TYPEOF(api)>{}(api);
+    }
+
+    /** get the number of instruction can be issued in parallel */
+    consteval uint32_t getNumPipelines(auto const api)
+    {
+        return trait::GetNumPipelines::Op<ALPAKA_TYPEOF(api)>{}(api);
+    }
+
+    /**  Get the number of elements to compute per thread.
+     *
+     * This function considers the SIMD width for the corresponding data type and the potential for instruction
+     * parallelism.
+     *
+     * @tparam T_Type The data type used to determine the SIMD width.
+     * @return The minimum number of elements a thread should compute to achieve optimal utilization.
+     */
+    template<typename T_Type>
+    constexpr uint32_t getNumElemPerThread(auto const api)
+    {
+        return getArchSimdWidth<T_Type>(api) * getNumPipelines(api);
     }
 
     /** get the cacheline size in bytes

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -106,7 +106,7 @@ namespace alpaka::internal
     template<typename T_Platform>
     struct GetApi::Op<onHost::unifiedCudaHip::Device<T_Platform>>
     {
-        decltype(auto) operator()(auto&& device) const
+        inline constexpr auto operator()(auto&& device) const
         {
             return onHost::getApi(device.m_platform);
         }
@@ -233,7 +233,7 @@ namespace alpaka::onHost
                             maxValue = numThreadBlocks[i];
                         }
                     if(numThreadBlocks.product() > maxBlocks)
-                        numThreadBlocks[maxIdx] = core::divCeil(numThreadBlocks[maxIdx], IdxType{2u});
+                        numThreadBlocks[maxIdx] = divCeil(numThreadBlocks[maxIdx], IdxType{2u});
                 }
 #        endif
                 return ThreadSpec{numThreadBlocks, dataBlocking.getThreadSpec().m_numThreads};

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -212,7 +212,7 @@ namespace alpaka::internal
     template<typename T_Device>
     struct GetApi::Op<onHost::unifiedCudaHip::Queue<T_Device>>
     {
-        decltype(auto) operator()(auto&& queue) const
+        inline constexpr auto operator()(auto&& queue) const
         {
             return onHost::getApi(queue.m_device);
         }

--- a/include/alpaka/core/Utility.hpp
+++ b/include/alpaka/core/Utility.hpp
@@ -5,28 +5,39 @@
 
 #include "alpaka/core/common.hpp"
 
+#include <algorithm>
 #include <type_traits>
 #include <utility>
 
-namespace alpaka::core
+namespace alpaka
 {
-    //! convert any type to a reference type
-    //
-    // This function is equivalent to std::declval() but can be used
-    // within an alpaka accelerator kernel too.
-    // This function can be used only within std::decltype().
+    namespace core
+    {
+        //! convert any type to a reference type
+        //
+        // This function is equivalent to std::declval() but can be used
+        // within an alpaka accelerator kernel too.
+        // This function can be used only within std::decltype().
 #if ALPAKA_LANG_CUDA && ALPAKA_COMP_CLANG_CUDA || ALPAKA_COMP_HIP
-    template<class T>
-    ALPAKA_FN_HOST_ACC std::add_rvalue_reference_t<T> declval();
+        template<class T>
+        ALPAKA_FN_HOST_ACC std::add_rvalue_reference_t<T> declval();
 #else
-    using std::declval;
+        using std::declval;
 #endif
+    } // namespace core
 
     /// Returns the ceiling of a / b, as integer.
     template<std::integral Integral>
     [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto divCeil(Integral a, Integral b) -> Integral
     {
         return (a + b - Integral{1}) / b;
+    }
+
+    /// Returns the  max(a / b, 1) as integer.
+    template<std::integral Integral>
+    [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto divExZero(Integral a, Integral b) -> Integral
+    {
+        return std::max(a / b, Integral{1});
     }
 
     /// Computes the nth power of base, in integers.
@@ -59,4 +70,4 @@ namespace alpaka::core
         return L;
     }
 
-} // namespace alpaka::core
+} // namespace alpaka

--- a/include/alpaka/internal.hpp
+++ b/include/alpaka/internal.hpp
@@ -45,14 +45,14 @@ namespace alpaka
             template<typename T_Any>
             struct Op
             {
-                decltype(auto) operator()(auto&& any) const
+                inline constexpr auto operator()(auto&& any) const
                 {
                     return any.getApi();
                 }
             };
         };
 
-        inline auto getApi(auto&& any)
+        inline constexpr auto getApi(auto&& any)
         {
             return GetApi::Op<std::decay_t<decltype(any)>>{}(any);
         }

--- a/include/alpaka/mem/FlatIdxContainer.hpp
+++ b/include/alpaka/mem/FlatIdxContainer.hpp
@@ -210,7 +210,7 @@ namespace alpaka::onAcc
                 auto linearCurrent = linearize(numThreads[selectedDims], threadIdx[selectedDims]);
                 auto linearStride = numThreads[selectedDims].product();
                 auto strideMD = m_idxRange.m_stride[selectedDims];
-                auto extentMD = core::divCeil(m_idxRange.distance()[selectedDims], strideMD);
+                auto extentMD = divCeil(m_idxRange.distance()[selectedDims], strideMD);
 
                 return const_iterator(begin, linearCurrent, linearStride, extentMD.product(), extentMD, strideMD);
             }
@@ -222,12 +222,12 @@ namespace alpaka::onAcc
                 auto begin = m_idxRange.m_begin + groupOffset;
 
                 auto strideMD = m_idxRange.m_stride[selectedDims];
-                auto numElements = core::divCeil(
+                auto numElements = divCeil(
                     m_idxRange.distance()[selectedDims].product(),
                     (m_threadSpace.m_threadCount[selectedDims].product() * strideMD.product()));
                 auto linearCurrent
                     = linearize(m_threadSpace.m_threadCount[selectedDims], threadIdx[selectedDims]) * numElements;
-                auto extentMD = core::divCeil(m_idxRange.distance()[selectedDims], strideMD);
+                auto extentMD = divCeil(m_idxRange.distance()[selectedDims], strideMD);
                 return const_iterator(
                     begin,
                     linearCurrent,
@@ -245,17 +245,17 @@ namespace alpaka::onAcc
 
             if constexpr(std::is_same_v<T_IdxMapperFn, layout::Strided>)
             {
-                auto extentMD = core::divCeil(m_idxRange.distance()[selectedDims], m_idxRange.m_stride[selectedDims]);
+                auto extentMD = divCeil(m_idxRange.distance()[selectedDims], m_idxRange.m_stride[selectedDims]);
                 return const_iterator_end(extentMD.product());
             }
             else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contigious>)
             {
                 auto strideMD = m_idxRange.m_stride[selectedDims];
-                auto numElements = core::divCeil(
+                auto numElements = divCeil(
                     m_idxRange.distance()[selectedDims].product(),
                     (numThreads[selectedDims].product() * strideMD.product()));
                 auto linearCurrent = linearize(numThreads[selectedDims], threadIdx[selectedDims]) * numElements;
-                auto extentMD = core::divCeil(m_idxRange.distance()[selectedDims], strideMD);
+                auto extentMD = divCeil(m_idxRange.distance()[selectedDims], strideMD);
                 return const_iterator_end(std::min(linearCurrent + numElements, extentMD.product()));
             }
         }

--- a/include/alpaka/mem/TiledIdxContainer.hpp
+++ b/include/alpaka/mem/TiledIdxContainer.hpp
@@ -261,7 +261,7 @@ namespace alpaka::onAcc
             else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contigious>)
             {
                 auto extent = m_idxRange.distance();
-                auto numElements = core::divCeil(extent, m_idxRange.m_stride * numThreads);
+                auto numElements = divCeil(extent, m_idxRange.m_stride * numThreads);
                 auto first = threadIdx * numElements * m_idxRange.m_stride;
 
                 return const_iterator(
@@ -284,7 +284,7 @@ namespace alpaka::onAcc
             else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contigious>)
             {
                 auto extent = m_idxRange.distance();
-                auto numElements = core::divCeil(extent, m_idxRange.m_stride * numThreads);
+                auto numElements = divCeil(extent, m_idxRange.m_stride * numThreads);
                 auto first = threadIdx * numElements * m_idxRange.m_stride;
 
                 return const_iterator_end(m_idxRange.m_begin + extent.min(first + numElements * m_idxRange.m_stride));

--- a/include/alpaka/onAcc/SimdForEach.hpp
+++ b/include/alpaka/onAcc/SimdForEach.hpp
@@ -47,6 +47,48 @@ namespace alpaka::onAcc
          *
          * @attention The number of elements to process is derived from the first MdSpan object.
          *            All other MdSpan objects must have hat least the same number of elements.
+         *            The optimal concurrency is also derived from the first MdSpan.
+         *
+         * @param T_func the functor to be executed
+         * @param T_data0 the first data to be processed
+         * @param T_dataN the remaining data to be processed
+         *
+         * @{
+         */
+        ALPAKA_FN_INLINE ALPAKA_FN_ACC constexpr void concurrent(
+            auto const& acc,
+            auto&& func,
+            auto&& data0,
+            auto&&... dataN) const
+        {
+            concurrent(acc, data0.getExtents(), ALPAKA_FORWARD(func), ALPAKA_FORWARD(data0), ALPAKA_FORWARD(dataN)...);
+        }
+
+        /**
+         * @param extents number of elements to process in each dimension
+         */
+        ALPAKA_FN_INLINE ALPAKA_FN_ACC constexpr void concurrent(
+            auto const& acc,
+            alpaka::concepts::Vector auto extents,
+            auto&& func,
+            auto&& data0,
+            auto&&... dataN) const
+        {
+            using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
+            concurrent<alpaka::getNumElemPerThread<ValueType>(thisApi()) * sizeof(ValueType)>(
+                acc,
+                extents,
+                ALPAKA_FORWARD(func),
+                ALPAKA_FORWARD(data0),
+                ALPAKA_FORWARD(dataN)...);
+        }
+
+        /** @} */
+
+        /** execute the functor concurrently over the given data.
+         *
+         * @attention The number of elements to process is derived from the first MdSpan object.
+         *            All other MdSpan objects must have hat least the same number of elements.
          *
          * @param T_maxConcurrencyInByte
          *    Maximum number of bytes to be used for concurrency.
@@ -88,7 +130,7 @@ namespace alpaka::onAcc
             auto&&... dataN) const
         {
             auto numElements = typename ALPAKA_TYPEOF(extents)::UniVec{extents};
-            using ValueType = ALPAKA_TYPEOF(data0[ALPAKA_TYPEOF(extents)::all(0)]);
+            using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
 
             constexpr uint32_t maxArchSimdWidth = getArchSimdWidth<ValueType>(thisApi());
             constexpr uint32_t cachlineBytes = getCachelineSize(thisApi());
@@ -101,16 +143,17 @@ namespace alpaka::onAcc
                 constexpr uint32_t simdWidthInByte = width * sizeof(ValueType);
                 // number of simd packs fitting into the maxConcurrencyInByte
                 constexpr uint32_t numSimdPacksToUtilizeConcurrency
-                    = std::max(T_maxConcurrencyInByte / simdWidthInByte, 1u);
+                    = alpaka::divExZero(T_maxConcurrencyInByte, simdWidthInByte);
                 // number of simd packs fitting into the cacheline
                 constexpr uint32_t numSimdPacksPerCacheLine = std::max(cachlineBytes / simdWidthInByte, 1u);
                 /* number of simd packs used per functor call
                  * - the number of simd packs per functor call should be a multiple of the number of simd packs per
                  * cacheline
                  */
-                constexpr uint32_t numSimdPacksPerFnCall = std::max(
-                    (numSimdPacksToUtilizeConcurrency / numSimdPacksPerCacheLine) * numSimdPacksPerCacheLine,
-                    1u);
+                constexpr uint32_t numSimdPacksPerFnCall
+                    = alpaka::divExZero(numSimdPacksToUtilizeConcurrency, numSimdPacksPerCacheLine)
+                      * numSimdPacksPerCacheLine;
+
 
                 // we SIMDfy only over the fast moving dimension (columns of memory)
                 auto const wSize = m_workGroup.size(acc).back();
@@ -222,11 +265,7 @@ namespace alpaka::onAcc
         static constexpr auto calcSimdWidth()
         {
             constexpr uint32_t maxSimdBytes = std::min(T_cacheLineInByte, T_maxConcurrencyInByte);
-
-            constexpr uint32_t numElemPerSimd = maxSimdBytes / sizeof(T_Type);
-            constexpr uint32_t simdWidth = std::max(numElemPerSimd, 1u);
-
-            return simdWidth;
+            return alpaka::divExZero(maxSimdBytes, static_cast<uint32_t>(sizeof(T_Type)));
         }
     };
 } // namespace alpaka::onAcc

--- a/include/alpaka/onHost.hpp
+++ b/include/alpaka/onHost.hpp
@@ -174,12 +174,12 @@ namespace alpaka::onHost
      *
      * @{
      */
-    inline decltype(auto) getApi(auto&& any)
+    inline constexpr decltype(auto) getApi(auto&& any)
     {
         return alpaka::internal::getApi(ALPAKA_FORWARD(any));
     }
 
-    inline decltype(auto) getApi(alpaka::concepts::HasGet auto&& any)
+    inline constexpr decltype(auto) getApi(alpaka::concepts::HasGet auto&& any)
     {
         return alpaka::internal::getApi(*any.get());
     }

--- a/include/alpaka/onHost/mem/Data.hpp
+++ b/include/alpaka/onHost/mem/Data.hpp
@@ -150,7 +150,7 @@ namespace alpaka::internal
         concepts::Alignment T_MemAlignmen>
     struct GetApi::Op<onHost::Data<T_BaseHandle, T_Type, T_Extents, T_Pitches, T_MemAlignmen>>
     {
-        decltype(auto) operator()(auto&& data) const
+        inline constexpr auto operator()(auto&& data) const
         {
             return onHost::getApi(data.m_base);
         }

--- a/include/alpaka/onHost/mem/View.hpp
+++ b/include/alpaka/onHost/mem/View.hpp
@@ -165,7 +165,7 @@ namespace alpaka::internal
     template<typename... T_Args>
     struct GetApi::Op<onHost::View<T_Args...>>
     {
-        decltype(auto) operator()(auto&& buffer) const
+        inline constexpr auto operator()(auto&& buffer) const
         {
             return onHost::getApi(buffer.m_data);
         }

--- a/include/alpaka/onHost/mem/stdContainer.hpp
+++ b/include/alpaka/onHost/mem/stdContainer.hpp
@@ -22,7 +22,7 @@ namespace alpaka
         template<typename T_Type, typename T_Allocator>
         struct GetApi::Op<std::vector<T_Type, T_Allocator>>
         {
-            decltype(auto) operator()(auto&& platform) const
+            inline constexpr auto operator()(auto&& platform) const
             {
                 return api::Cpu{};
             }
@@ -32,7 +32,7 @@ namespace alpaka
         template<typename T_Type, size_t T_size>
         struct GetApi::Op<std::array<T_Type, T_size>>
         {
-            decltype(auto) operator()(auto&& platform) const
+            inline constexpr auto operator()(auto&& platform) const
             {
                 return thisApi();
             }


### PR DESCRIPTION
This PR is mixing adding `GetNumPipelines` and a few interface changes, including a new function `divExZero()`

The interface of `getApi()` changed, the function is now `inline constexpr`.
Move most functions from `alpaka::core` utility to `::alpaka`.

Simplify usage of `SimdForEach::concurrent()`