### PR TITLE
support Buffer and View as kernel arguments

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -476,26 +476,17 @@ void testKernels(auto cfg)
         {
             // Test the copy-kernel. Copy A one by one to C.
             measureKernelExec(
-                [&]()
-                {
+                [&]() {
                     queue.enqueue(
                         exec,
                         dataBlocking,
-                        KernelBundle{CopyKernel(), bufAccInputA.getMdSpan(), bufAccOutputC.getMdSpan(), arraySize});
+                        KernelBundle{CopyKernel(), bufAccInputA, bufAccOutputC, arraySize});
                 },
                 "CopyKernel");
 
             // Test the scaling-kernel. Calculate B=scalar*C. Where C = A.
             measureKernelExec(
-                [&]() {
-                    queue.enqueue(
-                        exec,
-                        dataBlocking,
-                        MultKernel(),
-                        bufAccInputB.getMdSpan(),
-                        bufAccOutputC.getMdSpan(),
-                        arraySize);
-                },
+                [&]() { queue.enqueue(exec, dataBlocking, MultKernel(), bufAccInputB, bufAccOutputC, arraySize); },
                 "MultKernel");
 
             // Test the addition-kernel. Calculate C=A+B. Where B=scalar*C or B=scalar*A.
@@ -505,12 +496,7 @@ void testKernels(auto cfg)
                     queue.enqueue(
                         exec,
                         dataBlocking,
-                        KernelBundle{
-                            AddKernel(),
-                            bufAccInputA.getMdSpan(),
-                            bufAccInputB.getMdSpan(),
-                            bufAccOutputC.getMdSpan(),
-                            arraySize});
+                        KernelBundle{AddKernel(), bufAccInputA, bufAccInputB, bufAccOutputC, arraySize});
                 },
                 "AddKernel");
         }
@@ -524,12 +510,7 @@ void testKernels(auto cfg)
                     queue.enqueue(
                         exec,
                         dataBlocking,
-                        KernelBundle{
-                            TriadKernel(),
-                            bufAccInputA.getMdSpan(),
-                            bufAccInputB.getMdSpan(),
-                            bufAccOutputC.getMdSpan(),
-                            arraySize});
+                        KernelBundle{TriadKernel(), bufAccInputA, bufAccInputB, bufAccOutputC, arraySize});
                 },
                 "TriadKernel");
         }
@@ -557,9 +538,9 @@ void testKernels(auto cfg)
                         dataBlockingDot,
                         KernelBundle{
                             DotKernel(), // Dot kernel
-                            bufAccInputA.getMdSpan(),
-                            bufAccInputB.getMdSpan(),
-                            bufAccSumPerBlock.getMdSpan(),
+                            bufAccInputA,
+                            bufAccInputB,
+                            bufAccSumPerBlock,
                             arraySize});
                     onHost::memcpy(queue, bufHostSumPerBlock, bufAccSumPerBlock);
                     onHost::wait(queue);

--- a/example/grayScale/src/grayScale.cpp
+++ b/example/grayScale/src/grayScale.cpp
@@ -214,10 +214,7 @@ auto example(T_Cfg const& cfg, size_t numElements, bool enableStdForEach) -> int
                   << deviceSpec.getApi().getName() << std::endl;
         onHost::wait(queue);
         auto const beginT = std::chrono::high_resolution_clock::now();
-        queue.enqueue(
-            exec,
-            dataBlocking,
-            KernelBundle{kernel, bufAccARGB.getMdSpan(), static_cast<size_t>(extent[0])});
+        queue.enqueue(exec, dataBlocking, KernelBundle{kernel, bufAccARGB, static_cast<size_t>(extent[0])});
         onHost::wait(queue); // Ensure kernel execution completes before proceeding
         auto const endT = std::chrono::high_resolution_clock::now();
         double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -149,16 +149,7 @@ auto example(T_Cfg const& cfg) -> int
         computeQueue.enqueue(
             exec,
             dataBlockingStencil,
-            KernelBundle{
-                stencilKernel,
-                uCurrBufAcc.getMdSpan(),
-                uNextBufAcc.getMdSpan(),
-                chunkSize,
-                sharedMemExtents,
-                numNodes,
-                dx,
-                dy,
-                dt});
+            KernelBundle{stencilKernel, uCurrBufAcc, uNextBufAcc, chunkSize, sharedMemExtents, numNodes, dx, dy, dt});
 
         // Apply boundaries
         computeQueue.enqueue(

--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -108,14 +108,7 @@ void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto comp
     auto frameSpec = alpaka::onHost::FrameSpec{32u, 32u};
 
     std::cout << "Testing VectorAddKernel with scalar indices with a grid of " << frameSpec << "\n";
-    queue.enqueue(
-        computeExec,
-        frameSpec,
-        VectorAddKernel{},
-        in1_d.getMdSpan(),
-        in2_d.getMdSpan(),
-        out_d.getMdSpan(),
-        size);
+    queue.enqueue(computeExec, frameSpec, VectorAddKernel{}, in1_d, in2_d, out_d, size);
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);
@@ -202,14 +195,7 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
     auto frameSpec = alpaka::onHost::FrameSpec{Vec3D{5, 5, 1}, Vec3D{4, 4, 4}};
     std::cout << "Testing VectorAddKernel3D with vector indices with a grid of " << frameSpec << "\n";
 
-    queue.enqueue(
-        computeExec,
-        frameSpec,
-        VectorAddKernel3D{},
-        in1_d.getMdSpan(),
-        in2_d.getMdSpan(),
-        out_d.getMdSpan(),
-        ndsize);
+    queue.enqueue(computeExec, frameSpec, VectorAddKernel3D{}, in1_d, in2_d, out_d, ndsize);
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);

--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -137,14 +137,7 @@ void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto comp
 
 
     std::cout << "Testing VectorAddKernel with vector indices with a grid of " << frameSpec << "\n";
-    queue.enqueue(
-        computeExec,
-        frameSpec,
-        VectorAddKernel1D{},
-        in1_d.getMdSpan(),
-        in2_d.getMdSpan(),
-        out_d.getMdSpan(),
-        Vec1D{size});
+    queue.enqueue(computeExec, frameSpec, VectorAddKernel1D{}, in1_d, in2_d, out_d, Vec1D{size});
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -131,14 +131,7 @@ void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto comp
 
     std::cout << "Testing VectorAddKernel with vector indices with " << threadSpec.m_numBlocks << " blocks and "
               << threadSpec.m_numThreads << "\n";
-    queue.enqueue(
-        computeExec,
-        threadSpec,
-        VectorAddKernel1D{},
-        in1_d.getMdSpan(),
-        in2_d.getMdSpan(),
-        out_d.getMdSpan(),
-        Vec1D{size});
+    queue.enqueue(computeExec, threadSpec, VectorAddKernel1D{}, in1_d, in2_d, out_d, Vec1D{size});
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);
@@ -222,14 +215,7 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
     std::cout << "Testing VectorAddKernel with vector indices with " << threadSpec.m_numBlocks << " blocks and "
               << threadSpec.m_numThreads << "\n";
 
-    queue.enqueue(
-        computeExec,
-        threadSpec,
-        VectorAddKernel3D{},
-        in1_d.getMdSpan(),
-        in2_d.getMdSpan(),
-        out_d.getMdSpan(),
-        ndsize);
+    queue.enqueue(computeExec, threadSpec, VectorAddKernel3D{}, in1_d, in2_d, out_d, ndsize);
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -201,8 +201,7 @@ void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto comp
     alpaka::onHost::memset(queue, out_d, 0x00);
 
     std::cout << "Testing VectorAddKernel with vector indices with a grid of " << frameSpec << "\n";
-    queue
-        .enqueue(computeExec, frameSpec, VectorAddKernel1D{}, in1_d.getMdSpan(), in2_d.getMdSpan(), out_d.getMdSpan());
+    queue.enqueue(computeExec, frameSpec, VectorAddKernel1D{}, in1_d, in2_d, out_d);
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);
@@ -274,8 +273,7 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
 
     std::cout << "Testing VectorAddKernel3D with vector indices with a grid of " << frameSpec << "\n";
 
-    queue
-        .enqueue(computeExec, frameSpec, VectorAddKernel3D{}, in1_d.getMdSpan(), in2_d.getMdSpan(), out_d.getMdSpan());
+    queue.enqueue(computeExec, frameSpec, VectorAddKernel3D{}, in1_d, in2_d, out_d);
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -93,9 +93,9 @@ auto example(T_Cfg const& cfg, size_t numElements) -> int
 
     for(auto i(0u); i < extent; ++i)
     {
-        bufHostA.getMdSpan()[i] = dist(eng);
-        bufHostB.getMdSpan()[i] = dist(eng);
-        bufHostC.getMdSpan()[i] = 0;
+        bufHostA[i] = dist(eng);
+        bufHostB[i] = dist(eng);
+        bufHostC[i] = 0;
     }
 
     // Allocate 3 buffers on the accelerator
@@ -143,8 +143,8 @@ auto example(T_Cfg const& cfg, size_t numElements) -> int
     static constexpr int MAX_PRINT_FALSE_RESULTS = 20;
     for(auto i(0u); i < extent; ++i)
     {
-        Data const& val(bufHostC.getMdSpan()[i]);
-        Data const correctResult(bufHostA.getMdSpan()[i] + bufHostB.getMdSpan()[i]);
+        Data const& val(bufHostC[i]);
+        Data const correctResult(bufHostA[i] + bufHostB[i]);
         if(val != correctResult)
         {
             if(falseResults < MAX_PRINT_FALSE_RESULTS)

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -110,8 +110,7 @@ auto example(T_Cfg const& cfg, size_t numElements) -> int
 
     // Instantiate the kernel function object
     VectorAddKernel kernel;
-    auto const taskKernel
-        = KernelBundle{kernel, bufAccA.getMdSpan(), bufAccB.getMdSpan(), bufAccC.getMdSpan(), extent};
+    auto const taskKernel = KernelBundle{kernel, bufAccA, bufAccB, bufAccC, extent};
 
     Vec<size_t, 1u> chunkSize = 256u;
     // how many elements one worker should compute to ensure vectorization or instruction parallelism

--- a/include/alpaka/KernelBundle.hpp
+++ b/include/alpaka/KernelBundle.hpp
@@ -8,16 +8,45 @@
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/config.hpp"
 
+#include <alpaka/mem/concepts.hpp>
+
 #include <tuple>
 #include <type_traits>
 
 namespace alpaka
 {
+    namespace onHost
+    {
+        /** Provides an instance of an object which can be used within the compute kernel*/
+        struct MakeDeviceAccessible
+        {
+            template<typename T_Any>
+            struct Op
+            {
+                /** @return @attention returns a reference to the original data */
+                auto& operator()(auto&& any) const
+                {
+                    return any;
+                }
+            };
+        };
 
-    //! \brief The class used to bind kernel function object and arguments together. Once an instance of this class is
-    //! created, arguments are not needed to be separately given to functions who need kernel function and arguments.
+        /** Provides an instance of an object which can be used within the compute kernel
+         *
+         * @return compute kernel compatible object if MakeDeviceAccessible is specialized else the identity
+         */
+        inline decltype(auto) makeDeviceAccessible(auto&& any)
+        {
+            return MakeDeviceAccessible::Op<ALPAKA_TYPEOF(any)>{}(ALPAKA_FORWARD(any));
+        }
+    } // namespace onHost
+
+    //! \brief The class used to bind kernel function object and arguments together. Once an instance of this class
+    //! is created, arguments are not needed to be separately given to functions who need kernel function and
+    //! arguments.
     //! \tparam TKernelFn The kernel function object type.
-    //! \tparam TArgs Kernel function object invocation argument types as a parameter pack.
+    //! \tparam TArgs Kernel function object
+    //! invocation argument types as a parameter pack.
     template<typename TKernelFn, typename... TArgs>
     class KernelBundle
     {
@@ -25,10 +54,13 @@ namespace alpaka
         //! The function object type
         using KernelFn = std::decay_t<TKernelFn>;
         //! Tuple type to encapsulate kernel function argument types and argument values
-        using ArgTuple = std::tuple<remove_restrict_t<std::decay_t<TArgs>>...>;
+        using ArgTuple
+            = std::tuple<remove_restrict_t<ALPAKA_TYPEOF(onHost::makeDeviceAccessible(std::declval<TArgs>()))>...>;
 
         // Constructor
-        constexpr KernelBundle(KernelFn const& kernelFn, TArgs const&... args) : m_kernelFn{kernelFn}, m_args(args...)
+        constexpr KernelBundle(KernelFn const& kernelFn, auto&&... args)
+            : m_kernelFn{kernelFn}
+            , m_args(onHost::makeDeviceAccessible(ALPAKA_FORWARD(args))...)
         {
         }
 
@@ -66,5 +98,5 @@ namespace alpaka
     //! \return Kernel function bundle. An instance of KernelBundle which consists the kernel function object and its
     //! arguments.
     template<typename TKernelFn, typename... TArgs>
-    ALPAKA_FN_HOST KernelBundle(TKernelFn const&, TArgs const&...) -> KernelBundle<TKernelFn, TArgs...>;
+    ALPAKA_FN_HOST KernelBundle(TKernelFn const&, TArgs&&...) -> KernelBundle<TKernelFn, TArgs...>;
 } // namespace alpaka

--- a/include/alpaka/KernelBundle.hpp
+++ b/include/alpaka/KernelBundle.hpp
@@ -18,7 +18,7 @@ namespace alpaka
     namespace onHost
     {
         /** Provides an instance of an object which can be used within the compute kernel*/
-        struct MakeDeviceAccessible
+        struct MakeAccessibleOnAcc
         {
             template<typename T_Any>
             struct Op
@@ -33,11 +33,11 @@ namespace alpaka
 
         /** Provides an instance of an object which can be used within the compute kernel
          *
-         * @return compute kernel compatible object if MakeDeviceAccessible is specialized else the identity
+         * @return compute kernel compatible object if MakeAccessibleOnAcc is specialized else the identity
          */
-        inline decltype(auto) makeDeviceAccessible(auto&& any)
+        inline decltype(auto) makeAccessibleOnAcc(auto&& any)
         {
-            return MakeDeviceAccessible::Op<ALPAKA_TYPEOF(any)>{}(ALPAKA_FORWARD(any));
+            return MakeAccessibleOnAcc::Op<ALPAKA_TYPEOF(any)>{}(ALPAKA_FORWARD(any));
         }
     } // namespace onHost
 
@@ -55,12 +55,12 @@ namespace alpaka
         using KernelFn = std::decay_t<TKernelFn>;
         //! Tuple type to encapsulate kernel function argument types and argument values
         using ArgTuple
-            = std::tuple<remove_restrict_t<ALPAKA_TYPEOF(onHost::makeDeviceAccessible(std::declval<TArgs>()))>...>;
+            = std::tuple<remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>...>;
 
         // Constructor
         constexpr KernelBundle(KernelFn const& kernelFn, auto&&... args)
             : m_kernelFn{kernelFn}
-            , m_args(onHost::makeDeviceAccessible(ALPAKA_FORWARD(args))...)
+            , m_args(onHost::makeAccessibleOnAcc(ALPAKA_FORWARD(args))...)
         {
         }
 

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -79,7 +79,7 @@ namespace alpaka::onHost
                 *m_queue.get(),
                 std::move(executor),
                 blockCfg,
-                KernelBundle{f, onHost::makeDeviceAccessible(ALPAKA_FORWARD(args))...});
+                KernelBundle{f, onHost::makeAccessibleOnAcc(ALPAKA_FORWARD(args))...});
         }
 
         /** Enqueue a kernel to a queue

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -79,7 +79,7 @@ namespace alpaka::onHost
                 *m_queue.get(),
                 std::move(executor),
                 blockCfg,
-                KernelBundle{f, std::forward<decltype(args)>(args)...});
+                KernelBundle{f, onHost::makeDeviceAccessible(ALPAKA_FORWARD(args))...});
         }
 
         /** Enqueue a kernel to a queue

--- a/include/alpaka/onHost/mem/Buffer.hpp
+++ b/include/alpaka/onHost/mem/Buffer.hpp
@@ -201,6 +201,20 @@ namespace alpaka::onHost
         alpaka::concepts::Vector T_UserPitches>
     Buffer(T_Any const&, T_Type*, T_UserExtents const&, T_UserPitches const&, std::invocable<> auto)
         -> Buffer<ALPAKA_TYPEOF(getApi(std::declval<T_Any>())), T_Type, typename T_UserPitches::UniVec, Alignment<>>;
+
+    template<
+        alpaka::concepts::Api T_Api,
+        typename T_Type,
+        alpaka::concepts::Vector T_Extents,
+        alpaka::concepts::Alignment T_MemAlignment>
+    struct MakeDeviceAccessible::Op<Buffer<T_Api, T_Type, T_Extents, T_MemAlignment>>
+    {
+        decltype(auto) operator()(auto&& any) const
+        {
+            return any.getMdSpan();
+        }
+    };
+
 } // namespace alpaka::onHost
 
 namespace alpaka::internal

--- a/include/alpaka/onHost/mem/Buffer.hpp
+++ b/include/alpaka/onHost/mem/Buffer.hpp
@@ -207,7 +207,7 @@ namespace alpaka::onHost
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment>
-    struct MakeDeviceAccessible::Op<Buffer<T_Api, T_Type, T_Extents, T_MemAlignment>>
+    struct MakeAccessibleOnAcc::Op<Buffer<T_Api, T_Type, T_Extents, T_MemAlignment>>
     {
         decltype(auto) operator()(auto&& any) const
         {

--- a/include/alpaka/onHost/mem/View.hpp
+++ b/include/alpaka/onHost/mem/View.hpp
@@ -172,6 +172,19 @@ namespace alpaka::onHost
         alpaka::concepts::Vector T_UserPitches>
     View(T_Any, T_Type*, T_UserExtents const&, T_UserPitches const&)
         -> View<ALPAKA_TYPEOF(getApi(std::declval<T_Any>())), T_Type, typename T_UserPitches::UniVec, Alignment<>>;
+
+    template<
+        alpaka::concepts::Api T_Api,
+        typename T_Type,
+        alpaka::concepts::Vector T_Extents,
+        alpaka::concepts::Alignment T_MemAlignment>
+    struct MakeDeviceAccessible::Op<View<T_Api, T_Type, T_Extents, T_MemAlignment>>
+    {
+        decltype(auto) operator()(auto&& any) const
+        {
+            return any.getMdSpan();
+        }
+    };
 } // namespace alpaka::onHost
 
 namespace alpaka::internal

--- a/include/alpaka/onHost/mem/View.hpp
+++ b/include/alpaka/onHost/mem/View.hpp
@@ -178,7 +178,7 @@ namespace alpaka::onHost
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment>
-    struct MakeDeviceAccessible::Op<View<T_Api, T_Type, T_Extents, T_MemAlignment>>
+    struct MakeAccessibleOnAcc::Op<View<T_Api, T_Type, T_Extents, T_MemAlignment>>
     {
         decltype(auto) operator()(auto&& any) const
         {

--- a/tests/unit/block/block.cpp
+++ b/tests/unit/block/block.cpp
@@ -73,10 +73,7 @@ TEMPLATE_LIST_TEST_CASE("block iota", "", TestApis)
     auto hBuff = onHost::allocHostMirror(dBuff);
     onHost::wait(queue);
 
-    queue.enqueue(
-        exec,
-        FrameSpec{numBlocks / 2u, blockExtent},
-        KernelBundle{BlockIotaKernel{}, dBuff.getMdSpan(), numBlocks});
+    queue.enqueue(exec, FrameSpec{numBlocks / 2u, blockExtent}, KernelBundle{BlockIotaKernel{}, dBuff, numBlocks});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);
 

--- a/tests/unit/cvecKernelCall/cvecKernelCall.cpp
+++ b/tests/unit/cvecKernelCall/cvecKernelCall.cpp
@@ -65,10 +65,7 @@ TEMPLATE_LIST_TEST_CASE("CVec frame extent kernel call", "", TestApis)
     auto hBuff = onHost::allocHostMirror(dBuff);
     onHost::wait(queue);
     {
-        queue.enqueue(
-            exec,
-            FrameSpec{Vec{1u}, CVec<uint32_t, 43u>{}},
-            KernelBundle{KernelCVecFrameExtents{}, dBuff.getMdSpan()});
+        queue.enqueue(exec, FrameSpec{Vec{1u}, CVec<uint32_t, 43u>{}}, KernelBundle{KernelCVecFrameExtents{}, dBuff});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
         CHECK(hBuff[0] == true);
@@ -118,7 +115,7 @@ TEMPLATE_LIST_TEST_CASE("CVec thread extent kernel call", "", TestApis)
             // we need to use one thread per thread block because serial executors will reduce the number of threads to
             // a single thread
             ThreadSpec{Vec{1u}, CVec<uint32_t, 1u>{}},
-            KernelBundle{KernelCVecThreadExtents{}, dBuff.getMdSpan()});
+            KernelBundle{KernelCVecThreadExtents{}, dBuff});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
         CHECK(hBuff[0] == true);

--- a/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -96,7 +96,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
         queue.enqueue(
             exec,
             FrameSpec{numBlocks, blockExtent},
-            KernelBundle{DeviceGlobalMemKernelVec{}, dBuff.getMdSpan(), dataExtent});
+            KernelBundle{DeviceGlobalMemKernelVec{}, dBuff, dataExtent});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
 
@@ -112,7 +112,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
         queue.enqueue(
             exec,
             FrameSpec{numBlocks, blockExtent},
-            KernelBundle{DeviceGlobalMemKernelScalar{}, dBuff.getMdSpan(), dataExtent});
+            KernelBundle{DeviceGlobalMemKernelScalar{}, dBuff, dataExtent});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
 
@@ -128,7 +128,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
         queue.enqueue(
             exec,
             FrameSpec{numBlocks, blockExtent},
-            KernelBundle{DeviceGlobalMemKernelCArray{}, dBuff.getMdSpan(), dataExtent});
+            KernelBundle{DeviceGlobalMemKernelCArray{}, dBuff, dataExtent});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
 
@@ -144,7 +144,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
         queue.enqueue(
             exec,
             FrameSpec{numBlocks, blockExtent},
-            KernelBundle{DeviceGlobalMemKernelCArray2D{}, dBuff.getMdSpan(), dataExtent});
+            KernelBundle{DeviceGlobalMemKernelCArray2D{}, dBuff, dataExtent});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
 

--- a/tests/unit/math/mathFunctions.cpp
+++ b/tests/unit/math/mathFunctions.cpp
@@ -248,7 +248,7 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Test", "", TestApis)
     queue.enqueue(
         exec,
         alpaka::onHost::FrameSpec{numBlocks, blockExtent},
-        KernelBundle{SqrtKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+        KernelBundle{SqrtKernel{}, inDev, outDev, size});
     alpaka::onHost::memcpy(queue, outHost, outDev);
     alpaka::onHost::wait(queue);
     for(uint32_t i = 0; i < size; ++i)
@@ -262,7 +262,7 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Test", "", TestApis)
     queue.enqueue(
         exec,
         alpaka::onHost::FrameSpec{numBlocks, blockExtent},
-        KernelBundle{CosKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+        KernelBundle{CosKernel{}, inDev, outDev, size});
     alpaka::onHost::memcpy(queue, outHost, outDev);
     alpaka::onHost::wait(queue);
     for(uint32_t i = 0; i < size; ++i)
@@ -275,7 +275,7 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Test", "", TestApis)
     queue.enqueue(
         exec,
         alpaka::onHost::FrameSpec{numBlocks, blockExtent},
-        KernelBundle{LogKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+        KernelBundle{LogKernel{}, inDev, outDev, size});
     alpaka::onHost::memcpy(queue, outHost, outDev);
     alpaka::onHost::wait(queue);
     for(uint32_t i = 0; i < size; ++i)
@@ -289,7 +289,7 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Test", "", TestApis)
     queue.enqueue(
         exec,
         alpaka::onHost::FrameSpec{numBlocks, blockExtent},
-        KernelBundle{TanKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+        KernelBundle{TanKernel{}, inDev, outDev, size});
     alpaka::onHost::memcpy(queue, outHost, outDev);
     alpaka::onHost::wait(queue);
     for(uint32_t i = 0; i < size; ++i)
@@ -303,7 +303,7 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Test", "", TestApis)
     queue.enqueue(
         exec,
         alpaka::onHost::FrameSpec{numBlocks, blockExtent},
-        KernelBundle{AcosKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+        KernelBundle{AcosKernel{}, inDev, outDev, size});
     alpaka::onHost::memcpy(queue, outHost, outDev);
     alpaka::onHost::wait(queue);
     for(uint32_t i = 0; i < size; ++i)
@@ -317,7 +317,7 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Test", "", TestApis)
     queue.enqueue(
         exec,
         alpaka::onHost::FrameSpec{numBlocks, blockExtent},
-        KernelBundle{AsinKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+        KernelBundle{AsinKernel{}, inDev, outDev, size});
     alpaka::onHost::memcpy(queue, outHost, outDev);
     alpaka::onHost::wait(queue);
     for(uint32_t i = 0; i < size; ++i)
@@ -331,7 +331,7 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Test", "", TestApis)
     queue.enqueue(
         exec,
         alpaka::onHost::FrameSpec{numBlocks, blockExtent},
-        KernelBundle{ExpKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+        KernelBundle{ExpKernel{}, inDev, outDev, size});
     alpaka::onHost::memcpy(queue, outHost, outDev);
     alpaka::onHost::wait(queue);
     for(uint32_t i = 0; i < size; ++i)
@@ -410,7 +410,7 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Returning Boolean - Test", "", TestApis)
     queue.enqueue(
         exec,
         alpaka::onHost::FrameSpec{numBlocks, blockExtent},
-        KernelBundle{IsNanKernel{}, inDev.getMdSpan(), outDev.getMdSpan(), size});
+        KernelBundle{IsNanKernel{}, inDev, outDev, size});
     alpaka::onHost::memcpy(queue, outHost, outDev);
     alpaka::onHost::wait(queue);
     for(uint32_t i = 0; i < size; ++i)

--- a/tests/unit/precision/precision.cpp
+++ b/tests/unit/precision/precision.cpp
@@ -76,7 +76,7 @@ void iotaTest(auto cfg, auto const extents, auto frameSize)
     queue.enqueue(
         exec,
         FrameSpec{pCast<KenelIdxScalarType>(extents) / frameSize, frameSize},
-        KernelBundle{IotaKernelND<T_LoopIdxType>{}, dBuff.getMdSpan(), extents});
+        KernelBundle{IotaKernelND<T_LoopIdxType>{}, dBuff, extents});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);
 

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -60,10 +60,7 @@ TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
     auto hBuff = onHost::allocHostMirror(dBuff);
 
     constexpr auto frameSize = CVec<uint32_t, 4u>{};
-    queue.enqueue(
-        exec,
-        FrameSpec{extent / frameSize, frameSize},
-        KernelBundle{IotaKernel{}, dBuff.getMdSpan(), extent.x()});
+    queue.enqueue(exec, FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernel{}, dBuff, extent.x()});
     memcpy(queue, hBuff, dBuff);
     wait(queue);
 #    if 1
@@ -116,10 +113,7 @@ TEMPLATE_LIST_TEST_CASE("iota2D", "", TestApis)
 
     wait(queue);
     constexpr auto frameSize = Vec{2u, 4u};
-    queue.enqueue(
-        exec,
-        FrameSpec{extent / frameSize, frameSize},
-        KernelBundle{IotaKernelND{}, dBuff.getMdSpan(), extent});
+    queue.enqueue(exec, FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernelND{}, dBuff, extent});
     memcpy(queue, hBuff, dBuff);
     wait(queue);
 #    if 1
@@ -162,10 +156,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D", "", TestApis)
 
     wait(queue);
     constexpr auto frameSize = Vec{2u, 4u, 8u};
-    queue.enqueue(
-        exec,
-        FrameSpec{extent / frameSize, frameSize},
-        KernelBundle{IotaKernelND{}, dBuff.getMdSpan(), extent});
+    queue.enqueue(exec, FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernelND{}, dBuff, extent});
     memcpy(queue, hBuff, dBuff);
     wait(queue);
 #    if 1
@@ -248,7 +239,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
     queue.enqueue(
         exec,
         FrameSpec{numBlocksReduced, frameSize},
-        KernelBundle{IotaKernelNDSelection<ALPAKA_TYPEOF(selection)>{}, dBuff.getMdSpan(), numBlocks});
+        KernelBundle{IotaKernelNDSelection<ALPAKA_TYPEOF(selection)>{}, dBuff, numBlocks});
     memcpy(queue, hBuff, dBuff);
     wait(queue);
 #if 1

--- a/tests/unit/sharedMem/sharedMem.cpp
+++ b/tests/unit/sharedMem/sharedMem.cpp
@@ -76,7 +76,7 @@ TEMPLATE_LIST_TEST_CASE("block shared iota", "", TestApis)
     queue.enqueue(
         exec,
         onHost::FrameSpec{numBlocks / 2u, blockExtent},
-        KernelBundle{SharedBlockIotaKernel<blockExtent.x()>{}, dBuff.getMdSpan(), numBlocks});
+        KernelBundle{SharedBlockIotaKernel<blockExtent.x()>{}, dBuff, numBlocks});
     alpaka::onHost::memcpy(queue, hBuff, dBuff);
     alpaka::onHost::wait(queue);
 
@@ -211,28 +211,19 @@ TEMPLATE_LIST_TEST_CASE("block shared alias", "", TestApis)
     auto hBuff = onHost::allocHostMirror(dBuff);
     alpaka::onHost::wait(queue);
     {
-        queue.enqueue(
-            exec,
-            onHost::FrameSpec{numBlocks, blockExtent},
-            KernelBundle{SharedMemAlias{}, dBuff.getMdSpan()});
+        queue.enqueue(exec, onHost::FrameSpec{numBlocks, blockExtent}, KernelBundle{SharedMemAlias{}, dBuff});
         alpaka::onHost::memcpy(queue, hBuff, dBuff);
         alpaka::onHost::wait(queue);
         CHECK(hBuff[0] == true);
     }
     {
-        queue.enqueue(
-            exec,
-            onHost::FrameSpec{numBlocks, blockExtent},
-            KernelBundle{DynSharedMemMember{}, dBuff.getMdSpan()});
+        queue.enqueue(exec, onHost::FrameSpec{numBlocks, blockExtent}, KernelBundle{DynSharedMemMember{}, dBuff});
         alpaka::onHost::memcpy(queue, hBuff, dBuff);
         alpaka::onHost::wait(queue);
         CHECK(hBuff[0] == true);
     }
     {
-        queue.enqueue(
-            exec,
-            onHost::FrameSpec{numBlocks, blockExtent},
-            KernelBundle{DynSharedMemTrait{}, dBuff.getMdSpan()});
+        queue.enqueue(exec, onHost::FrameSpec{numBlocks, blockExtent}, KernelBundle{DynSharedMemTrait{}, dBuff});
         alpaka::onHost::memcpy(queue, hBuff, dBuff);
         alpaka::onHost::wait(queue);
         CHECK(hBuff[0] == true);


### PR DESCRIPTION
- Provide `makeAccessibleOnAcc()` function to create an instance of an
  object which can be used within a compute kernel.
- remove explicit .getMdSpan() call for arguments passed into a kernel