### PR TITLE
add more math functions

### DIFF
--- a/include/alpaka/api/unifiedCudaHip/math.hpp
+++ b/include/alpaka/api/unifiedCudaHip/math.hpp
@@ -12,13 +12,13 @@
 #include "alpaka/core/decay.hpp"
 
 #include <cmath>
+#include <concepts>
 
 namespace alpaka::math::internal
 {
 #if ALPAKA_LANG_CUDA || ALPAKA_LANG_HIP
     //! The CUDA sin trait specialization for real types.
-    template<typename T_Arg>
-    requires(std::is_floating_point_v<T_Arg>)
+    template<std::floating_point T_Arg>
     struct Sin::Op<CudaHipMath, T_Arg>
     {
         constexpr auto operator()(CudaHipMath, T_Arg const& arg)
@@ -34,8 +34,7 @@ namespace alpaka::math::internal
         }
     };
 
-    template<typename T_Arg>
-    requires(std::is_floating_point_v<T_Arg>)
+    template<std::floating_point T_Arg>
     struct Exp::Op<CudaHipMath, T_Arg>
     {
         constexpr auto operator()(CudaHipMath, T_Arg const& arg)
@@ -44,6 +43,125 @@ namespace alpaka::math::internal
                 return ::expf(arg);
             else if constexpr(is_decayed_v<T_Arg, double>)
                 return ::exp(arg);
+            else
+                static_assert(!sizeof(T_Arg), "Unsupported data type");
+
+            ALPAKA_UNREACHABLE(T_Arg{});
+        }
+    };
+
+    //! The CUDA sqrt trait specialization for real types.
+    template<std::floating_point T_Arg>
+    struct Sqrt::Op<CudaHipMath, T_Arg>
+    {
+        constexpr auto operator()(CudaHipMath, T_Arg const& arg)
+        {
+            if constexpr(is_decayed_v<T_Arg, float>)
+                return ::sqrtf(arg);
+            else if constexpr(is_decayed_v<T_Arg, double>)
+                return ::sqrt(arg);
+            else
+                static_assert(!sizeof(T_Arg), "Unsupported data type");
+
+            ALPAKA_UNREACHABLE(T_Arg{});
+        }
+    };
+
+    //! The CUDA cos trait specialization for real types.
+    template<std::floating_point T_Arg>
+    struct Cos::Op<CudaHipMath, T_Arg>
+    {
+        constexpr auto operator()(CudaHipMath, T_Arg const& arg)
+        {
+            if constexpr(is_decayed_v<T_Arg, float>)
+                return ::cosf(arg);
+            else if constexpr(is_decayed_v<T_Arg, double>)
+                return ::cos(arg);
+            else
+                static_assert(!sizeof(T_Arg), "Unsupported data type");
+
+            ALPAKA_UNREACHABLE(T_Arg{});
+        }
+    };
+
+    //! The CUDA log trait specialization for real types.
+    template<std::floating_point T_Arg>
+    struct Log::Op<CudaHipMath, T_Arg>
+    {
+        constexpr auto operator()(CudaHipMath, T_Arg const& arg)
+        {
+            if constexpr(is_decayed_v<T_Arg, float>)
+                return ::logf(arg);
+            else if constexpr(is_decayed_v<T_Arg, double>)
+                return ::log(arg);
+            else
+                static_assert(!sizeof(T_Arg), "Unsupported data type");
+
+            ALPAKA_UNREACHABLE(T_Arg{});
+        }
+    };
+
+    //! The CUDA tan trait specialization for real types.
+    template<std::floating_point T_Arg>
+    struct Tan::Op<CudaHipMath, T_Arg>
+    {
+        constexpr auto operator()(CudaHipMath, T_Arg const& arg)
+        {
+            if constexpr(is_decayed_v<T_Arg, float>)
+                return ::tanf(arg);
+            else if constexpr(is_decayed_v<T_Arg, double>)
+                return ::tan(arg);
+            else
+                static_assert(!sizeof(T_Arg), "Unsupported data type");
+
+            ALPAKA_UNREACHABLE(T_Arg{});
+        }
+    };
+
+    //! The CUDA asin trait specialization for real types.
+    template<std::floating_point T_Arg>
+    struct Asin::Op<CudaHipMath, T_Arg>
+    {
+        constexpr auto operator()(CudaHipMath, T_Arg const& arg)
+        {
+            if constexpr(is_decayed_v<T_Arg, float>)
+                return ::asinf(arg);
+            else if constexpr(is_decayed_v<T_Arg, double>)
+                return ::asin(arg);
+            else
+                static_assert(!sizeof(T_Arg), "Unsupported data type");
+
+            ALPAKA_UNREACHABLE(T_Arg{});
+        }
+    };
+
+    //! The CUDA acos trait specialization for real types.
+    template<std::floating_point T_Arg>
+    struct Acos::Op<CudaHipMath, T_Arg>
+    {
+        constexpr auto operator()(CudaHipMath, T_Arg const& arg)
+        {
+            if constexpr(is_decayed_v<T_Arg, float>)
+                return ::acosf(arg);
+            else if constexpr(is_decayed_v<T_Arg, double>)
+                return ::acos(arg);
+            else
+                static_assert(!sizeof(T_Arg), "Unsupported data type");
+
+            ALPAKA_UNREACHABLE(T_Arg{});
+        }
+    };
+
+    //! The CUDA isnan trait specialization for real types.
+    template<std::floating_point T_Arg>
+    struct IsNan::Op<CudaHipMath, T_Arg>
+    {
+        constexpr auto operator()(CudaHipMath, T_Arg const& arg)
+        {
+            if constexpr(is_decayed_v<T_Arg, float> || is_decayed_v<T_Arg, double>)
+            {
+                return ::isnan(arg);
+            }
             else
                 static_assert(!sizeof(T_Arg), "Unsupported data type");
 

--- a/include/alpaka/math.hpp
+++ b/include/alpaka/math.hpp
@@ -23,4 +23,53 @@ namespace alpaka::math
         auto const mathImpl = trait::getMathImpl(thisApi());
         return internal::Exp::Op<ALPAKA_TYPEOF(mathImpl), ALPAKA_TYPEOF(arg)>{}(mathImpl, arg);
     }
+
+    // Square root function
+    constexpr auto sqrt(auto const& arg)
+    {
+        auto const mathImpl = trait::getMathImpl(thisApi());
+        return internal::Sqrt::Op<ALPAKA_TYPEOF(mathImpl), ALPAKA_TYPEOF(arg)>{}(mathImpl, arg);
+    }
+
+    // Cosine function
+    constexpr auto cos(auto const& arg)
+    {
+        auto const mathImpl = trait::getMathImpl(thisApi());
+        return internal::Cos::Op<ALPAKA_TYPEOF(mathImpl), ALPAKA_TYPEOF(arg)>{}(mathImpl, arg);
+    }
+
+    // Natural logarithm function
+    constexpr auto log(auto const& arg)
+    {
+        auto const mathImpl = trait::getMathImpl(thisApi());
+        return internal::Log::Op<ALPAKA_TYPEOF(mathImpl), ALPAKA_TYPEOF(arg)>{}(mathImpl, arg);
+    }
+
+    // Tangent function
+    constexpr auto tan(auto const& arg)
+    {
+        auto const mathImpl = trait::getMathImpl(thisApi());
+        return internal::Tan::Op<ALPAKA_TYPEOF(mathImpl), ALPAKA_TYPEOF(arg)>{}(mathImpl, arg);
+    }
+
+    // Arc cosine function
+    constexpr auto acos(auto const& arg)
+    {
+        auto const mathImpl = trait::getMathImpl(thisApi());
+        return internal::Acos::Op<ALPAKA_TYPEOF(mathImpl), ALPAKA_TYPEOF(arg)>{}(mathImpl, arg);
+    }
+
+    // Arc sine function
+    constexpr auto asin(auto const& arg)
+    {
+        auto const mathImpl = trait::getMathImpl(thisApi());
+        return internal::Asin::Op<ALPAKA_TYPEOF(mathImpl), ALPAKA_TYPEOF(arg)>{}(mathImpl, arg);
+    }
+
+    constexpr auto isnan(auto const& arg)
+    {
+        auto const mathImpl = trait::getMathImpl(thisApi());
+        return internal::IsNan::Op<ALPAKA_TYPEOF(mathImpl), ALPAKA_TYPEOF(arg)>{}(mathImpl, arg);
+    }
+
 } // namespace alpaka::math

--- a/include/alpaka/math/math.hpp
+++ b/include/alpaka/math/math.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cmath>
+#include <type_traits>
 
 namespace alpaka::math::internal
 {
@@ -15,6 +16,7 @@ namespace alpaka::math::internal
 
     constexpr auto stlMath = StlMath{};
 
+    // Sine function
     struct Sin
     {
         template<typename T_MathImpl, typename T_Arg>
@@ -28,6 +30,7 @@ namespace alpaka::math::internal
         };
     };
 
+    // Exponential function
     struct Exp
     {
         template<typename T_MathImpl, typename T_Arg>
@@ -40,4 +43,104 @@ namespace alpaka::math::internal
             }
         };
     };
+
+    // Square root function
+    struct Sqrt
+    {
+        template<typename T_MathImpl, typename T_Arg>
+        struct Op
+        {
+            constexpr auto operator()(T_MathImpl, T_Arg const& arg) const
+            {
+                using std::sqrt;
+                return sqrt(arg);
+            }
+        };
+    };
+
+    // Cosine function
+    struct Cos
+    {
+        template<typename T_MathImpl, typename T_Arg>
+        struct Op
+        {
+            constexpr auto operator()(T_MathImpl, T_Arg const& arg) const
+            {
+                using std::cos;
+                return cos(arg);
+            }
+        };
+    };
+
+    // Natural logarithm function
+    struct Log
+    {
+        template<typename T_MathImpl, typename T_Arg>
+        struct Op
+        {
+            constexpr auto operator()(T_MathImpl, T_Arg const& arg) const
+            {
+                using std::log;
+                return log(arg);
+            }
+        };
+    };
+
+    // Tangent function
+    struct Tan
+    {
+        template<typename T_MathImpl, typename T_Arg>
+        struct Op
+        {
+            constexpr auto operator()(T_MathImpl, T_Arg const& arg) const
+            {
+                using std::tan;
+                return tan(arg);
+            }
+        };
+    };
+
+    // Arc cosine function
+    struct Acos
+    {
+        template<typename T_MathImpl, typename T_Arg>
+        struct Op
+        {
+            constexpr auto operator()(T_MathImpl, T_Arg const& arg) const
+            {
+                using std::acos;
+                return acos(arg);
+            }
+        };
+    };
+
+    // Arc sine function
+    struct Asin
+    {
+        template<typename T_MathImpl, typename T_Arg>
+        struct Op
+        {
+            constexpr auto operator()(T_MathImpl, T_Arg const& arg) const
+            {
+                using std::asin;
+                return asin(arg);
+            }
+        };
+    };
+
+    //! The IsNan trait specialization for real types.
+    struct IsNan
+    {
+        template<typename T_MathImpl, typename T_Arg>
+        struct Op
+        {
+            constexpr auto operator()(T_MathImpl, T_Arg const& arg) const
+            {
+                using std::isnan;
+                return isnan(arg);
+            }
+        };
+    };
+
+
 } // namespace alpaka::math::internal

--- a/tests/unit/math/mathFunctions.cpp
+++ b/tests/unit/math/mathFunctions.cpp
@@ -1,0 +1,432 @@
+/* Copyright
+ * SPDX-License-Identifier:
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executeForEach.hpp>
+#include <alpaka/example/executors.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <thread>
+
+using namespace alpaka;
+using namespace alpaka::onHost;
+
+using TestApis = std::decay_t<decltype(allExecutorsAndApis(enabledApis))>;
+
+// Kernels for individual mathematical functions
+struct SqrtKernel
+{
+    template<typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in,
+        alpaka::concepts::MdSpan auto out,
+        uint32_t size) const
+    {
+        for(auto i : alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))
+        {
+            // Ensure x >= 0
+            float x = (in[i] < 0) ? -in[i] : in[i];
+            out[i] = alpaka::math::sqrt(x);
+        }
+    }
+};
+
+struct CosKernel
+{
+    template<typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in,
+        alpaka::concepts::MdSpan auto out,
+        uint32_t size) const
+    {
+        for(auto i : alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))
+        {
+            out[i] = alpaka::math::cos(in[i]);
+        }
+    }
+};
+
+struct LogKernel
+{
+    template<typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in,
+        alpaka::concepts::MdSpan auto out,
+        uint32_t size) const
+    {
+        for(auto i : alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))
+        {
+            // Make input valid
+            float x = (in[i] > 0) ? in[i] : 1e-6f;
+            out[i] = alpaka::math::log(x);
+        }
+    }
+};
+
+struct TanKernel
+{
+    template<typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in,
+        alpaka::concepts::MdSpan auto out,
+        uint32_t size) const
+    {
+        for(auto i : alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))
+        {
+            // Avoid singularities
+            float x = (in[i] < 0) ? -3.14f / 3 : 3.14f / 3;
+            out[i] = alpaka::math::tan(x);
+        }
+    }
+};
+
+struct AcosKernel
+{
+    template<typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in,
+        alpaka::concepts::MdSpan auto out,
+        uint32_t size) const
+    {
+        for(auto i : alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))
+        {
+            // Clamp to [-1, 1] to make the input valid
+            float x = std::clamp(in[i], -1.0f, 1.0f);
+            out[i] = alpaka::math::acos(x);
+        }
+    }
+};
+
+struct AsinKernel
+{
+    template<typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in,
+        alpaka::concepts::MdSpan auto out,
+        uint32_t size) const
+    {
+        for(auto i : alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))
+        {
+            // Clamp to [-1, 1] to make the input valid
+            float x = std::clamp(in[i], -1.0f, 1.0f);
+            out[i] = alpaka::math::asin(x);
+        }
+    }
+};
+
+struct ExpKernel
+{
+    template<typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in,
+        alpaka::concepts::MdSpan auto out,
+        uint32_t size) const
+    {
+        for(auto i : alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))
+        {
+            // scale not to have too big values
+            float scaleExpInput = 0.2f;
+            out[i] = alpaka::math::exp(scaleExpInput * in[i]);
+        }
+    }
+};
+
+//
+// Bool returning function test kernels
+//
+struct IsNanKernel
+{
+    template<typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        TAcc const& acc,
+        alpaka::concepts::MdSpan auto const in,
+        alpaka::concepts::MdSpan auto out,
+        uint32_t size) const
+    {
+        for(auto i : alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{size}))
+        {
+            out[i] = alpaka::math::isnan(in[i]);
+        }
+    }
+};
+
+// Helper functions
+// FuzzyEqual compares two floating-point or integral type values.
+template<typename T>
+[[maybe_unused]] bool FuzzyEqual(T a, T b)
+{
+    if constexpr(std::is_floating_point_v<T>)
+    {
+        return std::fabs(a - b) < (std::numeric_limits<T>::epsilon() * static_cast<T>(1000.0));
+    }
+    else if constexpr(std::is_integral_v<T>)
+    {
+        return a == b;
+    }
+    else
+    {
+        static_assert(
+            std::is_floating_point_v<T> || std::is_integral_v<T>,
+            "FuzzyEqual<T> is only supported for integral or floating-point types.");
+    }
+}
+
+// Test case using Catch2 for floating point input and ouput math functions
+TEMPLATE_LIST_TEST_CASE("Math Functions Test", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto api = cfg[object::api];
+    auto exec = cfg[object::exec];
+
+    std::cout << api.getName() << std::endl;
+
+    // Use the single host device
+    alpaka::onHost::Platform platform_host = alpaka::onHost::makePlatform(alpaka::api::cpu);
+    alpaka::onHost::Device host = platform_host.makeDevice(0);
+    std::cout << "Host:   " << alpaka::onHost::getName(host) << "\n\n";
+
+    // Use the first device
+    alpaka::onHost::Platform platform_device = alpaka::onHost::makePlatform(api);
+    alpaka::onHost::Device device = platform_device.makeDevice(0);
+    std::cout << "Device: " << alpaka::onHost::getName(device) << "\n\n";
+
+    Queue queue = device.makeQueue();
+
+    // Random number generator
+    std::random_device rd{};
+    std::default_random_engine rand{rd()};
+    std::uniform_real_distribution<float> dist{-10.0f, 10.0f};
+
+    // Buffer size
+    constexpr uint32_t size = 32;
+
+    // Allocate input and output buffers on the host
+    auto inHost = alpaka::onHost::alloc<float>(host, size);
+    auto outHost = alpaka::onHost::alloc<float>(host, size);
+
+    // Fill the input buffer with random data
+    for(uint32_t i = 0; i < size; ++i)
+    {
+        inHost[i] = dist(rand);
+    }
+
+    // Device memory allocation
+    auto inDev = alpaka::onHost::allocMirror(device, inHost);
+    auto outDev = alpaka::onHost::allocMirror(device, outHost);
+
+    // Copy input data to the device
+    alpaka::onHost::memcpy(queue, inDev, inHost);
+
+    // Helper lambda to print values and perform FuzzyEqual comparison
+    auto fuzzyEqualWithLogging = [](char const* functionName, auto input, auto expected, auto actual)
+    {
+        std::cout << "Testing " << functionName << ": Input = " << input << ", Expected = " << expected
+                  << ", Actual = " << actual << std::endl;
+        return FuzzyEqual(expected, actual);
+    };
+
+    // Launch and validate each kernel
+    constexpr Vec numBlocks = Vec{1u};
+    constexpr Vec blockExtent = Vec{size};
+
+    // Sqrt kernel
+    alpaka::onHost::enqueue(
+        queue,
+        exec,
+        alpaka::onHost::FrameSpec{numBlocks, blockExtent},
+        KernelBundle{SqrtKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+    alpaka::onHost::memcpy(queue, outHost, outDev);
+    alpaka::onHost::wait(queue);
+    for(uint32_t i = 0; i < size; ++i)
+    {
+        float xForSqrt = (inHost[i] < 0) ? -inHost[i] : inHost[i];
+        float expectedSqrt = std::sqrt(xForSqrt);
+        REQUIRE(fuzzyEqualWithLogging("sqrt", xForSqrt, expectedSqrt, outHost[i]));
+    }
+
+    // Cos kernel
+    alpaka::onHost::enqueue(
+        queue,
+        exec,
+        alpaka::onHost::FrameSpec{numBlocks, blockExtent},
+        KernelBundle{CosKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+    alpaka::onHost::memcpy(queue, outHost, outDev);
+    alpaka::onHost::wait(queue);
+    for(uint32_t i = 0; i < size; ++i)
+    {
+        float expectedCos = std::cos(inHost[i]);
+        REQUIRE(fuzzyEqualWithLogging("cos", inHost[i], expectedCos, outHost[i]));
+    }
+
+    // Log kernel
+    alpaka::onHost::enqueue(
+        queue,
+        exec,
+        alpaka::onHost::FrameSpec{numBlocks, blockExtent},
+        KernelBundle{LogKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+    alpaka::onHost::memcpy(queue, outHost, outDev);
+    alpaka::onHost::wait(queue);
+    for(uint32_t i = 0; i < size; ++i)
+    {
+        float xForLog = (inHost[i] > 0) ? inHost[i] : 1e-6f;
+        float expectedLog = std::log(xForLog);
+        REQUIRE(fuzzyEqualWithLogging("log", xForLog, expectedLog, outHost[i]));
+    }
+
+    // Tan kernel
+    alpaka::onHost::enqueue(
+        queue,
+        exec,
+        alpaka::onHost::FrameSpec{numBlocks, blockExtent},
+        KernelBundle{TanKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+    alpaka::onHost::memcpy(queue, outHost, outDev);
+    alpaka::onHost::wait(queue);
+    for(uint32_t i = 0; i < size; ++i)
+    {
+        float xForTan = (inHost[i] < 0) ? -3.14f / 3 : 3.14f / 3;
+        float expectedTan = std::tan(xForTan);
+        REQUIRE(fuzzyEqualWithLogging("tan", xForTan, expectedTan, outHost[i]));
+    }
+
+    // Acos kernel
+    alpaka::onHost::enqueue(
+        queue,
+        exec,
+        alpaka::onHost::FrameSpec{numBlocks, blockExtent},
+        KernelBundle{AcosKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+    alpaka::onHost::memcpy(queue, outHost, outDev);
+    alpaka::onHost::wait(queue);
+    for(uint32_t i = 0; i < size; ++i)
+    {
+        float xForAcos = std::clamp(inHost[i], -1.0f, 1.0f);
+        float expectedAcos = std::acos(xForAcos);
+        REQUIRE(fuzzyEqualWithLogging("acos", xForAcos, expectedAcos, outHost[i]));
+    }
+
+    // Asin kernel
+    alpaka::onHost::enqueue(
+        queue,
+        exec,
+        alpaka::onHost::FrameSpec{numBlocks, blockExtent},
+        KernelBundle{AsinKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+    alpaka::onHost::memcpy(queue, outHost, outDev);
+    alpaka::onHost::wait(queue);
+    for(uint32_t i = 0; i < size; ++i)
+    {
+        float xForAsin = std::clamp(inHost[i], -1.0f, 1.0f);
+        float expectedAsin = std::asin(xForAsin);
+        REQUIRE(fuzzyEqualWithLogging("asin", xForAsin, expectedAsin, outHost[i]));
+    }
+
+    // Exp kernel
+    alpaka::onHost::enqueue(
+        queue,
+        exec,
+        alpaka::onHost::FrameSpec{numBlocks, blockExtent},
+        KernelBundle{ExpKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+    alpaka::onHost::memcpy(queue, outHost, outDev);
+    alpaka::onHost::wait(queue);
+    for(uint32_t i = 0; i < size; ++i)
+    {
+        float scaleExpInput = 0.2f;
+        float expectedExp = std::exp(inHost[i] * scaleExpInput);
+        REQUIRE(fuzzyEqualWithLogging("exp", inHost[i] * scaleExpInput, expectedExp, outHost[i]));
+    }
+}
+
+// Test case using Catch2, boolean returning math functions like isNan, isInf
+TEMPLATE_LIST_TEST_CASE("Math Functions Returning Boolean - Test", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto api = cfg[object::api];
+    auto exec = cfg[object::exec];
+
+    std::cout << api.getName() << std::endl;
+
+    // Use the single host device
+    alpaka::onHost::Platform platform_host = alpaka::onHost::makePlatform(alpaka::api::cpu);
+    alpaka::onHost::Device host = platform_host.makeDevice(0);
+    std::cout << "Host:   " << alpaka::onHost::getName(host) << "\n\n";
+
+    // Use the first device
+    alpaka::onHost::Platform platform_device = alpaka::onHost::makePlatform(api);
+    alpaka::onHost::Device device = platform_device.makeDevice(0);
+    std::cout << "Device: " << alpaka::onHost::getName(device) << "\n\n";
+
+    Queue queue = device.makeQueue();
+
+    // Random number generator
+    std::random_device rd{};
+    std::default_random_engine rand{rd()};
+    std::uniform_real_distribution<float> dist{-10.0f, 10.0f};
+
+    // Buffer size
+    constexpr uint32_t size = 32;
+
+    // Allocate input and output buffers on the host
+    auto inHost = alpaka::onHost::alloc<float>(host, size);
+    // Return type of the array items is bool
+    auto outHost = alpaka::onHost::alloc<bool>(host, size);
+
+    // Fill the input buffer with random data
+    for(uint32_t i = 0; i < size; ++i)
+    {
+        inHost[i] = dist(rand);
+    }
+
+    // Set some values to NaN values to test isnan
+    inHost[0] = std::numeric_limits<float>::quiet_NaN();
+    inHost[1] = std::numeric_limits<float>::signaling_NaN();
+
+
+    // Device memory allocation
+    auto inDev = alpaka::onHost::allocMirror(device, inHost);
+    auto outDev = alpaka::onHost::allocMirror(device, outHost);
+
+    // Copy input data to the device
+    alpaka::onHost::memcpy(queue, inDev, inHost);
+
+    // Helper lambda to print values and perform FuzzyEqual comparison
+    auto fuzzyEqualWithLogging = [](char const* functionName, auto input, auto expected, auto actual)
+    {
+        std::cout << "Testing " << functionName << ": Input = " << input << ", Expected = " << expected
+                  << ", Actual = " << actual << std::endl;
+        return FuzzyEqual(expected, actual);
+    };
+
+    // Launch and validate each kernel
+    constexpr Vec numBlocks = Vec{1u};
+    constexpr Vec blockExtent = Vec{size};
+
+    // isnan kernel
+    alpaka::onHost::enqueue(
+        queue,
+        exec,
+        alpaka::onHost::FrameSpec{numBlocks, blockExtent},
+        KernelBundle{IsNanKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+    alpaka::onHost::memcpy(queue, outHost, outDev);
+    alpaka::onHost::wait(queue);
+    for(uint32_t i = 0; i < size; ++i)
+    {
+        bool expectedIsNan = std::isnan(inHost[i]);
+        std::cout << "Testing "
+                  << "isnan"
+                  << ": Input = " << inHost[i] << ", Expected = " << expectedIsNan << ", Actual = " << outHost[i]
+                  << std::endl;
+        REQUIRE(expectedIsNan == outHost[i]);
+    }
+}


### PR DESCRIPTION
While adding random function generators to alpaka3, I noticed some math functions needed for generators were not implemented.

Add math functions (except SYCL backend): `sqrt, cos, log, tan, acos, asin` and `isnan`. There were already 2 functions: sin and exp.

TO DO: 1. Tests. 2. Sycl backend 3. Other   input types of `isnan` be determined.