### PR TITLE
fix CUDA and HIP compile

### DIFF
--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -171,7 +171,8 @@ namespace alpaka
          *   constexpr auto vec4 = Vec<int, 3u>{ {1, 2, 3} };
          * @endcode
          */
-        template<typename... T_Args, typename = std::enable_if_t<(std::is_convertible_v<T_Args, T_Type> && ...)>>
+        template<typename... T_Args>
+        requires(std::is_convertible_v<T_Args, T_Type> && ...)
         constexpr Vec(T_Args... args) : Storage(static_cast<T_Type>(args)...)
         {
         }

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -202,13 +202,14 @@ namespace alpaka::onHost
             template<
                 typename T_Executor,
                 typename T_Device,
-                alpaka::concepts::ThreadSpec T_ThreadSpec,
-                alpaka::concepts::KernelBundle T_KernelBundle,
+                typename T_NumBlocks,
+                typename T_NumThreads,
+                typename T_KernelBundle,
                 typename... T_Args>
             void operator()(
                 T_Executor const executor,
                 unifiedCudaHip::Queue<T_Device>& queue,
-                T_ThreadSpec const& threadSpec,
+                ThreadSpec<T_NumBlocks, T_NumThreads> const& threadSpec,
                 T_KernelBundle const& kernelBundle,
                 T_Args const&... args) const
             {
@@ -217,7 +218,6 @@ namespace alpaka::onHost
                     ApiInterface,
                     ApiInterface::setDevice(onHost::getNativeHandle(queue.m_device)));
 
-                using T_NumBlocks = T_ThreadSpec::NumBlocksVecType;
                 constexpr uint32_t dim = T_NumBlocks::dim();
                 // dimension of the cuda/hip layer
                 constexpr uint32_t layerDim = dim >= 4u ? 1u : dim;
@@ -287,14 +287,16 @@ namespace alpaka::onHost
         template<
             typename T_Device,
             alpaka::concepts::UnifiedCudaHipExecutor T_Executor,
-            alpaka::concepts::ThreadSpec T_ThreadSpec,
-            alpaka::concepts::KernelBundle T_KernelBundle>
-        struct Enqueue::Kernel<unifiedCudaHip::Queue<T_Device>, T_Executor, T_ThreadSpec, T_KernelBundle>
+            typename T_NumBlocks,
+            typename T_NumThreads,
+            typename T_KernelBundle>
+        struct Enqueue::
+            Kernel<unifiedCudaHip::Queue<T_Device>, T_Executor, ThreadSpec<T_NumBlocks, T_NumThreads>, T_KernelBundle>
         {
             void operator()(
                 unifiedCudaHip::Queue<T_Device>& queue,
                 T_Executor const executor,
-                T_ThreadSpec const& threadBlocking,
+                ThreadSpec<T_NumBlocks, T_NumThreads> const& threadBlocking,
                 T_KernelBundle const& kernelBundle) const
             {
                 unifiedCudaHip::CallKernel{}(executor, queue, threadBlocking, kernelBundle);
@@ -304,14 +306,20 @@ namespace alpaka::onHost
         template<
             typename T_Device,
             alpaka::concepts::UnifiedCudaHipExecutor T_Executor,
-            alpaka::concepts::FrameSpec T_FrameSpec,
-            alpaka::concepts::KernelBundle T_KernelBundle>
-        struct Enqueue::Kernel<unifiedCudaHip::Queue<T_Device>, T_Executor, T_FrameSpec, T_KernelBundle>
+            typename T_NumFrames,
+            typename T_FrameExtents,
+            typename T_ThreadExtents,
+            typename T_KernelBundle>
+        struct Enqueue::Kernel<
+            unifiedCudaHip::Queue<T_Device>,
+            T_Executor,
+            FrameSpec<T_NumFrames, T_FrameExtents, T_ThreadExtents>,
+            T_KernelBundle>
         {
             void operator()(
                 unifiedCudaHip::Queue<T_Device>& queue,
                 T_Executor const executor,
-                T_FrameSpec const& frameSpec,
+                FrameSpec<T_NumFrames, T_FrameExtents, T_ThreadExtents> const& frameSpec,
                 T_KernelBundle const& kernelBundle) const
             {
                 auto threadBlocking

--- a/tests/unit/queue/kernelMD.cpp
+++ b/tests/unit/queue/kernelMD.cpp
@@ -42,21 +42,25 @@ struct LastSetDataBlockIdx
 template<alpaka::concepts::Vector T_Extents, alpaka::concepts::Vector T_FrameSize>
 struct Case
 {
-    T_Extents extents;
-    T_FrameSize frameSize;
+    Case(T_Extents extents, T_FrameSize frameSize) : m_extents(extents), m_frameSize(frameSize)
+    {
+    }
+
+    T_Extents m_extents;
+    T_FrameSize m_frameSize;
 };
 
 void validate(auto& queue, auto& device, auto exec, auto testCase)
 {
-    Vec extentMd = testCase.extents;
-    std::cout << " exec=" << core::demangledName(exec) << " extents=" << testCase.extents
-              << " frame size=" << testCase.frameSize << std::endl;
+    Vec extentMd = testCase.m_extents;
+    std::cout << " exec=" << core::demangledName(exec) << " extents=" << testCase.m_extents
+              << " frame size=" << testCase.m_frameSize << std::endl;
     auto dBuff = onHost::alloc<Vec<uint32_t, extentMd.dim()>>(device, extentMd);
 
     auto hBuff = onHost::allocHostMirror(dBuff);
 
     wait(queue);
-    auto frameSize = testCase.frameSize;
+    auto frameSize = testCase.m_frameSize;
     queue.enqueue(
         exec,
         FrameSpec{divExZero(extentMd, frameSize), frameSize},


### PR DESCRIPTION
- nvcc + gcc 11 shows issues when using concepts to specialize structs, therefore #146 is rolled back for `unifiedCudaHip/Queue.hpp`

```
/home/rwidera/workspace/alpaka2/include/alpaka/api/unifiedCudaHip/Queue.hpp:309:17: error: redefinition of ‘struct alpaka::onHost::internal::Enqueue::Kernel<alpaka::onHost::unifiedCudaHip::Queue<T_Device>, T_Executor, T_ThreadSpec, T_KernelBundle>’
  309 |         struct Enqueue::Kernel<unifiedCudaHip::Queue<T_Device>, T_Executor, T_FrameSpec, T_KernelBundle>
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/rwidera/workspace/alpaka2/include/alpaka/api/unifiedCudaHip/Queue.hpp:292:17: note: previous definition of ‘struct alpaka::onHost::internal::Enqueue::Kernel<alpaka::onHost::unifiedCudaHip::Queue<T_Device>, T_Executor, T_ThreadSpec, T_KernelBundle>’
  292 |         struct Enqueue::Kernel<unifiedCudaHip::Queue<T_Device>, T_Executor, T_ThreadSpec, T_KernelBundle>
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

- AMD ROCm 6.0.2 what we normally not support shows issues with the kernelMD test, this is fixed in this PR too

```
/home/widera/workspace/alpaka2/tests/unit/queue/kernelMD.cpp:119:9: error: no viable constructor or deduction guide for deduction of template arguments of 'Case'
        Case{Vec{3u}, Vec{2u}},
        ^
/home/widera/workspace/alpaka2/tests/unit/queue/kernelMD.cpp:43:8: note: candidate function template not viable: requires 1 argument, but 2 were provided
struct Case
       ^
```