### PR TITLE
improve readablility of examples

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -230,16 +230,13 @@ struct DotKernel
 //! \brief The Function for testing babelstream kernels for given Acc type and data type.
 //! \tparam TAcc the accelerator type
 //! \tparam DataType The data type to differentiate single or double data type based tests.
-template<typename DataType, typename T_Cfg>
-void testKernels(T_Cfg cfg)
+template<typename DataType>
+void testKernels(auto const deviceSpec, auto const exec)
 {
     if(kernelsToBeExecuted == KernelsToRun::All)
     {
         std::cout << "Kernels: Init, Copy, Mul, Add, Triad, Dot Kernels" << std::endl;
     }
-
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
@@ -603,20 +600,20 @@ void testKernels(T_Cfg cfg)
     std::cout << metaData.serializeAsTable() << std::endl;
 }
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis))>;
+using Backends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis))>;
 
 // Run for all Accs given by the argument
-TEMPLATE_LIST_TEST_CASE("TEST: Babelstream Kernels<Float>", "[benchmark-test]", TestApis)
+TEMPLATE_LIST_TEST_CASE("TEST: Babelstream Kernels<Float>", "[benchmark-test]", Backends)
 {
-    auto apiAndExecutors = TestType::makeDict();
+    auto backend = TestType::makeDict();
     // Run tests for the float data type
-    testKernels<float>(apiAndExecutors);
+    testKernels<float>(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]);
 }
 
 // Run for all Accs given by the argument
-TEMPLATE_LIST_TEST_CASE("TEST: Babelstream Kernels<Double>", "[benchmark-test]", TestApis)
+TEMPLATE_LIST_TEST_CASE("TEST: Babelstream Kernels<Double>", "[benchmark-test]", Backends)
 {
-    auto apiAndExecutors = TestType::makeDict();
+    auto backend = TestType::makeDict();
     // Run tests for the double data type
-    testKernels<double>(apiAndExecutors);
+    testKernels<double>(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]);
 }

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -36,8 +36,7 @@
 //! Instead, a single accelerator is selected once from the active accelerators and the kernels are executed with the
 //! selected accelerator only. If you use the example as the starting point for your project, you can rename the
 //! example() function to main() and move the accelerator tag to the function body.
-template<typename T_Cfg>
-auto example(T_Cfg const& cfg) -> int
+int example(auto const deviceSpec, auto const computeExec)
 {
     using namespace alpaka;
     using namespace alpaka::onHost;
@@ -45,13 +44,10 @@ auto example(T_Cfg const& cfg) -> int
     using Idx = uint32_t;
     using IdxVec = alpaka::Vec<Idx, 2u>;
 
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
-
     std::cout << deviceSpec.getApi().getName() << std::endl;
 
-    std::cout << "Using alpaka accelerator: " << core::demangledName(exec) << " for " << deviceSpec.getApi().getName()
-              << std::endl;
+    std::cout << "Using alpaka accelerator: " << core::demangledName(computeExec) << " for "
+              << deviceSpec.getApi().getName() << std::endl;
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     onHost::Device devAcc = devSelector.makeDevice(0);
@@ -147,13 +143,13 @@ auto example(T_Cfg const& cfg) -> int
     {
         // Compute next values
         computeQueue.enqueue(
-            exec,
+            computeExec,
             dataBlockingStencil,
             KernelBundle{stencilKernel, uCurrBufAcc, uNextBufAcc, chunkSize, sharedMemExtents, numNodes, dx, dy, dt});
 
         // Apply boundaries
         computeQueue.enqueue(
-            exec,
+            computeExec,
             dataBlockingBorder,
             KernelBundle{boundaryKernel, uNextBufAcc.getMdSpan(), chunkSize, numNodesWithHalo, step, dx, dy, dt});
 
@@ -201,18 +197,9 @@ auto example(T_Cfg const& cfg) -> int
 auto main() -> int
 {
     using namespace alpaka;
-    // Execute the example once for each enabled accelerator.
-    // If you would like to execute it for a single accelerator only you can use the following code.
-    //  \code{.cpp}
-    //  auto tag = TagCpuSerial;
-    //  return example(tag);
-    //  \endcode
-    //
-    // valid tags:
-    //   TagCpuSerial, TagGpuHipRt, TagGpuCudaRt, TagCpuOmp2Blocks, TagCpuTbbBlocks,
-    //   TagCpuOmp2Threads, TagCpuSycl, TagCpuTbbBlocks, TagCpuThreads,
-    //   TagFpgaSyclIntel, TagGenericSycl, TagGpuSyclIntel
+
     return executeForEachIfHasDevice(
-        [=](auto const& tag) { return example(tag); },
+        [=](auto const& backend)
+        { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
         onHost::allBackends(onHost::enabledApis));
 }

--- a/example/scan/src/scan_improved.hpp
+++ b/example/scan/src/scan_improved.hpp
@@ -76,7 +76,7 @@ ALPAKA_FN_ACC Data scanMiniBlock(Data* block, concepts::CVector auto const& exte
     // -- DOWN-SWEEP --
     for(IdxType d = 1, offset = extent.x() / 2_idx; d < extent.x(); d <<= 1, offset >>= 1)
     {
-        for(auto frameElem = 0; frameElem < 2_idx * d; frameElem += 2_idx)
+        for(auto frameElem = 0_idx; frameElem < 2_idx * d; frameElem += 2_idx)
         {
             IdxType left = offset * (frameElem + 1_idx) - 1_idx;
             IdxType right = offset * (frameElem + 2_idx) - 1_idx;
@@ -95,7 +95,7 @@ ALPAKA_FN_ACC Data scanMiniBlock(Data* block, concepts::CVector auto const& exte
  */
 ALPAKA_FN_ACC void addIncrements(Data* block, Data const& blockSum, concepts::CVector auto const& extent)
 {
-    for(auto i = 0; i < extent.x(); ++i)
+    for(auto i = 0_idx; i < extent.x(); ++i)
     {
         block[i] += blockSum;
     }

--- a/example/scan/src/scan_main.hpp
+++ b/example/scan/src/scan_main.hpp
@@ -41,18 +41,15 @@ void printExampleHeader(ScanType const scanType, IdxType const numElements, bool
     std::cout << std::endl;
 }
 
-template<typename T_Cfg>
 auto example(
-    T_Cfg const& cfg,
+    auto const deviceSpec,
+    auto const exec,
     IdxType numElements,
     bool enableStdScan,
     bool enableCheck,
     bool enableInPlace,
     ScanType scanType) -> int
 {
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
-
     // Number of elements to process
     Vec1D const extent(numElements);
 
@@ -195,8 +192,17 @@ auto main(int argc, char* argv[]) -> int
 
     // Execute the example once for each enabled API and executor.
     auto result = executeForEachIfHasDevice(
-        [=](auto const& tag)
-        { return example(tag, numElements, enableStdScan, enableCheck, enableInPlace, scanType); },
+        [=](auto const& backend)
+        {
+            return example(
+                backend[alpaka::object::deviceSpec],
+                backend[alpaka::object::exec],
+                numElements,
+                enableStdScan,
+                enableCheck,
+                enableInPlace,
+                scanType);
+        },
         onHost::allBackends(onHost::enabledApis));
 
     return result;

--- a/example/tutorial/src/00_enumerate.cpp
+++ b/example/tutorial/src/00_enumerate.cpp
@@ -36,7 +36,19 @@ int example(auto const devSpec)
 auto main() -> int
 {
     using namespace alpaka;
-    // Execute the example once for each enabled API and executor.
+
+    /** This call is showing what is hidden in the generator onHost::getDeviceSpecsFor later on used.
+     *
+     * A DeviceSpec is a combination of an API and a device kind.
+     * You can query the number of devices and properties for each device index.
+     *
+     * If you change this example to `onHost::DeviceSpec{api::cuda, deviceKind::nvidiaGpu}` and the CMake option
+     * `alpaka_DEP_CUDA` is set to `OFF` compile will fail.
+     */
+    example(onHost::DeviceSpec{api::host, deviceKind::cpu});
+
+    /** Execute the example once for each enabled API and device kind including `onHost::DeviceSpec{api::host,
+     * deviceKind::cpu}` explicitly called before.*/
     return executeForEachIfHasDevice(
         [=](auto const& devSpec) { return example(devSpec); },
         onHost::getDeviceSpecsFor(onHost::enabledApis));

--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -214,11 +214,8 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
     std::cout << "success\n";
 }
 
-int example(auto const cfg)
+int example(auto const deviceSpec, auto const computeExec)
 {
-    auto deviceSpec = cfg[alpaka::object::deviceSpec];
-    auto computeExec = cfg[alpaka::object::exec];
-
     auto devSelector = alpaka::onHost::makeDeviceSelector(deviceSpec);
 
     // require at least one device
@@ -242,8 +239,15 @@ int example(auto const cfg)
 auto main() -> int
 {
     using namespace alpaka;
-    // Execute the example once for each enabled API and executor.
+
+    /** This example requires additionally to the device specification and executor the description how the parallelism
+     * on the compute device is organised.
+     */
+    example(onHost::DeviceSpec{api::host, deviceKind::cpu}, exec::cpuSerial);
+
+    // Execute the example once for each enabled API, device kind, and executor.
     return executeForEachIfHasDevice(
-        [=](auto const& tag) { return example(tag); },
+        [=](auto const& backend)
+        { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
         onHost::allBackends(onHost::enabledApis));
 }

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -234,11 +234,8 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
     std::cout << "success\n";
 }
 
-int example(auto const cfg)
+int example(auto const deviceSpec, auto const computeExec)
 {
-    auto deviceSpec = cfg[alpaka::object::deviceSpec];
-    auto computeExec = cfg[alpaka::object::exec];
-
     auto devSelector = alpaka::onHost::makeDeviceSelector(deviceSpec);
 
     // require at least one device
@@ -265,6 +262,7 @@ auto main() -> int
     using namespace alpaka;
     // Execute the example once for each enabled API and executor.
     return executeForEachIfHasDevice(
-        [=](auto const& tag) { return example(tag); },
+        [=](auto const& backend)
+        { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
         onHost::allBackends(onHost::enabledApis));
 }

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -292,11 +292,8 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
     std::cout << "success\n";
 }
 
-int example(auto const cfg)
+int example(auto const deviceSpec, auto const computeExec)
 {
-    auto deviceSpec = cfg[alpaka::object::deviceSpec];
-    auto computeExec = cfg[alpaka::object::exec];
-
     auto devSelector = alpaka::onHost::makeDeviceSelector(deviceSpec);
 
     // require at least one device
@@ -322,6 +319,7 @@ auto main() -> int
     using namespace alpaka;
     // Execute the example once for each enabled API and executor.
     return executeForEachIfHasDevice(
-        [=](auto const& tag) { return example(tag); },
+        [=](auto const& backend)
+        { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
         onHost::allBackends(onHost::enabledApis));
 }

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -54,13 +54,9 @@ public:
 // Instead, a single accelerator is selected once from the active accelerators and the kernels are executed with the
 // selected accelerator only. If you use the example as the starting point for your project, you can rename the
 // example() function to main() and move the accelerator tag to the function body.
-template<typename T_Cfg>
-auto example(T_Cfg const& cfg, size_t numElements) -> int
+auto example(auto const deviceSpec, auto const exec, size_t numElements) -> int
 {
     using IdxVec = Vec<std::size_t, 1u>;
-
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
 
     // Define problem size
     IdxVec const extent(numElements);
@@ -209,6 +205,7 @@ auto main(int argc, char* argv[]) -> int
     using namespace alpaka;
     // Execute the example once for each enabled API and executor.
     return executeForEachIfHasDevice(
-        [=](auto const& tag) { return example(tag, numElements); },
+        [=](auto const& backend)
+        { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec], numElements); },
         onHost::allBackends(onHost::enabledApis));
 }

--- a/include/alpaka/onHost/DeviceSelector.hpp
+++ b/include/alpaka/onHost/DeviceSelector.hpp
@@ -10,7 +10,7 @@
 
 namespace alpaka::onHost
 {
-    template<typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<alpaka::concepts::Api T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
     struct DeviceSpec
     {
     public:
@@ -40,7 +40,7 @@ namespace alpaka::onHost
         T_DeviceKind m_deviceType;
     };
 
-    template<typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<alpaka::concepts::Api T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
     struct DeviceSelector
     {
     public:


### PR DESCRIPTION
- be more explicit with the arguments when using the generator `onHost::allBackends()`
- `example/tutorial`: add explicit example how to get a host device and use the cpu serial executor
- sneaked in: fix for warning in the scan example (unsigned/signed comparisn)