### PR TITLE
Fix index type in adjustToLimit

### DIFF
--- a/include/alpaka/api/util.hpp
+++ b/include/alpaka/api/util.hpp
@@ -30,7 +30,8 @@ namespace alpaka::api::util
 
                 constexpr auto newValue = CVec<
                     typename ALPAKA_TYPEOF(input)::type,
-                    (T_idx == T_index ? divExZero(input[T_idx], 2u) : input[T_idx])...>{};
+                    (T_idx == T_index ? divExZero(input[T_idx], static_cast<ALPAKA_TYPEOF(T_limit)>(2))
+                                      : input[T_idx])...>{};
 
                 constexpr auto nextIncrement = dim == 1u ? 0u : T_increment;
                 constexpr auto nextIdx = T_index + T_increment;


### PR DESCRIPTION
The function now correctly deduces the used index type to work generically.