### PR TITLE
`concepts::MdSpan` to function

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -99,7 +99,11 @@ struct CopyKernel
     //! \param a MdSpan for vector a
     //! \param c MdSpan for vector c
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const a, auto c, auto arraySize) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const a,
+        alpaka::concepts::MdSpan auto c,
+        auto arraySize) const
     {
         auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
         simdGrid.concurrent(
@@ -121,7 +125,11 @@ struct MultKernel
     //! \param c MdSpan for vector c
     //! \param b Pointer for result vector b
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto b, auto const c, auto arraySize) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto b,
+        alpaka::concepts::MdSpan auto const c,
+        auto arraySize) const
     {
         using T = trait::GetValueType_t<ALPAKA_TYPEOF(b)>;
         T const scalar = static_cast<T>(scalarVal);
@@ -147,7 +155,12 @@ struct AddKernel
     //! \param b MdSpan for vector b
     //! \param c Pointer for result vector c
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const a, auto const b, auto c, auto arraySize) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const a,
+        alpaka::concepts::MdSpan auto const b,
+        auto c,
+        auto arraySize) const
     {
         auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
         simdGrid.concurrent(
@@ -172,7 +185,12 @@ struct TriadKernel
     //! \param b MdSpan for vector b
     //! \param c Pointer for result vector c
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto a, auto const b, auto const c, auto arraySize) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto a,
+        alpaka::concepts::MdSpan auto const b,
+        alpaka::concepts::MdSpan auto const c,
+        auto arraySize) const
     {
         using T = trait::GetValueType_t<ALPAKA_TYPEOF(a)>;
         T const scalar = static_cast<T>(scalarVal);
@@ -213,7 +231,12 @@ struct DotKernel
     //! \param sum Pointer for result vector consisting sums of blocks
     //! \param arraySize the size of the array
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const a, auto const b, auto sum, auto arraySize) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const a,
+        alpaka::concepts::MdSpan auto const b,
+        auto sum,
+        auto arraySize) const
     {
         using T = trait::GetValueType_t<ALPAKA_TYPEOF(sum)>;
         auto tbSum = onAcc::declareSharedMdArray<T, uniqueId()>(acc, CVec<uint32_t, blockThreadExtentMain>{});

--- a/example/grayScale/src/grayScale.cpp
+++ b/example/grayScale/src/grayScale.cpp
@@ -25,7 +25,7 @@ constexpr uint32_t scalar32 = 32u;
 class GrayscaleKernel
 {
 public:
-    ALPAKA_FN_ACC void operator()(auto const& acc, auto&& argb, auto const numElements) const
+    ALPAKA_FN_ACC void operator()(auto const& acc, alpaka::concepts::MdSpan auto&& argb, auto const numElements) const
     {
         constexpr uint32_t maskFF = 0xFFu;
         auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};

--- a/example/heatEquation2D/src/BoundaryKernel.hpp
+++ b/example/heatEquation2D/src/BoundaryKernel.hpp
@@ -26,7 +26,7 @@ struct BoundaryKernel
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(
         TAcc const& acc,
-        auto uBuf,
+        alpaka::concepts::MdSpan auto uBuf,
         alpaka::concepts::Vector auto const chunkSize,
         alpaka::concepts::Vector auto numNodes,
         uint32_t step,

--- a/example/heatEquation2D/src/StencilKernel.hpp
+++ b/example/heatEquation2D/src/StencilKernel.hpp
@@ -28,8 +28,8 @@ struct StencilKernel
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(
         TAcc const& acc,
-        auto const uCurrBuf,
-        auto uNextBuf,
+        alpaka::concepts::MdSpan auto const uCurrBuf,
+        alpaka::concepts::MdSpan auto uNextBuf,
         alpaka::concepts::Vector auto const chunkSize,
         alpaka::concepts::CVector auto sharedMemExtents,
         alpaka::concepts::Vector auto numNodes,

--- a/example/heatEquation2D/src/analyticalSolution.hpp
+++ b/example/heatEquation2D/src/analyticalSolution.hpp
@@ -61,7 +61,7 @@ auto validateSolution(
 //! \param extent extents of the buffer
 //! \param dx
 //! \param dy
-template<typename T_MdSpan>
+template<alpaka::concepts::MdSpan T_MdSpan>
 auto initalizeBuffer(T_MdSpan dataMdSpan, double const dx, double const dy) -> void
 {
     auto extents = dataMdSpan.getExtents();

--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -12,7 +12,12 @@
 struct VectorAddKernel
 {
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const in1, auto const in2, auto out, uint32_t size) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in1,
+        alpaka::concepts::MdSpan auto const in2,
+        alpaka::concepts::MdSpan auto out,
+        uint32_t size) const
     {
         for(auto [index] :
             alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))
@@ -25,7 +30,12 @@ struct VectorAddKernel
 struct VectorAddKernel1D
 {
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const in1, auto const in2, auto out, Vec1D size) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in1,
+        alpaka::concepts::MdSpan auto const in2,
+        alpaka::concepts::MdSpan auto out,
+        Vec1D size) const
     {
         for(auto ndindex :
             alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))
@@ -38,7 +48,12 @@ struct VectorAddKernel1D
 struct VectorAddKernel3D
 {
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const in1, auto const in2, auto out, Vec3D size) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in1,
+        alpaka::concepts::MdSpan auto const in2,
+        alpaka::concepts::MdSpan auto out,
+        Vec3D size) const
     {
         for(auto ndindex :
             alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -20,7 +20,12 @@
 struct VectorAddKernel1D
 {
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const in1, auto const in2, auto out, Vec1D size) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in1,
+        alpaka::concepts::MdSpan auto const in2,
+        alpaka::concepts::MdSpan auto out,
+        Vec1D size) const
     {
         auto [threadIndex] = acc[alpaka::layer::thread].idx();
         auto [blockDimension] = acc[alpaka::layer::thread].count();
@@ -41,7 +46,12 @@ struct VectorAddKernel1D
 struct VectorAddKernel3D
 {
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const in1, auto const in2, auto out, Vec3D size) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in1,
+        alpaka::concepts::MdSpan auto const in2,
+        alpaka::concepts::MdSpan auto out,
+        Vec3D size) const
     {
         auto threadIndexMD = acc[alpaka::layer::thread].idx();
         auto blockDimensionMD = acc[alpaka::layer::thread].count();

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -23,7 +23,11 @@
 struct VectorAddKernel1D
 {
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const in1, auto const in2, auto out) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in1,
+        alpaka::concepts::MdSpan auto const in2,
+        alpaka::concepts::MdSpan auto out) const
     {
         // product() returns a scalar therefore we need the explicit Vec1D type
         Vec1D linearNumFrames = acc[alpaka::frame::count].product();
@@ -88,7 +92,11 @@ struct VectorAddKernel1D
 struct VectorAddKernel3D
 {
     template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, auto const in1, auto const in2, auto out) const
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in1,
+        alpaka::concepts::MdSpan auto const in2,
+        alpaka::concepts::MdSpan auto out) const
     {
         auto numFramesMD = acc[alpaka::frame::count];
         auto frameExtentMD = acc[alpaka::frame::extent];

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -28,8 +28,12 @@ public:
     //! \param B The second source vector.
     //! \param C The destination vector.
     //! \param numElements The number of elements.
-    ALPAKA_FN_ACC auto operator()(auto const& acc, auto const A, auto const B, auto C, auto const& numElements) const
-        -> void
+    ALPAKA_FN_ACC auto operator()(
+        auto const& acc,
+        alpaka::concepts::MdSpan auto const A,
+        alpaka::concepts::MdSpan auto const B,
+        alpaka::concepts::MdSpan auto C,
+        auto const& numElements) const -> void
     {
         using namespace alpaka;
         static_assert(ALPAKA_TYPEOF(numElements)::dim() == 1, "The VectorAddKernel expects 1-dimensional indices!");

--- a/include/alpaka/SimdPtr.hpp
+++ b/include/alpaka/SimdPtr.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/cast.hpp"
 #include "alpaka/core/util.hpp"
 #include "alpaka/mem/Alignment.hpp"
+#include "alpaka/mem/concepts.hpp"
 #include "alpaka/trait.hpp"
 
 #include <array>
@@ -28,7 +29,7 @@ namespace alpaka
      * @tparam T_SimdWidth width of the SIMD pack
      */
     template<
-        typename T_MdSpan,
+        alpaka::concepts::MdSpan T_MdSpan,
         alpaka::concepts::Vector T_IdxType,
         alpaka::concepts::Alignment T_MemAlignment,
         alpaka::concepts::CVector T_SimdWidth>

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -332,11 +332,6 @@ namespace alpaka
     namespace trait
     {
         template<typename T>
-        struct IsMdSpan : std::false_type
-        {
-        };
-
-        template<typename T>
         requires(isSpecializationOf_v<std::remove_cvref_t<T>, MdSpan>)
         struct IsMdSpan<T> : std::true_type
         {
@@ -348,17 +343,4 @@ namespace alpaka
         {
         };
     } // namespace trait
-
-    template<typename T>
-    constexpr bool isMdSpan_v = trait::IsMdSpan<T>::value;
-
-    namespace concepts
-    {
-        template<typename T>
-        concept MdSpan = isMdSpan_v<T>;
-
-        template<typename T>
-        concept Reference = std::is_reference_v<T>;
-
-    } // namespace concepts
 } // namespace alpaka

--- a/include/alpaka/mem/concepts.hpp
+++ b/include/alpaka/mem/concepts.hpp
@@ -1,0 +1,20 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/trait.hpp"
+
+#include <concepts>
+#include <type_traits>
+
+namespace alpaka::concepts
+{
+    template<typename T>
+    concept MdSpan = alpaka::isMdSpan_v<T>;
+
+    template<typename T>
+    concept Reference = std::is_reference_v<T>;
+
+} // namespace alpaka::concepts

--- a/include/alpaka/onAcc/SimdAlgo.hpp
+++ b/include/alpaka/onAcc/SimdAlgo.hpp
@@ -6,6 +6,7 @@
 
 #include "alpaka/Vec.hpp"
 #include "alpaka/core/common.hpp"
+#include "alpaka/mem/concepts.hpp"
 #include "alpaka/onAcc/internel/SimdConcurrent.hpp"
 #include "alpaka/onAcc/internel/SimdTransformReduce.hpp"
 

--- a/include/alpaka/onAcc/internel/SimdConcurrent.hpp
+++ b/include/alpaka/onAcc/internel/SimdConcurrent.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/Vec.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/core/common.hpp"
+#include "alpaka/mem/concepts.hpp"
 #include "alpaka/onAcc.hpp"
 
 #include <cstdint>
@@ -28,8 +29,8 @@ namespace alpaka::onAcc::internal
             auto const& acc,
             alpaka::concepts::Vector auto extents,
             auto&& func,
-            auto&& data0,
-            auto&&... dataN) const
+            alpaka::concepts::MdSpan auto&& data0,
+            alpaka::concepts::MdSpan auto&&... dataN) const
         {
             auto numElements = typename ALPAKA_TYPEOF(extents)::UniVec{extents};
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
@@ -79,7 +80,7 @@ namespace alpaka::onAcc::internal
             auto const& acc,
             auto const& dataIdx,
             auto&& func,
-            auto&&... data)
+            alpaka::concepts::MdSpan auto&&... data)
         {
             func(acc, SimdPtr{ALPAKA_FORWARD(data), dataIdx, T_MemAlignment{}, CVec<uint32_t, T_width>{}}...);
         }
@@ -97,7 +98,7 @@ namespace alpaka::onAcc::internal
             auto& iter,
             std::integer_sequence<uint32_t, T_repeat...>,
             auto&& func,
-            auto&&... data)
+            alpaka::concepts::MdSpan auto&&... data)
         {
             /* We do not check if the iterator points to a valid element, the caller must ensure that we can safely
              * increase the iterator without jumping over iter.end().
@@ -118,8 +119,8 @@ namespace alpaka::onAcc::internal
             auto const& acc,
             alpaka::concepts::Vector auto numElements,
             auto&& func,
-            auto&& data0,
-            auto&&... dataN) const
+            alpaka::concepts::MdSpan auto&& data0,
+            alpaka::concepts::MdSpan auto&&... dataN) const
         {
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
             constexpr uint32_t simdWidthInByte = T_simdWidth * sizeof(ValueType);

--- a/include/alpaka/onAcc/internel/SimdTransformReduce.hpp
+++ b/include/alpaka/onAcc/internel/SimdTransformReduce.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/Vec.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/core/common.hpp"
+#include "alpaka/mem/concepts.hpp"
 #include "alpaka/onAcc.hpp"
 
 #include <cstdint>
@@ -31,8 +32,8 @@ namespace alpaka::onAcc::internal
             auto const& neutralElement,
             auto&& reduceFunc,
             auto&& func,
-            auto&& data0,
-            auto&&... dataN) const
+            alpaka::concepts::MdSpan auto&& data0,
+            alpaka::concepts::MdSpan auto&&... dataN) const
         {
             auto numElements = typename ALPAKA_TYPEOF(extents)::UniVec{extents};
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
@@ -89,7 +90,7 @@ namespace alpaka::onAcc::internal
             auto const& acc,
             auto const& dataIdx,
             auto&& func,
-            auto&&... data)
+            alpaka::concepts::MdSpan auto&&... data)
         {
             return func(acc, SimdPtr{ALPAKA_FORWARD(data), dataIdx, T_MemAlignment{}, CVec<uint32_t, T_width>{}}...);
         }
@@ -108,7 +109,7 @@ namespace alpaka::onAcc::internal
             std::integer_sequence<uint32_t, T_repeat...>,
             auto&& reduceFunc,
             auto&& func,
-            auto&&... data)
+            alpaka::concepts::MdSpan auto&&... data)
         {
             /* We do not check if the iterator points to a valid element, the caller must ensure that we can safely
              * increase the iterator without jumping over iter.end().
@@ -141,7 +142,7 @@ namespace alpaka::onAcc::internal
             auto const& acc,
             auto const& dataIdx,
             auto&& func,
-            auto&&... data)
+            alpaka::concepts::MdSpan auto&&... data)
         {
             func(acc, SimdPtr{ALPAKA_FORWARD(data), dataIdx, T_MemAlignment{}, CVec<uint32_t, T_width>{}}...);
         }
@@ -159,7 +160,7 @@ namespace alpaka::onAcc::internal
             auto& iter,
             std::integer_sequence<uint32_t, T_repeat...>,
             auto&& func,
-            auto&&... data)
+            alpaka::concepts::MdSpan auto&&... data)
         {
             /* We do not check if the iterator points to a valid element, the caller must ensure that we can safely
              * increase the iterator without jumping over iter.end().
@@ -182,8 +183,8 @@ namespace alpaka::onAcc::internal
             auto const& neutralElement,
             auto&& reduceFunc,
             auto&& func,
-            auto&& data0,
-            auto&&... dataN) const
+            alpaka::concepts::MdSpan auto&& data0,
+            alpaka::concepts::MdSpan auto&&... dataN) const
         {
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
             constexpr uint32_t simdWidthInByte = T_simdWidth * sizeof(ValueType);

--- a/include/alpaka/onHost/mem/View.hpp
+++ b/include/alpaka/onHost/mem/View.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/core/config.hpp"
 #include "alpaka/internal.hpp"
 #include "alpaka/mem/MdSpan.hpp"
+#include "alpaka/mem/concepts.hpp"
 #include "alpaka/onHost.hpp"
 #include "alpaka/onHost/Handle.hpp"
 
@@ -87,7 +88,7 @@ namespace alpaka::onHost
             return onHost::data(m_data);
         }
 
-        auto getMdSpan() const
+        alpaka::concepts::MdSpan auto getMdSpan() const
         {
             auto* ptr = onHost::data(m_data);
             return makeMdSpan(

--- a/include/alpaka/trait.hpp
+++ b/include/alpaka/trait.hpp
@@ -52,6 +52,12 @@ namespace alpaka
         template<typename T>
         using GetValueType_t = typename GetValueType<T>::type;
 
+        // true for alpaka MdSpan implementations
+        template<typename T>
+        struct IsMdSpan : std::false_type
+        {
+        };
+
     } // namespace trait
 
     /** checks if T is a instance of U
@@ -82,5 +88,8 @@ namespace alpaka
 
     template<typename T_From, typename T_To>
     constexpr bool isConvertible_v = concepts::IsConvertible<T_From, T_To>;
+
+    template<typename T>
+    constexpr bool isMdSpan_v = trait::IsMdSpan<T>::value;
 
 } // namespace alpaka

--- a/tests/unit/precision/precision.cpp
+++ b/tests/unit/precision/precision.cpp
@@ -79,7 +79,7 @@ void iotaTest(auto cfg, auto const extents, auto frameSize)
     wait(queue);
 
 
-    auto mdSpan = hBuff.getMdSpan();
+    alpaka::concepts::MdSpan auto mdSpan = hBuff.getMdSpan();
 
     meta::ndLoopIncIdx(extents, [&](auto idx) { CHECK(idx == pCast<T_MemIdxType>(mdSpan[idx])); });
 }


### PR DESCRIPTION
Use the `MdSpan` concpet to enforce an alpaka MdSpan for different function where a template or `auto` is used.

Move `IsMdSpan` to `alpaka/trait.hpp` and `concpets::MdSpan` to `alpaka/mem/concepts.hpp`