### PR TITLE
simplify iota validation

### DIFF
--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -163,7 +163,7 @@ namespace alpaka::onHost
                 /* Get all required properties outside the lambda function to not extend the life-time of the data.
                  * The life-time is not extended to have some life-time behaviours with all backends.
                  */
-                auto* destPtr = alpaka::onHost::data(dest);
+                void* destPtr = static_cast<void*>(alpaka::onHost::data(dest));
                 auto const* srcPtr = alpaka::onHost::data(source);
 
                 if constexpr(dim == 1u)
@@ -212,7 +212,7 @@ namespace alpaka::onHost
             {
                 constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
 
-                auto* destPtr = alpaka::onHost::data(dest);
+                void* destPtr = static_cast<void*>(alpaka::onHost::data(dest));
 
                 if constexpr(dim == 1u)
                 {

--- a/tests/unit/queue/kernelMD.cpp
+++ b/tests/unit/queue/kernelMD.cpp
@@ -63,36 +63,15 @@ void validate(auto& queue, auto& device, auto exec, auto testCase)
         KernelBundle{LastSetDataBlockIdx{}, dBuff, extentMd});
     memcpy(queue, hBuff, dBuff);
     wait(queue);
-    // the result must be the index of the last valid element in the extent range
-    auto hostDevice = onHost::makeHostDevice();
 
     // validate that each data entry has its corresponding MD-element index
-    hostDevice.makeQueue().enqueue(
-        exec::cpuSerial,
-        FrameSpec{extentMd, frameSize},
-        [=](auto const& acc, alpaka::concepts::MdSpan auto in)
-        {
-            for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange(extentMd)))
-            {
-                CHECK(in[i] == i);
-            }
-        },
-        hBuff);
+    meta::ndLoopIncIdx(extentMd, [&](auto idx) { CHECK(hBuff[idx] == idx); });
+
     memset(queue, dBuff, 0u);
     memcpy(queue, hBuff, dBuff);
     wait(queue);
     // validate that all data is zero
-    hostDevice.makeQueue().enqueue(
-        exec::cpuSerial,
-        FrameSpec{extentMd, frameSize},
-        [=](auto const& acc, alpaka::concepts::MdSpan auto in)
-        {
-            for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange(extentMd)))
-            {
-                CHECK(in[i] == ALPAKA_TYPEOF(extentMd)::all(0));
-            }
-        },
-        hBuff);
+    meta::ndLoopIncIdx(extentMd, [&](auto idx) { CHECK(hBuff[idx] == ALPAKA_TYPEOF(extentMd)::all(0)); });
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelCallMD", "", TestApis)

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -63,13 +63,7 @@ TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
     queue.enqueue(exec, FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernel{}, dBuff, extent.x()});
     memcpy(queue, hBuff, dBuff);
     wait(queue);
-#    if 1
-    auto* ptr = onHost::data(hBuff);
-    for(uint32_t i = 0u; i < extent; ++i)
-    {
-        CHECK(i == ptr[i]);
-    }
-#    endif
+    meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(idx.x() == hBuff[idx]); });
 }
 #endif
 
@@ -116,14 +110,7 @@ TEMPLATE_LIST_TEST_CASE("iota2D", "", TestApis)
     queue.enqueue(exec, FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernelND{}, dBuff, extent});
     memcpy(queue, hBuff, dBuff);
     wait(queue);
-#    if 1
-    auto mdSpan = hBuff.getMdSpan();
-    for(uint32_t j = 0u; j < extent.y(); ++j)
-        for(uint32_t i = 0u; i < extent.x(); ++i)
-        {
-            CHECK(Vec{j, i} == mdSpan[Vec{j, i}]);
-        }
-#    endif
+    meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(idx == hBuff[idx]); });
 }
 #endif
 
@@ -159,15 +146,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D", "", TestApis)
     queue.enqueue(exec, FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernelND{}, dBuff, extent});
     memcpy(queue, hBuff, dBuff);
     wait(queue);
-#    if 1
-    auto mdSpan = hBuff.getMdSpan();
-    for(uint32_t k = 0u; k < extent.z(); ++k)
-        for(uint32_t j = 0u; j < extent.y(); ++j)
-            for(uint32_t i = 0u; i < extent.x(); ++i)
-            {
-                CHECK(Vec{k, j, i} == mdSpan[Vec{k, j, i}]);
-            }
-#    endif
+    meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(idx == hBuff[idx]); });
 }
 #endif
 
@@ -201,16 +180,7 @@ TEMPLATE_LIST_TEST_CASE("iota4D", "", TestApis)
     queue.enqueue(exec, FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernelND{}, dBuff, extent});
     memcpy(queue, hBuff, dBuff);
     wait(queue);
-#if 1
-    auto mdSpan = hBuff.getMdSpan();
-    for(uint32_t l = 0u; l < extent.w(); ++l)
-        for(uint32_t k = 0u; k < extent.z(); ++k)
-            for(uint32_t j = 0u; j < extent.y(); ++j)
-                for(uint32_t i = 0u; i < extent.x(); ++i)
-                {
-                    CHECK(Vec{l, k, j, i} == mdSpan[Vec{l, k, j, i}]);
-                }
-#endif
+    meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(idx == hBuff[idx]); });
 }
 
 template<typename T_Selection>
@@ -283,13 +253,5 @@ TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
         KernelBundle{IotaKernelNDSelection<ALPAKA_TYPEOF(selection)>{}, dBuff, numBlocks});
     memcpy(queue, hBuff, dBuff);
     wait(queue);
-#if 1
-    auto mdSpan = hBuff.getMdSpan();
-    for(uint32_t k = 0u; k < numBlocks.z(); ++k)
-        for(uint32_t j = 0u; j < numBlocks.y(); ++j)
-            for(uint32_t i = 0u; i < numBlocks.x(); ++i)
-            {
-                CHECK(Vec{k, j, i} == mdSpan[Vec{k, j, i}]);
-            }
-#endif
+    meta::ndLoopIncIdx(numBlocks, [&](auto idx) { CHECK(idx == hBuff[idx]); });
 }


### PR DESCRIPTION
Use `meta::ndLoopIncIdx` to validate iota results.