### PR TITLE
add Tuple

### DIFF
--- a/include/alpaka/KernelBundle.hpp
+++ b/include/alpaka/KernelBundle.hpp
@@ -4,9 +4,13 @@
 
 #pragma once
 
+#include "alpaka/apply.hpp"
+#include "alpaka/core/Dict.hpp"
 #include "alpaka/core/RemoveRestrict.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/config.hpp"
+#include "alpaka/trait.hpp"
+#include "alpaka/utility.hpp"
 
 #include <alpaka/mem/concepts.hpp>
 
@@ -60,13 +64,22 @@ namespace alpaka
         using KernelFn = std::decay_t<TKernelFn>;
         //! Tuple type to encapsulate kernel function argument types and argument values
         using ArgTuple
-            = std::tuple<remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>...>;
+            = alpaka::Tuple<remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>...>;
 
         // Constructor
         constexpr KernelBundle(KernelFn const& kernelFn, auto&&... args)
             : m_kernelFn{kernelFn}
             , m_args(onHost::makeAccessibleOnAcc(ALPAKA_FORWARD(args))...)
         {
+            static_assert(
+                alpaka::concepts::KernelFn<KernelFn>,
+                "Kernel functor must be trivially copyable or specialize trait::IsKernelTriviallyCopyable<>!");
+            static_assert(
+                (alpaka::concepts::KernelArg<
+                     remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>>
+                 && ...),
+                "All kernel arguments must be trivially copyable or specialize "
+                "trai::IsKernelArgumentTriviallyCopyable<>!");
         }
 
         constexpr KernelBundle(KernelBundle const& b) = default;
@@ -85,13 +98,19 @@ namespace alpaka
         /** @} */
 
         template<typename TAcc>
-        requires(std::invocable<
-                 KernelFn,
-                 TAcc,
-                 remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>...>)
+        requires(
+            alpaka::concepts::KernelFn<KernelFn>
+            && std::same_as<
+                void,
+                std::invoke_result_t<
+                    KernelFn,
+                    TAcc,
+                    remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>...>>)
         constexpr auto operator()(TAcc const& acc) const
         {
-            std::apply([&](auto const&... args) constexpr { m_kernelFn(acc, args...); }, m_args);
+            alpaka::apply(
+                [&](alpaka::concepts::KernelArg auto const&... args) constexpr { m_kernelFn(acc, args...); },
+                m_args);
         }
 
         KernelFn m_kernelFn;

--- a/include/alpaka/Tuple.hpp
+++ b/include/alpaka/Tuple.hpp
@@ -1,0 +1,113 @@
+/* Copyright 2025 Tapish Narwal, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/common.hpp"
+#include "alpaka/utility.hpp"
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace alpaka
+{
+    template<typename... T_Args>
+    struct Tuple;
+
+    namespace detail
+    {
+        template<std::size_t I, typename T>
+        struct TupleLeaf
+        {
+            using type = T;
+            T value;
+        };
+
+        template<typename IndexSequence, typename... T_Args>
+        struct TupleImpl;
+
+        template<std::size_t... Is, typename... T_Args>
+        struct TupleImpl<std::index_sequence<Is...>, T_Args...> : TupleLeaf<Is, T_Args>...
+        {
+            template<typename... T_CArgs>
+            constexpr TupleImpl(T_CArgs&&... us) noexcept((std::is_nothrow_constructible_v<T_Args, T_CArgs&&> && ...))
+                : TupleLeaf<Is, T_Args>{std::forward<T_CArgs>(us)}...
+            {
+            }
+        };
+    } // namespace detail
+
+    /** basic tuple implementation
+     *
+     * This class is trivially copyable if all members are trivially copable too and can therefore used for a
+     * collection to pass arguments into kernels. You should use @see alpaka::apply to apply operation to the tuple.
+     */
+    template<typename... T_Args>
+    struct Tuple : detail::TupleImpl<std::make_index_sequence<sizeof...(T_Args)>, T_Args...>
+    {
+        using StdTuple = std::tuple<T_Args...>;
+        using Base = detail::TupleImpl<std::make_index_sequence<sizeof...(T_Args)>, T_Args...>;
+
+        template<typename... T_CArgs>
+        requires(
+            sizeof...(T_Args) == sizeof...(T_CArgs) && sizeof...(T_Args) > 0
+            && (!std::is_same_v<std::remove_cvref_t<std::tuple_element_t<0, std::tuple<T_CArgs...>>>, Tuple>)
+            && (std::is_constructible_v<T_Args, T_CArgs&&> && ...))
+        constexpr Tuple(T_CArgs&&... us) noexcept((std::is_nothrow_constructible_v<T_Args, T_CArgs&&> && ...))
+            : Base(std::forward<T_CArgs>(us)...)
+        {
+        }
+
+        /** get element by index
+         *
+         * @tparam I index which should not be larger than the number of elements -1
+         * @{
+         */
+        template<size_t I>
+        constexpr auto const& get() const
+        {
+            static_assert(I < sizeof...(T_Args), "Index is outside of the allowed range.");
+            return static_cast<detail::TupleLeaf<I, std::tuple_element_t<I, StdTuple>> const&>(*this).value;
+        }
+
+        template<size_t I>
+        constexpr auto const& get()
+        {
+            static_assert(I < sizeof...(T_Args), "Index is outside of the allowed range.");
+            return static_cast<detail::TupleLeaf<I, std::tuple_element_t<I, StdTuple>>&>(*this).value;
+        }
+
+        /** @} */
+    };
+
+    template<typename... T_Args>
+    Tuple(T_Args&&...) -> Tuple<T_Args...>;
+
+    template<size_t T_idx>
+    constexpr decltype(auto) get(auto&& t) noexcept requires(alpaka::isSpecializationOf_v<ALPAKA_TYPEOF(t), Tuple>)
+    {
+        return ALPAKA_FORWARD(t).template get<T_idx>();
+    }
+
+    constexpr auto makeTuple(auto&&... args)
+    {
+        return Tuple{ALPAKA_FORWARD(args)...};
+    }
+} // namespace alpaka
+
+namespace std
+{
+    // Specialization of tuple_size for our custom Tuple
+    template<typename... T_Args>
+    struct tuple_size<alpaka::Tuple<T_Args...>> : std::integral_constant<std::size_t, sizeof...(T_Args)>
+    {
+    };
+
+    template<std::size_t I, typename... T_Args>
+    struct tuple_element<I, alpaka::Tuple<T_Args...>>
+    {
+        using type = typename std::tuple_element_t<I, typename alpaka::Tuple<T_Args...>::StdTuple>;
+    };
+} // namespace std

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -16,7 +16,6 @@
 #include "alpaka/core/DemangleTypeNames.hpp"
 #include "alpaka/core/Dict.hpp"
 #include "alpaka/core/Tag.hpp"
-#include "alpaka/core/Utility.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/interface.hpp"
@@ -39,3 +38,4 @@
 #include "alpaka/onHost/algo/transform.hpp"
 #include "alpaka/onHost/mem/stdContainer.hpp"
 #include "alpaka/tag.hpp"
+#include "utility.hpp"

--- a/include/alpaka/api/cuda/Api.hpp
+++ b/include/alpaka/api/cuda/Api.hpp
@@ -7,9 +7,9 @@
 
 #include "alpaka/api/unifiedCudaHip/trait.hpp"
 #include "alpaka/concepts.hpp"
-#include "alpaka/core/Utility.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/onHost/trait.hpp"
+#include "alpaka/utility.hpp"
 
 #include <memory>
 #include <sstream>

--- a/include/alpaka/api/hip/Api.hpp
+++ b/include/alpaka/api/hip/Api.hpp
@@ -7,9 +7,9 @@
 
 #include "alpaka/api/unifiedCudaHip/trait.hpp"
 #include "alpaka/concepts.hpp"
-#include "alpaka/core/Utility.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/onHost/trait.hpp"
+#include "alpaka/utility.hpp"
 
 #include <memory>
 #include <sstream>

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -7,7 +7,6 @@
 #include "alpaka/api/host/Api.hpp"
 #include "alpaka/api/host/Queue.hpp"
 #include "alpaka/api/host/sysInfo.hpp"
-#include "alpaka/core/Utility.hpp"
 #include "alpaka/core/alignedAlloc.hpp"
 #include "alpaka/internal.hpp"
 #include "alpaka/onHost.hpp"
@@ -17,6 +16,7 @@
 #include "alpaka/onHost/Queue.hpp"
 #include "alpaka/onHost/mem/ManagedView.hpp"
 #include "alpaka/onHost/trait.hpp"
+#include "alpaka/utility.hpp"
 
 #include <cstdint>
 #include <memory>

--- a/include/alpaka/api/host/cpuArchSize.hpp
+++ b/include/alpaka/api/host/cpuArchSize.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "alpaka/core/Utility.hpp"
+#include "alpaka/utility.hpp"
 
 #include <cstdint>
 #include <new>

--- a/include/alpaka/api/oneApi/Api.hpp
+++ b/include/alpaka/api/oneApi/Api.hpp
@@ -8,9 +8,9 @@
 #include "alpaka/api/syclGeneric/Api.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/concepts.hpp"
-#include "alpaka/core/Utility.hpp"
 #include "alpaka/mem/trait.hpp"
 #include "alpaka/onHost/trait.hpp"
+#include "alpaka/utility.hpp"
 
 #include <string>
 

--- a/include/alpaka/api/unifiedCudaHip/atomicBuiltIn.hpp
+++ b/include/alpaka/api/unifiedCudaHip/atomicBuiltIn.hpp
@@ -4,10 +4,10 @@
 
 #pragma once
 
-#include "alpaka/core/Utility.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/onAcc/atomicHierarchy.hpp"
 #include "alpaka/onAcc/atomicOp.hpp"
+#include "alpaka/utility.hpp"
 
 #include <type_traits>
 

--- a/include/alpaka/core/Dict.hpp
+++ b/include/alpaka/core/Dict.hpp
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include "alpaka/Tuple.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/util.hpp"
+#include "alpaka/utility.hpp"
 
 #include <cstdio>
 #include <tuple>
@@ -26,7 +28,11 @@ namespace alpaka
         template<std::size_t... idx>
         static constexpr ssize_t find_idx(std::index_sequence<idx...>)
         {
-            return -1 + static_cast<ssize_t>(((std::is_same<X, typename T::KeyType>::value ? idx + 1 : 0) + ...));
+            ssize_t found_idx = -1;
+            // notUsed is required to avoid warning that the expression is not used
+            [[maybe_unused]] bool notUsed
+                = ((std::is_same_v<X, typename T::KeyType> && (found_idx = idx, true)) || ...);
+            return found_idx;
         }
 
     public:
@@ -65,7 +71,7 @@ namespace alpaka
         constexpr auto idx = Idx<T_Key, std::decay_t<T_Tuple>>::value;
         static_assert(idx != -1, "Member in dict missing!");
         static_assert(idx < std::tuple_size_v<std::decay_t<T_Tuple>>, "index out of range!");
-        return unWrapp(std::get<idx>(std::forward<T_Tuple>(t)).value);
+        return unWrapp(get<idx>(std::forward<T_Tuple>(t)).value);
     }
 
     template<typename T_Key, typename T_Value>
@@ -103,15 +109,16 @@ namespace alpaka
     };
 
     template<typename... T_Keys, typename... T_Values>
-    struct Dict<DictEntry<T_Keys, T_Values>...> : std::tuple<DictEntry<T_Keys, T_Values>...>
+    struct Dict<DictEntry<T_Keys, T_Values>...> : Tuple<DictEntry<T_Keys, T_Values>...>
     {
-        constexpr Dict(std::tuple<DictEntry<T_Keys, T_Values>...> const& data)
-            : std::tuple<DictEntry<T_Keys, T_Values>...>{data}
+        using TupleType = Tuple<DictEntry<T_Keys, T_Values>...>;
+
+        constexpr Dict(Tuple<DictEntry<T_Keys, T_Values>...> const& data) : Tuple<DictEntry<T_Keys, T_Values>...>{data}
         {
         }
 
         constexpr Dict(DictEntry<T_Keys, T_Values> const&... dictEntries)
-            : std::tuple<DictEntry<T_Keys, T_Values>...>{dictEntries...}
+            : Tuple<DictEntry<T_Keys, T_Values>...>{dictEntries...}
         {
         }
 
@@ -120,7 +127,7 @@ namespace alpaka
 
         static constexpr auto makeDict() requires(std::default_initializable<T_Values>, ...)
         {
-            return Dict{std::make_tuple(DictEntry<T_Keys, T_Values>{}...)};
+            return Dict{alpaka::makeTuple(DictEntry<T_Keys, T_Values>{}...)};
         }
 
         ALPAKA_NO_HOST_ACC_WARNING
@@ -136,9 +143,21 @@ namespace alpaka
         }
     };
 
+    template<size_t T_idx>
+    constexpr decltype(auto) get(auto& t) noexcept requires(alpaka::isSpecializationOf_v<ALPAKA_TYPEOF(t), Dict>)
+    {
+        return t.template get<T_idx>();
+    }
+
+    template<size_t T_idx>
+    constexpr decltype(auto) get(auto const& t) noexcept requires(alpaka::isSpecializationOf_v<ALPAKA_TYPEOF(t), Dict>)
+    {
+        return t.template get<T_idx>();
+    }
+
     // type deduction guide
     template<typename... T_Keys, typename... T_Values>
-    ALPAKA_FN_HOST_ACC Dict(std::tuple<DictEntry<T_Keys, T_Values>...> const&) -> Dict<DictEntry<T_Keys, T_Values>...>;
+    ALPAKA_FN_HOST_ACC Dict(Tuple<DictEntry<T_Keys, T_Values>...> const&) -> Dict<DictEntry<T_Keys, T_Values>...>;
 
     template<typename... T_Keys, typename... T_Values>
     ALPAKA_FN_HOST_ACC Dict(DictEntry<T_Keys, T_Values> const&...) -> Dict<DictEntry<T_Keys, T_Values>...>;
@@ -156,7 +175,7 @@ namespace std
     template<std::size_t I, typename... T_Keys, typename... T_Values>
     struct tuple_element<I, alpaka::Dict<alpaka::DictEntry<T_Keys, T_Values>...>>
     {
-        using type = decltype(std::get<I>(std::declval<std::tuple<alpaka::DictEntry<T_Keys, T_Values>...>>()));
+        using type = decltype(alpaka::get<I>(std::declval<alpaka::Tuple<alpaka::DictEntry<T_Keys, T_Values>...>>()));
     };
 } // namespace std
 
@@ -170,7 +189,7 @@ namespace alpaka
         T_Dict0 dict0,
         T_Dict1 dict1)
     {
-        return Dict{std::get<idx0>(dict0)..., std::get<idx1>(dict1)...};
+        return Dict{get<idx0>(dict0)..., get<idx1>(dict1)...};
     }
 
     template<typename... T_Entries0, typename... T_Entries1>

--- a/include/alpaka/mem/FlatIdxContainer.hpp
+++ b/include/alpaka/mem/FlatIdxContainer.hpp
@@ -8,12 +8,12 @@
 #include "alpaka/api/api.hpp"
 #include "alpaka/core/Dict.hpp"
 #include "alpaka/core/PP.hpp"
-#include "alpaka/core/Utility.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/mem/IdxRange.hpp"
 #include "alpaka/mem/ThreadSpace.hpp"
 #include "alpaka/onAcc/layout.hpp"
 #include "alpaka/tag.hpp"
+#include "alpaka/utility.hpp"
 
 #include <cstdint>
 #include <functional>

--- a/include/alpaka/mem/Iter.hpp
+++ b/include/alpaka/mem/Iter.hpp
@@ -8,7 +8,6 @@
 #include "alpaka/api/api.hpp"
 #include "alpaka/core/Dict.hpp"
 #include "alpaka/core/PP.hpp"
-#include "alpaka/core/Utility.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/mem/IdxRange.hpp"
 #include "alpaka/mem/ThreadSpace.hpp"
@@ -18,6 +17,7 @@
 #include "alpaka/onAcc/tag.hpp"
 #include "alpaka/onAcc/traverse.hpp"
 #include "alpaka/tag.hpp"
+#include "alpaka/utility.hpp"
 
 #include <cstdint>
 #include <functional>

--- a/include/alpaka/mem/TiledIdxContainer.hpp
+++ b/include/alpaka/mem/TiledIdxContainer.hpp
@@ -8,12 +8,12 @@
 #include "alpaka/api/api.hpp"
 #include "alpaka/core/Dict.hpp"
 #include "alpaka/core/PP.hpp"
-#include "alpaka/core/Utility.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/mem/IdxRange.hpp"
 #include "alpaka/mem/ThreadSpace.hpp"
 #include "alpaka/onAcc/layout.hpp"
 #include "alpaka/tag.hpp"
+#include "alpaka/utility.hpp"
 
 #include <cstdint>
 #include <functional>

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -5,10 +5,10 @@
 #pragma once
 
 #include "Handle.hpp"
-#include "alpaka/core/Utility.hpp"
 #include "alpaka/onHost/Queue.hpp"
 #include "alpaka/onHost/concepts.hpp"
 #include "alpaka/onHost/internal.hpp"
+#include "alpaka/utility.hpp"
 
 #include <bit>
 #include <climits>

--- a/include/alpaka/onHost/algo/internal/transform.hpp
+++ b/include/alpaka/onHost/algo/internal/transform.hpp
@@ -45,11 +45,10 @@ namespace alpaka::onHost::internal
                     {
                         outPtr = loadAncExecuteScalarOp(
                             std::make_integer_sequence<uint32_t, ALPAKA_TYPEOF(outPtr)::width()>{},
-                            [this](
-                                alpaka::concepts::CVector auto idx,
-                                auto const& acc,
-                                auto&& func,
-                                auto&&... data) constexpr { return callFunctor(acc, func, data[idx.x()]...); },
+                            [](alpaka::concepts::CVector auto idx,
+                               auto const& acc,
+                               auto&& func,
+                               auto&&... data) constexpr { return callFunctor(acc, func, data[idx.x()]...); },
                             acc,
                             func,
                             inPtr.load()...);

--- a/include/alpaka/onHost/trait.hpp
+++ b/include/alpaka/onHost/trait.hpp
@@ -99,7 +99,7 @@ namespace alpaka::onHost
                                      std::declval<remove_restrict_t<std::decay_t<T_Args>>>()...);
                              })
                 {
-                    return std::apply(
+                    return alpaka::apply(
                         [&](auto const&... args) {
                             return BlockDynSharedMemBytes<T_KernelFn, T_Spec>{kernelBundle.m_kernelFn, spec}(
                                 executor,

--- a/include/alpaka/trait.hpp
+++ b/include/alpaka/trait.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/utility.hpp"
 #include "alpaka/vecConcepts.hpp"
 
 #include <concepts>
@@ -68,24 +69,51 @@ namespace alpaka
         {
         };
 
+        //! Check if a type used as kernel argument is trivially copyable
+        //!
+        //! \attention In case this trait is specialized for a user type the user should be sure that the result of
+        //! calling the copy constructor is equal to use memcpy to duplicate the object. An existing destructor should
+        //! be free of side effects.
+        //!
+        //! It's implementation defined whether the closure type of a lambda is trivially copyable.
+        //! Therefor the default implementation is true for trivially copyable or empty (stateless) types.
+        //!
+        //! @tparam T type to check
+        template<typename T, typename = void>
+        struct IsKernelArgumentTriviallyCopyable
+            : std::bool_constant<std::is_empty_v<T> || std::is_trivially_copyable_v<T>>
+        {
+        };
+
+        //! Check if the kernel type is trivially copyable
+        //!
+        //! \attention In case this trait is specialized for a user type the user should be sure that the result of
+        //! calling the copy constructor is equal to use memcpy to duplicate the object. An existing destructor should
+        //! be free of side effects.
+        //!
+        //! The default implementation is true for trivially copyable types (or for extended lambda expressions for
+        //! CUDA).
+        //!
+        //! @tparam T type to check
+        //! @{
+        template<typename T, typename = void>
+        struct IsKernelTriviallyCopyable
+#if ALPAKA_COMP_NVCC
+            : std::bool_constant<
+                  std::is_trivially_copyable_v<T> || __nv_is_extended_device_lambda_closure_type(T)
+                  || __nv_is_extended_host_device_lambda_closure_type(T)>
+#else
+            : std::is_trivially_copyable<T>
+#endif
+        {
+        };
     } // namespace trait
 
-    /** checks if T is a instance of U
-     *
-     * @tparam T full type specialization
-     * @tparam U unspecialized template type
-     *
-     * @return true if T is a specialization of U
-     *
-     * @{
-     */
-    template<typename T, template<typename...> typename U>
-    inline constexpr bool isSpecializationOf_v = std::false_type{};
+    template<typename T>
+    inline constexpr bool isKernelArgumentTriviallyCopyable_v = trait::IsKernelArgumentTriviallyCopyable<T>::value;
 
-    template<template<typename...> typename U, typename... Vs>
-    inline constexpr bool isSpecializationOf_v<U<Vs...>, U> = std::true_type{};
-
-    /** @} */
+    template<typename T>
+    inline constexpr bool isKernelTriviallyCopyable_v = trait::IsKernelTriviallyCopyable<T>::value;
 
     template<typename T>
     consteval uint32_t getDim([[maybe_unused]] T const& any)
@@ -102,4 +130,12 @@ namespace alpaka
     template<typename T>
     constexpr bool isMdSpan_v = trait::IsMdSpan<T>::value;
 
+    namespace concepts
+    {
+        template<typename T>
+        concept KernelFn = isKernelArgumentTriviallyCopyable_v<T>;
+
+        template<typename T>
+        concept KernelArg = isKernelArgumentTriviallyCopyable_v<T>;
+    } // namespace concepts
 } // namespace alpaka

--- a/include/alpaka/utility.hpp
+++ b/include/alpaka/utility.hpp
@@ -89,4 +89,21 @@ namespace alpaka
         return T{1} << firstSetBit(value);
     }
 
+    /** checks if T is a instance of U
+     *
+     * @tparam T full type specialization
+     * @tparam U unspecialized template type
+     *
+     * @return true if T is a specialization of U
+     *
+     * @{
+     */
+    template<typename T, template<typename...> typename U>
+    inline constexpr bool isSpecializationOf_v = std::false_type{};
+
+    template<template<typename...> typename U, typename... Vs>
+    inline constexpr bool isSpecializationOf_v<U<Vs...>, U> = std::true_type{};
+
+    /** @} */
+
 } // namespace alpaka

--- a/tests/unit/dict/dict.cpp
+++ b/tests/unit/dict/dict.cpp
@@ -23,7 +23,7 @@ TEST_CASE("dict mutate entry", "")
 
     int aValue = 42;
     int bValue = 43;
-    Dict dictionary = Dict{std::make_tuple(DictEntry(a_, std::ref(aValue)), DictEntry(b_, bValue))};
+    Dict dictionary = Dict{makeTuple(DictEntry(a_, std::ref(aValue)), DictEntry(b_, bValue))};
 
     static_assert(hasTag(dictionary, a_));
     static_assert(hasTag(dictionary, b_));
@@ -45,11 +45,11 @@ TEST_CASE("dict mutate entry", "")
     Dict dictionary2 = {entry0, DictEntry(b_, bValue)};
     CHECK(getTag(dictionary2, a_) == 43);
 
-    Dict dictionary4 = Dict{std::make_tuple(DictEntry(a_, std::ref(aValue)), DictEntry(b_, bValue))};
+    Dict dictionary4 = Dict{makeTuple(DictEntry(a_, std::ref(aValue)), DictEntry(b_, bValue))};
     dictionary4[a_] = 1;
     CHECK(dictionary4[a_] == 1);
 
-    Dict dictionary5 = Dict{std::make_tuple(DictEntry(c_, 5))};
+    Dict dictionary5 = Dict{makeTuple(DictEntry(c_, 5))};
     auto joinedDict = joinDict(dictionary4, dictionary5);
     CHECK(joinedDict[a_] == 1);
     CHECK(joinedDict[c_] == 5);

--- a/tests/unit/tuple/tuple.cpp
+++ b/tests/unit/tuple/tuple.cpp
@@ -1,0 +1,28 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/Tuple.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <functional>
+
+using namespace alpaka;
+
+TEST_CASE("tuple", "")
+{
+    // tuple should be trivially copyable if all members are trivially copyable
+    constexpr auto tuple = makeTuple(1, 2);
+    static_assert(std::is_trivially_copyable_v<ALPAKA_TYPEOF(tuple)>);
+
+    auto copyTuple = tuple;
+    CHECK(tuple.get<0>() == copyTuple.get<0>());
+    CHECK(tuple.get<1>() == copyTuple.get<1>());
+
+    auto tuple1 = makeTuple(3, 4);
+    tuple1 = tuple;
+    CHECK(tuple.get<0>() == tuple1.get<0>());
+    CHECK(tuple.get<1>() == tuple1.get<1>());
+}


### PR DESCRIPTION
- provide own tuple which is trivially copyable
- use alpaka tuple in KernelBundle
  - enforece trivially copable kernel functions and arguments
- move `core/Utility.hpp` to `utility.hpp`
- provide concepts and the coresponding trait
  - `KernelFn`
  - `KernelArg`