### PR TITLE
move wrongly placed alpaka functions from `alpaka::onHost` to `alpaka`

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -400,7 +400,7 @@ void testKernels(auto cfg)
      * a kernel can reflect the concurrency bytes used for the `SimdAlgo::concurrent()` back to the host, e.g. some
      * as we use for dynamic shared memory.
      */
-    uint32_t elementsPerFrameItem = onHost::getNumElemPerThread<DataType>(queue);
+    uint32_t elementsPerFrameItem = getNumElemPerThread<DataType>(queue);
 
     auto numFrames = divExZero(arraySize, static_cast<Idx>(blockThreadExtentMain) * elementsPerFrameItem);
     auto dataBlocking = onHost::FrameSpec{numFrames, static_cast<Idx>(blockThreadExtentMain)};
@@ -535,7 +535,7 @@ void testKernels(auto cfg)
         }
         if(kernelsToBeExecuted == KernelsToRun::All)
         {
-            uint32_t elementsPerFrameItem = onHost::getNumElemPerThread<DataType>(queue);
+            uint32_t elementsPerFrameItem = getNumElemPerThread<DataType>(queue);
             auto numFrames = std::min(
                 static_cast<Idx>(dotGridBlockExtent),
                 alpaka::divExZero(arraySize, (static_cast<Idx>(blockThreadExtentMain) * elementsPerFrameItem)));

--- a/example/grayScale/src/grayScale.cpp
+++ b/example/grayScale/src/grayScale.cpp
@@ -205,7 +205,7 @@ auto example(T_Cfg const& cfg, size_t numElements, bool enableStdForEach) -> int
 
     // Define frameExtent
     Vec<size_t, 1u> frameExtent = 256u;
-    uint32_t elementsPerWorker = onHost::getNumElemPerThread<Data>(queue);
+    uint32_t elementsPerWorker = getNumElemPerThread<Data>(queue);
     auto dataBlocking = onHost::FrameSpec{divCeil(extent, frameExtent * elementsPerWorker), frameExtent};
 
     // Enqueue the kernel execution task

--- a/example/tutorial/src/03_memory.cpp
+++ b/example/tutorial/src/03_memory.cpp
@@ -44,8 +44,8 @@ int example(auto const devSpec)
     {
         // allocate a buffer of floats in global device memory
         auto device_buffer = alpaka::onHost::alloc<float>(device, size);
-        std::cout << "memory buffer on " << alpaka::onHost::getStaticName(alpaka::onHost::getApi(device_buffer))
-                  << " at " << std::data(device_buffer) << "\n\n";
+        std::cout << "memory buffer on " << alpaka::onHost::getStaticName(alpaka::getApi(device_buffer)) << " at "
+                  << std::data(device_buffer) << "\n\n";
 
         // set the device memory to all zeros (byte-wise, not element-wise)
         alpaka::onHost::memset(queue, device_buffer, 0x00);

--- a/example/tutorial/src/04_views.cpp
+++ b/example/tutorial/src/04_views.cpp
@@ -43,8 +43,8 @@ int example(auto const devSpec)
     {
         // allocate a buffer of floats in global device memory
         auto device_buffer = alpaka::onHost::alloc<float>(device, size);
-        std::cout << "memory buffer on " << alpaka::onHost::getStaticName(alpaka::onHost::getApi(device_buffer))
-                  << " at " << std::data(device_buffer) << "\n\n";
+        std::cout << "memory buffer on " << alpaka::onHost::getStaticName(alpaka::getApi(device_buffer)) << " at "
+                  << std::data(device_buffer) << "\n\n";
 
         // set the device memory to all zeros (byte-wise, not element-wise)
         alpaka::onHost::memset(queue, device_buffer, 0x00);

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -115,7 +115,7 @@ auto example(T_Cfg const& cfg, size_t numElements) -> int
 
     Vec<size_t, 1u> chunkSize = 256u;
     // how many elements one worker should compute to ensure vectorization or instruction parallelism
-    uint32_t elementsPerWorker = onHost::getNumElemPerThread<Data>(queue);
+    uint32_t elementsPerWorker = getNumElemPerThread<Data>(queue);
     auto dataBlocking = onHost::FrameSpec{divCeil(extent, chunkSize * elementsPerWorker), chunkSize};
 
     // Enqueue the kernel execution task

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -18,6 +18,7 @@
 #include "alpaka/core/Utility.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/config.hpp"
+#include "alpaka/interface.hpp"
 #include "alpaka/internal.hpp"
 #include "alpaka/math.hpp"
 #include "alpaka/math/constants.hpp"

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -345,7 +345,7 @@ namespace alpaka::internal
     {
         inline constexpr auto operator()(auto&& device) const
         {
-            return onHost::getApi(device.m_platform);
+            return alpaka::getApi(device.m_platform);
         }
     };
 } // namespace alpaka::internal

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/api/host/exec/OmpThreads.hpp"
 #include "alpaka/api/host/exec/Serial.hpp"
 #include "alpaka/core/CallbackThread.hpp"
+#include "alpaka/interface.hpp"
 #include "alpaka/internal.hpp"
 #include "alpaka/meta/NdLoop.hpp"
 #include "alpaka/onHost.hpp"
@@ -107,7 +108,7 @@ namespace alpaka::onHost
                             DictEntry(frame::count, frameSpec.m_numFrames),
                             DictEntry(frame::extent, frameSpec.m_frameExtent),
                             DictEntry(object::api, api::host),
-                            DictEntry(object::deviceKind, onHost::getDeviceKind(m_device)),
+                            DictEntry(object::deviceKind, alpaka::getDeviceKind(m_device)),
                             DictEntry(object::exec, executor)};
                         onAcc::Acc acc = makeAcc(executor, threadBlocking);
                         acc(kernelBundle, moreLayer);
@@ -263,7 +264,7 @@ namespace alpaka::internal
     {
         inline constexpr auto operator()(auto&& queue) const
         {
-            return onHost::getApi(queue.m_device);
+            return alpaka::getApi(queue.m_device);
         }
     };
 } // namespace alpaka::internal

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -137,7 +137,7 @@ namespace alpaka::onHost::internal
                             auto acc = onAcc::Acc{onAcc::makeSyclGenericAccDict<
                                 T_Executor,
                                 T_Api,
-                                ALPAKA_TYPEOF(onHost::getDeviceKind(queue)),
+                                ALPAKA_TYPEOF(getDeviceKind(queue)),
                                 T_NumBlocks,
                                 T_NumThreads>(work_item, ssm, dsm)};
                             kernelBundle(acc);
@@ -198,7 +198,7 @@ namespace alpaka::onHost::internal
                                 onAcc::makeSyclGenericAccDict<
                                     T_Executor,
                                     T_Api,
-                                    ALPAKA_TYPEOF(onHost::getDeviceKind(queue)),
+                                    ALPAKA_TYPEOF(getDeviceKind(queue)),
                                     ALPAKA_TYPEOF(threadBlocking.m_numBlocks),
                                     ALPAKA_TYPEOF(threadBlocking.m_numThreads)>(work_item, ssm, dsm),
                                 Dict{

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -9,6 +9,7 @@
 #if ALPAKA_LANG_SYCL
 
 #    include "alpaka/api/syclGeneric/onAcc.hpp"
+#    include "alpaka/interface.hpp"
 #    include "alpaka/internal.hpp"
 #    include "alpaka/onAcc/Acc.hpp"
 #    include "alpaka/onHost.hpp"
@@ -146,7 +147,7 @@ namespace alpaka::internal
     {
         inline constexpr auto operator()(auto&& queue) const
         {
-            return onHost::getApi(queue.m_device);
+            return alpaka::getApi(queue.m_device);
         }
     };
 } // namespace alpaka::internal

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -122,7 +122,7 @@ namespace alpaka::internal
     {
         inline constexpr auto operator()(auto&& device) const
         {
-            return onHost::getApi(device.m_platform);
+            return getApi(device.m_platform);
         }
     };
 } // namespace alpaka::internal

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -204,8 +204,8 @@ namespace alpaka::onHost
                     ApiInterface::setDevice(onHost::getNativeHandle(queue.m_device)));
 
                 auto kernelName = gpuKernel<
-                    ALPAKA_TYPEOF(onHost::getApi(queue)),
-                    ALPAKA_TYPEOF(onHost::getDeviceKind(queue)),
+                    ALPAKA_TYPEOF(getApi(queue)),
+                    ALPAKA_TYPEOF(getDeviceKind(queue)),
                     T_Executor,
                     T_NumBlocks,
                     T_NumThreads,
@@ -232,7 +232,7 @@ namespace alpaka::internal
     {
         inline constexpr auto operator()(auto&& queue) const
         {
-            return onHost::getApi(queue.m_device);
+            return getApi(queue.m_device);
         }
     };
 } // namespace alpaka::internal

--- a/include/alpaka/interface.hpp
+++ b/include/alpaka/interface.hpp
@@ -1,0 +1,95 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/concepts.hpp"
+#include "alpaka/internal.hpp"
+#include "alpaka/tag.hpp"
+#include "alpaka/trait.hpp"
+
+namespace alpaka
+{
+
+    /** Get the API an object depends on
+     *
+     * @param any can be a platform, device, queue, view
+     * @return API tag
+     *
+     * @{
+     */
+    inline constexpr decltype(auto) getApi(auto&& any)
+    {
+        return alpaka::internal::getApi(ALPAKA_FORWARD(any));
+    }
+
+    inline constexpr decltype(auto) getApi(alpaka::concepts::HasGet auto&& any)
+    {
+        return alpaka::internal::getApi(*any.get());
+    }
+
+    namespace concepts
+    {
+        template<typename T_Any>
+        concept HasApi = requires(T_Any&& any) {
+            {
+                getApi(any)
+            } -> alpaka::concepts::Api;
+        };
+    } // namespace concepts
+
+    /** @} */
+
+    /** Get the device type of an object
+     *
+     * @param any can be a platform, device, queue, view
+     * @return type from alpaka::deviceKind
+     *
+     * @{
+     */
+    inline constexpr decltype(auto) getDeviceKind(auto&& any)
+    {
+        return alpaka::internal::getDeviceKind(ALPAKA_FORWARD(any));
+    }
+
+    inline constexpr decltype(auto) getDeviceKind(alpaka::concepts::HasGet auto&& any)
+    {
+        return alpaka::internal::getDeviceKind(*any.get());
+    }
+
+    /** @} */
+
+
+    /**  Get the number of elements to compute per thread.
+     *
+     * This function considers the SIMD width for the corresponding data type and the potential for instruction
+     * parallelism.
+     *
+     * @tparam T_Type The data type used to determine the SIMD width.
+     * @return The minimum number of elements a thread should compute to achieve optimal utilization.
+     */
+    template<typename T_Type>
+    constexpr uint32_t getNumElemPerThread(auto&& any)
+    {
+        return alpaka::getNumElemPerThread<T_Type>(ALPAKA_TYPEOF(getApi(any)){}, ALPAKA_TYPEOF(getDeviceKind(any)){});
+    }
+
+    /** get SIMD with in bytes for the
+     *
+     * @tparam T_Type data type
+     * @return number of elements that can be processed in parallel in a vector register
+     */
+    template<typename T_Type>
+    constexpr uint32_t getArchSimdWidth(auto&& any)
+    {
+        return alpaka::getArchSimdWidth<T_Type>(ALPAKA_TYPEOF(getApi(any)){}, ALPAKA_TYPEOF(getDeviceKind(any)){});
+    }
+
+    /** get the number of instruction can be issued in parallel */
+    constexpr uint32_t getNumPipelines(auto&& any)
+    {
+        return alpaka::getNumPipelines(ALPAKA_TYPEOF(getApi(any)){}, ALPAKA_TYPEOF(getDeviceKind(any)){});
+    }
+
+} // namespace alpaka

--- a/include/alpaka/onHost.hpp
+++ b/include/alpaka/onHost.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "alpaka/KernelBundle.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/concepts.hpp"
 #include "alpaka/onHost/DeviceSelector.hpp"
@@ -107,86 +106,6 @@ namespace alpaka::onHost
     }
 
     /** @} */
-
-    /** Get the API an object depends on
-     *
-     * @param any can be a platform, device, queue, view
-     * @return API tag
-     *
-     * @{
-     */
-    inline constexpr decltype(auto) getApi(auto&& any)
-    {
-        return alpaka::internal::getApi(ALPAKA_FORWARD(any));
-    }
-
-    inline constexpr decltype(auto) getApi(alpaka::concepts::HasGet auto&& any)
-    {
-        return alpaka::internal::getApi(*any.get());
-    }
-
-    namespace concepts
-    {
-        template<typename T_Any>
-        concept HasApi = requires(T_Any&& any) {
-            {
-                getApi(any)
-            } -> alpaka::concepts::Api;
-        };
-    } // namespace concepts
-
-    /** @} */
-
-    /** Get the device type of an object
-     *
-     * @param any can be a platform, device, queue, view
-     * @return type from alpaka::deviceKind
-     *
-     * @{
-     */
-    inline constexpr decltype(auto) getDeviceKind(auto&& any)
-    {
-        return alpaka::internal::getDeviceKind(ALPAKA_FORWARD(any));
-    }
-
-    inline constexpr decltype(auto) getDeviceKind(alpaka::concepts::HasGet auto&& any)
-    {
-        return alpaka::internal::getDeviceKind(*any.get());
-    }
-
-    /** @} */
-
-
-    /**  Get the number of elements to compute per thread.
-     *
-     * This function considers the SIMD width for the corresponding data type and the potential for instruction
-     * parallelism.
-     *
-     * @tparam T_Type The data type used to determine the SIMD width.
-     * @return The minimum number of elements a thread should compute to achieve optimal utilization.
-     */
-    template<typename T_Type>
-    constexpr uint32_t getNumElemPerThread(auto&& any)
-    {
-        return alpaka::getNumElemPerThread<T_Type>(ALPAKA_TYPEOF(getApi(any)){}, ALPAKA_TYPEOF(getDeviceKind(any)){});
-    }
-
-    /** get SIMD with in bytes for the
-     *
-     * @tparam T_Type data type
-     * @return number of elements that can be processed in parallel in a vector register
-     */
-    template<typename T_Type>
-    constexpr uint32_t getArchSimdWidth(auto&& any)
-    {
-        return alpaka::getArchSimdWidth<T_Type>(ALPAKA_TYPEOF(getApi(any)){}, ALPAKA_TYPEOF(getDeviceKind(any)){});
-    }
-
-    /** get the number of instruction can be issued in parallel */
-    constexpr uint32_t getNumPipelines(auto&& any)
-    {
-        return alpaka::getNumPipelines(ALPAKA_TYPEOF(getApi(any)){}, ALPAKA_TYPEOF(getDeviceKind(any)){});
-    }
 
     /** allocate memory on the given device
      *

--- a/include/alpaka/onHost/mem/Buffer.hpp
+++ b/include/alpaka/onHost/mem/Buffer.hpp
@@ -90,7 +90,7 @@ namespace alpaka::onHost
 
     public:
         template<
-            concepts::HasApi T_Any,
+            alpaka::concepts::HasApi T_Any,
             alpaka::concepts::Vector T_UserExtents,
             alpaka::concepts::Vector T_UserPitches>
         Buffer(
@@ -176,7 +176,7 @@ namespace alpaka::onHost
     }; // namespace alpaka::onHost
 
     template<
-        concepts::HasApi T_Any,
+        alpaka::concepts::HasApi T_Any,
         typename T_Type,
         alpaka::concepts::Vector T_UserExtents,
         alpaka::concepts::Vector T_UserPitches,
@@ -189,21 +189,18 @@ namespace alpaka::onHost
         std::invocable<> auto,
         T_MemAlignment const)
         -> Buffer<
-            ALPAKA_TYPEOF(onHost::getApi(std::declval<T_Any>())),
+            ALPAKA_TYPEOF(getApi(std::declval<T_Any>())),
             T_Type,
             typename T_UserPitches::UniVec,
             T_MemAlignment>;
 
     template<
-        concepts::HasApi T_Any,
+        alpaka::concepts::HasApi T_Any,
         typename T_Type,
         alpaka::concepts::Vector T_UserExtents,
         alpaka::concepts::Vector T_UserPitches>
-    Buffer(T_Any const&, T_Type*, T_UserExtents const&, T_UserPitches const&, std::invocable<> auto) -> Buffer<
-        ALPAKA_TYPEOF(onHost::getApi(std::declval<T_Any>())),
-        T_Type,
-        typename T_UserPitches::UniVec,
-        Alignment<>>;
+    Buffer(T_Any const&, T_Type*, T_UserExtents const&, T_UserPitches const&, std::invocable<> auto)
+        -> Buffer<ALPAKA_TYPEOF(getApi(std::declval<T_Any>())), T_Type, typename T_UserPitches::UniVec, Alignment<>>;
 } // namespace alpaka::onHost
 
 namespace alpaka::internal

--- a/include/alpaka/onHost/mem/View.hpp
+++ b/include/alpaka/onHost/mem/View.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/core/config.hpp"
+#include "alpaka/interface.hpp"
 #include "alpaka/internal.hpp"
 #include "alpaka/mem/MdSpan.hpp"
 #include "alpaka/mem/concepts.hpp"
@@ -41,7 +42,7 @@ namespace alpaka::onHost
          * handle.
          */
         template<
-            concepts::HasApi T_Any,
+            alpaka::concepts::HasApi T_Any,
             alpaka::concepts::Vector T_UserExtents,
             alpaka::concepts::Vector T_UserPitches>
         View(
@@ -156,27 +157,21 @@ namespace alpaka::onHost
     };
 
     template<
-        concepts::HasApi T_Any,
+        alpaka::concepts::HasApi T_Any,
         typename T_Type,
         alpaka::concepts::Vector T_UserExtents,
         alpaka::concepts::Vector T_UserPitches,
         alpaka::concepts::Alignment T_MemAlignment>
-    View(T_Any const&, T_Type*, T_UserExtents const&, T_UserPitches const&, T_MemAlignment const memAlignment) -> View<
-        ALPAKA_TYPEOF(onHost::getApi(std::declval<T_Any>())),
-        T_Type,
-        typename T_UserPitches::UniVec,
-        T_MemAlignment>;
+    View(T_Any const&, T_Type*, T_UserExtents const&, T_UserPitches const&, T_MemAlignment const memAlignment)
+        -> View<ALPAKA_TYPEOF(getApi(std::declval<T_Any>())), T_Type, typename T_UserPitches::UniVec, T_MemAlignment>;
 
     template<
-        concepts::HasApi T_Any,
+        alpaka::concepts::HasApi T_Any,
         typename T_Type,
         alpaka::concepts::Vector T_UserExtents,
         alpaka::concepts::Vector T_UserPitches>
-    View(T_Any, T_Type*, T_UserExtents const&, T_UserPitches const&) -> View<
-        ALPAKA_TYPEOF(onHost::getApi(std::declval<T_Any>())),
-        T_Type,
-        typename T_UserPitches::UniVec,
-        Alignment<>>;
+    View(T_Any, T_Type*, T_UserExtents const&, T_UserPitches const&)
+        -> View<ALPAKA_TYPEOF(getApi(std::declval<T_Any>())), T_Type, typename T_UserPitches::UniVec, Alignment<>>;
 } // namespace alpaka::onHost
 
 namespace alpaka::internal


### PR DESCRIPTION
Move `getNumElemPerThread()` , `getArchSimdWidth()`,  `getNumPipelines()`, `getDeviceKind()` and `getApi()` from host
namespace to alpaka