### PR TITLE
refactor View and Buffer behaviours

### DIFF
--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -15,7 +15,7 @@
 #include "alpaka/onHost/DeviceProperties.hpp"
 #include "alpaka/onHost/Handle.hpp"
 #include "alpaka/onHost/Queue.hpp"
-#include "alpaka/onHost/mem/Buffer.hpp"
+#include "alpaka/onHost/mem/ManagedView.hpp"
 #include "alpaka/onHost/mem/View.hpp"
 #include "alpaka/onHost/trait.hpp"
 
@@ -167,7 +167,7 @@ namespace alpaka::onHost
                     // deviceDependency is captured to keep the device alive until the memory is deleted
                     auto deleter = [ptr, deviceDependency]() { alpaka::core::alignedFree(alignment, ptr); };
                     auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
-                    auto buffer = onHost::Buffer{
+                    auto buffer = onHost::ManagedView{
                         deviceDependency,
                         ptr,
                         extents,
@@ -188,7 +188,7 @@ namespace alpaka::onHost
                     // deviceDependency is captured to keep the device alive until the memory is deleted
                     auto deleter = [ptr, deviceDependency]() { alpaka::core::alignedFree(alignment, ptr); };
 
-                    auto buffer = onHost::Buffer{
+                    auto buffer = onHost::ManagedView{
                         deviceDependency,
                         ptr,
                         extents,

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -10,7 +10,7 @@
 
 #    include "Queue.hpp"
 #    include "alpaka/Vec.hpp"
-#    include "alpaka/onHost/mem/Buffer.hpp"
+#    include "alpaka/onHost/mem/ManagedView.hpp"
 #    include "alpaka/onHost/mem/View.hpp"
 
 #    include <sycl/sycl.hpp>
@@ -122,7 +122,7 @@ namespace alpaka::onHost
                     auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
                     auto deleter = [ctx = sycl_context, ptr]() { sycl::free(ptr, ctx); };
 
-                    auto buffer = onHost::Buffer{
+                    auto buffer = onHost::ManagedView{
                         onHost::Device{device.getSharedPtr()},
                         ptr,
                         extents,
@@ -143,7 +143,7 @@ namespace alpaka::onHost
                         sycl::aligned_alloc_device(alignment, memSizeInByte, sycl_device, sycl_context));
                     auto deleter = [ctx = sycl_context, ptr]() { sycl::free(ptr, ctx); };
 
-                    auto buffer = onHost::Buffer{
+                    auto buffer = onHost::ManagedView{
                         onHost::Device{device.getSharedPtr()},
                         ptr,
                         extents,

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -9,7 +9,7 @@
 #if ALPAKA_LANG_CUDA || ALPAKA_LANG_HIP
 #    include "alpaka/api/unifiedCudaHip/Queue.hpp"
 #    include "alpaka/core/UniformCudaHip.hpp"
-#    include "alpaka/onHost/mem/Buffer.hpp"
+#    include "alpaka/onHost/mem/ManagedView.hpp"
 #    include "alpaka/onHost/mem/View.hpp"
 
 #    include <cstdint>
@@ -190,7 +190,7 @@ namespace alpaka::onHost
                  */
                 constexpr uint32_t alignment = 128u;
 
-                auto buffer = onHost::Buffer{
+                auto buffer = onHost::ManagedView{
                     deviceDependency,
                     ptr,
                     extents,

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -53,7 +53,10 @@ namespace alpaka
     {
         using value_type = T_Type;
         using reference = value_type&;
+        using pointer = value_type*;
         using index_type = typename T_Pitches::type;
+
+        using ConstThis = MdSpan<std::add_const_t<value_type>, T_Extents, T_Pitches, T_MemAlignment>;
 
         static_assert(std::is_convertible_v<index_type, typename T_Extents::type>);
 
@@ -74,20 +77,11 @@ namespace alpaka
         /** get origin pointer
          *
          * If the pointer is const and therefore read only depends on T_Type and not the const-ness of MdSPan.
-         *
-         * @{
          */
-        constexpr value_type* data() const
+        constexpr pointer data() const
         {
             return this->m_ptr;
         }
-
-        constexpr value_type* data()
-        {
-            return this->m_ptr;
-        }
-
-        /** @} */
 
         /*Object must init by copy a valid instance*/
         constexpr MdSpan() = default;
@@ -124,26 +118,13 @@ namespace alpaka
          *
          * @param idx n-dimensional offset, relative to the origin pointer
          * @return reference to the value
-         * @{
          */
-        constexpr value_type const& operator[](concepts::Vector auto const& idx) const
+        constexpr reference operator[](concepts::Vector auto const& idx) const
         {
             return *ptr(idx);
         }
 
-        constexpr reference operator[](concepts::Vector auto const& idx)
-        {
-            return *const_cast<value_type*>(ptr(idx));
-        }
-
-        /** }@ */
-
-        constexpr value_type operator[](std::integral auto const& idx) const requires(dim() == 1u)
-        {
-            return *ptr(Vec{idx});
-        }
-
-        constexpr reference operator[](std::integral auto const& idx) requires(dim() == 1u)
+        constexpr reference operator[](std::integral auto const& idx) const requires(dim() == 1u)
         {
             return *ptr(Vec{idx});
         }
@@ -153,32 +134,28 @@ namespace alpaka
             return m_extent;
         }
 
-        T_Extents getPitches() const
+        constexpr T_Extents getPitches() const
         {
             return m_pitch.getPitches();
         }
 
-        auto getConstMdSpan() const
+        constexpr auto getConstMdSpan() const
         {
-            using ConstPtrType = ConstPtr_t<ALPAKA_TYPEOF(m_ptr)>;
+            using ConstValueType = std::add_const_t<value_type>;
             return makeMdSpan(
-                static_cast<ConstPtrType>(m_ptr),
+                static_cast<ConstValueType*>(m_ptr),
                 this->getExtents(),
                 this->getPitches(),
                 T_MemAlignment{});
         }
 
     protected:
-        /** @todo move this to trais or somewhere else that it can be used everywhere */
-        template<alpaka::concepts::IsPointer T>
-        using ConstPtr_t = std::add_pointer_t<std::add_const_t<std::remove_pointer_t<T>>>;
-
         /** get the pointer of the value relative to the origin pointer m_ptr
          *
          * @param idx n-dimensional offset
          * @return pointer to value
          */
-        constexpr value_type const* ptr(concepts::Vector auto const& idx) const requires(dim() >= 2u)
+        constexpr pointer ptr(concepts::Vector auto const& idx) const requires(dim() >= 2u)
         {
             /** offset in bytes
              *
@@ -190,36 +167,17 @@ namespace alpaka
             {
                 offset += m_pitch[d] * idx[d];
             }
-            return reinterpret_cast<value_type const*>(reinterpret_cast<char const*>(this->m_ptr) + offset);
+            using CharPtrType = std::conditional_t<std::is_const_v<value_type>, char const*, char*>;
+            return reinterpret_cast<pointer>(reinterpret_cast<CharPtrType>(this->m_ptr) + offset);
         }
 
-        constexpr value_type* ptr(concepts::Vector auto const& idx) requires(dim() >= 2u)
-        {
-            /** offset in bytes
-             *
-             * We calculate the complete offset in bytes even if it would be possible to change the x-dimension
-             * with the native value_types pointer, this is reducing the register footprint.
-             */
-            index_type offset = sizeof(value_type) * idx.back();
-            for(uint32_t d = 0u; d < dim() - 1u; ++d)
-            {
-                offset += m_pitch[d] * idx[d];
-            }
-            return reinterpret_cast<value_type*>(reinterpret_cast<char*>(this->m_ptr) + offset);
-        }
-
-        constexpr value_type* ptr(concepts::Vector auto const& idx) const requires(dim() == 1u)
-        {
-            return this->m_ptr + idx.x();
-        }
-
-        constexpr value_type* ptr(concepts::Vector auto const& idx) requires(dim() == 1u)
+        constexpr pointer ptr(concepts::Vector auto const& idx) const requires(dim() == 1u)
         {
             return this->m_ptr + idx.x();
         }
 
     private:
-        value_type* m_ptr;
+        pointer m_ptr;
         T_Extents m_extent;
         DataPitches<value_type, T_Pitches> m_pitch;
     };
@@ -271,6 +229,7 @@ namespace alpaka
         using extentType = std::extent<T_ArrayType, std::rank_v<T_ArrayType>>;
         using value_type = std::remove_all_extents_t<T_ArrayType>;
         using reference = value_type&;
+        using pointer = value_type*;
         using index_type = typename extentType::value_type;
 
         static consteval uint32_t dim()
@@ -282,26 +241,16 @@ namespace alpaka
          *
          * @return value at the current location
          */
-        constexpr reference operator*()
+        constexpr reference operator*() const
         {
             return *this->m_ptr;
         }
 
-        /** get origin pointer
-         *
-         * @{
-         */
-        constexpr value_type const* data() const
+        /** get origin pointer */
+        constexpr pointer data() const
         {
             return this->m_ptr;
         }
-
-        constexpr value_type* data()
-        {
-            return this->m_ptr;
-        }
-
-        /** @} */
 
         /*Object must init by copy a valid instance*/
         constexpr MdSpanArray() = default;
@@ -328,22 +277,12 @@ namespace alpaka
          * @return reference to the value
          * @{
          */
-        constexpr value_type const& operator[](concepts::Vector auto const& idx) const
+        constexpr reference operator[](concepts::Vector auto const& idx) const
         {
             return ResolveArrayAccess<dim()>{}(*m_ptr, idx);
         }
 
-        constexpr reference operator[](concepts::Vector auto const& idx)
-        {
-            return ResolveArrayAccess<dim()>{}(*m_ptr, idx);
-        }
-
-        constexpr value_type const& operator[](index_type const& idx) const
-        {
-            return (*m_ptr)[idx];
-        }
-
-        constexpr reference operator[](index_type const& idx)
+        constexpr reference operator[](index_type const& idx) const
         {
             return (*m_ptr)[idx];
         }

--- a/include/alpaka/mem/concepts.hpp
+++ b/include/alpaka/mem/concepts.hpp
@@ -11,8 +11,10 @@
 
 namespace alpaka::concepts
 {
-    template<typename T>
-    concept MdSpan = alpaka::isMdSpan_v<T>;
+    template<typename T, typename T_ValueType = alpaka::NotRequired>
+    concept MdSpan = alpaka::isMdSpan_v<T>
+                     && (std::same_as<T_ValueType, trait::GetValueType_t<std::decay_t<T>>>
+                         || std::same_as<T_ValueType, alpaka::NotRequired>);
 
     template<typename T>
     concept Reference = std::is_reference_v<T>;

--- a/include/alpaka/onHost/mem/ManagedView.hpp
+++ b/include/alpaka/onHost/mem/ManagedView.hpp
@@ -57,23 +57,23 @@ namespace alpaka::onHost
         }
     } // namespace mem
 
-    /** Container with contiguous data
+    /** Life time managed view with contiguous data
      *
-     * The container owns the data and will deallocate it when the buffer is destroyed.
-     * Const-ness of the buffer is propagated to the data region.
+     * This managed view owns the data and will deallocate it when the view is destroyed.
+     * Const-ness of the managed view is NOT propagated to the data region.
      */
     template<
         alpaka::concepts::Api T_Api,
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment = Alignment<>>
-    struct Buffer : View<T_Api, T_Type, T_Extents, T_MemAlignment>
+    struct ManagedView : View<T_Api, T_Type, T_Extents, T_MemAlignment>
     {
     private:
         using BaseView = View<T_Api, T_Type, T_Extents, T_MemAlignment>;
 
         /** Constructor with existing managed deleter */
-        Buffer(
+        ManagedView(
             T_Api const api,
             T_Type* data,
             T_Extents const& extents,
@@ -85,15 +85,16 @@ namespace alpaka::onHost
         {
         }
 
-        // friend declaration is required that a non const buffer can access the private constructor
-        friend struct Buffer<T_Api, std::remove_const_t<T_Type>, T_Extents, T_MemAlignment>;
+        // friend declaration is required that a non const managed view can access the private constructor
+        friend struct ManagedView<T_Api, std::remove_const_t<T_Type>, T_Extents, T_MemAlignment>;
+
 
     public:
         template<
             alpaka::concepts::HasApi T_Any,
             alpaka::concepts::Vector T_UserExtents,
             alpaka::concepts::Vector T_UserPitches>
-        Buffer(
+        ManagedView(
             T_Any const& any,
             T_Type* data,
             T_UserExtents const& extents,
@@ -109,69 +110,55 @@ namespace alpaka::onHost
         }
 
         auto getView() const
-
-        {
-            return this->getConstView();
-        }
-
-        BaseView getView()
         {
             return *this;
         }
 
-        /** create a read only buffer */
-        auto getConstBuffer() const
+        /** create a read only managed view */
+        auto getConstManagedView() const
         {
-            auto const* ptr = this->data();
-            return Buffer<T_Api, std::remove_pointer_t<decltype(ptr)>, T_Extents, T_MemAlignment>(
+            using ConstValueType = std::add_const_t<typename BaseView::value_type>;
+            return ManagedView<T_Api, ConstValueType, T_Extents, T_MemAlignment>(
                 T_Api{},
-                ptr,
+                static_cast<ConstValueType*>(this->data()),
                 this->getExtents(),
                 this->getPitches(),
                 m_deleter,
                 T_MemAlignment{});
         }
 
-        /** Creates a sub buffer to a part of the memory.
+        /** Creates a sub managed view to a part of the memory.
          *
          * @param extents number of elements for each dimension
-         * @return View which is pointing only to a part of the original buffer.
+         * @return View which is pointing only to a part of the original managed view.
          */
-        auto getSubBuffer(alpaka::concepts::Vector auto const& extents) const
+        auto getManagedSubView(alpaka::concepts::Vector auto const& extents) const
         {
             assert(extents <= this->getExtents());
-            return Buffer{T_Api{}, this->data(), extents, this->getPitches(), m_deleter, T_MemAlignment{}};
+            return ManagedView{T_Api{}, this->data(), extents, this->getPitches(), m_deleter, T_MemAlignment{}};
         }
 
-        auto getSubBuffer(alpaka::concepts::Vector auto const& extents)
-        {
-            assert(extents <= this->getExtents());
-            return Buffer{T_Api{}, this->data(), extents, this->getPitches(), m_deleter, T_MemAlignment{}};
-        }
-
-        /** Creates a sub buffer to a part of the memory.
+        /** Creates a sub managed view to a part of the memory.
          *
-         * @param offset offset in elements to the original buffer
+         * @param offset offset in elements to the original managed view
          * @param extents number of elements for each dimension
-         * @return View which is pointing only to a part of the original buffer with a shifted origin pointer.
+         * @return View which is pointing only to a part of the original managed view with a shifted origin pointer.
          *         View which pointThe alignment of the sub view is reduced to the element alignment.
          */
-        auto getSubBuffer(alpaka::concepts::Vector auto const& offset, alpaka::concepts::Vector auto const& extents)
-            const
+        auto getManagedSubView(
+            alpaka::concepts::Vector auto const& offset,
+            alpaka::concepts::Vector auto const& extents) const
         {
             assert(offset + extents <= this->getExtents());
             auto shiftedPtr = &this->getMdSpan()[offset];
-            return Buffer{T_Api{}, shiftedPtr, extents, this->getPitches(), Alignment<>{}};
-        }
-
-        auto getSubBuffer(alpaka::concepts::Vector auto const& offset, alpaka::concepts::Vector auto const& extents)
-        {
-            assert(offset + extents <= this->getExtents());
-            auto shiftedPtr = &this->getMdSpan()[offset];
-            return Buffer{T_Api{}, shiftedPtr, extents - offset, this->getPitches(), Alignment<>{}};
+            return ManagedView{T_Api{}, shiftedPtr, extents, this->getPitches(), Alignment<>{}};
         }
 
     private:
+        /** @todo move this to trais or somewhere else that it can be used everywhere */
+        template<alpaka::concepts::IsPointer T>
+        using ConstPtr_t = std::add_pointer_t<std::add_const_t<std::remove_pointer_t<T>>>;
+
         std::shared_ptr<mem::ManagedDealloc> m_deleter;
     }; // namespace alpaka::onHost
 
@@ -181,14 +168,14 @@ namespace alpaka::onHost
         alpaka::concepts::Vector T_UserExtents,
         alpaka::concepts::Vector T_UserPitches,
         alpaka::concepts::Alignment T_MemAlignment>
-    Buffer(
+    ManagedView(
         T_Any const&,
         T_Type*,
         T_UserExtents const&,
         T_UserPitches const&,
         std::invocable<> auto,
         T_MemAlignment const)
-        -> Buffer<
+        -> ManagedView<
             ALPAKA_TYPEOF(getApi(std::declval<T_Any>())),
             T_Type,
             typename T_UserPitches::UniVec,
@@ -199,15 +186,19 @@ namespace alpaka::onHost
         typename T_Type,
         alpaka::concepts::Vector T_UserExtents,
         alpaka::concepts::Vector T_UserPitches>
-    Buffer(T_Any const&, T_Type*, T_UserExtents const&, T_UserPitches const&, std::invocable<> auto)
-        -> Buffer<ALPAKA_TYPEOF(getApi(std::declval<T_Any>())), T_Type, typename T_UserPitches::UniVec, Alignment<>>;
+    ManagedView(T_Any const&, T_Type*, T_UserExtents const&, T_UserPitches const&, std::invocable<> auto)
+        -> ManagedView<
+            ALPAKA_TYPEOF(getApi(std::declval<T_Any>())),
+            T_Type,
+            typename T_UserPitches::UniVec,
+            Alignment<>>;
 
     template<
         alpaka::concepts::Api T_Api,
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment>
-    struct MakeAccessibleOnAcc::Op<Buffer<T_Api, T_Type, T_Extents, T_MemAlignment>>
+    struct MakeAccessibleOnAcc::Op<ManagedView<T_Api, T_Type, T_Extents, T_MemAlignment>>
     {
         decltype(auto) operator()(auto&& any) const
         {
@@ -225,7 +216,7 @@ namespace alpaka::internal
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment>
-    struct GetApi::Op<onHost::Buffer<T_Api, T_Type, T_Extents, T_MemAlignment>>
+    struct GetApi::Op<onHost::ManagedView<T_Api, T_Type, T_Extents, T_MemAlignment>>
     {
         inline constexpr auto operator()(auto&& data) const
         {

--- a/include/alpaka/onHost/mem/View.hpp
+++ b/include/alpaka/onHost/mem/View.hpp
@@ -22,7 +22,7 @@ namespace alpaka::onHost
     /** Non owning view to data
      *
      * This view is only holding a points to real data, copying the view is cheap.
-     * Const-ness of the view is propagated to the data region.
+     * Const-ness of the view is NOT propagated to the data region.
      */
     template<
         typename T_Api,
@@ -72,25 +72,7 @@ namespace alpaka::onHost
             return T_Api{};
         }
 
-        /** pointer to data */
-        decltype(auto) data()
-        {
-            return BaseMdSpan::data();
-        }
-
-        /** pointer to data */
-        decltype(auto) data() const
-        {
-            using RetType = ConstPtr_t<ALPAKA_TYPEOF(BaseMdSpan::data())>;
-            return static_cast<RetType>(BaseMdSpan::data());
-        }
-
         alpaka::concepts::MdSpan auto getMdSpan() const
-        {
-            return this->getConstMdSpan();
-        }
-
-        alpaka::concepts::MdSpan auto getMdSpan()
         {
             return BaseMdSpan{*this};
         }
@@ -98,9 +80,10 @@ namespace alpaka::onHost
         /** create a read only view */
         auto getConstView() const
         {
-            return View<T_Api, std::remove_pointer_t<decltype(this->data())>, T_Extents, T_MemAlignment>{
+            using ConstValueType = std::add_const_t<typename BaseMdSpan::value_type>;
+            return View<T_Api, ConstValueType, T_Extents, T_MemAlignment>{
                 T_Api{},
-                this->data(),
+                static_cast<ConstValueType*>(this->data()),
                 this->getExtents(),
                 this->getPitches(),
                 T_MemAlignment{}};
@@ -114,13 +97,7 @@ namespace alpaka::onHost
         auto getSubView(alpaka::concepts::Vector auto const& extents) const
         {
             assert(extents <= this->getExtents());
-            return View{T_Api{}, data(), extents, this->getPitches(), T_MemAlignment{}};
-        }
-
-        auto getSubView(alpaka::concepts::Vector auto const& extents)
-        {
-            assert(extents <= this->getExtents());
-            return View{T_Api{}, data(), extents, this->getPitches(), T_MemAlignment{}};
+            return View{T_Api{}, this->data(), extents, this->getPitches(), T_MemAlignment{}};
         }
 
         /** Creates a sub view to a part of the memory.
@@ -138,18 +115,7 @@ namespace alpaka::onHost
             return View{T_Api{}, shiftedPtr, extents, this->getPitches(), Alignment<>{}};
         }
 
-        auto getSubView(alpaka::concepts::Vector auto const& offset, alpaka::concepts::Vector auto const& extents)
-        {
-            assert(offset + extents <= this->getExtents());
-            auto shiftedPtr = &getMdSpan()[offset];
-            return View{T_Api{}, shiftedPtr, extents - offset, this->getPitches(), Alignment<>{}};
-        }
-
     private:
-        /** @todo move this to trais or somewhere else that it can be used everywhere */
-        template<alpaka::concepts::IsPointer T>
-        using ConstPtr_t = std::add_pointer_t<std::add_const_t<std::remove_pointer_t<T>>>;
-
         void _()
         {
             //                static_assert(concepts::Device<Device>);

--- a/include/alpaka/trait.hpp
+++ b/include/alpaka/trait.hpp
@@ -11,6 +11,12 @@
 
 namespace alpaka
 {
+    /** This types is used in cases where the type is not required and can be given optionally into a trait or concept.
+     */
+    struct NotRequired
+    {
+    };
+
     namespace trait
     {
         template<typename T>

--- a/tests/unit/math/mathFunctions.cpp
+++ b/tests/unit/math/mathFunctions.cpp
@@ -212,7 +212,7 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Test", "", TestApis)
     std::default_random_engine rand{rd()};
     std::uniform_real_distribution<float> dist{-10.0f, 10.0f};
 
-    // Buffer size
+    // ManagedView size
     constexpr uint32_t size = 32;
 
     // Allocate input and output buffers on the host
@@ -368,7 +368,7 @@ TEMPLATE_LIST_TEST_CASE("Math Functions Returning Boolean - Test", "", TestApis)
     std::default_random_engine rand{rd()};
     std::uniform_real_distribution<float> dist{-10.0f, 10.0f};
 
-    // Buffer size
+    // ManagedView size
     constexpr uint32_t size = 32;
 
     // Allocate input and output buffers on the host


### PR DESCRIPTION
- rename `Buffer` into `ManagedView`
- The constness of the managed view and view will not be projected to the data
- fix access methods on `MdSpan` the `operator[]` for a const instance was returning the value as value but not writable reference.

After discussions with @SimeonEhrig and @chillenzer I decided that a view behaves like a MdSpan object which requires for read only data that the value_type must be `type const`. To avoid misinterpretation the `Buffer` is now called `ManagedView` to reflect the new access behaviour. 
