### PR TITLE
benchmark: bable  stream

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -241,6 +241,7 @@ struct DotKernel
         {
             for(auto elemIdxInFrame : traverseInFrame)
             {
+                T tmpValue = T{0};
                 auto allThreads = onAcc::SimdForEach{onAcc::WorkerGroup{frameIdx + elemIdxInFrame, frameDataExtent}};
                 allThreads.concurrent(
                     acc,
@@ -248,10 +249,11 @@ struct DotKernel
                     [&](auto const&, auto&& simdA, auto&& simdB) constexpr
                     {
                         auto tmp = simdA.load() * simdB.load();
-                        tbSum[elemIdxInFrame] += tmp.sum();
+                        tmpValue += tmp.sum();
                     },
                     a,
                     b);
+                tbSum[elemIdxInFrame] += tmpValue;
             }
         }
         // sync is required because we do not know which thread wrote whcih value


### PR DESCRIPTION
Add temporary result to avoid numerical instabilities for the single precision DOT kernel when the serial executor is used.

The reason for the numerical instability is the optimization #78. If a single thread is accumulating too many values the numerical error is becoming to large.