### PR TITLE
fix host and oneApi memory allocation

### DIFF
--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -182,8 +182,7 @@ namespace alpaka::onHost
                     IdxType rowPitchInBytes = divCeil(rowExtentInBytes, alignment) * alignment;
                     auto pitches = mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
 
-                    // product of pitches does contain the size for the first dimension
-                    size_t memSizeInByte = pCast<size_t>(pitches).product() * static_cast<size_t>(extents[0]);
+                    size_t memSizeInByte = pCast<size_t>(pitches)[0] * static_cast<size_t>(extents[0]);
                     auto* ptr = reinterpret_cast<T_Type*>(alpaka::core::alignedAlloc(alignment, memSizeInByte));
                     // deviceDependency is captured to keep the device alive until the memory is deleted
                     auto deleter = [ptr, deviceDependency]() { alpaka::core::alignedFree(alignment, ptr); };

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -137,8 +137,7 @@ namespace alpaka::onHost
                     IdxType rowPitchInBytes = divCeil(rowExtentInBytes, alignment) * alignment;
                     auto pitches = mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
 
-                    // product of pitches does contain the size for the first dimension
-                    size_t memSizeInByte = pCast<size_t>(pitches).product() * static_cast<size_t>(extents[0]);
+                    size_t memSizeInByte = pCast<size_t>(pitches)[0] * static_cast<size_t>(extents[0]);
                     T_Type* ptr = reinterpret_cast<T_Type*>(
                         sycl::aligned_alloc_device(alignment, memSizeInByte, sycl_device, sycl_context));
                     auto deleter = [ctx = sycl_context, ptr]() { sycl::free(ptr, ctx); };


### PR DESCRIPTION
For both backends multi dimensional allocation allocated to much memory. The result of this bug is that we run very fast out of memory.