### PR TITLE
refactor accelerator index query operations

### DIFF
--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -27,13 +27,11 @@ struct VectorAddKernel1D
         alpaka::concepts::MdSpan auto out,
         Vec1D size) const
     {
-        auto [threadIndex] = acc[alpaka::layer::thread].idx();
-        auto [blockDimension] = acc[alpaka::layer::thread].count();
-        auto [blockIndex] = acc[alpaka::layer::block].idx();
-        auto [gridDimension] = acc[alpaka::layer::block].count();
+        auto threadIdxInGrid = acc.getIdxWithin(alpaka::onAcc::origin::grid, alpaka::onAcc::unit::threads);
+        auto numThreadsInGrid = acc.getExtentsOf(alpaka::onAcc::origin::grid, alpaka::onAcc::unit::threads);
 
-        auto linearGridThreadIndex = blockDimension * blockIndex + threadIndex;
-        auto linearGridSize = gridDimension * blockDimension;
+        auto linearGridThreadIndex = alpaka::linearize(numThreadsInGrid, threadIdxInGrid);
+        auto linearGridSize = numThreadsInGrid.product();
 
         // grid strided loop
         for(uint32_t i = linearGridThreadIndex; i < size.x(); i += linearGridSize)

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -26,6 +26,7 @@
 #include "alpaka/onAcc/GlobalMem.hpp"
 #include "alpaka/onAcc/SimdAlgo.hpp"
 #include "alpaka/onAcc/atomic.hpp"
+#include "alpaka/onAcc/tag.hpp"
 #include "alpaka/onHost.hpp"
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/onHost/Platform.hpp"

--- a/include/alpaka/mem/FlatIdxContainer.hpp
+++ b/include/alpaka/mem/FlatIdxContainer.hpp
@@ -24,7 +24,7 @@
 namespace alpaka::onAcc
 {
 
-    template<typename T_IdxRange, typename T_ThreadSpace, typename T_IdxMapperFn, concepts::CVector T_CSelect>
+    template<typename T_IdxRange, typename T_ThreadSpace, typename T_IdxMapperFn, alpaka::concepts::CVector T_CSelect>
     class FlatIdxContainer : private T_IdxMapperFn
     {
         void _()
@@ -121,12 +121,12 @@ namespace alpaka::onAcc
             }
 
             constexpr const_iterator(
-                concepts::Vector auto offsetMD,
+                alpaka::concepts::Vector auto offsetMD,
                 IdxType const current,
                 IdxType const stride,
                 IdxType const end,
-                concepts::Vector auto const extentMD,
-                concepts::Vector auto const strideMD)
+                alpaka::concepts::Vector auto const extentMD,
+                alpaka::concepts::Vector auto const strideMD)
                 : m_offsetMD{offsetMD}
                 , m_current{current}
                 , m_end{end}
@@ -260,7 +260,7 @@ namespace alpaka::onAcc
             }
         }
 
-        ALPAKA_FN_HOST_ACC constexpr auto operator[](concepts::CVector auto const iterDir) const
+        ALPAKA_FN_HOST_ACC constexpr auto operator[](alpaka::concepts::CVector auto const iterDir) const
         {
             return FlatIdxContainer<T_IdxRange, T_ThreadSpace, T_IdxMapperFn, ALPAKA_TYPEOF(iterDir)>(
                 m_idxRange,

--- a/include/alpaka/mem/Iter.hpp
+++ b/include/alpaka/mem/Iter.hpp
@@ -12,7 +12,9 @@
 #include "alpaka/core/common.hpp"
 #include "alpaka/mem/IdxRange.hpp"
 #include "alpaka/mem/ThreadSpace.hpp"
+#include "alpaka/onAcc/WorkGroup.hpp"
 #include "alpaka/onAcc/layout.hpp"
+#include "alpaka/onAcc/tag.hpp"
 #include "alpaka/onAcc/traverse.hpp"
 #include "alpaka/tag.hpp"
 
@@ -77,148 +79,6 @@ namespace alpaka::onAcc
         template<typename T>
         concept IdxTraversing = trait::isIdxTraversing_v<T>;
     } // namespace concepts
-
-    namespace idxTrait
-    {
-        struct TotalFrameSpecExtent
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[frame::count] * acc[frame::extent];
-            }
-        };
-
-        struct FrameCount
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[frame::count];
-            }
-        };
-
-        struct FrameExtent
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[frame::extent];
-            }
-        };
-
-        struct GridThreadIdx
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[layer::thread].count() * acc[layer::block].idx() + acc[layer::thread].idx();
-            }
-        };
-
-        struct BlockIdx
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[layer::block].idx();
-            }
-        };
-
-        struct BlockCount
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[layer::block].count();
-            }
-        };
-
-        struct GridThreadCount
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[layer::block].count() * acc[layer::thread].count();
-            }
-        };
-
-        struct ThreadCountInBlock
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[layer::thread].count();
-            }
-        };
-
-        struct ThreadIdxInBlock
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[layer::thread].idx();
-            }
-        };
-
-        struct LinearizedBlockIdx
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return Vec{linearize(BlockCount{}(acc), BlockIdx{}(acc))};
-            }
-        };
-
-        struct LinearizedBlockCount
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return Vec{BlockCount{}(acc).product()};
-            }
-        };
-
-        struct LinearizedThreadIdxInBlock
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return Vec{linearize(ThreadCountInBlock{}(acc), ThreadIdxInBlock{}(acc))};
-            }
-        };
-
-        struct LinearizedThreadCountInBlock
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return Vec{ThreadCountInBlock{}(acc).product()};
-            }
-        };
-
-        struct LinearGridThreadIdx
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return Vec{linearize(GridThreadCount{}(acc), GridThreadIdx{}(acc))};
-            }
-        };
-
-        struct LinearGridThreadCount
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return Vec{GridThreadCount{}(acc).product()};
-            }
-        };
-    } // namespace idxTrait
-
-    ALPAKA_TAG(firstFn);
-    ALPAKA_TAG(extentFn);
-    ALPAKA_TAG(threadCountFn);
 
     namespace internal
     {
@@ -331,6 +191,33 @@ namespace alpaka::onAcc
         private:
             T_ExtentFn const m_extentFn;
         };
+
+        template<
+            concepts::Origin T_Origin,
+            concepts::Unit T_Unit,
+            typename T_MultiDimensional = MultiDimensional<true>>
+        struct IdxRangeLazy
+        {
+            constexpr IdxRangeLazy(
+                T_Origin const& origin,
+                T_Unit const& unit,
+                T_MultiDimensional = T_MultiDimensional{})
+            {
+            }
+
+            constexpr auto getIdxRange(auto const& acc)
+            {
+                auto const extent = internalCompute::GetExtentsOf::Op<ALPAKA_TYPEOF(acc), T_Origin, T_Unit>{}(
+                    acc,
+                    T_Origin{},
+                    T_Unit{});
+
+                if constexpr(T_MultiDimensional::value == false)
+                    return IdxRange{Vec{extent.product()}};
+                else
+                    return IdxRange{extent};
+            }
+        };
     } // namespace detail
 
     template<typename T_WorkGroup, typename T_IdxRange>
@@ -371,62 +258,49 @@ namespace alpaka::onAcc
         T_IdxRange m_idxRange;
     };
 
-    template<typename T_Idx, typename T_Extent>
-    struct WorkerGroup
+    namespace idxTrait
     {
-        constexpr WorkerGroup(T_Idx const& idxFn, T_Extent const& extentFn) : m_idxFn{idxFn}, m_extentFn{extentFn}
+        struct TotalFrameSpecExtent
         {
-        }
+            template<typename T_Acc>
+            constexpr auto operator()(T_Acc const& acc) const
+            {
+                return acc[frame::count] * acc[frame::extent];
+            }
+        };
 
-        constexpr auto size(auto const& acc) const
+        struct FrameCount
         {
-            return getThreadSpace(acc).size();
-        }
+            template<typename T_Acc>
+            constexpr auto operator()(T_Acc const& acc) const
+            {
+                return acc[frame::count];
+            }
+        };
 
-    private:
-        template<typename T_ThreadGroup, typename T_IdxRange>
-        friend struct DomainSpec;
-
-        constexpr auto getThreadSpace([[maybe_unused]] auto const& acc) const
+        struct FrameExtent
         {
-            return ThreadSpace{m_idxFn, m_extentFn};
-        }
-
-        constexpr auto getThreadSpace(auto const& acc) const requires(requires {
-            std::declval<T_Idx>()(acc);
-            std::declval<T_Extent>()(acc);
-        })
-        {
-            return ThreadSpace{m_idxFn(acc), m_extentFn(acc)};
-        }
-
-    private:
-        T_Idx const m_idxFn;
-        T_Extent const m_extentFn;
-    };
-
-    namespace worker
-    {
-        constexpr auto threadsInGrid = WorkerGroup{idxTrait::GridThreadIdx{}, idxTrait::GridThreadCount{}};
-        constexpr auto blocksInGrid = WorkerGroup{idxTrait::BlockIdx{}, idxTrait::BlockCount{}};
-        constexpr auto threadsInBlock = WorkerGroup{idxTrait::ThreadIdxInBlock{}, idxTrait::ThreadCountInBlock{}};
-
-        constexpr auto linearThreadsInGrid
-            = WorkerGroup{idxTrait::LinearGridThreadIdx{}, idxTrait::LinearGridThreadCount{}};
-        constexpr auto linearThreadsInBlock
-            = WorkerGroup{idxTrait::LinearizedThreadIdxInBlock{}, idxTrait::LinearizedThreadCountInBlock{}};
-        constexpr auto linearBlocksInGrid
-            = WorkerGroup{idxTrait::LinearizedBlockIdx{}, idxTrait::LinearizedBlockCount{}};
-    } // namespace worker
+            template<typename T_Acc>
+            constexpr auto operator()(T_Acc const& acc) const
+            {
+                return acc[frame::extent];
+            }
+        };
+    } // namespace idxTrait
 
     namespace range
     {
         constexpr auto totalFrameSpecExtent = detail::IdxRangeFn{idxTrait::TotalFrameSpecExtent{}};
         constexpr auto frameCount = detail::IdxRangeFn{idxTrait::FrameCount{}};
         constexpr auto frameExtent = detail::IdxRangeFn{idxTrait::FrameExtent{}};
-        constexpr auto threadsInGrid = detail::IdxRangeFn{idxTrait::GridThreadCount{}};
-        constexpr auto blocksInGrid = detail::IdxRangeFn{idxTrait::BlockCount{}};
-        constexpr auto threadsInBlock = detail::IdxRangeFn{idxTrait::ThreadCountInBlock{}};
+
+        constexpr auto threadsInGrid = detail::IdxRangeLazy{origin::grid, unit::threads};
+        constexpr auto blocksInGrid = detail::IdxRangeLazy{origin::grid, unit::blocks};
+        constexpr auto threadsInBlock = detail::IdxRangeLazy{origin::block, unit::threads};
+
+        constexpr auto linearThreadsInGrid = detail::IdxRangeLazy{origin::grid, unit::threads, linearized};
+        constexpr auto linearBlocksInGrid = detail::IdxRangeLazy{origin::grid, unit::blocks, linearized};
+        constexpr auto linearThreadsInBlock = detail::IdxRangeLazy{origin::block, unit::threads, linearized};
     } // namespace range
 
 } // namespace alpaka::onAcc

--- a/include/alpaka/mem/ThreadSpace.hpp
+++ b/include/alpaka/mem/ThreadSpace.hpp
@@ -12,7 +12,7 @@
 
 namespace alpaka
 {
-    template<typename T_ThreadIdx, typename T_ThreadCount>
+    template<concepts::Vector T_ThreadIdx, concepts::Vector T_ThreadCount>
     struct ThreadSpace
     {
         constexpr ThreadSpace(T_ThreadIdx const& threadIdx, T_ThreadCount const& threadCount)
@@ -44,6 +44,11 @@ namespace alpaka
         constexpr auto size() const
         {
             return m_threadCount;
+        }
+
+        constexpr auto idx() const
+        {
+            return m_threadIdx;
         }
 
         template<concepts::CVector T_CSelect>

--- a/include/alpaka/mem/TiledIdxContainer.hpp
+++ b/include/alpaka/mem/TiledIdxContainer.hpp
@@ -58,7 +58,7 @@ namespace alpaka::onAcc
         };
     } // namespace detail
 
-    template<typename T_IdxRange, typename T_ThreadSpace, typename T_IdxMapperFn, concepts::CVector T_CSelect>
+    template<typename T_IdxRange, typename T_ThreadSpace, typename T_IdxMapperFn, alpaka::concepts::CVector T_CSelect>
     class TiledIdxContainer
     {
         void _()
@@ -104,7 +104,7 @@ namespace alpaka::onAcc
                 static_assert(std::forward_iterator<const_iterator_end>);
             }
 
-            ALPAKA_FN_ACC inline const_iterator_end(concepts::Vector auto const& extent)
+            ALPAKA_FN_ACC inline const_iterator_end(alpaka::concepts::Vector auto const& extent)
                 : m_extentSlowDim{extent[T_CSelect{}][0]}
             {
             }
@@ -154,10 +154,10 @@ namespace alpaka::onAcc
             }
 
             constexpr const_iterator(
-                concepts::Vector auto const offset,
-                concepts::Vector auto const first,
-                concepts::Vector auto const extent,
-                concepts::Vector auto const stride)
+                alpaka::concepts::Vector auto const offset,
+                alpaka::concepts::Vector auto const first,
+                alpaka::concepts::Vector auto const extent,
+                alpaka::concepts::Vector auto const stride)
                 : m_current{first + offset}
                 , m_stride{stride[T_CSelect{}]}
                 , m_extent{(extent + offset)[T_CSelect{}]}
@@ -291,7 +291,7 @@ namespace alpaka::onAcc
             }
         }
 
-        ALPAKA_FN_HOST_ACC constexpr auto operator[](concepts::CVector auto const iterDir) const
+        ALPAKA_FN_HOST_ACC constexpr auto operator[](alpaka::concepts::CVector auto const iterDir) const
         {
             return TiledIdxContainer<T_IdxRange, T_ThreadSpace, T_IdxMapperFn, ALPAKA_TYPEOF(iterDir)>(
                 m_idxRange,

--- a/include/alpaka/onAcc.hpp
+++ b/include/alpaka/onAcc.hpp
@@ -20,6 +20,30 @@
 
 namespace alpaka::onAcc
 {
+    /** get the M-dimensional indices within the origin in the quantity of the selected unit */
+    constexpr alpaka::concepts::Vector auto getIdxWithin(
+        auto const& acc,
+        concepts::Origin auto origin,
+        concepts::Unit auto unit)
+    {
+        return internalCompute::GetIdxWithin::Op<ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(origin), ALPAKA_TYPEOF(unit)>{}(
+            acc,
+            origin,
+            unit);
+    }
+
+    /** get the M-dimensional extents of an origin in the quantity of the selected unit */
+    constexpr alpaka::concepts::Vector auto getExtentsOf(
+        auto const& acc,
+        concepts::Origin auto origin,
+        concepts::Unit auto unit)
+    {
+        return internalCompute::GetExtentsOf::Op<ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(origin), ALPAKA_TYPEOF(unit)>{}(
+            acc,
+            origin,
+            unit);
+    }
+
     /** synchronize all threads within a thread block layer */
     constexpr void syncBlockThreads(auto const& acc)
     {

--- a/include/alpaka/onAcc/Acc.hpp
+++ b/include/alpaka/onAcc/Acc.hpp
@@ -52,6 +52,20 @@ namespace alpaka::onAcc
             (*this)[action::sync]();
         }
 
+        /** get the M-dimensional indices within the origin in the quantity of the selected unit */
+        constexpr alpaka::concepts::Vector auto getIdxWithin(concepts::Origin auto origin, concepts::Unit auto unit)
+            const
+        {
+            return onAcc::getIdxWithin(*this, origin, unit);
+        }
+
+        /** get the M-dimensional extents of an origin in the quantity of the selected unit */
+        constexpr alpaka::concepts::Vector auto getExtentsOf(concepts::Origin auto origin, concepts::Unit auto unit)
+            const
+        {
+            return onAcc::getExtentsOf(*this, origin, unit);
+        }
+
         static constexpr bool hasKey(auto key)
         {
             constexpr auto idx = Idx<ALPAKA_TYPEOF(key), std::decay_t<T_Storage>>::value;

--- a/include/alpaka/onAcc/WorkGroup.hpp
+++ b/include/alpaka/onAcc/WorkGroup.hpp
@@ -1,0 +1,114 @@
+/* Copyright 2024 Andrea Bocci, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/mem/ThreadSpace.hpp"
+#include "alpaka/onAcc/internal.hpp"
+#include "alpaka/onAcc/tag.hpp"
+#include "alpaka/tag.hpp"
+
+#include <cstdint>
+
+namespace alpaka::onAcc
+{
+    template<bool T_multiDimensional = true>
+    struct MultiDimensional : std::bool_constant<T_multiDimensional>
+    {
+    };
+
+    constexpr auto linearized = MultiDimensional<false>{};
+
+    template<
+        typename T_ThreadIdxOrOrigin,
+        typename T_NumThreadsOrUnit,
+        typename T_MultiDimensional = MultiDimensional<true>>
+    struct WorkerGroup
+    {
+        /** WorkerGroup constructor
+         *
+         * @param threadIdxOrOrigin the index of the thread or onAcc::origin
+         * @param numThreadsOrUnit the number of threads or the onAcc::unit
+         * @param multiDimensional keep the dimensionality for both input parameters, if 'linearized' is used the
+         * workgroup will be reduced to a one dimensional group.
+         */
+        constexpr WorkerGroup(
+            T_ThreadIdxOrOrigin threadIdxOrOrigin,
+            T_NumThreadsOrUnit numThreadsOrUnit,
+            T_MultiDimensional = MultiDimensional<true>{})
+            : m_threadIdxOrOrigin{threadIdxOrOrigin}
+            , m_numThreadsOrUnit{numThreadsOrUnit}
+        {
+        }
+
+        constexpr auto size(auto const& acc) const
+        {
+            return getThreadSpace(acc).size();
+        }
+
+        constexpr auto idx(auto const& acc) const
+        {
+            return getThreadSpace(acc).idx();
+        }
+
+    private:
+        template<typename T_ThreadGroup, typename T_ThreadIdxOrOriginRange>
+        friend struct DomainSpec;
+
+        /** get the thread configuration
+         *
+         * Implementation specialization for vectors.
+         */
+        constexpr auto getThreadSpace([[maybe_unused]] auto const& acc) const
+            requires(isVector_v<T_ThreadIdxOrOrigin> && isVector_v<T_NumThreadsOrUnit>)
+        {
+            if constexpr(T_MultiDimensional::value == false)
+                return ThreadSpace{
+                    Vec{linearize(m_numThreadsOrUnit, m_threadIdxOrOrigin)},
+                    Vec{m_numThreadsOrUnit.product()}};
+            else
+                return ThreadSpace{m_threadIdxOrOrigin, m_numThreadsOrUnit};
+        }
+
+        /** get the thread configuration
+         *
+         * Implementation specialization for lazy evaluated acc properties based on an origin and unit.
+         */
+        constexpr auto getThreadSpace(auto const& acc) const
+            requires(isOrigin_v<T_ThreadIdxOrOrigin> && isUnit_v<T_NumThreadsOrUnit>)
+        {
+            auto const idx
+                = internalCompute::GetIdxWithin::Op<ALPAKA_TYPEOF(acc), T_ThreadIdxOrOrigin, T_NumThreadsOrUnit>{}(
+                    acc,
+                    m_threadIdxOrOrigin,
+                    m_numThreadsOrUnit);
+            auto const extent
+                = internalCompute::GetExtentsOf::Op<ALPAKA_TYPEOF(acc), T_ThreadIdxOrOrigin, T_NumThreadsOrUnit>{}(
+                    acc,
+                    m_threadIdxOrOrigin,
+                    m_numThreadsOrUnit);
+
+            if constexpr(T_MultiDimensional::value == false)
+                return ThreadSpace{Vec{linearize(extent, idx)}, Vec{extent.product()}};
+            else
+                return ThreadSpace{idx, extent};
+        }
+
+    private:
+        T_ThreadIdxOrOrigin m_threadIdxOrOrigin;
+        T_NumThreadsOrUnit m_numThreadsOrUnit;
+    };
+
+    namespace worker
+    {
+        constexpr auto threadsInGrid = WorkerGroup{origin::grid, unit::threads};
+        constexpr auto blocksInGrid = WorkerGroup{origin::grid, unit::blocks};
+        constexpr auto threadsInBlock = WorkerGroup{origin::block, unit::threads};
+
+        constexpr auto linearThreadsInGrid = WorkerGroup{origin::grid, unit::threads, linearized};
+        constexpr auto linearThreadsInBlock = WorkerGroup{origin::block, unit::threads, linearized};
+        constexpr auto linearBlocksInGrid = WorkerGroup{origin::grid, unit::blocks, linearized};
+    } // namespace worker
+
+} // namespace alpaka::onAcc

--- a/include/alpaka/onAcc/internal.hpp
+++ b/include/alpaka/onAcc/internal.hpp
@@ -5,7 +5,9 @@
 #pragma once
 
 #include "alpaka/UniqueId.hpp"
+#include "alpaka/Vec.hpp"
 #include "alpaka/core/common.hpp"
+#include "alpaka/onAcc/tag.hpp"
 #include "alpaka/tag.hpp"
 
 namespace alpaka::onAcc
@@ -72,6 +74,100 @@ namespace alpaka::onAcc
             /** Implements a atomic operation */
             template<typename TOp, typename TAtomicImpl, typename T, typename THierarchy, typename TSfinae = void>
             struct Op;
+        };
+
+        /** Get the index of an object within a layer in the selected units*/
+        struct GetIdxWithin
+        {
+            template<typename T_Acc, typename T_Origin, typename T_Unit>
+            struct Op
+            {
+                constexpr alpaka::concepts::Vector auto operator()(T_Acc const& acc, T_Origin origin, T_Unit unit)
+                    const;
+            };
+
+            template<typename T_Acc>
+            struct Op<T_Acc, ALPAKA_TYPEOF(origin::block), ALPAKA_TYPEOF(unit::threads)>
+            {
+                constexpr alpaka::concepts::Vector auto operator()(
+                    T_Acc const& acc,
+                    ALPAKA_TYPEOF(origin::block),
+                    ALPAKA_TYPEOF(unit::threads)) const
+                {
+                    return acc[layer::thread].idx();
+                }
+            };
+
+            template<typename T_Acc>
+            struct Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::threads)>
+            {
+                constexpr alpaka::concepts::Vector auto operator()(
+                    T_Acc const& acc,
+                    ALPAKA_TYPEOF(origin::grid),
+                    ALPAKA_TYPEOF(unit::threads)) const
+                {
+                    return acc[layer::thread].count() * acc[layer::block].idx() + acc[layer::thread].idx();
+                }
+            };
+
+            template<typename T_Acc>
+            struct Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::blocks)>
+            {
+                constexpr alpaka::concepts::Vector auto operator()(
+                    T_Acc const& acc,
+                    ALPAKA_TYPEOF(origin::grid),
+                    ALPAKA_TYPEOF(unit::blocks)) const
+                {
+                    return acc[layer::block].idx();
+                }
+            };
+        };
+
+        /** Get the number of elments in a layer in the selected units*/
+        struct GetExtentsOf
+        {
+            template<typename T_Acc, typename T_Origin, typename T_Unit>
+            struct Op
+            {
+                constexpr alpaka::concepts::Vector auto operator()(T_Acc const& acc, T_Origin origin, T_Unit unit)
+                    const;
+            };
+
+            template<typename T_Acc>
+            struct Op<T_Acc, ALPAKA_TYPEOF(origin::block), ALPAKA_TYPEOF(unit::threads)>
+            {
+                constexpr alpaka::concepts::Vector auto operator()(
+                    T_Acc const& acc,
+                    ALPAKA_TYPEOF(origin::block),
+                    ALPAKA_TYPEOF(unit::threads)) const
+                {
+                    return acc[layer::thread].count();
+                }
+            };
+
+            template<typename T_Acc>
+            struct Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::blocks)>
+            {
+                constexpr alpaka::concepts::Vector auto operator()(
+                    T_Acc const& acc,
+                    ALPAKA_TYPEOF(origin::grid),
+                    ALPAKA_TYPEOF(unit::blocks)) const
+                {
+                    return acc[layer::block].count();
+                }
+            };
+
+            template<typename T_Acc>
+            struct Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::threads)>
+            {
+                constexpr alpaka::concepts::Vector auto operator()(
+                    T_Acc const& acc,
+                    ALPAKA_TYPEOF(origin::grid),
+                    ALPAKA_TYPEOF(unit::threads)) const
+                {
+                    return acc[layer::block].count() * acc[layer::thread].count();
+                }
+            };
         };
     } // namespace internalCompute
 } // namespace alpaka::onAcc

--- a/include/alpaka/onAcc/tag.hpp
+++ b/include/alpaka/onAcc/tag.hpp
@@ -1,0 +1,84 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/PP.hpp"
+#include "alpaka/core/Tag.hpp"
+#include "alpaka/core/util.hpp"
+
+#include <cassert>
+#include <tuple>
+
+namespace alpaka::onAcc
+{
+    /** Origin of index domains
+     *
+     * An origin is used to query the index domain within a block or grid.
+     */
+    namespace origin
+    {
+        ALPAKA_TAG(block);
+        ALPAKA_TAG(grid);
+    } // namespace origin
+
+    /** Unit of index domains
+     *
+     * A unit is used to describe the quantity of the index domain with respect to an origin
+     */
+    namespace unit
+    {
+        ALPAKA_TAG(threads);
+        ALPAKA_TAG(blocks);
+    } // namespace unit
+
+    namespace trait
+    {
+        template<typename T>
+        struct IsOrigin : std::false_type
+        {
+        };
+
+        template<>
+        struct IsOrigin<ALPAKA_TYPEOF(origin::block)> : std::true_type
+        {
+        };
+
+        template<>
+        struct IsOrigin<ALPAKA_TYPEOF(origin::grid)> : std::true_type
+        {
+        };
+
+        template<typename T>
+        struct IsUnit : std::false_type
+        {
+        };
+
+        template<>
+        struct IsUnit<ALPAKA_TYPEOF(unit::threads)> : std::true_type
+        {
+        };
+
+        template<>
+        struct IsUnit<ALPAKA_TYPEOF(unit::blocks)> : std::true_type
+        {
+        };
+    } // namespace trait
+
+    template<typename T>
+    constexpr bool isOrigin_v = trait::IsOrigin<T>::value;
+
+    template<typename T>
+    constexpr bool isUnit_v = trait::IsUnit<T>::value;
+
+    namespace concepts
+    {
+        template<typename T>
+        concept Origin = isOrigin_v<T>;
+
+        template<typename T>
+        concept Unit = isUnit_v<T>;
+    } // namespace concepts
+
+} // namespace alpaka::onAcc

--- a/include/alpaka/onAcc/traverse.hpp
+++ b/include/alpaka/onAcc/traverse.hpp
@@ -24,7 +24,7 @@ namespace alpaka::onAcc
                 auto const& idxRange,
                 auto const& threadSpace,
                 auto const& idxLayout,
-                concepts::CVector auto const& cSelect)
+                alpaka::concepts::CVector auto const& cSelect)
             {
                 return FlatIdxContainer{idxRange, threadSpace, idxLayout, cSelect};
             }
@@ -44,7 +44,7 @@ namespace alpaka::onAcc
                 auto const& idxRange,
                 auto const& threadSpace,
                 auto const& idxLayout,
-                concepts::CVector auto const& cSelect)
+                alpaka::concepts::CVector auto const& cSelect)
             {
                 return TiledIdxContainer{idxRange, threadSpace, idxLayout, cSelect};
             }

--- a/tests/unit/cvecKernelCall/cvecKernelCall.cpp
+++ b/tests/unit/cvecKernelCall/cvecKernelCall.cpp
@@ -30,7 +30,10 @@ struct KernelCVecFrameExtents
     {
         alpaka::concepts::CVector auto frameExtent = acc[alpaka::frame::extent];
         // compile will fail if the type is silently cast to non CVec type
-        [[maybe_unused]] alpaka::concepts::CVector auto blockThreadCount = acc[alpaka::layer::thread].count();
+        [[maybe_unused]] alpaka::concepts::CVector auto blockThreadCount
+            = onAcc::getExtentsOf(acc, onAcc::origin::block, onAcc::unit::threads);
+        [[maybe_unused]] alpaka::concepts::CVector auto blockThreadCount2 = acc[alpaka::layer::thread].count();
+        static_assert(blockThreadCount2 == blockThreadCount);
         static_assert(frameExtent.x() == 43u);
         result[0] = frameExtent.x() == 43u;
     }


### PR DESCRIPTION
- add methods `getIdxWithin()` and `getExtentsOf()` supporting an origin and unit to describe the index space
- move `WorkGroup` into its own file and add support for index origins and units
- remove most indexTrait's and use new oring/unit descriptions