### PR TITLE
add `onHost::fill()` and small fixed

### DIFF
--- a/include/alpaka/SimdPtr.hpp
+++ b/include/alpaka/SimdPtr.hpp
@@ -97,7 +97,7 @@ namespace alpaka
          *
          * @return the alignment of the memory (in byte) the pointer is pointing to
          */
-        static consteval auto getAlignment()
+        static constexpr auto getAlignment()
         {
             using SpanElemType = typename T_MdSpan::value_type;
             constexpr uint32_t spanAlignment = T_MdSpan::getAlignment().template get<SpanElemType>();

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -537,6 +537,58 @@ namespace alpaka
             auto array = ArrayType{std::ref((*this)[T_values])...};
             return Vec<T_Type, InType::dim(), ALPAKA_TYPEOF(array)>{array};
         };
+
+        /** reduce all elements to a single value
+         *
+         * For better numerical stability a tree reduce algorithm is used.
+         *
+         * @tparam BinaryOp binary functor executed to reduce the range
+         *                  The binary operation must be associative.
+         * @return the type of the result depends on the binary functor
+         */
+        [[nodiscard]] constexpr auto reduce(auto&& reduceFunc) const
+            -> decltype(reduceFunc(std::declval<type>(), std::declval<type>()))
+        {
+            return reduce_range(ALPAKA_FORWARD(reduceFunc));
+        }
+
+    private:
+        /** reduce over a range of elements
+         *
+         * @tparam BinaryOp binary functor executed to reduce the range
+         * @tparam T_start start index
+         * @tparam T_end end index (excluded)
+         * @return the type of the result depends on the binary functor
+         */
+        template<uint32_t T_start = 0u, uint32_t T_end = dim()>
+        [[nodiscard]] constexpr auto reduce_range(auto&& reduceFunc) const
+            -> decltype(reduceFunc(std::declval<type>(), std::declval<type>()))
+        {
+            // elements in the range
+            constexpr uint32_t size = T_end - T_start;
+            // single element termination
+            if constexpr(size == 1u)
+            {
+                return (*this)[T_start];
+            }
+#if ALPAKA_LANG_SYCL
+            // SYCL can not call recursive functions
+            auto result = (*this)[T_start];
+            for(uint32_t i = T_start + 1u; i < T_end; ++i)
+            {
+                result = reduceFunc(result, (*this)[i]);
+            }
+            return result;
+#else
+            // split range at midpoint
+            constexpr uint32_t mid = T_start + size / 2u;
+
+            // recursively reduce both halves and combine
+            return reduceFunc(
+                reduce_range<T_start, mid>(ALPAKA_FORWARD(reduceFunc)),
+                reduce_range<mid, T_end>(ALPAKA_FORWARD(reduceFunc)));
+#endif
+        }
     };
 
     template<std::size_t I, typename T_Type, uint32_t T_dim, typename T_Storage>

--- a/include/alpaka/api/generic.hpp
+++ b/include/alpaka/api/generic.hpp
@@ -1,0 +1,69 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+#pragma once
+
+#include "alpaka/internal.hpp"
+#include "alpaka/onAcc.hpp"
+#include "alpaka/onAcc/SimdAlgo.hpp"
+#include "alpaka/onHost/FrameSpec.hpp"
+#include "alpaka/onHost/internal.hpp"
+
+#include <algorithm>
+
+namespace alpaka::internal::generic
+{
+    /** assign a value to each element of the destination
+     *
+     * @todo replace the kernel as soon as we have an algorithm forEach callable from host
+     */
+    struct SimdFillKernel
+    {
+        ALPAKA_FN_ACC void operator()(auto const& acc, alpaka::concepts::MdSpan auto const& dest, auto const value)
+            const
+        {
+            auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
+            simdGrid.concurrent(
+                acc,
+                dest.getExtents(),
+                [value](auto const& acc, auto destSimdPtr) constexpr
+                {
+                    using SimdType = ALPAKA_TYPEOF(destSimdPtr.load());
+                    destSimdPtr = SimdType::all(value);
+                },
+                dest);
+        }
+    };
+
+    template<typename T_Value>
+    inline void fill(
+        auto& internalQueue,
+        auto executor,
+        alpaka::concepts::MdSpan<T_Value> auto&& dest,
+        T_Value elementValue)
+    {
+        uint32_t elementsPerFrameItem = getNumElemPerThread<T_Value>(internalQueue);
+
+        auto extents = onHost::getExtents(dest);
+
+        using ExtentsType = ALPAKA_TYPEOF(extents);
+        using IndexType = typename ExtentsType::index_type;
+        auto virtualFrameExtent = ExtentsType::all(1u);
+        // 512 is randomly chosen because it is on all devices a good value for a value assign kernel
+        virtualFrameExtent.x() = std::min(static_cast<IndexType>(512u * elementsPerFrameItem), extents.x());
+
+        auto numFrames = divExZero(extents, virtualFrameExtent);
+        auto realFrameExtent = ExtentsType::all(1u);
+        realFrameExtent.x() = IndexType{512u};
+
+        auto frameSpec = onHost::FrameSpec{numFrames, realFrameExtent};
+
+        onHost::internal::enqueue(
+            internalQueue,
+            executor,
+            frameSpec,
+            KernelBundle{SimdFillKernel{}, dest, elementValue});
+    }
+} // namespace alpaka::internal::generic

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/api/generic.hpp"
 #include "alpaka/api/host/Api.hpp"
 #include "alpaka/api/host/exec/OmpBlocks.hpp"
 #include "alpaka/api/host/exec/OmpThreads.hpp"
@@ -215,8 +216,11 @@ namespace alpaka::onHost
         template<typename T_Device, typename T_Dest, typename T_Extents>
         struct Memset::Op<cpu::Queue<T_Device>, T_Dest, T_Extents>
         {
+            /** @attention Do not use `requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>` here else gcc 11.X
+             * (tested 11.4 and 11.3) will run into an internal compiler segfault during the evaluation of the
+             * constraints */
             void operator()(cpu::Queue<T_Device>& queue, auto&& dest, uint8_t byteValue, T_Extents const& extents)
-                const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
+                const requires(std::is_same_v<ALPAKA_TYPEOF(dest), T_Dest>)
             {
                 constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
 
@@ -261,7 +265,24 @@ namespace alpaka::onHost
             }
         };
 
+        template<typename T_Device, typename T_Dest, typename T_Value, typename T_Extents>
+        struct Fill::Op<cpu::Queue<T_Device>, T_Dest, T_Value, T_Extents>
+        {
+            void operator()(cpu::Queue<T_Device>& queue, auto&& dest, T_Value elementValue, T_Extents const& extents)
+                const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
+                               && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
+            {
+                auto executors = supportedMappings(getDevice(queue));
+                // avoid that we pass a ManagedView and convert non alpaka data views
+                alpaka::concepts::MdSpan<T_Value> auto dataView = makeView(dest);
 
+                alpaka::internal::generic::fill(
+                    queue,
+                    std::get<0>(executors),
+                    dataView.getSubView(extents),
+                    elementValue);
+            }
+        };
     } // namespace internal
 } // namespace alpaka::onHost
 

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -105,6 +105,49 @@ namespace alpaka::onHost::internal
         }
     };
 
+    template<typename T_Device, typename T_Dest, typename T_Value, typename T_Extents>
+    requires(alpaka::trait::getDim_v<T_Extents> > 1u)
+    struct internal::Fill::Op<syclGeneric::Queue<T_Device>, T_Dest, T_Value, T_Extents>
+    {
+        void operator()(
+            syclGeneric::Queue<T_Device> queue,
+            auto&& dest,
+            T_Value elementValue,
+            T_Extents const& extents) const
+            requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
+                     && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
+        {
+            auto* destPtr = data(dest);
+            auto const destPitchBytesWithoutColumn = dest.getPitches().eraseBack();
+            auto extentMd = pCast<size_t>(extents);
+
+            sycl::queue sycl_queue = queue.getNativeHandle();
+
+
+            constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
+
+            if constexpr(dim == 2u)
+            {
+                sycl_queue.ext_oneapi_fill2d(
+                    destPtr,
+                    destPitchBytesWithoutColumn.back(),
+                    elementValue,
+                    extentMd.x(),
+                    extentMd.y());
+            }
+            else if constexpr(dim >= 3u)
+            {
+                auto const dstExtentWithoutColumn = extentMd.eraseBack();
+                sycl_queue.ext_oneapi_fill2d(
+                    destPtr,
+                    destPitchBytesWithoutColumn.back(),
+                    elementValue,
+                    extentMd.x(),
+                    dstExtentWithoutColumn.product());
+            }
+        }
+    };
+
     namespace detail
     {
         template<alpaka::concepts::Vector TVec>

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -8,6 +8,7 @@
 
 #if ALPAKA_LANG_ONEAPI
 
+#    include "alpaka/api/generic.hpp"
 #    include "alpaka/api/oneApi/StaticSharedMemory.hpp"
 #    include "alpaka/api/syclGeneric/Queue.hpp"
 #    include "alpaka/onHost/internal.hpp"
@@ -117,34 +118,11 @@ namespace alpaka::onHost::internal
             requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
                      && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
         {
-            auto* destPtr = data(dest);
-            auto const destPitchBytesWithoutColumn = dest.getPitches().eraseBack();
-            auto extentMd = pCast<size_t>(extents);
+            auto executors = supportedMappings(getDevice(queue));
+            // avoid that we pass a ManagedView and convert non alpaka data views
+            auto dataView = makeView(dest);
 
-            sycl::queue sycl_queue = queue.getNativeHandle();
-
-
-            constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
-
-            if constexpr(dim == 2u)
-            {
-                sycl_queue.ext_oneapi_fill2d(
-                    destPtr,
-                    destPitchBytesWithoutColumn.back(),
-                    elementValue,
-                    extentMd.x(),
-                    extentMd.y());
-            }
-            else if constexpr(dim >= 3u)
-            {
-                auto const dstExtentWithoutColumn = extentMd.eraseBack();
-                sycl_queue.ext_oneapi_fill2d(
-                    destPtr,
-                    destPitchBytesWithoutColumn.back(),
-                    elementValue,
-                    extentMd.x(),
-                    dstExtentWithoutColumn.product());
-            }
+            alpaka::internal::generic::fill(queue, std::get<0>(executors), dataView.getSubView(extents), elementValue);
         }
     };
 

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -145,6 +145,23 @@ namespace alpaka::onHost
                 extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
         }
     };
+
+    template<typename T_Device, typename T_Dest, typename T_Value, typename T_Extents>
+    requires(alpaka::trait::getDim_v<T_Extents> == 1u)
+    struct internal::Fill::Op<syclGeneric::Queue<T_Device>, T_Dest, T_Value, T_Extents>
+    {
+        void operator()(
+            syclGeneric::Queue<T_Device> queue,
+            auto&& dest,
+            T_Value elementValue,
+            T_Extents const& extents) const
+            requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
+                     && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
+        {
+            sycl::queue sycl_queue = queue.getNativeHandle();
+            sycl_queue.fill(internal::Data::data(dest), elementValue, extents.x());
+        }
+    };
 } // namespace alpaka::onHost
 
 namespace alpaka::internal

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -11,6 +11,7 @@
 
 #if ALPAKA_LANG_CUDA || ALPAKA_LANG_HIP
 #    include "alpaka/api/cuda/IdxLayer.hpp"
+#    include "alpaka/api/generic.hpp"
 #    include "alpaka/api/hip/IdxLayer.hpp"
 #    include "alpaka/api/unifiedCudaHip/ComputeApi.hpp"
 #    include "alpaka/api/unifiedCudaHip/MemcpyKind.hpp"
@@ -425,11 +426,14 @@ namespace alpaka::onHost
         template<typename T_Device, typename T_Dest, typename T_Extents>
         struct Memset::Op<unifiedCudaHip::Queue<T_Device>, T_Dest, T_Extents>
         {
+            /** @attention Do not use `requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>` here else gcc 11.X
+             * (tested 11.4 and 11.3) will run into an internal compiler segfault during the evaluation of the
+             * constraints */
             void operator()(
                 unifiedCudaHip::Queue<T_Device>& queue,
                 auto&& dest,
                 uint8_t byteValue,
-                T_Extents const& extents) const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
+                T_Extents const& extents) const requires(std::is_same_v<ALPAKA_TYPEOF(dest), T_Dest>)
             {
                 using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
                 auto extentMd = pCast<size_t>(extents);
@@ -485,6 +489,29 @@ namespace alpaka::onHost
                             extentVal,
                             internal::getNativeHandle(queue)));
                 }
+            }
+        };
+
+        template<typename T_Device, typename T_Dest, typename T_Value, typename T_Extents>
+        struct Fill::Op<unifiedCudaHip::Queue<T_Device>, T_Dest, T_Value, T_Extents>
+        {
+            void operator()(
+                unifiedCudaHip::Queue<T_Device>& queue,
+                auto&& dest,
+                T_Value elementValue,
+                T_Extents const& extents) const
+                requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
+                         && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
+            {
+                auto executors = supportedMappings(getDevice(queue));
+                // avoid that we pass a ManagedView and convert non alpaka data views
+                auto dataView = makeView(dest);
+
+                alpaka::internal::generic::fill(
+                    queue,
+                    std::get<0>(executors),
+                    dataView.getSubView(extents),
+                    elementValue);
             }
         };
     } // namespace internal

--- a/include/alpaka/apply.hpp
+++ b/include/alpaka/apply.hpp
@@ -34,9 +34,10 @@ namespace alpaka
     template<typename T_Func, typename T_TupleLike>
     ALPAKA_FN_INLINE constexpr decltype(auto) apply(T_Func&& func, T_TupleLike&& tuple)
     {
+        /** @attention Do not use std::tuple_size_v here because it results in compile issues with gcc11.4 */
         return detail::applyImpl(
             std::forward<T_Func>(func),
             std::forward<T_TupleLike>(tuple),
-            std::make_index_sequence<std::tuple_size_v<std::decay_t<T_TupleLike>>>{});
+            std::make_index_sequence<std::tuple_size<std::decay_t<T_TupleLike>>::value>{});
     }
 } // namespace alpaka

--- a/include/alpaka/interface.hpp
+++ b/include/alpaka/interface.hpp
@@ -97,7 +97,7 @@ namespace alpaka
      * @param any type derive the alignment from
      * @return alignment in bytes, if not defined the alignment of the value_type will be returned
      */
-    consteval auto getAlignment(auto&& any)
+    constexpr auto getAlignment(auto&& any)
     {
         return internal::getAlignment(ALPAKA_FORWARD(any));
     }

--- a/include/alpaka/interface.hpp
+++ b/include/alpaka/interface.hpp
@@ -92,4 +92,14 @@ namespace alpaka
         return alpaka::getNumPipelines(ALPAKA_TYPEOF(getApi(any)){}, ALPAKA_TYPEOF(getDeviceKind(any)){});
     }
 
+    /** Get the value type alignment of an object
+     *
+     * @param any type derive the alignment from
+     * @return alignment in bytes, if not defined the alignment of the value_type will be returned
+     */
+    consteval auto getAlignment(auto&& any)
+    {
+        return internal::getAlignment(ALPAKA_FORWARD(any));
+    }
+
 } // namespace alpaka

--- a/include/alpaka/internal.hpp
+++ b/include/alpaka/internal.hpp
@@ -80,19 +80,19 @@ namespace alpaka
             template<typename T_Any>
             struct Op
             {
-                consteval auto operator()(auto&& any) const requires requires { any.getAlignment(); }
+                constexpr auto operator()(auto&& any) const requires requires { any.getAlignment(); }
                 {
                     return any.getAlignment();
                 }
 
-                consteval auto operator()(auto&& any) const
+                constexpr auto operator()(auto&& any) const
                 {
                     return Alignment<>{};
                 }
             };
         };
 
-        consteval auto getAlignment(auto&& any)
+        constexpr auto getAlignment(auto&& any)
         {
             return GetAlignment::Op<std::decay_t<decltype(any)>>{}(any);
         }

--- a/include/alpaka/internal.hpp
+++ b/include/alpaka/internal.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/KernelBundle.hpp"
 #include "alpaka/core/DemangleTypeNames.hpp"
 #include "alpaka/core/common.hpp"
+#include "alpaka/mem/Alignment.hpp"
 #include "alpaka/onHost/Handle.hpp"
 
 namespace alpaka
@@ -74,5 +75,26 @@ namespace alpaka
             return GetDeviceType::Op<std::decay_t<decltype(any)>>{}(any);
         }
 
+        struct GetAlignment
+        {
+            template<typename T_Any>
+            struct Op
+            {
+                consteval auto operator()(auto&& any) const requires requires { any.getAlignment(); }
+                {
+                    return any.getAlignment();
+                }
+
+                consteval auto operator()(auto&& any) const
+                {
+                    return Alignment<>{};
+                }
+            };
+        };
+
+        consteval auto getAlignment(auto&& any)
+        {
+            return GetAlignment::Op<std::decay_t<decltype(any)>>{}(any);
+        }
     } // namespace internal
 } // namespace alpaka

--- a/include/alpaka/mem/Alignment.hpp
+++ b/include/alpaka/mem/Alignment.hpp
@@ -14,8 +14,6 @@ namespace alpaka
     template<uint32_t T_byte = std::numeric_limits<uint32_t>::max()>
     struct Alignment
     {
-        static constexpr uint32_t value = T_byte;
-
         /** Get the alignment value.
          *
          * @tparam T_Type The type for which to get the alignment.
@@ -35,6 +33,9 @@ namespace alpaka
         {
             return value;
         }
+
+    private:
+        static constexpr uint32_t value = T_byte;
     };
 
     using AutoAligned = Alignment<>;

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/CVec.hpp"
 #include "alpaka/Vec.hpp"
 #include "alpaka/core/config.hpp"
+#include "alpaka/interface.hpp"
 #include "alpaka/mem/Alignment.hpp"
 #include "alpaka/mem/DataPitches.hpp"
 #include "alpaka/mem/MdForwardIter.hpp"
@@ -42,7 +43,7 @@ namespace alpaka
 
     inline constexpr auto makeMdSpan(auto&& any)
     {
-        return MdSpan{onHost::data(any), onHost::getExtents(any), onHost::getPitches(any), any.getAlignment()};
+        return MdSpan{onHost::data(any), onHost::getExtents(any), onHost::getPitches(any), alpaka::getAlignment(any)};
     }
 
     template<

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -131,7 +131,7 @@ namespace alpaka
         constexpr MdSpan& operator=(MdSpan const&) = default;
         constexpr MdSpan& operator=(MdSpan&&) = default;
 
-        static consteval auto getAlignment()
+        static constexpr auto getAlignment()
         {
             return T_MemAlignment{};
         }
@@ -315,7 +315,7 @@ namespace alpaka
         constexpr MdSpanArray(MdSpanArray const&) = default;
         constexpr MdSpanArray(MdSpanArray&&) = default;
 
-        static consteval auto getAlignment()
+        static constexpr auto getAlignment()
         {
             return T_MemAlignment{};
         }

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -68,7 +68,7 @@ namespace alpaka
             T_Type* data,
             T_UserExtents const& extents,
             T_UserPitches const& pitches,
-            T_MemAlignment const memAlignment = Alignment{})
+            T_MemAlignment const memAlignment = T_MemAlignment{})
             : BaseMdSpan{
                 data,
                 typename ALPAKA_TYPEOF(extents)::UniVec{extents},

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -19,6 +19,7 @@
 
 namespace alpaka
 {
+
     /** Non owning view to data
      *
      * This view is only holding a points to real data, copying the view is cheap.
@@ -29,6 +30,23 @@ namespace alpaka
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment = Alignment<>>
+    struct View;
+
+    inline constexpr auto makeView(auto&& any)
+    {
+        return View{
+            getApi(any),
+            onHost::data(any),
+            onHost::getExtents(any),
+            onHost::getPitches(any),
+            alpaka::getAlignment(any)};
+    }
+
+    template<
+        typename T_Api,
+        typename T_Type,
+        alpaka::concepts::Vector T_Extents,
+        alpaka::concepts::Alignment T_MemAlignment>
     struct View : MdSpan<T_Type, typename T_Extents::UniVec, typename T_Extents::UniVec, T_MemAlignment>
     {
     private:
@@ -96,7 +114,7 @@ namespace alpaka
          */
         constexpr auto getSubView(alpaka::concepts::Vector auto const& extents) const
         {
-            assert(extents <= this->getExtents());
+            assert((extents <= this->getExtents()).reduce(std::logical_and{}));
             return View{T_Api{}, this->data(), extents, this->getPitches(), T_MemAlignment{}};
         }
 
@@ -111,7 +129,7 @@ namespace alpaka
             alpaka::concepts::Vector auto const& offset,
             alpaka::concepts::Vector auto const& extents) const
         {
-            assert(offset + extents <= this->getExtents());
+            assert((extents <= this->getExtents()).reduce(std::logical_and{}));
             auto shiftedPtr = &getMdSpan()[offset];
             return View{T_Api{}, shiftedPtr, extents, this->getPitches(), Alignment<>{}};
         }

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -42,6 +42,11 @@ namespace alpaka::onHost
             return m_queue.get();
         }
 
+        constexpr auto getApi() const
+        {
+            return alpaka::internal::getApi(*m_queue.get());
+        }
+
         void _()
         {
             static_assert(internal::concepts::Queue<element_type>);
@@ -154,14 +159,14 @@ namespace alpaka::onHost
      * @{
      */
     template<typename T_Device>
-    inline auto memset(Queue<T_Device> const& queue, auto&& dest, uint8_t byteValue)
+    inline void memset(Queue<T_Device> const& queue, auto&& dest, uint8_t byteValue)
     {
         return memset(queue, ALPAKA_FORWARD(dest), byteValue, internal::getExtents(dest));
     }
 
     /** @param extents M-dimensional data extents in elements, can be smaller than the container capacity */
     template<typename T_Device>
-    inline auto memset(
+    inline void memset(
         Queue<T_Device> const& queue,
         auto&& dest,
         uint8_t byteValue,
@@ -172,6 +177,48 @@ namespace alpaka::onHost
             std::decay_t<decltype(*queue.get())>,
             std::decay_t<decltype(dest)>,
             std::decay_t<decltype(extentsVec)>>{}(*queue.get(), ALPAKA_FORWARD(dest), byteValue, extentsVec);
+    }
+
+    /** @} */
+
+    /** fill memory element wise
+     *
+     * @param dest can be a container/view where the data should be written to
+     *             The caller should ensure that the memory is valid until the operation is completed not until the
+     *             execution handle is given back because alpaka is not extending the life-time until the operation
+     *             is finished.
+     * @param elementValue value to be written to each element
+     *
+     * @{
+     */
+    template<typename T_Device, typename T_Value>
+    inline void fill(Queue<T_Device> const& queue, auto&& dest, T_Value elementValue)
+        requires std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
+                 && std::same_as<
+                     ALPAKA_TYPEOF(alpaka::internal::getApi(queue)),
+                     ALPAKA_TYPEOF(alpaka::internal::getApi(dest))>
+    {
+        return fill(queue, ALPAKA_FORWARD(dest), elementValue, internal::getExtents(dest));
+    }
+
+    /** @param extents M-dimensional data extents in elements, can be smaller than the container capacity */
+    template<typename T_Device, typename T_Value>
+    inline void fill(
+        Queue<T_Device> const& queue,
+        auto&& dest,
+        T_Value elementValue,
+        alpaka::concepts::VectorOrScalar auto const& extents)
+        requires std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
+                 && std::same_as<
+                     ALPAKA_TYPEOF(alpaka::internal::getApi(queue)),
+                     ALPAKA_TYPEOF(alpaka::internal::getApi(dest))>
+    {
+        Vec const extentsVec = extents;
+        return internal::Fill::Op<
+            ALPAKA_TYPEOF(*queue.get()),
+            ALPAKA_TYPEOF(dest),
+            ALPAKA_TYPEOF(elementValue),
+            ALPAKA_TYPEOF(extentsVec)>{}(*queue.get(), ALPAKA_FORWARD(dest), elementValue, extentsVec);
     }
 
     /** @} */

--- a/include/alpaka/onHost/internal.hpp
+++ b/include/alpaka/onHost/internal.hpp
@@ -243,6 +243,15 @@ namespace alpaka::onHost
             };
         };
 
+        struct Fill
+        {
+            template<typename T_Queue, typename T_Dest, typename T_Value, typename T_Extents>
+            struct Op
+            {
+                void operator()(T_Queue& queue, auto&&, T_Value, T_Extents const&) const;
+            };
+        };
+
         struct GetDeviceProperties
         {
             template<typename T_Any>

--- a/tests/unit/queue/kernelMD.cpp
+++ b/tests/unit/queue/kernelMD.cpp
@@ -59,6 +59,9 @@ void validate(auto& queue, auto& device, auto exec, auto testCase)
 
     auto hBuff = onHost::allocHostMirror(dBuff);
 
+    // fill with non-zero values
+    onHost::fill(queue, dBuff, extentMd);
+
     wait(queue);
     auto frameSize = testCase.m_frameSize;
     queue.enqueue(

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -325,6 +325,14 @@ TEMPLATE_LIST_TEST_CASE("memcpy", "", TestApis)
 
     // test rvalue
     onHost::memcpy(queue, TestMdSpan{dBuff.getView()}, TestMdSpan{hBuff.getView()});
+
+    // check fill
+    onHost::fill(queue, TestMdSpan{dBuff.getView()}, size_t{42u});
+    onHost::memcpy(queue, TestMdSpan{hBuff.getView()}, TestMdSpan{dBuff.getView()});
+    onHost::wait(queue);
+    meta::ndLoopIncIdx(problemSize, [&](auto idx) { CHECK(hBuff[idx] == size_t{42}); });
+
+    // check memset
     onHost::memset(queue, TestMdSpan{dBuff.getView()}, 0u);
     onHost::memcpy(queue, TestMdSpan{hBuff.getView()}, TestMdSpan{dBuff.getView()});
     onHost::wait(queue);
@@ -336,6 +344,8 @@ TEMPLATE_LIST_TEST_CASE("memcpy", "", TestApis)
 
     onHost::memcpy(queue, TestMdSpan{dBuff.getView()}, TestMdSpan{hBuff.getView()});
     onHost::wait(queue);
+
+    // overwrite host values to be sure that memcpy later on updates the host values
     for(auto& v : hBuff)
         v = 42;
 
@@ -346,6 +356,13 @@ TEMPLATE_LIST_TEST_CASE("memcpy", "", TestApis)
     onHost::wait(queue);
     meta::ndLoopIncIdx(problemSize, [&](auto idx) { CHECK(hBuff[idx] == linearize(problemSize, idx)); });
 
+    // check fill
+    onHost::fill(queue, dlvalue, size_t{42u});
+    onHost::memcpy(queue, hlvalue, dlvalue);
+    onHost::wait(queue);
+    meta::ndLoopIncIdx(problemSize, [&](auto idx) { CHECK(hBuff[idx] == size_t{42}); });
+
+    // check memset
     onHost::memset(queue, dlvalue, 0u);
     onHost::memcpy(queue, hlvalue, dlvalue);
     onHost::wait(queue);


### PR DESCRIPTION
- Provide `onHost::fill()` to fill memory element-wise.
- add `alpaka::getAlignment()
- `Vec` - `Copy the reduce implementation from `Simd` to `Vec` to simplify multidimensional comparison and asserts.
- `Simd` fix alignment for cases where e.g. MdSpan holts combond time e.g. `Vec<float,3>` where the size will by 12 bytes the alignment was not a power of 2 and fallback to `sizeof(Vec<float,3>)` is not allowed.
- fix alpaka::apply gcc 11 compile issue