### PR TITLE
refactor `Simd`

### DIFF
--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -21,8 +21,10 @@
 #include "alpaka/trait.hpp"
 
 #include <array>
+#include <bit>
 #include <concepts>
 #include <cstdint>
+#include <functional>
 #include <iostream>
 #include <ranges>
 #include <sstream>
@@ -30,7 +32,18 @@
 
 namespace alpaka
 {
+    namespace detail
+    {
+        template<typename T_ValueType, concepts::Alignment T_Alignment, uint32_t dataSizeInBytes>
+        consteval uint32_t optimalAlignment()
+        {
+            constexpr uint32_t alignment = std::min(T_Alignment::template get<T_ValueType>(), dataSizeInBytes);
+            if constexpr(std::has_single_bit(alignment))
+                return alignment;
 
+            return static_cast<uint32_t>(sizeof(T_ValueType));
+        }
+    } // namespace detail
     template<
         typename T_Type,
         uint32_t T_dim,
@@ -39,7 +52,8 @@ namespace alpaka
     struct Simd;
 
     template<typename T_Type, uint32_t T_dim, concepts::Alignment T_Alignment, typename T_Storage>
-    struct alignas(std::min(T_Alignment::template get<T_Type>(), static_cast<uint32_t>(sizeof(T_Type) * T_dim))) Simd
+    struct alignas(
+        alpaka::detail::optimalAlignment<T_Type, T_Alignment, static_cast<uint32_t>(sizeof(T_Type) * T_dim)>()) Simd
         : private T_Storage
     {
         using Storage = T_Storage;
@@ -348,24 +362,33 @@ namespace alpaka
          *
          * @return product of components
          */
-        constexpr type product() const
+        [[nodiscard]] constexpr type product() const
         {
-            type result = (*this)[0];
-            for(uint32_t i = 1u; i < T_dim; i++)
-                result *= (*this)[i];
-            return result;
+            return reduce<std::multiplies>();
         }
 
         /** Returns sum of all components.
          *
          * @return sum of components
          */
-        constexpr type sum() const
+        [[nodiscard]] constexpr type sum() const
         {
-            type result = (*this)[0];
-            for(uint32_t i = 1u; i < T_dim; i++)
-                result += (*this)[i];
-            return result;
+            return reduce<std::plus>();
+        }
+
+        /** reduce all elements to a single value
+         *
+         * For better numerical stability a tree reduce algorithm is used.
+         *
+         * @tparam BinaryOp binary functor executed to reduce the range
+         *                  The binary operation must be associative.
+         * @return the type of the result depends on the binary functor
+         */
+        template<template<typename> typename BinaryOp = std::plus>
+        [[nodiscard]] constexpr auto reduce() const
+            -> decltype(BinaryOp<type>{}(std::declval<type>(), std::declval<type>()))
+        {
+            return reduce_range<BinaryOp>();
         }
 
         /**
@@ -442,6 +465,32 @@ namespace alpaka
             stream << locale_enclosing_end;
             return stream.str();
         }
+
+    private:
+        /** reduce over a range of elements
+         *
+         * @tparam BinaryOp binary functor executed to reduce the range
+         * @tparam T_start start index
+         * @tparam T_end end index (excluded)
+         * @return the type of the result depends on the binary functor
+         */
+        template<template<typename> typename BinaryOp, uint32_t T_start = 0u, uint32_t T_end = dim()>
+        [[nodiscard]] constexpr auto reduce_range() const
+            -> decltype(BinaryOp<type>{}(std::declval<type>(), std::declval<type>()))
+        {
+            // elements in the range
+            constexpr uint32_t size = T_end - T_start;
+            // single element termination
+            if constexpr(size == 1u)
+            {
+                return (*this)[T_start];
+            }
+            // split range at midpoint
+            constexpr uint32_t mid = T_start + size / 2u;
+
+            // recursively reduce both halves and combine
+            return BinaryOp<type>{}(reduce_range<BinaryOp, T_start, mid>(), reduce_range<BinaryOp, mid, T_end>());
+        }
     };
 
     template<std::size_t I, typename T_Type, uint32_t T_dim, concepts::Alignment T_Alignment, typename T_Storage>
@@ -502,6 +551,14 @@ namespace alpaka
     {
         return s << vec.toString();
     }
+
+    // type deduction guide
+    template<typename T_1, typename... T_Args>
+    ALPAKA_FN_HOST_ACC Simd(T_1, T_Args...) -> Simd<
+        T_1,
+        uint32_t(sizeof...(T_Args) + 1u),
+        Alignment<sizeof(T_1) * uint32_t(sizeof...(T_Args) + 1u)>,
+        ArrayStorage<T_1, uint32_t(sizeof...(T_Args) + 1u)>>;
 
 /** binary operators
  * @{

--- a/tests/unit/simd/simd.cpp
+++ b/tests/unit/simd/simd.cpp
@@ -1,0 +1,206 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <tuple>
+
+/** @file
+ *
+ *  This file is testing simd functionality
+ */
+
+
+/** define one dimensional simd vector compile time test cases for operator +,-,*,/ */
+struct CompileTimeKernel1D
+{
+    ALPAKA_FN_HOST_ACC void operator()() const
+    {
+        using namespace alpaka;
+
+        constexpr auto simd = Simd{3};
+        static_assert(simd.dim() == 1);
+        static_assert(simd.x() == 3);
+        static_assert(simd == Simd{3});
+
+
+        constexpr auto typeLambda = [](auto const typeDummy) constexpr
+        {
+            using type = std::decay_t<decltype(typeDummy)>;
+
+            constexpr auto inputData = std::make_tuple(
+                std::make_tuple(std::plus{}, Simd(type{3}), Simd(type{7}), Simd(type{10})),
+                std::make_tuple(std::plus{}, Simd(type{3}), type{7}, Simd(type{10})),
+                std::make_tuple(std::plus{}, type{3}, Simd(type{7}), Simd(type{10})),
+
+                std::make_tuple(std::minus{}, Simd(type{17}), Simd(type{7}), Simd(type{10})),
+                std::make_tuple(std::minus{}, Simd(type{17}), type{7}, Simd(type{10})),
+                std::make_tuple(std::minus{}, type{17}, Simd(type{7}), Simd(type{10})),
+
+                std::make_tuple(std::multiplies{}, Simd(type{3}), Simd(type{7}), Simd(type{21})),
+                std::make_tuple(std::multiplies{}, Simd(type{3}), type{7}, Simd(type{21})),
+                std::make_tuple(std::multiplies{}, type{3}, Simd(type{7}), Simd(type{21})),
+
+                std::make_tuple(std::divides{}, Simd(type{21}), Simd(type{7}), Simd(type{3})),
+                std::make_tuple(std::divides{}, Simd(type{21}), type{7}, Simd(type{3})),
+                std::make_tuple(std::divides{}, type{21}, Simd(type{7}), Simd(type{3})));
+            constexpr bool x = std::apply(
+                [&](auto... args) constexpr
+                { return ((std::get<0>(args)(std::get<1>(args), std::get<2>(args)) == std::get<3>(args)) && ...); },
+                inputData);
+            return x;
+        };
+
+        constexpr auto inputTypes = std::tuple<int, uint32_t, uint64_t, float, double>{};
+        constexpr bool x = std::apply([&](auto... args) constexpr { return (typeLambda(args) && ...); }, inputTypes);
+        static_assert(x);
+    }
+};
+
+/** define two dimensional simd vector compile time test cases for operator +,-,*,/ */
+struct CompileTimeKernel2D
+{
+    ALPAKA_FN_HOST_ACC void operator()() const
+    {
+        using namespace alpaka;
+
+        constexpr auto simd = Simd{3, 7};
+        static_assert(simd.dim() == 2);
+        static_assert(simd.y() == 3 && simd.x() == 7);
+        static_assert(simd == Simd{3, 7});
+        static_assert(simd != Simd{7, 3});
+        static_assert(Simd{7} == Simd{7, 3}.eraseBack());
+
+        static_assert(Simd{3} == Simd{7, 3}.rshrink<1u>());
+        static_assert(Simd{3} == Simd{7, 3}.rshrink<1u>(1u));
+        static_assert(Simd{7} == Simd{7, 3}.rshrink<1u>(0u));
+
+        static_assert(Simd{7} == Simd{7, 3}.remove<1u>());
+        static_assert(Simd{3} == Simd{7, 3}.remove<0u>());
+
+        constexpr auto typeLambda = [](auto const typeDummy) constexpr
+        {
+            using type = std::decay_t<decltype(typeDummy)>;
+
+            constexpr auto inputData = std::make_tuple(
+                std::make_tuple(std::plus{}, Simd(type{3}, type{7}), Simd(type{7}, type{9}), Simd(type{10}, type{16})),
+                std::make_tuple(std::plus{}, Simd(type{3}, type{9}), type{7}, Simd(type{10}, type{16})),
+                std::make_tuple(std::plus{}, type{3}, Simd(type{7}, type{9}), Simd(type{10}, type{12})),
+
+                std::make_tuple(
+                    std::minus{},
+                    Simd(type{17}, type{7}),
+                    Simd(type{7}, type{3}),
+                    Simd(type{10}, type{4})),
+                std::make_tuple(std::minus{}, Simd(type{17}, type{7}), type{7}, Simd(type{10}, type{0})),
+                std::make_tuple(std::minus{}, type{17}, Simd(type{7}, type{3}), Simd(type{10}, type{14})),
+
+                std::make_tuple(
+                    std::multiplies{},
+                    Simd(type{3}, type{7}),
+                    Simd(type{7}, type{11}),
+                    Simd(type{21}, type{77})),
+                std::make_tuple(std::multiplies{}, Simd(type{3}, type{7}), type{7}, Simd(type{21}, type{49})),
+                std::make_tuple(std::multiplies{}, type{3}, Simd(type{7}, type{3}), Simd(type{21}, type{9})),
+
+                std::make_tuple(
+                    std::divides{},
+                    Simd(type{21}, type{3}),
+                    Simd(type{7}, type{3}),
+                    Simd(type{3}, type{1})),
+                std::make_tuple(std::divides{}, Simd(type{21}, type{14}), type{7}, Simd(type{3}, type{2})),
+                std::make_tuple(std::divides{}, type{21}, Simd(type{7}, type{3}), Simd(type{3}, type{7})));
+            constexpr bool x = std::apply(
+                [&](auto... args) constexpr
+                { return ((std::get<0>(args)(std::get<1>(args), std::get<2>(args)) == std::get<3>(args)) && ...); },
+                inputData);
+            return x;
+        };
+
+        constexpr auto inputTypes = std::tuple<int, uint32_t, uint64_t, float, double>{};
+        constexpr bool x = std::apply([&](auto... args) constexpr { return (typeLambda(args) && ...); }, inputTypes);
+        static_assert(x);
+    }
+};
+
+/** define two dimensional simd vector compile time test cases for operator >,>=,<,<= */
+struct CompileTimeKernelCompare2D
+{
+    ALPAKA_FN_HOST_ACC void operator()() const
+    {
+        using namespace alpaka;
+
+        constexpr auto typeLambda = [](auto const typeDummy) constexpr
+        {
+            using type = std::decay_t<decltype(typeDummy)>;
+
+            constexpr auto inputData = std::make_tuple(
+                std::make_tuple(std::greater{}, Simd(type{3}, type{7}), Simd(type{7}, type{9}), Simd(false, false)),
+                std::make_tuple(std::greater{}, Simd(type{3}, type{9}), type{7}, Simd(false, true)),
+                std::make_tuple(std::greater{}, type{3}, Simd(type{7}, type{9}), Simd(false, false)),
+
+                std::make_tuple(
+                    std::greater_equal{},
+                    Simd(type{3}, type{7}),
+                    Simd(type{3}, type{9}),
+                    Simd(true, false)),
+                std::make_tuple(std::greater_equal{}, Simd(type{3}, type{9}), type{3}, Simd(true, true)),
+                std::make_tuple(std::greater_equal{}, type{3}, Simd(type{7}, type{9}), Simd(false, false)),
+
+                std::make_tuple(std::less{}, Simd(type{3}, type{7}), Simd(type{7}, type{9}), Simd(true, true)),
+                std::make_tuple(std::less{}, Simd(type{3}, type{9}), type{7}, Simd(true, false)),
+                std::make_tuple(std::less{}, type{3}, Simd(type{7}, type{9}), Simd(true, true)),
+
+                std::make_tuple(std::less_equal{}, Simd(type{3}, type{7}), Simd(type{3}, type{9}), Simd(true, true)),
+                std::make_tuple(std::less_equal{}, Simd(type{3}, type{9}), type{3}, Simd(true, false)),
+                std::make_tuple(std::less_equal{}, type{3}, Simd(type{7}, type{9}), Simd(true, true))
+
+            );
+            constexpr bool x = std::apply(
+                [&](auto... args) constexpr
+                { return ((std::get<0>(args)(std::get<1>(args), std::get<2>(args)) == std::get<3>(args)) && ...); },
+                inputData);
+            return x;
+        };
+
+        constexpr auto inputTypes = std::tuple<int, uint32_t, uint64_t, float, double>{};
+        constexpr bool x = std::apply([&](auto... args) constexpr { return (typeLambda(args) && ...); }, inputTypes);
+        static_assert(x);
+    }
+};
+
+struct CompileTimeKernelReduce
+{
+    ALPAKA_FN_HOST_ACC void operator()() const
+    {
+        using namespace alpaka;
+
+        constexpr auto s1 = Simd{3, 7, 4};
+        static_assert(14 == s1.reduce());
+        static_assert(14 == s1.sum());
+
+        constexpr auto s2 = Simd{1, 2, 3, 4, 5};
+        static_assert(15 == s2.reduce());
+        static_assert(15 == s2.sum());
+
+        constexpr auto s3 = Simd{1, 2, 3, 4, 5};
+        static_assert(120 == s3.reduce<std::multiplies>());
+        static_assert(120 == s3.product());
+    }
+};
+
+TEST_CASE("simd generic", "[simd vector]")
+{
+    using namespace alpaka;
+
+    CompileTimeKernel1D{}();
+    CompileTimeKernel2D{}();
+    CompileTimeKernelCompare2D{}();
+    CompileTimeKernelReduce{}();
+}


### PR DESCRIPTION
- fix alignment and support non power of two alignments
- add basic compile tests for `Simd`
- add `reduce` method with support for std binary oeprator e.g. `std::plus`
  - for numerical stability a compile time tree reduce is used