### PR TITLE
add `onHost::concucctent()`

### DIFF
--- a/include/alpaka/SimdPtr.hpp
+++ b/include/alpaka/SimdPtr.hpp
@@ -146,11 +146,18 @@ namespace alpaka
          * @{
          */
         template<typename T_Storage>
-        constexpr void storeTo(Simd<value_type, SimdPtr::width(), T_Storage> const& rhs)
+        constexpr void storeTo(Simd<value_type, SimdPtr::width(), T_Storage> const& rhs) const
         {
             auto* ptr = &T_MdSpan::operator[](m_idx);
 
             rhs.copyTo(ptr, getAlignment());
+        }
+
+        template<typename T_Storage>
+        constexpr SimdPtr const& operator=(Simd<value_type, SimdPtr::width(), T_Storage> const& rhs) const
+        {
+            storeTo(rhs);
+            return *this;
         }
 
         template<typename T_Storage>

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -35,6 +35,7 @@
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/onHost/DeviceSelector.hpp"
 #include "alpaka/onHost/Queue.hpp"
+#include "alpaka/onHost/algo/concurrent.hpp"
 #include "alpaka/onHost/algo/transform.hpp"
 #include "alpaka/onHost/mem/stdContainer.hpp"
 #include "alpaka/tag.hpp"

--- a/include/alpaka/onHost/algo/concurrent.hpp
+++ b/include/alpaka/onHost/algo/concurrent.hpp
@@ -1,0 +1,76 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/trait.hpp"
+#include "alpaka/onHost/algo/internal/concurrent.hpp"
+
+namespace alpaka::onHost
+{
+    /** Execute a n-nary function on each element of all input data.
+     *
+     * Concurrent is is quite equal to a for-each algorithm with the difference that the functor is allowed to write to
+     * any argument. So it allows to implement a transform with a free number of output arguments.
+     *
+     * @param queue The queue to execute the transformation.
+     * @param exec The executor to use for the kernel execution.
+     * @param extentMd multi dimensional number of elements
+     * @param fn The function to apply to each element of the input data.
+     *   The functor should support Simd packages. If not you can enforce the element wise execution by wrapping into
+     * @see ScalarFunc. If you would like to support stencil executions wrapp fn into @see StencilFunc. StencilFunc is
+     * getting all arguments as @see SimdPtr. If StencilFunc is used you should take care to not read outside of valid
+     * memory ranges by using sub-views to your input and output data. Optionally a fn can have a accelerator as first
+     * argument.
+     * @param inOut The input/output data, all data is passed to fn.
+     *
+     * examples for a unary add one functor:
+     * @code{.cpp}
+     *   struct Foo {
+     *      constexpr auto operator()(onAcc::concepts::Acc auto const&, concepts::SimdPtr auto const& a) const {
+     *          a = a.load() + 1;
+     *      }
+     *   };
+     *   struct Bar {
+     *      constexpr auto operator()(concepts::SimdPtr auto const& a) const {
+     *          a = a.load() + 1;
+     *      }
+     *   };
+     * @endcode
+     *
+     * @{
+     */
+    template<typename T_DataType, typename T_Device>
+    inline void concurrent(
+        Queue<T_Device> const& queue,
+        alpaka::concepts::Executor auto const exec,
+        alpaka::concepts::Vector auto const& extentMd,
+        auto&& fn,
+        auto&&... inOut)
+    {
+        internal::concurrent<T_DataType>(queue, exec, extentMd, ALPAKA_FORWARD(fn), ALPAKA_FORWARD(inOut)...);
+    }
+
+    /**
+     * A available default executor will be selected automaticlally. The default executor is a executor with most
+     * parallelism/performance.
+     */
+    template<typename T_DataType, typename T_Device>
+    inline void transform(
+        Queue<T_Device> const& queue,
+        alpaka::concepts::Vector auto const& extentMd,
+        auto&& fn,
+        auto&&... inOut)
+    {
+        auto executor = supportedMappings(queue.getDevice());
+        internal::concurrent<T_DataType>(
+            queue,
+            std::get<0>(executor),
+            extentMd,
+            ALPAKA_FORWARD(fn),
+            ALPAKA_FORWARD(inOut)...);
+    }
+
+    /** @} */
+} // namespace alpaka::onHost

--- a/include/alpaka/onHost/algo/internal/concurrent.hpp
+++ b/include/alpaka/onHost/algo/internal/concurrent.hpp
@@ -1,0 +1,59 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+
+#include "alpaka/Simd.hpp"
+#include "alpaka/Vec.hpp"
+#include "alpaka/core/common.hpp"
+#include "alpaka/functor.hpp"
+#include "alpaka/mem/MdSpan.hpp"
+#include "alpaka/onAcc/Acc.hpp"
+#include "alpaka/onAcc/SimdAlgo.hpp"
+#include "alpaka/onHost.hpp"
+#include "alpaka/trait.hpp"
+
+namespace alpaka::onHost::internal
+{
+    struct SimdConcurrentKernel
+    {
+        ALPAKA_FN_ACC void operator()(
+            onAcc::concepts::Acc auto const& acc,
+            alpaka::concepts::Vector auto const& extentMd,
+            auto const& func,
+            alpaka::concepts::MdSpan auto&&... inputs) const
+        {
+            auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
+
+            return simdGrid.concurrent(
+                acc,
+                extentMd,
+                [&func](auto const& acc, auto&&... in)
+                {
+                    static_assert(
+                        std::same_as<decltype(callFunctor(acc, func, ALPAKA_FORWARD(in)...)), void>,
+                        "The return type for a stencil concurrent functor should be void.");
+                    callFunctor(acc, func, ALPAKA_FORWARD(in)...);
+                },
+                ALPAKA_FORWARD(inputs)...);
+        }
+    };
+
+    template<typename T_DataType>
+    inline void concurrent(
+        auto const& queue,
+        alpaka::concepts::Executor auto const exec,
+        alpaka::concepts::Vector auto const& extentMd,
+        auto&& fn,
+        auto&&... in)
+    {
+        auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), extentMd);
+
+        queue.enqueue(
+            exec,
+            frameSpec,
+            KernelBundle{SimdConcurrentKernel{}, extentMd, ALPAKA_FORWARD(fn), ALPAKA_FORWARD(in)...});
+    }
+} // namespace alpaka::onHost::internal

--- a/include/alpaka/onHost/algo/internal/transform.hpp
+++ b/include/alpaka/onHost/algo/internal/transform.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 René Widera
+/* Copyright 2025 René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/include/alpaka/onHost/algo/transform.hpp
+++ b/include/alpaka/onHost/algo/transform.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 René Widera
+/* Copyright 2025 René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/tests/unit/algorithm/concurrent.cpp
+++ b/tests/unit/algorithm/concurrent.cpp
@@ -1,0 +1,152 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executeForEach.hpp>
+#include <alpaka/example/executors.hpp>
+#include <alpaka/meta/CartesianProduct.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <type_traits>
+
+using namespace alpaka;
+
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis))>;
+
+/** Stencil SIMD functor
+ *
+ * The stencil functor is getting a SimdPtr as input which allows to call the operator[] to change the index.
+ * In this test we do not shift the memory to avoid out of memory access.
+ * We cannot use generic lambdas with CUDA therefor we need to write a functor.
+ */
+struct StencilAddWithAcc
+{
+    constexpr void operator()(
+        onAcc::concepts::Acc auto const&,
+        concepts::SimdPtr auto const& a,
+        concepts::SimdPtr auto const& b) const
+    {
+        a = a.load() + b.load();
+    }
+};
+
+struct StencilAddMin
+{
+    constexpr void operator()(concepts::SimdPtr auto a, concepts::SimdPtr auto const& b) const
+    {
+        constexpr uint32_t simdWidth = a.width();
+        alpaka::concepts::Simd auto aSimd = a.load();
+        alpaka::concepts::Simd auto bSimd = b.load();
+        for(uint32_t idx = 0u; idx < simdWidth; ++idx)
+            aSimd[idx] += math::min(aSimd[idx], bSimd[idx]);
+        // write result back to a
+        a = aSimd;
+    }
+};
+
+/**
+ * @param functorPair all functors should write the results to the first argument
+ */
+template<typename T_DataType>
+void executeTest(
+    concepts::Executor auto exec,
+    auto const& computeQueue,
+    auto const functorPair,
+    concepts::Vector auto extentMd)
+{
+    std::cout << "run func : " << core::demangledName(functorPair.second) << std::endl;
+
+    auto computeDev = computeQueue.getDevice();
+    using DataType = T_DataType;
+    onHost::ManagedView computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::ManagedView computeViewIn1 = onHost::allocMirror(computeDev, computeViewIn0);
+    onHost::ManagedView hostViewIota = onHost::allocMirror(onHost::makeHostDevice(), computeViewIn0);
+    onHost::ManagedView hostViewOut = onHost::allocMirror(onHost::makeHostDevice(), computeViewIn0);
+
+    // initialize with the linearized index
+    DataType iotaCounter = 0;
+    for(auto& value : hostViewIota)
+    {
+        value = iotaCounter;
+        ++iotaCounter;
+    }
+
+    onHost::memcpy(computeQueue, computeViewIn0, hostViewIota);
+    onHost::memcpy(computeQueue, computeViewIn1, hostViewIota);
+
+    onHost::wait(computeQueue);
+    auto const beginT = std::chrono::high_resolution_clock::now();
+
+    onHost::concurrent<DataType>(computeQueue, exec, extentMd, functorPair.first, computeViewIn0, computeViewIn1);
+
+    onHost::wait(computeQueue);
+    auto const endT = std::chrono::high_resolution_clock::now();
+    std::cout << "Time for concurrent: " << std::chrono::duration<double>(endT - beginT).count() << 's'
+              << " data size: " << extentMd << std::endl;
+
+    onHost::memcpy(computeQueue, hostViewOut, computeViewIn0);
+    onHost::wait(computeQueue);
+
+    // validate without using the forward iterator
+    DataType refIotaCounter = 0;
+    meta::ndLoopIncIdx(
+        extentMd,
+        [&](auto idx)
+        {
+            CHECK(hostViewOut[idx] == functorPair.second(refIotaCounter, refIotaCounter));
+            ++refIotaCounter;
+        });
+};
+
+template<typename T_DataType>
+void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTuples)
+{
+    using DataType = T_DataType;
+
+    auto deviceSpec = cfg[object::deviceSpec];
+    alpaka::concepts::Executor auto exec = cfg[object::exec];
+
+    auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!computeDevSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device computeDev = computeDevSelector.makeDevice(0);
+
+    std::cout << "device spec: " << getName(deviceSpec) << std::endl;
+    std::cout << "device name: " << computeDev.getName() << std::endl;
+    std::cout << "executor   : " << exec.getName() << std::endl;
+
+    onHost::Queue computeQueue = computeDev.makeQueue();
+
+    // execute for each functor
+    std::apply(
+        [&](auto const&... functorPair) { (executeTest<DataType>(exec, computeQueue, functorPair, extentMd), ...); },
+        functorTuples);
+}
+
+TEMPLATE_LIST_TEST_CASE("concurrent", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    using DataType = int;
+
+    // This list is not directly defined within the function `prepareTest()` due to nvcc compile issues.
+    auto functorList = std::make_tuple(
+        std::make_pair(StencilAddWithAcc{}, std::plus{}),
+        std::make_pair(StencilAddMin{}, [](DataType const& a, DataType const& b) { return a + math::min(a, b); }));
+
+    // different extents for testing
+    auto extentMdList
+        = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
+
+    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, functorList), ...); }, extentMdList);
+}

--- a/tests/unit/algorithm/transform.cpp
+++ b/tests/unit/algorithm/transform.cpp
@@ -146,7 +146,6 @@ void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTu
         functorTuples);
 }
 
-/** Test that memcpy and memset can be called with non copy-able and move-able data as lvalue and rvalue. */
 TEMPLATE_LIST_TEST_CASE("transform", "", TestBackends)
 {
     auto cfg = TestType::makeDict();


### PR DESCRIPTION
- Expose the concurrent algorithm to the host side.
- Add test case.


The first commit provides the functionality that `SimdPtr` is writable if the instance is const.