### PR TITLE
fix MdSpanArray

### DIFF
--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -205,13 +205,14 @@ namespace alpaka
     template<typename T, concepts::CVector T_Extent, uint32_t T_numDims = T_Extent::dim(), uint32_t T_dim = 0u>
     struct CArrayType
     {
-        using type = typename CArrayType<T[T_Extent{}[T_dim]], T_Extent, T_numDims - 1u, T_dim + 1u>::type;
+        using type =
+            typename CArrayType<T[T_Extent{}[T_numDims - T_dim - 1u]], T_Extent, T_numDims - 1u, T_dim + 1u>::type;
     };
 
     template<typename T, concepts::CVector T_Extent, uint32_t T_dim>
     struct CArrayType<T, T_Extent, 1u, T_dim>
     {
-        using type = T[T_Extent{}[T_dim]];
+        using type = T[T_Extent{}[0u]];
     };
 
     template<typename T_ArrayType, concepts::Alignment T_MemAlignment = Alignment<>>


### PR DESCRIPTION
The implementation of `CArrayType` was wrong and transposed the indices.