### PR TITLE
remove `std::move()`

### DIFF
--- a/include/alpaka/KernelBundle.hpp
+++ b/include/alpaka/KernelBundle.hpp
@@ -23,28 +23,38 @@ namespace alpaka
     {
     public:
         //! The function object type
-        using KernelFn = TKernelFn;
+        using KernelFn = std::decay_t<TKernelFn>;
         //! Tuple type to encapsulate kernel function argument types and argument values
         using ArgTuple = std::tuple<remove_restrict_t<std::decay_t<TArgs>>...>;
 
         // Constructor
-        constexpr KernelBundle(KernelFn kernelFn, TArgs&&... args)
-            : m_kernelFn{std::move(kernelFn)}
-            , m_args(std::forward<TArgs>(args)...)
+        constexpr KernelBundle(KernelFn const& kernelFn, TArgs const&... args) : m_kernelFn{kernelFn}, m_args(args...)
         {
         }
 
         constexpr KernelBundle(KernelBundle const& b) = default;
+        constexpr KernelBundle& operator=(KernelBundle const&) = default;
 
+        /** allow move assignment and constriction
+         *
+         *  @attention if the functor or the arguments contains non movable types the move operators can be
+         * inaccessible.
+         *
+         *  @{
+         */
         constexpr KernelBundle(KernelBundle&& b) = default;
+        constexpr KernelBundle& operator=(KernelBundle&&) = default;
+
+        /** @} */
 
         constexpr auto operator()(auto const& acc) const
         {
             std::apply([&](auto const&... args) constexpr { m_kernelFn(acc, args...); }, m_args);
         }
 
-        KernelFn const m_kernelFn;
-        ArgTuple const m_args; // Store the argument types without const and reference
+        KernelFn m_kernelFn;
+        // Store the argument types without const and reference
+        ArgTuple m_args;
     };
 
     //! \brief User defined deduction guide with trailing return type. For CTAD during the construction.
@@ -56,5 +66,5 @@ namespace alpaka
     //! \return Kernel function bundle. An instance of KernelBundle which consists the kernel function object and its
     //! arguments.
     template<typename TKernelFn, typename... TArgs>
-    ALPAKA_FN_HOST KernelBundle(TKernelFn, TArgs&&...) -> KernelBundle<TKernelFn, TArgs...>;
+    ALPAKA_FN_HOST KernelBundle(TKernelFn const&, TArgs const&...) -> KernelBundle<TKernelFn, TArgs...>;
 } // namespace alpaka

--- a/include/alpaka/api/cpu/Queue.hpp
+++ b/include/alpaka/api/cpu/Queue.hpp
@@ -81,22 +81,25 @@ namespace alpaka::onHost
             void enqueue(
                 auto const executor,
                 ThreadSpec<T_NumBlocks, T_NumThreads> const& threadBlocking,
-                auto kernelBundle)
+                auto const& kernelBundle)
             {
                 m_workerThread.submit(
-                    [=, kernel = std::move(kernelBundle)]()
+                    [=]()
                     {
                         onAcc::Acc acc = makeAcc(executor, threadBlocking);
-                        acc(std::move(kernel));
+                        acc(kernelBundle);
                     });
             }
 
             template<typename T_Mapping, alpaka::concepts::Vector T_NumFrames, alpaka::concepts::Vector T_FrameExtent>
-            void enqueue(T_Mapping const executor, FrameSpec<T_NumFrames, T_FrameExtent> frameSpec, auto kernelBundle)
+            void enqueue(
+                T_Mapping const executor,
+                FrameSpec<T_NumFrames, T_FrameExtent> frameSpec,
+                auto const& kernelBundle)
             {
                 auto threadBlocking = internal::adjustThreadSpec(*m_device.get(), executor, frameSpec, kernelBundle);
                 m_workerThread.submit(
-                    [=, kernel = std::move(kernelBundle)]()
+                    [=]()
                     {
                         auto moreLayer = Dict{
                             DictEntry(frame::count, frameSpec.m_numFrames),
@@ -104,11 +107,11 @@ namespace alpaka::onHost
                             DictEntry(object::api, api::cpu),
                             DictEntry(object::exec, executor)};
                         onAcc::Acc acc = makeAcc(executor, threadBlocking);
-                        acc(std::move(kernel), moreLayer);
+                        acc(kernelBundle, moreLayer);
                     });
             }
 
-            void enqueue(auto task)
+            void enqueue(auto const& task)
             {
                 m_workerThread.submit([task]() { task(); });
             }

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -182,7 +182,7 @@ namespace alpaka::onHost
                 T_Executor const executor,
                 unifiedCudaHip::Queue<T_Device>& queue,
                 ThreadSpec<T_NumBlocks, T_NumThreads> const& threadBlocking,
-                T_KernelBundle kernelBundle,
+                T_KernelBundle const& kernelBundle,
                 T_Args const&... args) const
             {
                 using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
@@ -241,9 +241,9 @@ namespace alpaka::onHost
                 unifiedCudaHip::Queue<T_Device>& queue,
                 T_Executor const executor,
                 ThreadSpec<T_NumBlocks, T_NumThreads> const& threadBlocking,
-                T_KernelBundle kernelBundle) const
+                T_KernelBundle const& kernelBundle) const
             {
-                unifiedCudaHip::CallKernel{}(executor, queue, threadBlocking, std::move(kernelBundle));
+                unifiedCudaHip::CallKernel{}(executor, queue, threadBlocking, kernelBundle);
             }
         };
 
@@ -260,7 +260,7 @@ namespace alpaka::onHost
                 unifiedCudaHip::Queue<T_Device>& queue,
                 T_Executor const executor,
                 FrameSpec<T_NumFrames, T_FrameExtent> const& frameSpec,
-                T_KernelBundle kernelBundle) const
+                T_KernelBundle const& kernelBundle) const
             {
                 auto threadBlocking
                     = internal::adjustThreadSpec(*queue.m_device.get(), executor, frameSpec, kernelBundle);
@@ -268,7 +268,7 @@ namespace alpaka::onHost
                     executor,
                     queue,
                     threadBlocking,
-                    std::move(kernelBundle),
+                    kernelBundle,
                     frameSpec.m_numFrames,
                     frameSpec.m_frameExtent);
             }

--- a/include/alpaka/onAcc/Acc.hpp
+++ b/include/alpaka/onAcc/Acc.hpp
@@ -25,8 +25,9 @@ namespace alpaka::onAcc
         }
 
         constexpr Acc(Acc const&) = delete;
-        constexpr Acc(Acc const&&) = delete;
+        constexpr Acc(Acc&&) = delete;
         constexpr Acc& operator=(Acc const&) = delete;
+        constexpr Acc& operator=(Acc&&) = delete;
 
         template<typename T, size_t T_uniqueId>
         constexpr decltype(auto) declareSharedVar() const

--- a/include/alpaka/onHost.hpp
+++ b/include/alpaka/onHost.hpp
@@ -134,9 +134,9 @@ namespace alpaka::onHost
         concepts::QueueHandle auto const& queue,
         auto const executor,
         auto const& specification,
-        KernelBundle<TKernelFn, TArgs...> kernelBundle)
+        KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
     {
-        internal::enqueue(*queue.get(), executor, specification, std::move(kernelBundle));
+        internal::enqueue(*queue.get(), executor, specification, kernelBundle);
     }
 
     /** Enqueue a operation which is executed on the host side
@@ -144,11 +144,11 @@ namespace alpaka::onHost
      * @param queue the task will be executed after all previous work in this queue is finished
      * @param task task to be executed on the host side
      */
-    inline void enqueue(concepts::QueueHandle auto const& queue, auto task)
+    inline void enqueue(concepts::QueueHandle auto const& queue, auto const& task)
     {
         return internal::Enqueue::Task<std::decay_t<decltype(*queue.get())>, std::decay_t<decltype(task)>>{}(
             *queue.get(),
-            std::move(task));
+            task);
     }
 
     /** pointer to data

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -57,19 +57,19 @@ namespace alpaka::onHost
             return onHost::wait(static_cast<Parent>(*this));
         }
 
-        void enqueue(auto const executor, auto const& blockCfg, auto&& f, auto&&... args)
+        void enqueue(auto const executor, auto const& blockCfg, auto const& f, auto&&... args)
         {
             return onHost::enqueue(
                 static_cast<Parent>(*this),
                 std::move(executor),
                 blockCfg,
-                std::move(KernelBundle{std::forward<decltype(f)>(f), std::forward<decltype(args)>(args)...}));
+                KernelBundle{f, std::forward<decltype(args)>(args)...});
         }
 
         template<typename TKernelFn, typename... TArgs>
-        void enqueue(auto const executor, auto const& blockCfg, KernelBundle<TKernelFn, TArgs...> kernelBundle)
+        void enqueue(auto const executor, auto const& blockCfg, KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
         {
-            return onHost::enqueue(static_cast<Parent>(*this), std::move(executor), blockCfg, std::move(kernelBundle));
+            return onHost::enqueue(static_cast<Parent>(*this), std::move(executor), blockCfg, kernelBundle);
         }
     };
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/internal.hpp
+++ b/include/alpaka/onHost/internal.hpp
@@ -108,25 +108,25 @@ namespace alpaka::onHost
                     T_Queue& queue,
                     T_Mapping const executor,
                     T_BlockCfg const& blockCfg,
-                    T_KernelBundle kernelBundle) const
+                    T_KernelBundle const& kernelBundle) const
                 {
-                    queue.enqueue(executor, blockCfg, std::move(kernelBundle));
+                    queue.enqueue(executor, blockCfg, kernelBundle);
                 }
             };
 
             template<typename T_Queue, typename T_Task>
             struct Task
             {
-                void operator()(T_Queue& queue, T_Task task) const
+                void operator()(T_Queue& queue, T_Task const& task) const
                 {
-                    queue.enqueue(std::move(task));
+                    queue.enqueue(task);
                 }
             };
         };
 
-        inline void enqueue(auto& queue, auto task)
+        inline void enqueue(auto& queue, auto const& task)
         {
-            Enqueue::Task<std::decay_t<decltype(queue)>, std::decay_t<decltype(task)>>{}(queue, std::move(task));
+            Enqueue::Task<std::decay_t<decltype(queue)>, std::decay_t<decltype(task)>>{}(queue, task);
         }
 
         template<typename TKernelFn, typename... TArgs>
@@ -134,13 +134,13 @@ namespace alpaka::onHost
             auto& queue,
             auto const executor,
             auto const& blockCfg,
-            KernelBundle<TKernelFn, TArgs...> kernelBundle)
+            KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
         {
             Enqueue::Kernel<
                 std::decay_t<decltype(queue)>,
                 std::decay_t<decltype(executor)>,
                 std::decay_t<decltype(blockCfg)>,
-                KernelBundle<TKernelFn, TArgs...>>{}(queue, executor, blockCfg, std::move(kernelBundle));
+                KernelBundle<TKernelFn, TArgs...>>{}(queue, executor, blockCfg, kernelBundle);
         }
 
         struct AdjustThreadSpec


### PR DESCRIPTION
- remove std::move()` for KernelBundle to avoid UB in cases where const members in the kernel functor or arguments are used
- use references to handle `Task` in the interfaces to avoid `std::move()` UB in cases where the task carry const members