### PR TITLE
fix trait `GetDynSharedMemBytes`

### DIFF
--- a/include/alpaka/onHost/trait.hpp
+++ b/include/alpaka/onHost/trait.hpp
@@ -87,11 +87,8 @@ namespace alpaka::onHost
                              })
                 {
                     return std::apply(
-                        [&](auto const&... args)
-                        {
-                            return BlockDynSharedMemBytes{kernelBundle.m_kernelFn, spec}(
-                                executor,
-                                remove_restrict_t<std::decay_t<T_Args>>()...);
+                        [&](auto const&... args) {
+                            return BlockDynSharedMemBytes{kernelBundle.m_kernelFn, spec}(executor, args...);
                         },
                         kernelBundle.m_args);
                 }


### PR DESCRIPTION
Arguments where not forwarded to the user trait, instead a new object was created and assumed that any argument is trivially contructable.