### PR TITLE
make `MdSpan` forward iteratable

### DIFF
--- a/include/alpaka/mem/MdForwardIter.hpp
+++ b/include/alpaka/mem/MdForwardIter.hpp
@@ -1,0 +1,170 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/Vec.hpp"
+#include "alpaka/core/common.hpp"
+#include "alpaka/mem/concepts.hpp"
+
+#include <cstdint>
+#include <iterator>
+
+namespace alpaka
+{
+
+    /** special implementation to define the end
+     *
+     * Only a scalar value must be stored which reduce the register footprint.
+     * The definition of end is that the index is behind or equal to the extent of the slowest moving dimension.
+     */
+    template<typename T_idxType>
+    class MdForwardIterEnd
+    {
+        using index_type = T_idxType;
+
+        void _()
+        {
+            static_assert(std::forward_iterator<MdForwardIterEnd>);
+        }
+
+    public:
+        constexpr MdForwardIterEnd(alpaka::concepts::MdSpan auto const& mdSpan)
+            : m_extentSlowDim{mdSpan.getExtents()[0]}
+        {
+        }
+
+        constexpr auto operator*() const
+        {
+            return m_extentSlowDim;
+        }
+
+        constexpr bool operator==(MdForwardIterEnd const& other) const
+        {
+            return (m_extentSlowDim == other.m_extentSlowDim);
+        }
+
+        constexpr bool operator!=(MdForwardIterEnd const& other) const
+        {
+            return not(*this == other);
+        }
+
+    private:
+        index_type m_extentSlowDim;
+    };
+
+    template<alpaka::concepts::MdSpan T_MdSpan>
+    ALPAKA_FN_HOST_ACC MdForwardIterEnd(T_MdSpan const&) -> MdForwardIterEnd<typename T_MdSpan::index_type>;
+
+    template<alpaka::concepts::MdSpan T_MdSpan>
+    class MdForwardIter
+    {
+        using index_type = typename T_MdSpan::index_type;
+
+        friend class MdForwardIterEnd<index_type>;
+
+        static constexpr uint32_t iterDim = T_MdSpan::dim();
+        using IterIdxVecType = Vec<index_type, iterDim>;
+
+        void _()
+        {
+            static_assert(std::forward_iterator<MdForwardIter>);
+            static_assert(std::input_or_output_iterator<MdForwardIter>);
+        }
+
+    public:
+        constexpr MdForwardIter(T_MdSpan const& mdSpan) : m_mdSpan(mdSpan), m_current{IterIdxVecType::all(0u)}
+        {
+        }
+
+        ALPAKA_FN_ACC constexpr index_type slowCurrent() const
+        {
+            return m_current[0];
+        }
+
+        constexpr decltype(auto) operator*() const
+        {
+            return m_mdSpan[m_current];
+        }
+
+        constexpr decltype(auto) operator*()
+        {
+            return m_mdSpan[m_current];
+        }
+
+        // pre-increment the iterator
+        ALPAKA_FN_ACC inline MdForwardIter& operator++()
+        {
+            for(uint32_t d = 0; d < iterDim; ++d)
+            {
+                uint32_t const idx = iterDim - 1u - d;
+                m_current[idx] += index_type{1u};
+                if constexpr(iterDim != 1u)
+                {
+                    if(idx >= 1u && m_current[idx] >= m_mdSpan.getExtents()[idx])
+                    {
+                        m_current[idx] = index_type{0u};
+                    }
+                    else
+                        break;
+                }
+            }
+            return *this;
+        }
+
+        // post-increment the iterator
+        ALPAKA_FN_ACC inline MdForwardIter operator++(int)
+        {
+            MdForwardIter old = *this;
+            ++(*this);
+            return old;
+        }
+
+        constexpr bool operator==(MdForwardIter const& other) const
+        {
+            return (m_current == other.m_current);
+        }
+
+        constexpr bool operator!=(MdForwardIter const& other) const
+        {
+            return not(*this == other);
+        }
+
+    private:
+        T_MdSpan m_mdSpan;
+        IterIdxVecType m_current;
+    };
+
+    template<typename T_MdSpan>
+    constexpr bool operator==(
+        MdForwardIter<T_MdSpan> const& mdIter,
+        MdForwardIterEnd<typename T_MdSpan::index_type> const& mdIteratorEnd)
+    {
+        return (*mdIteratorEnd <= mdIter.slowCurrent());
+    }
+
+    template<typename T_MdSpan>
+    constexpr bool operator!=(
+        MdForwardIter<T_MdSpan> const& mdIter,
+        MdForwardIterEnd<typename T_MdSpan::index_type> const& mdIteratorEnd)
+    {
+        return not(mdIteratorEnd == mdIter);
+    }
+
+    template<typename T_MdSpan>
+    constexpr bool operator==(
+        MdForwardIterEnd<typename T_MdSpan::index_type> const& mdIteratorEnd,
+        MdForwardIter<T_MdSpan> const& mdIter)
+    {
+        return (*mdIteratorEnd <= mdIter.slowCurrent());
+    }
+
+    template<typename T_MdSpan>
+    constexpr bool operator!=(
+        MdForwardIterEnd<typename T_MdSpan::index_type> const& mdIteratorEnd,
+        MdForwardIter<T_MdSpan> const& mdIter)
+    {
+        return not(mdIteratorEnd == mdIter);
+    }
+} // namespace alpaka

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/core/config.hpp"
 #include "alpaka/mem/Alignment.hpp"
 #include "alpaka/mem/DataPitches.hpp"
+#include "alpaka/mem/MdForwardIter.hpp"
 #include "alpaka/onHost.hpp"
 #include "alpaka/trait.hpp"
 
@@ -81,6 +82,26 @@ namespace alpaka
         constexpr pointer data() const
         {
             return this->m_ptr;
+        }
+
+        constexpr auto begin() const
+        {
+            return MdForwardIter{*this};
+        }
+
+        constexpr auto end() const
+        {
+            return MdForwardIterEnd{*this};
+        }
+
+        constexpr auto cbegin() const
+        {
+            return MdForwardIter{this->getConstMdSpan()};
+        }
+
+        constexpr auto cend() const
+        {
+            return MdForwardIterEnd{this->getConstMdSpan()};
         }
 
         /*Object must init by copy a valid instance*/
@@ -251,6 +272,32 @@ namespace alpaka
         constexpr pointer data() const
         {
             return this->m_ptr;
+        }
+
+        constexpr auto begin() const
+        {
+            return MdForwardIter{*this};
+        }
+
+        constexpr auto end() const
+        {
+            return MdForwardIterEnd{*this};
+        }
+
+        constexpr auto getConstMdSpan() const
+        {
+            using ConstArryType = std::add_const_t<T_ArrayType>;
+            return MdSpanArray<ConstArryType>(m_ptr);
+        }
+
+        constexpr auto cbegin() const
+        {
+            return MdForwardIter{this->getConstMdSpan()};
+        }
+
+        constexpr auto cend() const
+        {
+            return MdForwardIterEnd{this->getConstMdSpan()};
         }
 
         /*Object must init by copy a valid instance*/

--- a/tests/unit/mem/mdIterator.cpp
+++ b/tests/unit/mem/mdIterator.cpp
@@ -1,0 +1,34 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executeForEach.hpp>
+#include <alpaka/example/executors.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+
+using namespace alpaka;
+using namespace alpaka::onHost;
+
+TEST_CASE("mdIterator", "")
+{
+    constexpr auto numElements = Vec<size_t, 2u>{17, 31};
+    auto span = onHost::allocHost<uint32_t>(numElements);
+
+    size_t counter = 0u;
+    for(auto& v : span)
+        v = counter++;
+
+    // validate by using the forward iterator
+    size_t refence = 0u;
+    for(auto const& v : span)
+    {
+        CHECK(v == refence);
+        ++refence;
+    }
+
+    // validate without using the forward iterator
+    meta::ndLoopIncIdx(numElements, [&](auto idx) { CHECK(span[idx] == linearize(numElements, idx)); });
+}


### PR DESCRIPTION
- add `end()`, `begin()`, `cend()`, `cbegin()` to the MdSPan implementations
- provide a multidimensional forward iterator `MdForwardIter`
- add simple iterator test

@chillenzer only for you