### PR TITLE
add `alpaka::apply`

### DIFF
--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -546,7 +546,7 @@ namespace alpaka
     }
 
     template<std::size_t I, typename T_Type, uint32_t T_dim, typename T_Storage>
-    constexpr auto& get(Vec<T_Type, T_dim, T_Storage>& v)
+    constexpr decltype(auto) get(Vec<T_Type, T_dim, T_Storage>& v)
     {
         return v[I];
     }

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -12,6 +12,7 @@
 #include "alpaka/api/cpu.hpp"
 #include "alpaka/api/oneApi.hpp"
 #include "alpaka/api/unifiedCudaHip.hpp"
+#include "alpaka/apply.hpp"
 #include "alpaka/core/DemangleTypeNames.hpp"
 #include "alpaka/core/Dict.hpp"
 #include "alpaka/core/Tag.hpp"

--- a/include/alpaka/apply.hpp
+++ b/include/alpaka/apply.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/common.hpp"
+
+#include <utility>
+
+namespace alpaka
+{
+    namespace detail
+    {
+        template<typename T_Func, typename T_TupleLike, std::size_t... T_idx>
+        ALPAKA_FN_INLINE constexpr decltype(auto) applyImpl(
+            T_Func&& func,
+            T_TupleLike&& tuple,
+            std::index_sequence<T_idx...>)
+        {
+            using std::get;
+            return func(get<T_idx>(std::forward<T_TupleLike>(tuple))...);
+        }
+    } // namespace detail
+
+    /** Applies a function to the elements of a tuple-like object.
+     *
+     * This function forwards the function and the tuple-like object, and uses an index sequence to unpack the tuple.
+     *
+     * @param func The function to apply.
+     * @param tuple The tuple-like object containing the arguments for the function.
+     * @return The result of applying the function to the elements of the tuple-like object.
+     */
+    template<typename T_Func, typename T_TupleLike>
+    ALPAKA_FN_INLINE constexpr decltype(auto) apply(T_Func&& func, T_TupleLike&& tuple)
+    {
+        return detail::applyImpl(
+            std::forward<T_Func>(func),
+            std::forward<T_TupleLike>(tuple),
+            std::make_index_sequence<std::tuple_size_v<std::decay_t<T_TupleLike>>>{});
+    }
+} // namespace alpaka

--- a/tests/unit/vec/vec.cpp
+++ b/tests/unit/vec/vec.cpp
@@ -227,6 +227,11 @@ struct CompileTimeKernel3D
         constexpr auto inner = innerJoin(m0, m1);
         static_assert(inner == Vec{1});
 
+        constexpr auto vecSrcApply = CVec<int, 1, 2>{};
+        constexpr auto vecResApply
+            = alpaka::apply([](auto const... args) constexpr { return Vec{(args + 1)...}; }, vecSrcApply);
+        static_assert(vecResApply == Vec{2, 3});
+
 #if 0
 // add this to runtime etst as soon we add them back
          auto vecRT = Vec{3, 7, 5};


### PR DESCRIPTION
Since `std::apply` requires C++23 to work with tuple like objects alpaka must ship its own apply implementation.

@chillenzer first feature you ask for.