### PR TITLE
expose that ManagedView is following the concpets::MdSpan

### DIFF
--- a/include/alpaka/meta/NdLoop.hpp
+++ b/include/alpaka/meta/NdLoop.hpp
@@ -79,7 +79,10 @@ namespace alpaka::meta
     template<typename TExtentVec, typename TFnObj>
     auto ndLoopIncIdx(TExtentVec const& extent, TFnObj const& f) -> void
     {
-        TExtentVec idx = TExtentVec::all(0);
-        ndLoop(std::make_index_sequence<TExtentVec::dim()>(), idx, extent, f);
+        // TExtentVec could be a CVec therefore we need to make it writable
+        using IndexVector = typename TExtentVec::UniVec;
+        auto idx = IndexVector::all(0);
+
+        ndLoop(std::make_index_sequence<TExtentVec::dim()>(), idx, IndexVector{extent}, f);
     }
 } // namespace alpaka::meta

--- a/include/alpaka/onHost/mem/ManagedView.hpp
+++ b/include/alpaka/onHost/mem/ManagedView.hpp
@@ -12,6 +12,7 @@
 #include "alpaka/onHost.hpp"
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/onHost/Handle.hpp"
+#include "alpaka/onHost/concepts.hpp"
 #include "alpaka/onHost/mem/MangedDealloc.hpp"
 
 #include <cstdint>
@@ -224,3 +225,12 @@ namespace alpaka::internal
         }
     };
 } // namespace alpaka::internal
+
+namespace alpaka::trait
+{
+    template<typename T>
+    requires(isSpecializationOf_v<std::remove_cvref_t<T>, alpaka::onHost::ManagedView>)
+    struct IsMdSpan<T> : std::true_type
+    {
+    };
+} // namespace alpaka::trait

--- a/tests/unit/mem/mdIterator.cpp
+++ b/tests/unit/mem/mdIterator.cpp
@@ -14,21 +14,23 @@ using namespace alpaka::onHost;
 
 TEST_CASE("mdIterator", "")
 {
-    constexpr auto numElements = Vec<size_t, 2u>{17, 31};
-    auto span = onHost::allocHost<uint32_t>(numElements);
+    constexpr auto numElements = CVec<size_t, 17, 31>{};
+    alpaka::concepts::MdSpan auto span = onHost::allocHost<uint32_t>(numElements);
 
     size_t counter = 0u;
-    for(auto& v : span)
+    for(uint32_t& v : span)
         v = counter++;
 
     // validate by using the forward iterator
     size_t refence = 0u;
-    for(auto const& v : span)
+    for(uint32_t v : span)
     {
         CHECK(v == refence);
         ++refence;
     }
 
     // validate without using the forward iterator
-    meta::ndLoopIncIdx(numElements, [&](auto idx) { CHECK(span[idx] == linearize(numElements, idx)); });
+    meta::ndLoopIncIdx(
+        numElements,
+        [&](alpaka::concepts::Vector<size_t, 2> auto idx) { CHECK(span[idx] == linearize(numElements, idx)); });
 }


### PR DESCRIPTION
- expose that ManagedView is following the concpets::MdSpan
- add concepts and types to the code (be less generic, because it is a  test)
- sneak in: fix `meta::ndLoopIncIdx()` not worked with `CVec` as extent