### PR TITLE
tests: enable testing if `alpaka_TESTING` is activated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,7 @@ option(alpaka_HEADERCHECKS "Enable/Disable header check tests" OFF)
 
 if (alpaka_TESTING)
     include(CTest)
+    enable_testing()
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tests")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ spack load cmake@3.29.1
 spack load cuda@12.4.0
 
 # use -DCMAKE_CUDA_ARCHITECTURES=80 to set the GPU architecture
-cmake ../alpaka -Dalpaka_TESTING=ON -Dalpaka_BENCHMARKS=ON -Dalpaka_EXAMPLES=ON -DBUILD_TESTING=ON -Dalpaka_API_OMP=OFF -Dalpaka_API_CUDA=ON -Dalpaka_EXEC_CpuSerial=OFF  
+cmake ../alpaka -Dalpaka_TESTING=ON -Dalpaka_BENCHMARKS=ON -Dalpaka_EXAMPLES=ON -Dalpaka_API_OMP=OFF -Dalpaka_API_CUDA=ON -Dalpaka_EXEC_CpuSerial=OFF  
 make -j
 ctest --output-on-failure
 ```
@@ -65,7 +65,7 @@ spack load hip@6.3.4
 
 # use -DCMAKE_HIP_ARCHITECTURES=gfx906 to set the GPU architecture
 # for older CMake version sometimes the architecture must be set with -DAMDGPU_TARGETS=gfx906
-cmake ../alpaka -Dalpaka_TESTING=ON -Dalpaka_BENCHMARKS=ON -Dalpaka_EXAMPLES=ON -DBUILD_TESTING=ON -Dalpaka_API_OMP=OFF -Dalpaka_API_HIP=ON -Dalpaka_EXEC_CpuSerial=OFF
+cmake ../alpaka -Dalpaka_TESTING=ON -Dalpaka_BENCHMARKS=ON -Dalpaka_EXAMPLES=ON -Dalpaka_API_OMP=OFF -Dalpaka_API_HIP=ON -Dalpaka_EXEC_CpuSerial=OFF
 make -j
 ctest --output-on-failure
 ```


### PR DESCRIPTION
If `alpaka_TESTING` is enabled activate ctest so that there is no need to set `BUILD_TESTING` by hand.