### PR TITLE
fix `divExZero()` for vectors

### DIFF
--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -899,7 +899,7 @@ namespace alpaka
 
         using ValueType = alpaka::trait::GetValueType_t<T_Vector0>;
         for(uint32_t d = 0u; d < a.dim(); ++d)
-            tmp[d] = std::min(tmp[d], ValueType{1u});
+            tmp[d] = std::max(tmp[d], ValueType{1u});
         return tmp;
     }
 }; // namespace alpaka

--- a/tests/unit/vec/vec.cpp
+++ b/tests/unit/vec/vec.cpp
@@ -305,16 +305,17 @@ struct CompileTimeKernelDivCeilAndDivExZero
         // Test divExZero with 1D vectors
         constexpr auto vec5 = Vec{7};
         constexpr auto vec6 = Vec{3};
-        // 7 / 3 = 2 -> clamped to 1
-        static_assert(divExZero(vec5, vec6) == Vec{std::min(7 / 3, 1)});
+        // 7 / 3 = 2
+        static_assert(divExZero(vec5, vec6) == Vec{std::max(7 / 3, 1)});
+        static_assert(divExZero(vec5, Vec{8}) == Vec{1});
 
         // Test divExZero with 3D vectors
         constexpr auto vec7 = Vec{3, 7, 5};
         constexpr auto vec8 = Vec{2, 3, 4};
         // 3 / 2 = 1 -> no clamping needed, already 1
-        // 7 / 3 = 2 -> clamped to 1
+        // 7 / 3 = 2
         // 5 / 4 = 1 -> no clamping needed, already 1
-        static_assert(divExZero(vec7, vec8) == Vec{std::min(3 / 2, 1), std::min(7 / 3, 1), std::min(5 / 4, 1)});
+        static_assert(divExZero(vec7, vec8) == Vec{std::max(3 / 2, 1), std::max(7 / 3, 1), std::max(5 / 4, 1)});
     }
 };
 


### PR DESCRIPTION
With #76 we introduced divExZero and it behaves wrong. Instead of `max()` `min()` is used which results that nearly everywhere there result of this method is one.