### PR TITLE
fix type in variable name

### DIFF
--- a/include/alpaka/api/host/Api.hpp
+++ b/include/alpaka/api/host/Api.hpp
@@ -93,7 +93,7 @@ namespace alpaka
         {
             constexpr auto operator()(T_Acc const&, api::Host, deviceKind::Cpu) const
             {
-                return layout::Contigious{};
+                return layout::Contiguous{};
             }
         };
     } // namespace onAcc::internal::trait

--- a/include/alpaka/api/oneApi/Api.hpp
+++ b/include/alpaka/api/oneApi/Api.hpp
@@ -139,7 +139,7 @@ namespace alpaka
         {
             constexpr auto operator()(T_Acc const&, api::OneApi, deviceKind::Cpu) const
             {
-                return layout::Contigious{};
+                return layout::Contiguous{};
             }
         };
     } // namespace onAcc::internal::trait

--- a/include/alpaka/mem/FlatIdxContainer.hpp
+++ b/include/alpaka/mem/FlatIdxContainer.hpp
@@ -214,7 +214,7 @@ namespace alpaka::onAcc
 
                 return const_iterator(begin, linearCurrent, linearStride, extentMD.product(), extentMD, strideMD);
             }
-            else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contigious>)
+            else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contiguous>)
             {
                 auto groupOffset = threadIdx * m_idxRange.m_stride;
                 groupOffset.ref(selectedDims) -= groupOffset[selectedDims];
@@ -248,7 +248,7 @@ namespace alpaka::onAcc
                 auto extentMD = divCeil(m_idxRange.distance()[selectedDims], m_idxRange.m_stride[selectedDims]);
                 return const_iterator_end(extentMD.product());
             }
-            else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contigious>)
+            else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contiguous>)
             {
                 auto strideMD = m_idxRange.m_stride[selectedDims];
                 auto numElements = divCeil(

--- a/include/alpaka/mem/Iter.hpp
+++ b/include/alpaka/mem/Iter.hpp
@@ -45,7 +45,7 @@ namespace alpaka::onAcc
         };
 
         template<>
-        struct IsIdxMapping<layout::Contigious> : std::true_type
+        struct IsIdxMapping<layout::Contiguous> : std::true_type
         {
         };
 

--- a/include/alpaka/mem/TiledIdxContainer.hpp
+++ b/include/alpaka/mem/TiledIdxContainer.hpp
@@ -258,7 +258,7 @@ namespace alpaka::onAcc
                     m_idxRange.distance(),
                     numThreads * m_idxRange.m_stride);
             }
-            else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contigious>)
+            else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contiguous>)
             {
                 auto extent = m_idxRange.distance();
                 auto numElements = divCeil(extent, m_idxRange.m_stride * numThreads);
@@ -281,7 +281,7 @@ namespace alpaka::onAcc
             {
                 return const_iterator_end(m_idxRange.m_begin + m_idxRange.distance());
             }
-            else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contigious>)
+            else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contiguous>)
             {
                 auto extent = m_idxRange.distance();
                 auto numElements = divCeil(extent, m_idxRange.m_stride * numThreads);

--- a/include/alpaka/onAcc/layout.hpp
+++ b/include/alpaka/onAcc/layout.hpp
@@ -16,11 +16,11 @@ namespace alpaka::onAcc
         constexpr auto strided = Strided{};
 
         /** Indices will be contiguous within each dimension for each worker thread. */
-        struct Contigious
+        struct Contiguous
         {
         };
 
-        constexpr auto contigious = Contigious{};
+        constexpr auto contiguous = Contiguous{};
 
         /** The index layout will automatically selected based on the executor. */
         struct Optimized

--- a/tests/unit/block/block.cpp
+++ b/tests/unit/block/block.cpp
@@ -30,7 +30,7 @@ struct BlockIotaKernel
                 onAcc::worker::blocksInGrid,
                 IdxRange{ALPAKA_TYPEOF(numBlocks)::all(0), numBlocks * numDataElemInBlock, numDataElemInBlock},
                 onAcc::traverse::tiled,
-                onAcc::layout::contigious))
+                onAcc::layout::contiguous))
         {
             auto blockOffset = blockIdx;
             for(auto inBlockOffset : onAcc::makeIdxMap(


### PR DESCRIPTION
Rename `contigious` to `contiguous`