### PR TITLE
`Simd` add bitshift support

### DIFF
--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -570,6 +570,8 @@ namespace alpaka
     ALPAKA_VECTOR_BINARY_OP(bool, &&)
     ALPAKA_VECTOR_BINARY_OP(bool, ||)
     ALPAKA_VECTOR_BINARY_OP(T_Type, %)
+    ALPAKA_VECTOR_BINARY_OP(T_Type, <<)
+    ALPAKA_VECTOR_BINARY_OP(T_Type, >>)
 
 #undef ALPAKA_VECTOR_BINARY_OP
 


### PR DESCRIPTION
note: The bitshift is currently not guarded to work for Integral types only.