### PR TITLE
simplify host memory allocation and enqueue without executor

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -377,7 +377,6 @@ void testKernels(auto cfg)
 
     // Get the host device for allocating memory on the host
     onHost::Queue queue = devAcc.makeQueue();
-    onHost::Device devHost = onHost::makeHostDevice();
 
     // Create vectors
     using Idx = std::uint32_t;
@@ -389,9 +388,9 @@ void testKernels(auto cfg)
     auto bufAccOutputC = onHost::allocMirror(devAcc, bufAccInputA);
 
     // Host buffer as the result
-    auto bufHostOutputA = onHost::allocMirror(devHost, bufAccInputA);
-    auto bufHostOutputB = onHost::allocMirror(devHost, bufAccInputB);
-    auto bufHostOutputC = onHost::allocMirror(devHost, bufAccOutputC);
+    auto bufHostOutputA = onHost::allocHostMirror(bufAccInputA);
+    auto bufHostOutputB = onHost::allocHostMirror(bufAccInputB);
+    auto bufHostOutputC = onHost::allocHostMirror(bufAccOutputC);
 
     /* Each frame will have 64 elements processed by each thread.
      * The number of frames is calculated based on the array size and the number of elements processed by each thread.
@@ -545,8 +544,7 @@ void testKernels(auto cfg)
 
             // Vector of sums of each block
             auto bufAccSumPerBlock = onHost::alloc<DataType>(devAcc, 1u);
-            auto bufHostSumPerBlock = onHost::allocMirror(devHost, bufAccSumPerBlock);
-
+            auto bufHostSumPerBlock = onHost::allocHostMirror(bufAccSumPerBlock);
 
             // Test Dot kernel with specific blocksize which is larger than one
             measureKernelExec(

--- a/example/grayScale/src/grayScale.cpp
+++ b/example/grayScale/src/grayScale.cpp
@@ -148,16 +148,14 @@ auto example(T_Cfg const& cfg, size_t numElements, bool enableStdForEach) -> int
     // Create a queue on the device
     onHost::Queue queue = devAcc.makeQueue();
 
-    // Get the host device for allocating memory on the host.
-    onHost::Device devHost = onHost::makeHostDevice();
 
     // Allocate host memory buffers for R, G, B, and ARGB
-    auto bufHostR = onHost::alloc<uint8_t>(devHost, extent);
-    auto bufHostG = onHost::allocMirror(devHost, bufHostR);
-    auto bufHostB = onHost::allocMirror(devHost, bufHostR);
-    auto bufHostA = onHost::allocMirror(devHost, bufHostR);
-    auto bufHostARGB = onHost::alloc<Data>(devHost, extent);
-    auto bufHostScalarRGB = onHost::allocMirror(devHost, bufHostARGB);
+    auto bufHostR = onHost::allocHost<uint8_t>(extent);
+    auto bufHostG = onHost::allocHostMirror(bufHostR);
+    auto bufHostB = onHost::allocHostMirror(bufHostR);
+    auto bufHostA = onHost::allocHostMirror(bufHostR);
+    auto bufHostARGB = onHost::allocHost<Data>(extent);
+    auto bufHostScalarRGB = onHost::allocHostMirror(bufHostARGB);
 
     // Fill input data with random RGB values
     std::random_device rd{};

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -53,9 +53,6 @@ auto example(T_Cfg const& cfg) -> int
     std::cout << "Using alpaka accelerator: " << core::demangledName(exec) << " for " << deviceSpec.getApi().getName()
               << std::endl;
 
-    // Select specific devices
-    Device devHost = makeHostDevice();
-
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     onHost::Device devAcc = devSelector.makeDevice(0);
 
@@ -101,7 +98,7 @@ auto example(T_Cfg const& cfg) -> int
 
     // Initialize host-buffer
     // This buffer will hold the current values (used for the next step)
-    auto uBufHost = alpaka::onHost::alloc<double>(devHost, extent);
+    auto uBufHost = alpaka::onHost::allocHost<double>(extent);
 
     // Accelerator buffer
     auto uCurrBufAcc = alpaka::onHost::allocMirror(devAcc, uBufHost);

--- a/example/tutorial/src/00_enumerate.cpp
+++ b/example/tutorial/src/00_enumerate.cpp
@@ -11,14 +11,7 @@
 
 int example(auto const devSpec)
 {
-    // the cpu api always has a single device
-    // Get the host device for allocating memory on the host.
-    alpaka::onHost::Device host = alpaka::onHost::makeHostDevice();
-
-    std::cout << "Use host device:\n";
-    std::cout << "  - " << alpaka::onHost::getName(host) << "\n\n";
-
-    // get acces to querry number of devices
+    // get access to query the number of compute devices
     auto deviceSelector = alpaka::onHost::makeDeviceSelector(devSpec);
 
     auto numDevice = deviceSelector.getDeviceCount();

--- a/example/tutorial/src/03_memory.cpp
+++ b/example/tutorial/src/03_memory.cpp
@@ -23,15 +23,9 @@ int example(auto const devSpec)
         return EXIT_FAILURE;
     }
 
-    // use the single host device
-    alpaka::onHost::Device host = alpaka::onHost::makeHostDevice();
-
-    std::cout << "Use host device:\n";
-    std::cout << "  - " << alpaka::onHost::getName(host) << "\n\n";
-
     // allocate a buffer of floats in host memory
     uint32_t size = 42;
-    auto host_buffer = alpaka::onHost::alloc<float>(host, size);
+    auto host_buffer = alpaka::onHost::allocHost<float>(size);
     std::cout << "host memory buffer at " << std::data(host_buffer) << "\n\n";
 
     // fill the host buffers with values
@@ -41,7 +35,7 @@ int example(auto const devSpec)
     }
 
     // use the first device
-    alpaka::onHost::Device device = alpaka::onHost::makeHostDevice();
+    alpaka::onHost::Device device = devSelector.makeDevice(0);
     std::cout << "Device: " << alpaka::onHost::getName(device) << '\n';
 
     // create a work queue

--- a/example/tutorial/src/04_views.cpp
+++ b/example/tutorial/src/04_views.cpp
@@ -23,13 +23,7 @@ int example(auto const devSpec)
         return EXIT_FAILURE;
     }
 
-    // use the single host device
-    alpaka::onHost::Device host = alpaka::onHost::makeHostDevice();
-
-    std::cout << "Use host device:\n";
-    std::cout << "  - " << alpaka::onHost::getName(host) << "\n\n";
-
-    // allocate a buffer of floats in host memory
+    // use a std::vector as host buffer
     uint32_t size = 42;
     std::vector<float> host_data(size);
     std::cout << "host vector at " << std::data(host_data) << "\n\n";

--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -63,10 +63,7 @@ struct VectorAddKernel3D
     }
 };
 
-void testVectorAddKernel(
-    alpaka::onHost::concepts::Device auto host,
-    alpaka::onHost::concepts::Device auto device,
-    auto computeExec)
+void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto computeExec)
 {
     // random number generator with a gaussian distribution
     std::random_device rd{};
@@ -80,9 +77,9 @@ void testVectorAddKernel(
     constexpr uint32_t size = 1024 * 1024;
 
     // allocate input and output host buffers in pinned memory accessible by the Platform devices
-    auto in1_h = alpaka::onHost::alloc<float>(host, size);
-    auto in2_h = alpaka::onHost::allocMirror(host, in1_h);
-    auto out_h = alpaka::onHost::allocMirror(host, in1_h);
+    auto in1_h = alpaka::onHost::allocHost<float>(size);
+    auto in2_h = alpaka::onHost::allocHostMirror(in1_h);
+    auto out_h = alpaka::onHost::allocHostMirror(in1_h);
 
     // fill the input buffers with random data, and the output buffer with zeros
     for(uint32_t i = 0; i < size; ++i)
@@ -165,10 +162,7 @@ void testVectorAddKernel(
     std::cout << "success\n";
 }
 
-void testVectorAddKernel3D(
-    alpaka::onHost::concepts::Device auto host,
-    alpaka::onHost::concepts::Device auto device,
-    auto computeExec)
+void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto computeExec)
 {
     // random number generator with a gaussian distribution
     std::random_device rd{};
@@ -183,9 +177,9 @@ void testVectorAddKernel3D(
     constexpr uint32_t size = ndsize.product();
 
     // allocate input and output host buffers in pinned memory accessible by the Platform devices
-    auto in1_h = alpaka::onHost::alloc<float>(host, ndsize);
-    auto in2_h = alpaka::onHost::allocMirror(host, in1_h);
-    auto out_h = alpaka::onHost::allocMirror(host, in1_h);
+    auto in1_h = alpaka::onHost::allocHost<float>(ndsize);
+    auto in2_h = alpaka::onHost::allocHostMirror(in1_h);
+    auto out_h = alpaka::onHost::allocHostMirror(in1_h);
 
     // fill the input buffers with random data, and the output buffer with zeros
     for(uint32_t i = 0; i < size; ++i)
@@ -256,16 +250,12 @@ int example(auto const cfg)
         return EXIT_FAILURE;
     }
 
-    // use the single host device
-    alpaka::onHost::Device host = alpaka::onHost::makeHostDevice();
-    std::cout << "Host:   " << alpaka::onHost::getName(host) << "\n\n";
-
     // use the first device
     alpaka::onHost::Device device = devSelector.makeDevice(0);
     std::cout << "Device: " << alpaka::onHost::getName(device) << "\n\n";
 
-    testVectorAddKernel(host, device, computeExec);
-    testVectorAddKernel3D(host, device, computeExec);
+    testVectorAddKernel(device, computeExec);
+    testVectorAddKernel3D(device, computeExec);
 
     return EXIT_SUCCESS;
 }

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -69,10 +69,7 @@ struct VectorAddKernel3D
     }
 };
 
-void testVectorAddKernel(
-    alpaka::onHost::concepts::Device auto host,
-    alpaka::onHost::concepts::Device auto device,
-    auto computeExec)
+void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto computeExec)
 {
     // random number generator with a gaussian distribution
     std::random_device rd{};
@@ -86,9 +83,9 @@ void testVectorAddKernel(
     constexpr uint32_t size = 1024 * 1024;
 
     // allocate input and output host buffers in pinned memory accessible by the Platform devices
-    auto in1_h = alpaka::onHost::alloc<float>(host, Vec1D{size});
-    auto in2_h = alpaka::onHost::allocMirror(host, in1_h);
-    auto out_h = alpaka::onHost::allocMirror(host, in1_h);
+    auto in1_h = alpaka::onHost::allocHost<float>(Vec1D{size});
+    auto in2_h = alpaka::onHost::allocHostMirror(in1_h);
+    auto out_h = alpaka::onHost::allocHostMirror(in1_h);
 
     // fill the input buffers with random data, and the output buffer with zeros
     for(uint32_t i = 0; i < size; ++i)
@@ -159,10 +156,7 @@ void testVectorAddKernel(
     std::cout << "success\n";
 }
 
-void testVectorAddKernel3D(
-    alpaka::onHost::concepts::Device auto host,
-    alpaka::onHost::concepts::Device auto device,
-    auto computeExec)
+void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto computeExec)
 {
     // random number generator with a gaussian distribution
     std::random_device rd{};
@@ -177,9 +171,9 @@ void testVectorAddKernel3D(
     constexpr uint32_t size = ndsize.product();
 
     // allocate input and output host buffers in pinned memory accessible by the Platform devices
-    auto in1_h = alpaka::onHost::alloc<float>(host, ndsize);
-    auto in2_h = alpaka::onHost::allocMirror(host, in1_h);
-    auto out_h = alpaka::onHost::allocMirror(host, in1_h);
+    auto in1_h = alpaka::onHost::allocHost<float>(ndsize);
+    auto in2_h = alpaka::onHost::allocHostMirror(in1_h);
+    auto out_h = alpaka::onHost::allocHostMirror(in1_h);
 
     // fill the input buffers with random data, and the output buffer with zeros
     for(uint32_t i = 0; i < size; ++i)
@@ -269,16 +263,13 @@ int example(auto const cfg)
         return EXIT_FAILURE;
     }
 
-    // use the single host device
-    alpaka::onHost::Device host = alpaka::onHost::makeHostDevice();
-    std::cout << "Host:   " << alpaka::onHost::getName(host) << "\n\n";
 
     // use the first device
     alpaka::onHost::Device device = devSelector.makeDevice(0);
     std::cout << "Device: " << alpaka::onHost::getName(device) << "\n\n";
 
-    testVectorAddKernel(host, device, computeExec);
-    testVectorAddKernel3D(host, device, computeExec);
+    testVectorAddKernel(device, computeExec);
+    testVectorAddKernel3D(device, computeExec);
 
     return EXIT_SUCCESS;
 }

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -152,10 +152,7 @@ struct VectorAddKernel3D
     }
 };
 
-void testVectorAddKernel(
-    alpaka::onHost::concepts::Device auto host,
-    alpaka::onHost::concepts::Device auto device,
-    auto computeExec)
+void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto computeExec)
 {
     // random number generator with a gaussian distribution
     std::random_device rd{};
@@ -169,9 +166,9 @@ void testVectorAddKernel(
     constexpr uint32_t size = 1024 * 1024;
 
     // allocate input and output host buffers in pinned memory accessible by the Platform devices
-    auto in1_h = alpaka::onHost::alloc<float>(host, size);
-    auto in2_h = alpaka::onHost::allocMirror(host, in1_h);
-    auto out_h = alpaka::onHost::allocMirror(host, in1_h);
+    auto in1_h = alpaka::onHost::allocHost<float>(size);
+    auto in2_h = alpaka::onHost::allocHostMirror(in1_h);
+    auto out_h = alpaka::onHost::allocHostMirror(in1_h);
 
     // fill the input buffers with random data, and the output buffer with zeros
     for(uint32_t i = 0; i < size; ++i)
@@ -227,10 +224,7 @@ void testVectorAddKernel(
     std::cout << "success\n";
 }
 
-void testVectorAddKernel3D(
-    alpaka::onHost::concepts::Device auto host,
-    alpaka::onHost::concepts::Device auto device,
-    auto computeExec)
+void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto computeExec)
 {
     // random number generator with a gaussian distribution
     std::random_device rd{};
@@ -245,9 +239,9 @@ void testVectorAddKernel3D(
     constexpr uint32_t size = ndsize.product();
 
     // allocate input and output host buffers in pinned memory accessible by the Platform devices
-    auto in1_h = alpaka::onHost::alloc<float>(host, ndsize);
-    auto in2_h = alpaka::onHost::allocMirror(host, in1_h);
-    auto out_h = alpaka::onHost::allocMirror(host, in1_h);
+    auto in1_h = alpaka::onHost::allocHost<float>(ndsize);
+    auto in2_h = alpaka::onHost::allocHostMirror(in1_h);
+    auto out_h = alpaka::onHost::allocHostMirror(in1_h);
 
     // fill the input buffers with random data, and the output buffer with zeros
     for(uint32_t i = 0; i < size; ++i)
@@ -319,17 +313,12 @@ int example(auto const cfg)
         return EXIT_FAILURE;
     }
 
-    // Get the host device for allocating memory on the host.
-    alpaka::onHost::Device host = alpaka::onHost::makeHostDevice();
-    // use the single host device
-    std::cout << "Host:   " << alpaka::onHost::getName(host) << "\n\n";
-
     // use the first device
     alpaka::onHost::Device device = devSelector.makeDevice(0);
     std::cout << "Device: " << alpaka::onHost::getName(device) << "\n\n";
 
-    testVectorAddKernel(host, device, computeExec);
-    testVectorAddKernel3D(host, device, computeExec);
+    testVectorAddKernel(device, computeExec);
+    testVectorAddKernel3D(device, computeExec);
 
     return EXIT_SUCCESS;
 }

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -81,13 +81,10 @@ auto example(T_Cfg const& cfg, size_t numElements) -> int
     // Create a queue on the device
     onHost::Queue queue = devAcc.makeQueue();
 
-    // Get the host device for allocating memory on the host.
-    onHost::Device devHost = onHost::makeHostDevice();
-
     // Allocate 3 host memory buffers
-    auto bufHostA = onHost::alloc<Data>(devHost, extent);
-    auto bufHostB = onHost::allocMirror(devHost, bufHostA);
-    auto bufHostC = onHost::allocMirror(devHost, bufHostA);
+    auto bufHostA = onHost::allocHost<Data>(extent);
+    auto bufHostB = onHost::allocHostMirror(bufHostA);
+    auto bufHostC = onHost::allocHostMirror(bufHostA);
 
     // C++14 random generator for uniformly distributed numbers in {1,..,42}
     std::random_device rd{};

--- a/include/alpaka/onHost.hpp
+++ b/include/alpaka/onHost.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/KernelBundle.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/concepts.hpp"
+#include "alpaka/onHost/DeviceSelector.hpp"
 #include "alpaka/onHost/concepts.hpp"
 #include "alpaka/tag.hpp"
 #include "alpaka/trait.hpp"
@@ -103,11 +104,30 @@ namespace alpaka::onHost
     /** Enqueue a kernel to a queue
      *
      * @param queue the kernel will be executed after all previous work in this queue is finished
-     * @param executor description how native worker threads will be mapped and grouped to compute grid layers (blocks,
-     * threads).
      * @param specification thread or frame specification which provides a chunked description of the thread or frame
      * index domain
      * @param kernelBundle the compute kernel and there arguments
+     *
+     * @{
+     */
+
+    /**
+     * A available default executor will be selected automaticlally. The default executor is a executor with most
+     * parallelism.
+     */
+    template<typename TKernelFn, typename... TArgs>
+    inline void enqueue(
+        concepts::QueueHandle auto const& queue,
+        auto const& specification,
+        KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
+    {
+        auto executor = supportedMappings(getDevice(queue));
+        internal::enqueue(*queue.get(), std::get<0>(executor), specification, kernelBundle);
+    }
+
+    /**
+     * @param executor description how native worker threads will be mapped and grouped to compute grid layers (blocks,
+     * threads).
      */
     template<typename TKernelFn, typename... TArgs>
     inline void enqueue(
@@ -118,6 +138,8 @@ namespace alpaka::onHost
     {
         internal::enqueue(*queue.get(), executor, specification, kernelBundle);
     }
+
+    /** @} */
 
     /** Enqueue a operation which is executed on the host side
      *
@@ -225,9 +247,14 @@ namespace alpaka::onHost
     /** allocate memory on the given device
      *
      * @tparam T_Type type of the data elements
-     * @param device device handle
      * @param extents number of elements for each dimension
      * @return memory owning view to the allocated memory
+     *
+     * @{
+     */
+
+    /**
+     * @param device device handle
      */
     template<typename T_Type>
     inline auto alloc(auto const& device, alpaka::concepts::VectorOrScalar auto const& extents)
@@ -238,20 +265,51 @@ namespace alpaka::onHost
             extentsVec);
     }
 
+    /**
+     * The host controller device is the deviceKind::Cpu from api::Cpu.
+     */
+    template<typename T_Type>
+    inline auto allocHost(alpaka::concepts::VectorOrScalar auto const& extents)
+    {
+        auto device = makeHostDevice<T_Type>();
+        Vec const extentsVec = extents;
+        return internal::Alloc::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
+            *device.get(),
+            extentsVec);
+    }
+
+    /** @} */
+
     /** allocate memory on the given device based on a view
      *
      * Derives type and extents of the memory from the view.
      * The content of the memory is not copied to the created allocated memory.
      *
-     * @param device device handle
      * @param view memory where properties will be derived from
      *
      * @return memory owning view to the allocated memory
+     *
+     * @{
+     */
+
+    /**
+     * @param device device handle
      */
     inline auto allocMirror(auto const& device, auto const& view)
     {
         return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, getExtents(view));
     }
+
+    /**
+     * The host controller device is the deviceKind::Cpu from api::Cpu.
+     */
+    inline auto allocHostMirror(auto const& view)
+    {
+        auto device = makeHostDevice<ALPAKA_TYPEOF(view)>();
+        return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, getExtents(view));
+    }
+
+    /** @} */
 
     /** copy data byte wise from one to another container
      *

--- a/include/alpaka/onHost/DeviceSelector.hpp
+++ b/include/alpaka/onHost/DeviceSelector.hpp
@@ -4,10 +4,7 @@
 
 #pragma once
 
-#include "alpaka/api/cpu.hpp"
-#include "alpaka/api/oneApi.hpp"
-#include "alpaka/api/unifiedCudaHip.hpp"
-#include "alpaka/onHost/internal.hpp"
+#include "alpaka/api/cpu/Api.hpp"
 #include "alpaka/tag.hpp"
 
 namespace alpaka::onHost

--- a/tests/unit/block/block.cpp
+++ b/tests/unit/block/block.cpp
@@ -70,8 +70,7 @@ TEMPLATE_LIST_TEST_CASE("block iota", "", TestApis)
     std::cout << "block iota exec=" << core::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
 
-    Device cpuDevice = makeHostDevice();
-    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    auto hBuff = onHost::allocHostMirror(dBuff);
     wait(queue);
 
     onHost::enqueue(

--- a/tests/unit/cvecKernelCall/cvecKernelCall.cpp
+++ b/tests/unit/cvecKernelCall/cvecKernelCall.cpp
@@ -62,8 +62,7 @@ TEMPLATE_LIST_TEST_CASE("CVec frame extent kernel call", "", TestApis)
 
     auto dBuff = onHost::alloc<bool>(device, Vec{1u});
 
-    Device cpuDevice = makeHostDevice();
-    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    auto hBuff = onHost::allocHostMirror(dBuff);
     wait(queue);
     {
         onHost::enqueue(
@@ -112,8 +111,7 @@ TEMPLATE_LIST_TEST_CASE("CVec thread extent kernel call", "", TestApis)
 
     auto dBuff = onHost::alloc<bool>(device, Vec{1u});
 
-    Device cpuDevice = makeHostDevice();
-    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    auto hBuff = onHost::allocHostMirror(dBuff);
     wait(queue);
     {
         onHost::enqueue(

--- a/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -90,8 +90,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
     std::cout << "block shared iota exec=" << core::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
 
-    Device cpuDevice = makeHostDevice();
-    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    auto hBuff = onHost::allocHostMirror(dBuff);
     wait(queue);
     {
         onHost::enqueue(

--- a/tests/unit/math/mathFunctions.cpp
+++ b/tests/unit/math/mathFunctions.cpp
@@ -201,10 +201,6 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Test", "", TestApis)
 
     std::cout << deviceSpec.getApi().getName() << std::endl;
 
-    // Use the single host device
-    alpaka::onHost::Device host = alpaka::onHost::makeHostDevice();
-    std::cout << "Host:   " << alpaka::onHost::getName(host) << "\n\n";
-
     // Use the first device
     onHost::Device device = devSelector.makeDevice(0);
     std::cout << "Device: " << alpaka::onHost::getName(device) << "\n\n";
@@ -220,8 +216,8 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Test", "", TestApis)
     constexpr uint32_t size = 32;
 
     // Allocate input and output buffers on the host
-    auto inHost = alpaka::onHost::alloc<float>(host, size);
-    auto outHost = alpaka::onHost::alloc<float>(host, size);
+    auto inHost = alpaka::onHost::allocHost<float>(size);
+    auto outHost = alpaka::onHost::allocHost<float>(size);
 
     // Fill the input buffer with random data
     for(uint32_t i = 0; i < size; ++i)
@@ -368,10 +364,6 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Returning Boolean - Test", "", TestApis)
     }
     std::cout << deviceSpec.getApi().getName() << std::endl;
 
-    // Use the single host device
-    alpaka::onHost::Device host = alpaka::onHost::makeHostDevice();
-    std::cout << "Host:   " << alpaka::onHost::getName(host) << "\n\n";
-
     // Use the first device
     onHost::Device device = devSelector.makeDevice(0);
     std::cout << "Device: " << alpaka::onHost::getName(device) << "\n\n";
@@ -387,9 +379,9 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Returning Boolean - Test", "", TestApis)
     constexpr uint32_t size = 32;
 
     // Allocate input and output buffers on the host
-    auto inHost = alpaka::onHost::alloc<float>(host, size);
+    auto inHost = alpaka::onHost::allocHost<float>(size);
     // Return type of the array items is bool
-    auto outHost = alpaka::onHost::alloc<bool>(host, size);
+    auto outHost = alpaka::onHost::allocHost<bool>(size);
 
     // Fill the input buffer with random data
     for(uint32_t i = 0; i < size; ++i)

--- a/tests/unit/precision/precision.cpp
+++ b/tests/unit/precision/precision.cpp
@@ -70,8 +70,7 @@ void iotaTest(auto cfg, auto const extents, auto frameSize)
     std::cout << "exec=" << core::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<Vec<T_MemIdxType, ALPAKA_TYPEOF(extents)::dim()>>(device, extents);
 
-    Device cpuDevice = makeHostDevice();
-    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    auto hBuff = onHost::allocHostMirror(dBuff);
 
     wait(queue);
     onHost::enqueue(

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -57,8 +57,7 @@ TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
     std::cout << "exec=" << core::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<uint32_t>(device, extent);
 
-    Device cpuDevice = makeHostDevice();
-    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    auto hBuff = onHost::allocHostMirror(dBuff);
 
     constexpr auto frameSize = CVec<uint32_t, 4u>{};
     onHost::enqueue(
@@ -114,8 +113,7 @@ TEMPLATE_LIST_TEST_CASE("iota2D", "", TestApis)
     std::cout << "exec=" << core::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<Vec<uint32_t, 2u>>(device, extent);
 
-    Device cpuDevice = makeHostDevice();
-    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    auto hBuff = onHost::allocHostMirror(dBuff);
 
     wait(queue);
     constexpr auto frameSize = Vec{2u, 4u};
@@ -162,8 +160,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D", "", TestApis)
     std::cout << "exec=" << core::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<Vec<uint32_t, 3u>>(device, extent);
 
-    Device cpuDevice = makeHostDevice();
-    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    auto hBuff = onHost::allocHostMirror(dBuff);
 
     wait(queue);
     constexpr auto frameSize = Vec{2u, 4u, 8u};
@@ -243,8 +240,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
     std::cout << "exec=" << core::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<Vec<uint32_t, 3u>>(device, numBlocks);
 
-    Device cpuDevice = makeHostDevice();
-    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    auto hBuff = onHost::allocHostMirror(dBuff);
     onHost::memset(queue, dBuff, 0u);
 
     wait(queue);

--- a/tests/unit/sharedMem/sharedMem.cpp
+++ b/tests/unit/sharedMem/sharedMem.cpp
@@ -71,8 +71,7 @@ TEMPLATE_LIST_TEST_CASE("block shared iota", "", TestApis)
     std::cout << "block shared iota exec=" << core::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
 
-    Device cpuDevice = makeHostDevice();
-    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    auto hBuff = onHost::allocHostMirror(dBuff);
     wait(queue);
 
     onHost::enqueue(
@@ -211,8 +210,7 @@ TEMPLATE_LIST_TEST_CASE("block shared alias", "", TestApis)
 
     auto dBuff = onHost::alloc<bool>(device, Vec{1u});
 
-    Device cpuDevice = makeHostDevice();
-    auto hBuff = onHost::allocMirror(cpuDevice, dBuff);
+    auto hBuff = onHost::allocHostMirror(dBuff);
     wait(queue);
     {
         onHost::enqueue(


### PR DESCRIPTION
- add method `alocHost()`, `allocHostMirrow()`
- provide `enqueue()` without an executor