### PR TITLE
refactor `memset` and `memcpy`

### DIFF
--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -156,11 +156,8 @@ namespace alpaka::onHost
         template<typename T_Device, typename T_Dest, typename T_Source, typename T_Extents>
         struct Memcpy::Op<cpu::Queue<T_Device>, T_Dest, T_Source, T_Extents>
         {
-            void operator()(
-                cpu::Queue<T_Device>& queue,
-                T_Dest& dest,
-                T_Source const& source,
-                T_Extents const& extents) const
+            void operator()(cpu::Queue<T_Device>& queue, auto&& dest, T_Source const& source, T_Extents const& extents)
+                const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
             {
                 constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
 
@@ -211,8 +208,8 @@ namespace alpaka::onHost
         template<typename T_Device, typename T_Dest, typename T_Extents>
         struct Memset::Op<cpu::Queue<T_Device>, T_Dest, T_Extents>
         {
-            void operator()(cpu::Queue<T_Device>& queue, T_Dest& dest, uint8_t byteValue, T_Extents const& extents)
-                const
+            void operator()(cpu::Queue<T_Device>& queue, auto&& dest, uint8_t byteValue, T_Extents const& extents)
+                const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
             {
                 constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
 

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -28,8 +28,8 @@ namespace alpaka::onHost::internal
     requires(alpaka::trait::getDim_v<T_Extents> > 1u)
     struct Memset::Op<syclGeneric::Queue<T_Device>, T_Dest, T_Extents>
     {
-        void operator()(syclGeneric::Queue<T_Device>& queue, T_Dest& dest, uint8_t byteValue, T_Extents const& extents)
-            const
+        void operator()(syclGeneric::Queue<T_Device>& queue, auto&& dest, uint8_t byteValue, T_Extents const& extents)
+            const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
         {
             sycl::queue sycl_queue = queue.getNativeHandle();
 
@@ -67,9 +67,9 @@ namespace alpaka::onHost::internal
     {
         void operator()(
             syclGeneric::Queue<T_Device>& queue,
-            T_Dest& dest,
+            auto&& dest,
             T_Source const& source,
-            T_Extents const& extents) const
+            T_Extents const& extents) const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
         {
             sycl::queue sycl_queue = queue.getNativeHandle();
 

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -108,8 +108,8 @@ namespace alpaka::onHost
     requires(alpaka::trait::getDim_v<T_Extents> == 1u)
     struct internal::Memset::Op<syclGeneric::Queue<T_Device>, T_Dest, T_Extents>
     {
-        void operator()(syclGeneric::Queue<T_Device>& queue, T_Dest& dest, uint8_t byteValue, T_Extents const& extents)
-            const
+        void operator()(syclGeneric::Queue<T_Device>& queue, auto&& dest, uint8_t byteValue, T_Extents const& extents)
+            const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
         {
             // TODO: implement generic version for multidimensional memory
             sycl::queue sycl_queue = queue.getNativeHandle();
@@ -126,9 +126,9 @@ namespace alpaka::onHost
     {
         void operator()(
             syclGeneric::Queue<T_Device>& queue,
-            T_Dest& dest,
+            auto&& dest,
             T_Source const& source,
-            T_Extents const& extents) const
+            T_Extents const& extents) const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
         {
             // TODO: implement generic version for multidimensional memory
             sycl::queue sycl_queue = queue.getNativeHandle();

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -339,9 +339,9 @@ namespace alpaka::onHost
         {
             void operator()(
                 unifiedCudaHip::Queue<T_Device>& queue,
-                T_Dest& dest,
+                auto&& dest,
                 T_Source const& source,
-                T_Extents const& extents) const
+                T_Extents const& extents) const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
             {
                 using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
 
@@ -420,9 +420,9 @@ namespace alpaka::onHost
         {
             void operator()(
                 unifiedCudaHip::Queue<T_Device>& queue,
-                T_Dest& dest,
+                auto&& dest,
                 uint8_t byteValue,
-                T_Extents const& extents) const
+                T_Extents const& extents) const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
             {
                 using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
                 auto extentMd = pCast<size_t>(extents);

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -145,16 +145,16 @@ namespace alpaka::onHost
      * @{
      */
     template<typename T_Device>
-    inline auto memset(Queue<T_Device> const& queue, auto& dest, uint8_t byteValue)
+    inline auto memset(Queue<T_Device> const& queue, auto&& dest, uint8_t byteValue)
     {
-        return memset(queue, dest, byteValue, getExtents(dest));
+        return memset(queue, ALPAKA_FORWARD(dest), byteValue, internal::getExtents(dest));
     }
 
     /** @param extents M-dimensional data extents in elements, can be smaller than the container capacity */
     template<typename T_Device>
     inline auto memset(
         Queue<T_Device> const& queue,
-        auto& dest,
+        auto&& dest,
         uint8_t byteValue,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
@@ -162,7 +162,7 @@ namespace alpaka::onHost
         return internal::Memset::Op<
             std::decay_t<decltype(*queue.get())>,
             std::decay_t<decltype(dest)>,
-            std::decay_t<decltype(extentsVec)>>{}(*queue.get(), dest, byteValue, extentsVec);
+            std::decay_t<decltype(extentsVec)>>{}(*queue.get(), ALPAKA_FORWARD(dest), byteValue, extentsVec);
     }
 
     /** @} */
@@ -180,16 +180,16 @@ namespace alpaka::onHost
      * @{
      */
     template<typename T_Device>
-    inline void memcpy(Queue<T_Device> const& queue, auto& dest, auto const& source)
+    inline void memcpy(Queue<T_Device> const& queue, auto&& dest, auto const& source)
     {
-        return memcpy(queue, dest, source, getExtents(dest));
+        return memcpy(queue, ALPAKA_FORWARD(dest), source, internal::getExtents(dest));
     }
 
     /** @param extents M-dimensional data extents in elements, can be smaller than the container capacity */
     template<typename T_Device>
     inline void memcpy(
         Queue<T_Device> const& queue,
-        auto& dest,
+        auto&& dest,
         auto const& source,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
@@ -198,7 +198,7 @@ namespace alpaka::onHost
             std::decay_t<decltype(*queue.get())>,
             std::decay_t<decltype(dest)>,
             std::decay_t<decltype(source)>,
-            std::decay_t<decltype(extentsVec)>>{}(*queue.get(), dest, source, extentsVec);
+            std::decay_t<decltype(extentsVec)>>{}(*queue.get(), ALPAKA_FORWARD(dest), source, extentsVec);
     }
 
     /** @} */

--- a/include/alpaka/onHost/internal.hpp
+++ b/include/alpaka/onHost/internal.hpp
@@ -213,7 +213,7 @@ namespace alpaka::onHost
             template<typename T_Queue, typename T_Dest, typename T_Source, typename T_Extents>
             struct Op
             {
-                void operator()(T_Queue& queue, T_Dest&, T_Source const&, T_Extents const&) const;
+                void operator()(T_Queue& queue, auto&&, T_Source const&, T_Extents const&) const;
             };
         };
 
@@ -222,7 +222,7 @@ namespace alpaka::onHost
             template<typename T_Queue, typename T_Dest, typename T_Extents>
             struct Op
             {
-                void operator()(T_Queue& queue, T_Dest&, uint8_t, T_Extents const&) const;
+                void operator()(T_Queue& queue, auto&&, uint8_t, T_Extents const&) const;
             };
         };
 

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -255,3 +255,101 @@ TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
     wait(queue);
     meta::ndLoopIncIdx(numBlocks, [&](auto idx) { CHECK(idx == hBuff[idx]); });
 }
+
+/** ViewWrapper for validating the memcpy and memset interfaces.
+ *
+ * The wrapper is disabling the copy and move operations to within alpaka.
+ */
+template<alpaka::concepts::MdSpan T_Span>
+struct TestMdSpan
+{
+    using value_type = typename T_Span::value_type;
+
+    constexpr TestMdSpan(T_Span const& span) : m_span(span)
+    {
+    }
+
+    constexpr TestMdSpan() = delete;
+    constexpr TestMdSpan(TestMdSpan const&) = delete;
+    constexpr TestMdSpan& operator=(TestMdSpan const&) = delete;
+    constexpr TestMdSpan(TestMdSpan&&) = delete;
+    constexpr TestMdSpan& operator=(TestMdSpan&&) = delete;
+
+    constexpr auto* data() const
+    {
+        return m_span.data();
+    }
+
+    constexpr auto getExtents() const
+    {
+        return m_span.getExtents();
+    }
+
+    constexpr auto getPitches() const
+    {
+        return m_span.getPitches();
+    }
+
+    constexpr auto getApi() const
+    {
+        return alpaka::getApi(m_span);
+    }
+
+private:
+    T_Span m_span;
+};
+
+/** Test that memcpy and memset can be called with non copy-able and move-able data as lvalue and rvalue. */
+TEMPLATE_LIST_TEST_CASE("memcpy", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    std::cout << deviceSpec.getApi().getName() << std::endl;
+    Device device = devSelector.makeDevice(0);
+
+    std::cout << device.getName() << std::endl;
+
+    Queue queue = device.makeQueue();
+    constexpr Vec problemSize = Vec{16u};
+
+    auto dBuff = onHost::alloc<size_t>(device, problemSize);
+    auto hBuff = onHost::allocHostMirror(dBuff);
+
+    // test rvalue
+    onHost::memcpy(queue, TestMdSpan{dBuff.getView()}, TestMdSpan{hBuff.getView()});
+    onHost::memset(queue, TestMdSpan{dBuff.getView()}, 0u);
+    onHost::memcpy(queue, TestMdSpan{hBuff.getView()}, TestMdSpan{dBuff.getView()});
+    onHost::wait(queue);
+    meta::ndLoopIncIdx(problemSize, [&](auto idx) { CHECK(hBuff[idx] == size_t{0}); });
+
+    size_t refence = 0u;
+    for(auto& v : hBuff)
+        v = refence++;
+
+    onHost::memcpy(queue, TestMdSpan{dBuff.getView()}, TestMdSpan{hBuff.getView()});
+    onHost::wait(queue);
+    for(auto& v : hBuff)
+        v = 42;
+
+    // test lvalue
+    auto dlvalue = TestMdSpan{dBuff.getView()};
+    auto hlvalue = TestMdSpan{hBuff.getView()};
+    onHost::memcpy(queue, hlvalue, dlvalue);
+    onHost::wait(queue);
+    meta::ndLoopIncIdx(problemSize, [&](auto idx) { CHECK(hBuff[idx] == linearize(problemSize, idx)); });
+
+    onHost::memset(queue, dlvalue, 0u);
+    onHost::memcpy(queue, hlvalue, dlvalue);
+    onHost::wait(queue);
+
+    // validate without using the forward iterator
+    meta::ndLoopIncIdx(problemSize, [&](auto idx) { CHECK(hBuff[idx] == size_t{0}); });
+}


### PR DESCRIPTION
- for both methods take the destination as universal reference to be able to pass rvalues
- add test to ensure the destination taken as rvalue or lvalue is never copied or moved