### PR TITLE
refactor some concepts

### DIFF
--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -790,11 +790,14 @@ namespace alpaka
          *
          * @tparam T Type to check
          * @tparam T_ValueType enforce a value type of the vector, if not provided the value type is not checked
+         * @tparam T_dim enforce a dimensionality of the vector, if not provided the value is not checked
          */
-        template<typename T, typename T_ValueType = alpaka::NotRequired>
+        template<typename T, typename T_ValueType = alpaka::NotRequired, uint32_t T_dim = alpaka::notRequiredDim>
         concept Vector = isVector_v<T>
                          && (std::same_as<T_ValueType, trait::GetValueType_t<std::decay_t<T>>>
-                             || std::same_as<T_ValueType, alpaka::NotRequired>);
+                             || std::same_as<
+                                 T_ValueType,
+                                 alpaka::NotRequired>) &&((T_dim == alpaka::notRequiredDim) || (T::dim() == T_dim));
 
         /** Concept to check if a type is a vector or scalar variable
          *

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -205,7 +205,7 @@ namespace alpaka::onHost
          */
         template<
             typename T_Platform,
-            alpaka::concepts::FrameSpec T_FrameSpec,
+            onHost::concepts::FrameSpec T_FrameSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
         struct AdjustThreadSpec::Op<cpu::Device<T_Platform>, exec::CpuSerial, T_FrameSpec, T_KernelBundle>
         {
@@ -239,7 +239,7 @@ namespace alpaka::onHost
         template<
             typename T_Platform,
             typename T_Mapping,
-            alpaka::concepts::FrameSpec T_FrameSpec,
+            onHost::concepts::FrameSpec T_FrameSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
         requires exec::traits::isSeqExecutor_v<T_Mapping>
         struct AdjustThreadSpec::Op<cpu::Device<T_Platform>, T_Mapping, T_FrameSpec, T_KernelBundle>
@@ -291,7 +291,7 @@ namespace alpaka::onHost
 
         template<
             typename T_Platform,
-            alpaka::concepts::FrameSpec T_FrameSpec,
+            onHost::concepts::FrameSpec T_FrameSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
         struct AdjustThreadSpec::Op<cpu::Device<T_Platform>, exec::CpuOmpBlocksAndThreads, T_FrameSpec, T_KernelBundle>
         {

--- a/include/alpaka/api/host/exec/OmpBlocks.hpp
+++ b/include/alpaka/api/host/exec/OmpBlocks.hpp
@@ -25,7 +25,7 @@ namespace alpaka::onHost
 {
     namespace cpu
     {
-        template<alpaka::concepts::ThreadSpec T_ThreadSpec>
+        template<onHost::concepts::ThreadSpec T_ThreadSpec>
         struct OmpBlocks
         {
             constexpr OmpBlocks(T_ThreadSpec threadBlocking) : m_threadBlocking{std::move(threadBlocking)}

--- a/include/alpaka/api/host/exec/OmpThreads.hpp
+++ b/include/alpaka/api/host/exec/OmpThreads.hpp
@@ -25,7 +25,7 @@ namespace alpaka::onHost
 {
     namespace cpu
     {
-        template<alpaka::concepts::ThreadSpec T_ThreadSpec>
+        template<onHost::concepts::ThreadSpec T_ThreadSpec>
         struct OmpThreads
         {
             constexpr OmpThreads(T_ThreadSpec threadBlocking) : m_threadBlocking{std::move(threadBlocking)}

--- a/include/alpaka/api/host/exec/Serial.hpp
+++ b/include/alpaka/api/host/exec/Serial.hpp
@@ -21,7 +21,7 @@ namespace alpaka::onHost
 {
     namespace cpu
     {
-        template<alpaka::concepts::ThreadSpec T_ThreadSpec>
+        template<onHost::concepts::ThreadSpec T_ThreadSpec>
         struct Serial
         {
             using NumThreadsVecType = typename T_ThreadSpec::NumThreadsVecType;

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -137,7 +137,7 @@ namespace alpaka::onHost::internal
          * @return A pair of the sycl nd range and an optimized thread spec. The thread spec is not holding any data
          * for dimension smaller equal to 3u
          */
-        template<alpaka::concepts::ThreadSpec T_ThreadSpec>
+        template<onHost::concepts::ThreadSpec T_ThreadSpec>
         inline constexpr auto getWorkerDescription(T_ThreadSpec const& threadSpec)
         {
             constexpr uint32_t dim = T_ThreadSpec::dim();
@@ -174,7 +174,7 @@ namespace alpaka::onHost::internal
     template<
         typename T_Device,
         typename T_Executor,
-        alpaka::concepts::ThreadSpec T_ThreadSpec,
+        onHost::concepts::ThreadSpec T_ThreadSpec,
         alpaka::concepts::KernelBundle T_KernelBundle>
     struct Enqueue::Kernel<syclGeneric::Queue<T_Device>, T_Executor, T_ThreadSpec, T_KernelBundle>
     {
@@ -243,7 +243,7 @@ namespace alpaka::onHost::internal
     template<
         typename T_Device,
         typename T_Executor,
-        alpaka::concepts::FrameSpec T_FrameSpec,
+        onHost::concepts::FrameSpec T_FrameSpec,
         alpaka::concepts::KernelBundle T_KernelBundle>
     struct Enqueue::Kernel<syclGeneric::Queue<T_Device>, T_Executor, T_FrameSpec, T_KernelBundle>
     {

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -167,7 +167,7 @@ namespace alpaka::onHost
         template<
             typename T_Platform,
             typename T_Mapping,
-            alpaka::concepts::FrameSpec T_FrameSpec,
+            onHost::concepts::FrameSpec T_FrameSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
         struct AdjustThreadSpec::Op<syclGeneric::Device<T_Platform>, T_Mapping, T_FrameSpec, T_KernelBundle>
         {

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -214,7 +214,7 @@ namespace alpaka::onHost
         template<
             typename T_Platform,
             typename T_Mapping,
-            alpaka::concepts::FrameSpec T_FrameSpec,
+            onHost::concepts::FrameSpec T_FrameSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
         struct AdjustThreadSpec::Op<unifiedCudaHip::Device<T_Platform>, T_Mapping, T_FrameSpec, T_KernelBundle>
         {

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -14,7 +14,7 @@ namespace alpaka
 {
 
     template<
-        concepts::Vector T_End,
+        concepts::VectorOrScalar T_End,
         concepts::Vector T_Begin = typename T_End::UniVec,
         concepts::Vector T_Stride = typename T_End::UniVec>
     struct IdxRange

--- a/include/alpaka/onHost/FrameSpec.hpp
+++ b/include/alpaka/onHost/FrameSpec.hpp
@@ -16,8 +16,8 @@ namespace alpaka::onHost
 {
     template<
         alpaka::concepts::Vector T_NumFrames,
-        alpaka::concepts::Vector T_FrameExtents,
-        alpaka::concepts::Vector T_ThreadExtents>
+        alpaka::concepts::Vector<typename T_NumFrames::type, T_NumFrames::dim()> T_FrameExtents,
+        alpaka::concepts::Vector<typename T_NumFrames::type, T_NumFrames::dim()> T_ThreadExtents>
     struct FrameSpec
     {
         using type = typename T_NumFrames::type;
@@ -27,7 +27,7 @@ namespace alpaka::onHost
         using ThreadExtentsVecType = T_ThreadExtents;
         using ThreadSpecType = ThreadSpec<T_NumFrames, T_ThreadExtents>;
 
-        consteval uint32_t dim() const
+        static consteval uint32_t dim()
         {
             return T_FrameExtents::dim();
         }
@@ -88,65 +88,50 @@ namespace alpaka::onHost
         alpaka::trait::getVec_t<T_FrameExtents>,
         alpaka::trait::getVec_t<T_FrameExtents>>;
 
-} // namespace alpaka::onHost
-
-namespace alpaka
-{
-    template<typename T>
-    struct IsFrameSpec : std::false_type
+    namespace trait
     {
-    };
+        template<typename T>
+        struct IsFrameSpec : std::false_type
+        {
+        };
 
-    template<
-        alpaka::concepts::Vector T_NumFrames,
-        alpaka::concepts::Vector T_FrameExtents,
-        alpaka::concepts::Vector T_ThreadExtents>
-    struct IsFrameSpec<onHost::FrameSpec<T_NumFrames, T_FrameExtents, T_ThreadExtents>> : std::true_type
+        template<
+            alpaka::concepts::Vector T_NumFrames,
+            alpaka::concepts::Vector T_FrameExtents,
+            alpaka::concepts::Vector T_ThreadExtents>
+        struct IsFrameSpec<onHost::FrameSpec<T_NumFrames, T_FrameExtents, T_ThreadExtents>> : std::true_type
+        {
+        };
+
+    } // namespace trait
+
+    template<typename T>
+    constexpr bool isFrameSpec_v = trait::IsFrameSpec<T>::value;
+
+    namespace concepts
     {
-    };
+        /** Concept to check if a type is a FrameSpec
+         *
+         * @tparam T Type to check
+         * @tparam T_IndexType enforce a index type of the frame specification, if not provided the type is not checked
+         * @tparam T_dim enforce a dimensionality of the frame specification, if not provided the value is not
+         * checked
+         */
+        template<typename T, typename T_IndexType = alpaka::NotRequired, uint32_t T_dim = alpaka::notRequiredDim>
+        concept FrameSpec
+            = isFrameSpec_v<T>
+              && (std::same_as<T_IndexType, alpaka::NotRequired> || std::same_as<typename T::type, T_IndexType>) &&(
+                  (T_dim == alpaka::notRequiredDim) || (T::dim() == T_dim));
 
-    template<typename T>
-    constexpr bool isFrameSpec_v = IsFrameSpec<T>::value;
+        /** Concept to check if a type is a ThreadSpec or a FrameSpec
+         *
+         * @tparam T Type to check
+         */
+        template<typename T>
+        concept ThreadOrFrameSpec = isFrameSpec_v<T> || isThreadSpec_v<T>;
+    } // namespace concepts
 
-} // namespace alpaka
-
-namespace alpaka::concepts
-{
-    /** Concept to check if a type is a FrameSpec
-     *
-     * @tparam T Type to check
-     * @tparam T_NumFrames enforce a value type for T_NumFrames, if not provided the value type is not checked
-     * @tparam T_FrameExtents enforce a value type for T_FrameExtents, if not provided the value type is not
-     * checked
-     * @tparam T_ThreadExtents enforce a value type for T_ThreadExtents, if not provided the value type is not
-     * checked
-     */
-    template<
-        typename T,
-        typename T_NumFrames = alpaka::NotRequired,
-        typename T_FrameExtents = alpaka::NotRequired,
-        typename T_ThreadExtents = alpaka::NotRequired>
-    concept FrameSpec
-        = isFrameSpec_v<T>
-          && (std::same_as<T_NumFrames, alpaka::NotRequired> || std::same_as<T_NumFrames, typename T::NumFramesVecType>) &&(
-              std::same_as<T_FrameExtents, alpaka::NotRequired>
-              || std::same_as<
-                  T_FrameExtents,
-                  typename T::
-                      FrameExtentsVecType>) &&(std::same_as<T_ThreadExtents, alpaka::NotRequired> || std::same_as<T_ThreadExtents, typename T::ThreadExtentsVecType>);
-
-
-    /** Concept to check if a type is a ThreadSpec or a FrameSpec
-     *
-     * @tparam T Type to check
-     */
-    template<typename T>
-    concept ThreadOrFrameSpec = isFrameSpec_v<T> || isThreadSpec_v<T>;
-} // namespace alpaka::concepts
-
-namespace alpaka::onHost
-{
-    std::ostream& operator<<(std::ostream& s, alpaka::concepts::FrameSpec auto const& d)
+    std::ostream& operator<<(std::ostream& s, concepts::FrameSpec auto const& d)
     {
         return s << "frames=" << d.m_numFrames << " frameExtent=" << d.m_frameExtent;
     }

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -75,7 +75,7 @@ namespace alpaka::onHost
          */
         void enqueue(
             auto const executor,
-            alpaka::concepts::ThreadOrFrameSpec auto const& blockCfg,
+            onHost::concepts::ThreadOrFrameSpec auto const& blockCfg,
             auto const& f,
             auto&&... args) const
         {
@@ -101,7 +101,7 @@ namespace alpaka::onHost
          */
         template<typename TKernelFn, typename... TArgs>
         void enqueue(
-            alpaka::concepts::ThreadOrFrameSpec auto const& specification,
+            onHost::concepts::ThreadOrFrameSpec auto const& specification,
             KernelBundle<TKernelFn, TArgs...> const& kernelBundle) const
         {
             auto executor = supportedMappings(getDevice(*m_queue.get()));
@@ -114,7 +114,7 @@ namespace alpaka::onHost
          */
         void enqueue(
             auto const executor,
-            alpaka::concepts::ThreadOrFrameSpec auto const& specification,
+            onHost::concepts::ThreadOrFrameSpec auto const& specification,
             alpaka::concepts::KernelBundle auto const& kernelBundle) const
         {
             internal::enqueue(*m_queue.get(), executor, specification, kernelBundle);

--- a/include/alpaka/onHost/ThreadSpec.hpp
+++ b/include/alpaka/onHost/ThreadSpec.hpp
@@ -13,7 +13,9 @@
 
 namespace alpaka::onHost
 {
-    template<alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_NumThreads>
+    template<
+        alpaka::concepts::Vector T_NumBlocks,
+        alpaka::concepts::Vector<typename T_NumBlocks::type, T_NumBlocks::dim()> T_NumThreads>
     struct ThreadSpec
     {
         using type = typename T_NumBlocks::type;
@@ -39,44 +41,40 @@ namespace alpaka::onHost
     ThreadSpec(T_NumBlocks const&, T_NumThreads const&)
         -> ThreadSpec<alpaka::trait::getVec_t<T_NumBlocks>, alpaka::trait::getVec_t<T_NumThreads>>;
 
-} // namespace alpaka::onHost
-
-namespace alpaka
-{
-    template<typename T>
-    struct IsThreadSpec : std::false_type
+    namespace trait
     {
-    };
+        template<typename T>
+        struct IsThreadSpec : std::false_type
+        {
+        };
 
-    template<alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_NumThreads>
-    struct IsThreadSpec<onHost::ThreadSpec<T_NumBlocks, T_NumThreads>> : std::true_type
-    {
-    };
+        template<alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_NumThreads>
+        struct IsThreadSpec<onHost::ThreadSpec<T_NumBlocks, T_NumThreads>> : std::true_type
+        {
+        };
+    } // namespace trait
 
     template<typename T>
-    constexpr bool isThreadSpec_v = IsThreadSpec<T>::value;
-} // namespace alpaka
+    constexpr bool isThreadSpec_v = trait::IsThreadSpec<T>::value;
 
-namespace alpaka::concepts
-{
-    /** Concept to check if a type is a ThreadSpec
-     *
-     * @tparam T Type to check
-     * @tparam T_NumBlocks enforce a value type for T_NumBlocks, if not provided the value type is not checked
-     * @tparam T_NumThreads enforce a value type for T_NumThreads, if not provided the value type is not
-     * checked
-     */
-    template<typename T, typename T_NumBlocks = alpaka::NotRequired, typename T_NumThreads = alpaka::NotRequired>
-    concept ThreadSpec
-        = isThreadSpec_v<T>
-          && (std::same_as<T_NumBlocks, alpaka::NotRequired> || std::same_as<T_NumBlocks, typename T::NumBlocksVecType>) &&(
-              std::same_as<T_NumThreads, alpaka::NotRequired>
-              || std::same_as<T_NumThreads, typename T::NumThreadsVecType>);
-} // namespace alpaka::concepts
+    namespace concepts
+    {
+        /** Concept to check if a type is a ThreadSpec
+         *
+         * @tparam T Type to check
+         * @tparam T_IndexType enforce a index type of the thread specification, if not provided the type is not
+         * checked
+         * @tparam T_dim enforce a dimensionality of the thread specification, if not provided the value is not
+         * checked
+         */
+        template<typename T, typename T_IndexType = alpaka::NotRequired, uint32_t T_dim = alpaka::notRequiredDim>
+        concept ThreadSpec
+            = isThreadSpec_v<T>
+              && (std::same_as<T_IndexType, alpaka::NotRequired> || std::same_as<typename T::type, T_IndexType>) &&(
+                  (T_dim == alpaka::notRequiredDim) || (T::dim() == T_dim));
+    } // namespace concepts
 
-namespace alpaka::onHost
-{
-    std::ostream& operator<<(std::ostream& s, alpaka::concepts::ThreadSpec auto const& t)
+    std::ostream& operator<<(std::ostream& s, concepts::ThreadSpec auto const& t)
     {
         return s << "blocks=" << t.m_numBlocks << " threads=" << t.m_numThreads;
     }

--- a/include/alpaka/onHost/internal.hpp
+++ b/include/alpaka/onHost/internal.hpp
@@ -105,7 +105,7 @@ namespace alpaka::onHost
             template<
                 typename T_Queue,
                 typename T_Mapping,
-                alpaka::concepts::ThreadOrFrameSpec T_BlockCfg,
+                onHost::concepts::ThreadOrFrameSpec T_BlockCfg,
                 alpaka::concepts::KernelBundle T_KernelBundle>
             struct Kernel
             {
@@ -138,7 +138,7 @@ namespace alpaka::onHost
         inline void enqueue(
             auto& queue,
             auto const executor,
-            alpaka::concepts::ThreadOrFrameSpec auto const& blockCfg,
+            onHost::concepts::ThreadOrFrameSpec auto const& blockCfg,
             KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
         {
             Enqueue::Kernel<
@@ -153,7 +153,7 @@ namespace alpaka::onHost
             template<
                 typename T_Device,
                 typename T_Mapping,
-                alpaka::concepts::FrameSpec T_FrameSpec,
+                onHost::concepts::FrameSpec T_FrameSpec,
                 alpaka::concepts::KernelBundle T_KernelBundle>
             struct Op
             {
@@ -172,7 +172,7 @@ namespace alpaka::onHost
         static auto adjustThreadSpec(
             auto const& device,
             auto const& executor,
-            alpaka::concepts::FrameSpec auto const& dataBlocking,
+            onHost::concepts::FrameSpec auto const& dataBlocking,
             KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
         {
             return AdjustThreadSpec::Op<

--- a/include/alpaka/onHost/trait.hpp
+++ b/include/alpaka/onHost/trait.hpp
@@ -63,7 +63,7 @@ namespace alpaka::onHost
 
         template<
             typename T_Executor,
-            alpaka::concepts::ThreadSpec T_ThreadSpec,
+            onHost::concepts::ThreadSpec T_ThreadSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
         struct GetDynSharedMemBytes
         {
@@ -110,7 +110,7 @@ namespace alpaka::onHost
 
         template<
             typename T_Executor,
-            alpaka::concepts::ThreadSpec T_ThreadSpec,
+            onHost::concepts::ThreadSpec T_ThreadSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
         struct HasUserDefinedDynSharedMemBytes : std::true_type
         {
@@ -118,7 +118,7 @@ namespace alpaka::onHost
 
         template<
             typename T_Executor,
-            alpaka::concepts::ThreadSpec T_ThreadSpec,
+            onHost::concepts::ThreadSpec T_ThreadSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
         requires(trait::GetDynSharedMemBytes<T_Executor, T_ThreadSpec, T_KernelBundle>::zeroSharedMemory == true)
         struct HasUserDefinedDynSharedMemBytes<T_Executor, T_ThreadSpec, T_KernelBundle> : std::false_type
@@ -158,7 +158,7 @@ namespace alpaka::onHost
 
     template<
         typename T_Executor,
-        alpaka::concepts::ThreadSpec T_ThreadSpec,
+        onHost::concepts::ThreadSpec T_ThreadSpec,
         alpaka::concepts::KernelBundle T_KernelBundle>
     constexpr uint32_t getDynSharedMemBytes(
         T_Executor const executor,
@@ -170,7 +170,7 @@ namespace alpaka::onHost
 
     template<
         typename T_Executor,
-        alpaka::concepts::ThreadSpec T_ThreadSpec,
+        onHost::concepts::ThreadSpec T_ThreadSpec,
         alpaka::concepts::KernelBundle T_KernelBundle>
     consteval bool hasUserDefinedDynSharedMemBytes(
         T_Executor const executor,

--- a/include/alpaka/trait.hpp
+++ b/include/alpaka/trait.hpp
@@ -8,6 +8,7 @@
 
 #include <concepts>
 #include <cstdint>
+#include <limits>
 
 namespace alpaka
 {
@@ -16,6 +17,8 @@ namespace alpaka
     struct NotRequired
     {
     };
+
+    constexpr uint32_t notRequiredDim = std::numeric_limits<uint32_t>::max();
 
     namespace trait
     {

--- a/tests/unit/concepts/concepts.cpp
+++ b/tests/unit/concepts/concepts.cpp
@@ -54,34 +54,31 @@ TEST_CASE("frame spec concepts", "[concepts][framespec]")
 {
     using namespace alpaka::onHost;
 
-    using TestVec1 = Vec<std::size_t, 1>;
-    using TestVec2 = Vec<std::size_t, 2>;
-    using TestVec3 = Vec<std::size_t, 3>;
+    using TestVec1 = Vec<size_t, 1>;
+    using TestVec2 = Vec<size_t, 2>;
+    using TestVec3 = Vec<size_t, 3>;
 
-    STATIC_CHECK(alpaka::concepts::FrameSpec<FrameSpec<TestVec1, TestVec2, TestVec3>>);
-    STATIC_CHECK(alpaka::concepts::FrameSpec<FrameSpec<TestVec1, TestVec2, TestVec3>, TestVec1>);
-    STATIC_CHECK(alpaka::concepts::FrameSpec<FrameSpec<TestVec1, TestVec2, TestVec3>, TestVec1, TestVec2>);
-    STATIC_CHECK(alpaka::concepts::FrameSpec<FrameSpec<TestVec1, TestVec2, TestVec3>, TestVec1, TestVec2, TestVec3>);
+    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec1, TestVec1, TestVec1>>);
+    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec2, TestVec2, TestVec2>, size_t>);
+    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec3, TestVec3, TestVec3>, size_t, 3>);
+    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec2, TestVec2, TestVec2>, size_t, 2>);
 
-    STATIC_CHECK_FALSE(
-        alpaka::concepts::FrameSpec<FrameSpec<TestVec2, TestVec1, TestVec1>, TestVec1, TestVec1, TestVec1>);
-    STATIC_CHECK_FALSE(
-        alpaka::concepts::FrameSpec<FrameSpec<TestVec1, TestVec2, TestVec1>, TestVec1, TestVec1, TestVec1>);
-    STATIC_CHECK_FALSE(
-        alpaka::concepts::FrameSpec<FrameSpec<TestVec1, TestVec1, TestVec2>, TestVec1, TestVec1, TestVec1>);
+    STATIC_CHECK_FALSE(onHost::concepts::FrameSpec<FrameSpec<TestVec1, TestVec1, TestVec1>, int>);
+    STATIC_CHECK_FALSE(onHost::concepts::FrameSpec<FrameSpec<TestVec2, TestVec2, TestVec2>, size_t, 3>);
+    STATIC_CHECK_FALSE(onHost::concepts::FrameSpec<FrameSpec<TestVec3, TestVec3, TestVec3>, int, 2>);
 }
 
 TEST_CASE("thread spec concepts", "[concepts][threadspec]")
 {
     using namespace alpaka::onHost;
 
-    using TestVec1 = Vec<std::size_t, 1>;
-    using TestVec2 = Vec<std::size_t, 2>;
+    using TestVec1 = Vec<size_t, 1>;
+    using TestVec2 = Vec<size_t, 2>;
 
-    STATIC_CHECK(alpaka::concepts::ThreadSpec<ThreadSpec<TestVec1, TestVec2>>);
-    STATIC_CHECK(alpaka::concepts::ThreadSpec<ThreadSpec<TestVec1, TestVec2>, TestVec1>);
-    STATIC_CHECK(alpaka::concepts::ThreadSpec<ThreadSpec<TestVec1, TestVec2>, TestVec1, TestVec2>);
+    STATIC_CHECK(onHost::concepts::ThreadSpec<ThreadSpec<TestVec1, TestVec1>>);
+    STATIC_CHECK(onHost::concepts::ThreadSpec<ThreadSpec<TestVec2, TestVec2>, size_t>);
+    STATIC_CHECK(onHost::concepts::ThreadSpec<ThreadSpec<TestVec1, TestVec1>, size_t, 1>);
 
-    STATIC_CHECK_FALSE(alpaka::concepts::ThreadSpec<ThreadSpec<TestVec2, TestVec1>, TestVec1, TestVec1>);
-    STATIC_CHECK_FALSE(alpaka::concepts::ThreadSpec<ThreadSpec<TestVec1, TestVec2>, TestVec1, TestVec1>);
+    STATIC_CHECK_FALSE(onHost::concepts::ThreadSpec<ThreadSpec<TestVec2, TestVec2>, int>);
+    STATIC_CHECK_FALSE(onHost::concepts::ThreadSpec<ThreadSpec<TestVec1, TestVec1>, size_t, 2>);
 }

--- a/tests/unit/math/TestTemplate.hpp
+++ b/tests/unit/math/TestTemplate.hpp
@@ -174,7 +174,8 @@ namespace mathtest
 
             // Let alpaka calculate good block and grid sizes given our full problem extent
             constexpr uint32_t frameExtents = 256;
-            concepts::FrameSpec auto frameSpec = onHost::FrameSpec{divExZero(capacity, frameExtents), frameExtents};
+            onHost::concepts::FrameSpec auto frameSpec
+                = onHost::FrameSpec{divExZero(capacity, frameExtents), frameExtents};
             auto kernel = KernelBundle{
                 TestKernel<capacity>{},
                 results.m_deviceView.getMdSpan(),

--- a/tests/unit/math/executeOnComputeDevice.hpp
+++ b/tests/unit/math/executeOnComputeDevice.hpp
@@ -67,7 +67,7 @@ namespace alpaka::test
         auto dViewResults = onHost::allocMirror(device, hViewResults);
         onHost::memset(queue, dViewResults, static_cast<std::uint8_t>(true));
         // Let alpaka calculate good block and grid sizes given our full problem extent
-        concepts::FrameSpec auto frameSpec = onHost::FrameSpec{1u, 1u};
+        onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{1u, 1u};
         auto kernel = KernelBundle{kernelFnObj, dViewResults, ALPAKA_FORWARD(args)...};
         queue.enqueue(exec, frameSpec, kernel);
         onHost::memcpy(queue, hViewResults, dViewResults);


### PR DESCRIPTION
- move concept `FrameSpec` and `ThreadSpec` to namespace `onHost`
- change signature of the concepts `FrameSpec` and `ThreadSpec`
- extent signature of the concept `Vector`
- add new global variable `notRequiredDim` as helper to write concepts based on the dimensionallity of the type.


@AntonReinhard I changed the concepts signature to not work on fully specialized types.