### PR TITLE
CUDA/HIP: add destructor

### DIFF
--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -37,6 +37,13 @@ namespace alpaka::onHost
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::setDevice(idx));
             }
 
+            ~Device()
+            {
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::setDevice(getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::deviceSynchronize());
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::deviceReset());
+            }
+
             Device(Device const&) = delete;
             Device(Device&&) = delete;
 

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -52,6 +52,10 @@ namespace alpaka::onHost
             ~Queue()
             {
                 onHost::internal::Wait::wait(*this);
+                // setDevice is not required because wait() is setting the device
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+                    ApiInterface,
+                    ApiInterface::streamDestroy(getNativeHandle()));
             }
 
             Queue(Queue const&) = delete;


### PR DESCRIPTION
Add destructor to remove idevice/queue objects from CUDA/HIP to avoid memory leaks.