### PR TITLE
sync alpaka_TESTING to cmake built-in BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@
 cmake_minimum_required(VERSION 3.20)
 project(alpaka CXX)
 
+set(BUILD_TESTING OFF CACHE BOOL "Build the testing tree.")
+include(CTest)
+# Sync alpaka_TESTING internal variable with cache variable BUILD_TESTING. 
+# BUILD_TESTING could be used from cmake command line or ccmake to enable/disable testing.
+set(alpaka_TESTING ${BUILD_TESTING})
+
 include(cmake/buildDependencies.cmake)
 
 # Add append compiler flags to a variable or target
@@ -260,13 +266,11 @@ file(GLOB_RECURSE alpakaSources "${CMAKE_CURRENT_SOURCE_DIR}/include/**")
 add_custom_target("alpakaIde" SOURCES ${alpakaSources})
 source_group(TREE "${CMAKE_CURRENT_LIST_DIR}/include/alpaka" FILES ${alpakaSources})
 
-option(alpaka_TESTING "Enable/Disable testing" OFF)
 option(alpaka_BENCHMARKS "Enable/Disable benchmarks" OFF)
 option(alpaka_EXAMPLES "Enable/Disable examples" OFF)
 option(alpaka_HEADERCHECKS "Enable/Disable header check tests" OFF)
 
 if (alpaka_TESTING)
-    include(CTest)
     enable_testing()
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tests")
 endif()


### PR DESCRIPTION
Problem: BUILD_TESTING and alpaka_TESTING were both visible in ccmake since BUILD_TESTING is cmake build in. But alpaka_TESTING was the correct cmake cache variable to set.
Solution (To be discussed):
`alpaka_TESTING` cache variable is synched to cmake build in `BUILD_TESTING`. It is also converted to a internal variable. 

Only BUILD_TESTING will be visible and settable from command line/cmake.  