### PR TITLE
add `onHost::transformReduce()`

### DIFF
--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -110,7 +110,7 @@ namespace alpaka
          * @endcode
          */
         template<typename... T_Args, typename = std::enable_if_t<(std::is_convertible_v<T_Args, T_Type> && ...)>>
-        constexpr Simd(T_Args... args) : Storage(static_cast<T_Type>(args)...)
+        constexpr Simd(T_Args const&... args) : Storage(static_cast<T_Type>(args)...)
         {
         }
 

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -235,7 +235,7 @@ namespace alpaka
          */
         template<typename... T_Args>
         requires(std::is_convertible_v<T_Args, T_Type> && ...)
-        constexpr Vec(T_Args... args) : Storage(static_cast<T_Type>(args)...)
+        constexpr Vec(T_Args const&... args) : Storage(static_cast<T_Type>(args)...)
         {
         }
 

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -36,6 +36,7 @@
 #include "alpaka/onHost/Queue.hpp"
 #include "alpaka/onHost/algo/concurrent.hpp"
 #include "alpaka/onHost/algo/transform.hpp"
+#include "alpaka/onHost/algo/transformReduce.hpp"
 #include "alpaka/onHost/mem/stdContainer.hpp"
 #include "alpaka/tag.hpp"
 #include "utility.hpp"

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -179,7 +179,7 @@ namespace alpaka::onHost
                 {
                     IdxType rowExtentInBytes = extents.x() * static_cast<IdxType>(sizeof(T_Type));
                     IdxType rowPitchInBytes = divCeil(rowExtentInBytes, alignment) * alignment;
-                    auto pitches = mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
+                    auto pitches = alpaka::mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
 
                     size_t memSizeInByte = pCast<size_t>(pitches)[0] * static_cast<size_t>(extents[0]);
 

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -136,7 +136,7 @@ namespace alpaka::onHost
                 {
                     IdxType rowExtentInBytes = extents.x() * static_cast<IdxType>(sizeof(T_Type));
                     IdxType rowPitchInBytes = divCeil(rowExtentInBytes, alignment) * alignment;
-                    auto pitches = mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
+                    auto pitches = alpaka::mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
 
                     size_t memSizeInByte = pCast<size_t>(pitches)[0] * static_cast<size_t>(extents[0]);
                     T_Type* ptr = reinterpret_cast<T_Type*>(

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -161,7 +161,7 @@ namespace alpaka::onHost
                             static_cast<std::size_t>(extents.x()) * sizeof(T_Type),
                             static_cast<std::size_t>(extents.y())));
 
-                    pitches = mem::calculatePitches<T_Type>(extents, static_cast<Idx>(rowPitchInBytes));
+                    pitches = alpaka::mem::calculatePitches<T_Type>(extents, static_cast<Idx>(rowPitchInBytes));
                 }
                 else if constexpr(dim >= 3u)
                 {
@@ -176,7 +176,7 @@ namespace alpaka::onHost
 
                     ptr = reinterpret_cast<T_Type*>(pitchedPtrVal.ptr);
                     Idx rowPitchInBytes = pitchedPtrVal.pitch;
-                    pitches = mem::calculatePitches<T_Type>(extents, static_cast<Idx>(pitchedPtrVal.pitch));
+                    pitches = alpaka::mem::calculatePitches<T_Type>(extents, static_cast<Idx>(pitchedPtrVal.pitch));
                 }
 
                 auto deviceDependency = onHost::Device{device.getSharedPtr()};

--- a/include/alpaka/mem/DataPitches.hpp
+++ b/include/alpaka/mem/DataPitches.hpp
@@ -13,6 +13,40 @@
 
 namespace alpaka
 {
+    namespace mem
+    {
+        //! Calculate the pitches purely from the extents.
+        template<typename T_Elem, alpaka::concepts::Vector T_Vec>
+        constexpr auto calculatePitchesFromExtents(T_Vec const& extent)
+        {
+            constexpr auto dim = T_Vec::dim();
+            using type = typename T_Vec::type;
+            auto pitchBytes = typename T_Vec::UniVec{};
+            if constexpr(dim > 0)
+                pitchBytes.back() = static_cast<type>(sizeof(T_Elem));
+            if constexpr(dim > 1)
+                for(type i = dim - 1; i > 0; i--)
+                    pitchBytes[i - 1] = extent[i] * pitchBytes[i];
+            return pitchBytes;
+        }
+
+        //! Calculate the pitches purely from the extents.
+        template<typename T_Elem, alpaka::concepts::Vector T_Vec>
+        requires(T_Vec::dim() >= 2)
+        constexpr auto calculatePitches(T_Vec const& extent, typename T_Vec::type const& rowPitchBytes)
+        {
+            constexpr auto dim = T_Vec::dim();
+            using type = typename T_Vec::type;
+            auto pitchBytes = typename T_Vec::UniVec{};
+            pitchBytes.back() = static_cast<type>(sizeof(T_Elem));
+            if constexpr(dim > 1)
+                pitchBytes[dim - 2u] = rowPitchBytes;
+            if constexpr(dim > 2)
+                for(type i = dim - 2; i > 0; i--)
+                    pitchBytes[i - 1] = extent[i] * pitchBytes[i];
+            return pitchBytes;
+        }
+    } // namespace mem
 
     template<typename T_Type, concepts::Vector T_Pitches>
     struct DataPitches

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -32,13 +32,24 @@ namespace alpaka
         concepts::Alignment T_MemAlignment = Alignment<>>
     struct MdSpan;
 
+    template<concepts::Alignment T_MemAlignment = Alignment<>>
     inline constexpr auto makeMdSpan(
         auto* pointer,
         concepts::Vector auto const& extents,
         concepts::Vector auto const& pitchBytes,
-        concepts::Alignment auto const& memAlignment = Alignment{})
+        T_MemAlignment const memAlignment = T_MemAlignment{})
     {
         return MdSpan{pointer, extents, pitchBytes, memAlignment};
+    }
+
+    template<typename T_ValueType, concepts::Alignment T_MemAlignment = Alignment<>>
+    inline constexpr auto makeMdSpan(
+        T_ValueType* pointer,
+        concepts::Vector auto const& extents,
+        T_MemAlignment const memAlignment = T_MemAlignment{})
+    {
+        auto pitchMd = alpaka::mem::calculatePitchesFromExtents<T_ValueType>(extents);
+        return MdSpan{pointer, extents, pitchMd, memAlignment};
     }
 
     inline constexpr auto makeMdSpan(auto&& any)

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -32,6 +32,17 @@ namespace alpaka
         alpaka::concepts::Alignment T_MemAlignment = Alignment<>>
     struct View;
 
+    template<typename T_ValueType, concepts::Alignment T_MemAlignment = Alignment<>>
+    inline constexpr auto makeView(
+        auto&& anyWithApi,
+        T_ValueType* pointer,
+        concepts::Vector auto const& extents,
+        T_MemAlignment const memAlignment = T_MemAlignment{})
+    {
+        auto pitchMd = alpaka::mem::calculatePitchesFromExtents<T_ValueType>(extents);
+        return View{getApi(ALPAKA_FORWARD(anyWithApi)), pointer, extents, pitchMd, memAlignment};
+    }
+
     inline constexpr auto makeView(auto&& any)
     {
         return View{

--- a/include/alpaka/onAcc/atomic.hpp
+++ b/include/alpaka/onAcc/atomic.hpp
@@ -181,4 +181,23 @@ namespace alpaka::onAcc
     {
         return atomicOp<AtomicCas>(acc, addr, compare, value, hier);
     }
+
+    namespace trait
+    {
+
+        template<typename T_Functor>
+        struct FunctorToAtomicOp;
+
+        template<>
+        struct FunctorToAtomicOp<std::plus<>>
+
+        {
+            using type = alpaka::onAcc::AtomicAdd;
+        };
+    } // namespace trait
+
+    // Add more functors as needed
+    template<typename T_Functor>
+    using FunctorToAtomicOp_t = typename trait::FunctorToAtomicOp<std::decay_t<T_Functor>>::type;
+
 } // namespace alpaka::onAcc

--- a/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
+++ b/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/Vec.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/core/common.hpp"
+#include "alpaka/functor.hpp"
 #include "alpaka/mem/concepts.hpp"
 #include "alpaka/onAcc.hpp"
 
@@ -146,45 +147,6 @@ namespace alpaka::onAcc::internal
         constexpr auto const& asParent() const
         {
             return static_cast<T_Parent const&>(*this);
-        }
-
-        template<alpaka::concepts::Alignment T_MemAlignment, uint32_t T_width>
-        ALPAKA_FN_INLINE static constexpr void executeDo(
-            auto const& acc,
-            auto const& dataIdx,
-            auto&& func,
-            alpaka::concepts::MdSpan auto&&... data)
-        {
-            func(acc, SimdPtr{ALPAKA_FORWARD(data), dataIdx, T_MemAlignment{}, CVec<uint32_t, T_width>{}}...);
-        }
-
-        /** calls the functor and forward the data T_repeat times
-         *
-         * The calls to the functor are independent and compile time unrolled to support instruction parallelism.
-         *
-         * @param iter the caller must ensure tha the interator can be increased T_repeat times without jumping over
-         * iter.end()
-         */
-        template<alpaka::concepts::Alignment T_MemAlignment, uint32_t T_width, uint32_t... T_repeat>
-        ALPAKA_FN_INLINE static constexpr void execute(
-            auto const& acc,
-            auto& iter,
-            std::integer_sequence<uint32_t, T_repeat...>,
-            auto&& func,
-            alpaka::concepts::MdSpan auto&&... data)
-        {
-            /* We do not check if the iterator points to a valid element, the caller must ensure that we can
-             * safely increase the iterator without jumping over iter.end().
-             *
-             * The ternary operator is used to allow using the folding expression on iter.
-             */
-            auto ids = std::make_tuple(*(T_repeat + 1 != 0u ? iter++ : iter++)...);
-            std::apply(
-                [&](auto const&... dataIdx) constexpr {
-                    (executeDo<T_MemAlignment, T_width>(acc, dataIdx, ALPAKA_FORWARD(func), ALPAKA_FORWARD(data)...),
-                     ...);
-                },
-                ids);
         }
 
         template<uint32_t T_maxConcurrencyInByte, uint32_t T_simdWidth, alpaka::concepts::Alignment T_MemAlignment>

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -1,0 +1,252 @@
+/* Copyright 2025 René Widera, Mehmet Yusufoglu
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+
+#include "alpaka/Simd.hpp"
+#include "alpaka/Vec.hpp"
+#include "alpaka/core/common.hpp"
+#include "alpaka/functor.hpp"
+#include "alpaka/mem/MdSpan.hpp"
+#include "alpaka/onAcc/Acc.hpp"
+#include "alpaka/onAcc/SimdAlgo.hpp"
+#include "alpaka/onAcc/atomic.hpp"
+#include "alpaka/onHost.hpp"
+#include "alpaka/trait.hpp"
+
+namespace alpaka::onHost::internal
+{
+    struct SimdTransformReduceKernel
+    {
+        uint32_t dynSharedMemBytes = 0u;
+
+        template<typename T_DataType>
+        ALPAKA_FN_ACC void operator()(
+            onAcc::concepts::Acc auto const& acc,
+            alpaka::concepts::Vector auto const& extentMd,
+            T_DataType const& neutralElement,
+            T_DataType* output,
+            auto const& reduceFunc,
+            auto const& transformFunc,
+            alpaka::concepts::MdSpan auto&&... inputs) const
+        {
+            static_assert(
+                std::is_same_v<ALPAKA_TYPEOF(neutralElement), T_DataType>,
+                "The neutral element type must match the data output type.");
+
+            auto numFrames = acc[alpaka::frame::count];
+            alpaka::concepts::Vector auto frameExtent = acc[alpaka::frame::extent];
+
+            // Shared memory for block-wide reduction
+            T_DataType* dynS = onAcc::getDynSharedMem<T_DataType>(acc);
+            auto pitchMd = alpaka::mem::calculatePitchesFromExtents<T_DataType>(frameExtent);
+            auto tbSum = MdSpan{dynS, frameExtent, pitchMd}; // makeMdSpan(dynS, frameExtent, pitchMd);
+            //  auto tbSum = onAcc::declareSharedMdArray<T_DataType, uniqueId()>(acc, CVec<uint32_t, 2>{});
+            // T_DataType* dynS = &tbSum[0];
+
+            auto traverseInFrame
+                = alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInBlock, alpaka::IdxRange{frameExtent});
+
+            // Initialize shared memory by setting all elements to the neutral element or identity value
+            // for the reduction operation.
+            for(auto elemIdxInFrame : traverseInFrame)
+            {
+                tbSum[elemIdxInFrame] = neutralElement;
+            }
+
+            auto const frameDataExtent = numFrames * frameExtent;
+            auto traverseOverFrames = alpaka::onAcc::makeIdxMap(
+                acc,
+                alpaka::onAcc::worker::blocksInGrid,
+                alpaka::IdxRange{frameDataExtent.all(0), frameDataExtent, frameExtent});
+
+            for(auto frameIdx : traverseOverFrames)
+            {
+                for(alpaka::concepts::Vector auto elemIdxInFrame : traverseInFrame)
+                {
+                    auto allThreads = alpaka::onAcc::SimdAlgo{
+                        alpaka::onAcc::WorkerGroup{frameIdx + elemIdxInFrame, frameDataExtent}};
+                    if constexpr(isSpecializationOf_v<ALPAKA_TYPEOF(reduceFunc), ScalarFunc>)
+                    {
+                        // reduce functor with for scalar values only
+                        callTransformFn(
+                            acc,
+                            allThreads,
+                            extentMd,
+                            neutralElement,
+                            tbSum[elemIdxInFrame],
+                            [&](auto&& a, auto&& b) constexpr
+                            {
+                                return loadAncExecuteScalarOp(
+                                    std::make_integer_sequence<uint32_t, ALPAKA_TYPEOF(a)::width()>{},
+                                    [&](alpaka::concepts::CVector auto idx, auto const& acc, auto&&... data) constexpr
+                                    { return reduceFunc(data[idx.x()]...); },
+                                    acc,
+                                    a,
+                                    b);
+                            },
+                            transformFunc,
+                            ALPAKA_FORWARD(inputs)...);
+                    }
+                    else
+                    {
+                        // reduce functor with simd package support
+                        callTransformFn(
+                            acc,
+                            allThreads,
+                            extentMd,
+                            neutralElement,
+                            tbSum[elemIdxInFrame],
+                            reduceFunc,
+                            transformFunc,
+                            ALPAKA_FORWARD(inputs)...);
+                    }
+                }
+            }
+
+            auto const laneIdInBlock = linearize(acc[alpaka::layer::thread].count(), acc[alpaka::layer::thread].idx());
+            auto const blockSize = acc[alpaka::layer::thread].count().product();
+            // Synchronize threads before aggregation
+            alpaka::onAcc::syncBlockThreads(acc);
+
+            // Aggregate shared memory slots
+            for(auto [linearSharedElemIdx] : alpaka::onAcc::makeIdxMap(
+                    acc,
+                    alpaka::onAcc::worker::linearThreadsInBlock,
+                    alpaka::IdxRange{blockSize, frameExtent.product()}))
+            {
+                dynS[laneIdInBlock] = reduceFunc(dynS[laneIdInBlock], dynS[linearSharedElemIdx]);
+            }
+
+            alpaka::onAcc::syncBlockThreads(acc);
+
+            // Perform a parallel reduction within the block
+            // This is a tree reduction algorithm
+            for(auto offset = blockSize / 2; offset > 0; offset /= 2)
+            {
+                alpaka::onAcc::syncBlockThreads(acc);
+                if(laneIdInBlock < offset)
+                {
+                    dynS[laneIdInBlock] = reduceFunc(dynS[laneIdInBlock], dynS[laneIdInBlock + offset]);
+                }
+            }
+
+            // Atomic update of the global result
+            if(laneIdInBlock == 0)
+            {
+                using BinaryAtomicOp = onAcc::FunctorToAtomicOp_t<ALPAKA_TYPEOF(reduceFunc)>;
+                alpaka::onAcc::atomicOp<BinaryAtomicOp>(acc, output, dynS[laneIdInBlock]);
+            }
+        }
+
+        template<uint32_t... T_idx>
+        ALPAKA_FN_INLINE ALPAKA_FN_ACC static constexpr auto loadAncExecuteScalarOp(
+            std::integer_sequence<uint32_t, T_idx...>,
+            auto&& op,
+            auto const& acc,
+            auto&& func,
+            auto&&... data)
+
+        {
+            return Simd{op(CVec<uint32_t, T_idx>{}, acc, ALPAKA_FORWARD(func), ALPAKA_FORWARD(data)...)...};
+        }
+
+        ALPAKA_FN_INLINE ALPAKA_FN_ACC static constexpr void callTransformFn(
+            auto const& acc,
+            auto const& allThreads,
+            alpaka::concepts::Vector auto const& extentMd,
+            auto const& neutralElement,
+            auto& result,
+            auto&& reduceFunc,
+            auto&& transformFunc,
+            auto&&... inputs)
+
+        {
+            // Use the generic transformFunc and the variant reduceFunc
+            if constexpr(isSpecializationOf_v<ALPAKA_TYPEOF(transformFunc), StencilFunc>)
+            {
+                auto reducedValue = allThreads.transformReduce(
+                    acc,
+                    extentMd,
+                    neutralElement,
+                    ALPAKA_FORWARD(reduceFunc),
+                    [&](auto const& acc, alpaka::concepts::SimdPtr auto&&... in)
+                    { return callFunctor(acc, transformFunc, ALPAKA_FORWARD(in)...); },
+                    ALPAKA_FORWARD(inputs)...);
+                result = reduceFunc(result, reducedValue);
+            }
+            else if constexpr(isSpecializationOf_v<ALPAKA_TYPEOF(transformFunc), ScalarFunc>)
+            {
+                auto reducedValue = allThreads.transformReduce(
+                    acc,
+                    extentMd,
+                    neutralElement,
+                    ALPAKA_FORWARD(reduceFunc),
+                    [&](auto const& acc,
+                        alpaka::concepts::SimdPtr auto&& inPtr0,
+                        alpaka::concepts::SimdPtr auto const&... inPtr) constexpr
+                    {
+                        return loadAncExecuteScalarOp(
+                            std::make_integer_sequence<uint32_t, ALPAKA_TYPEOF(inPtr0)::width()>{},
+                            [](alpaka::concepts::CVector auto idx,
+                               auto const& acc,
+                               auto&& func,
+                               alpaka::concepts::Simd auto&&... data) constexpr
+                            { return callFunctor(acc, func, data[idx.x()]...); },
+                            acc,
+                            transformFunc,
+                            inPtr0.load(),
+                            inPtr.load()...);
+                    },
+                    ALPAKA_FORWARD(inputs)...);
+                result = reduceFunc(result, reducedValue);
+            }
+            else
+            {
+                auto reducedValue = allThreads.transformReduce(
+                    acc,
+                    extentMd,
+                    neutralElement,
+                    ALPAKA_FORWARD(reduceFunc),
+                    [&transformFunc](auto const& acc, alpaka::concepts::SimdPtr auto&&... inPtr)
+                    { return callFunctor(acc, transformFunc, inPtr.load()...); },
+                    ALPAKA_FORWARD(inputs)...);
+                result = reduceFunc(result, reducedValue);
+            }
+        }
+    };
+
+    template<typename DataType>
+    inline void transformReduce(
+        auto const& queue,
+        alpaka::concepts::Executor auto const exec,
+        DataType const& neutralElement,
+        DataType* out,
+        auto&& reduceFn,
+        auto&& transformFn,
+        auto&& in0,
+        auto&&... in)
+    {
+        auto extentMd = onHost::getExtents(in0);
+        auto frameSpec = getFrameSpec<DataType>(queue.getDevice(), extentMd);
+
+        auto kernelFn
+            = SimdTransformReduceKernel{static_cast<uint32_t>(frameSpec.m_frameExtent.product() * sizeof(DataType))};
+
+        onHost::fill(queue, makeView(queue, out, Vec{1}), neutralElement);
+        queue.enqueue(
+            exec,
+            frameSpec,
+            KernelBundle{
+                kernelFn,
+                extentMd,
+                neutralElement,
+                out,
+                ALPAKA_FORWARD(reduceFn),
+                ALPAKA_FORWARD(transformFn),
+                ALPAKA_FORWARD(in0),
+                ALPAKA_FORWARD(in)...});
+    }
+} // namespace alpaka::onHost::internal

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -1,0 +1,101 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/trait.hpp"
+#include "alpaka/onHost/algo/internal/transformReduce.hpp"
+
+namespace alpaka::onHost
+{
+    /** Transform the input data with the given function and accumulate the results into a scalar value.
+     *
+     * transformFn can be a lambda function if all arguments are specialized. This fully specialized functor must
+     * mostly wrapped by @see ScalarFunc. Generic lambdas are for some backends e.g. CUDA/HIP not supported. A lambda
+     * must be of the following form and should capture arguments only by copy.
+     *
+     * @code{.cpp}
+     *   [] ALPAKA_FN_ACC(){};
+     * @endcode
+     *
+     * @param queue The queue to execute the transformation.
+     * @param exec The executor to use for the kernel execution.
+     * @param neutralElement The neutral element in respect to binaryReduceFn.
+     * @param out Pointer to the output result. The type must be equal to neutralElement and the result of the binary
+     * reduce functor.
+     * @param binaryReduceFn Reduce binary functor, the functor operation must be transitive and commutative.
+     *   The atomic trait alpaka::onAcc::trait::FunctorToAtomicOp<> must be specialized.
+     *   Currently only std::plus<> is supported. The functor execution order is not specified.
+     * @param transformFn The function to apply to each element of the input data.
+     *   The functor should support Simd packages. If not you can enforce the element wise execution by wrapping into
+     * @see ScalarFunc. If you would like to support stencil executions wrapp fn into @see StencilFunc. StencilFunc is
+     * getting all arguments as @see SimdPtr. If StencilFunc is used you should take care to not read outside of valid
+     * memory ranges by using sub-views to your input and output data. Optionally a transformFn can have a accelerator
+     * as first argument.
+     * @param in The input data to transform, all input data is passed to fn. transformFn must support as many
+     * arguments as input data is provided. An optional argument for the accelerator is support as first argument if
+     * needed.
+     *
+     * examples for a identity unary transform functor:
+     * @code{.cpp}
+     *   struct Foo {
+     *      constexpr auto operator()(onAcc::concepts::Acc auto const&, concepts::SimdPtr auto const& a) const {
+     *          return a.load();
+     *      }
+     *   };
+     *   struct Bar {
+     *      constexpr auto operator()(concepts::SimdPtr auto const& a) const {
+     *          return a.load();
+     *      }
+     *   };
+     * @endcode
+     *
+     * @{
+     */
+    template<typename DataType, typename T_Device>
+    inline void transformReduce(
+        Queue<T_Device> const& queue,
+        alpaka::concepts::Executor auto const exec,
+        DataType const& neutralElement,
+        DataType* out,
+        auto&& binaryReduceFn,
+        auto&& transformFn,
+        auto&&... in)
+    {
+        internal::transformReduce(
+            queue,
+            exec,
+            neutralElement,
+            out,
+            ALPAKA_FORWARD(binaryReduceFn),
+            ALPAKA_FORWARD(transformFn),
+            ALPAKA_FORWARD(in)...);
+    }
+
+    /**
+     * A available default executor will be selected automaticlally. The default executor is a executor with most
+     * parallelism/performance.
+     */
+    template<typename DataType, typename T_Device>
+    inline void transformReduce(
+        Queue<T_Device> const& queue,
+        DataType const& neutralElement,
+        DataType* out,
+        auto&& binaryReduceFn,
+        auto&& transformFn,
+        auto&&... in)
+    {
+        auto executor = supportedMappings(queue.getDevice());
+        transformReduce(
+            queue,
+            std::get<0>(executor),
+            neutralElement,
+            out,
+            ALPAKA_FORWARD(binaryReduceFn),
+            ALPAKA_FORWARD(transformFn),
+            ALPAKA_FORWARD(in)...);
+    }
+
+    /** @} */
+} // namespace alpaka::onHost

--- a/include/alpaka/onHost/mem/ManagedView.hpp
+++ b/include/alpaka/onHost/mem/ManagedView.hpp
@@ -22,42 +22,6 @@
 
 namespace alpaka::onHost
 {
-
-    namespace mem
-    {
-        //! Calculate the pitches purely from the extents.
-        template<typename T_Elem, alpaka::concepts::Vector T_Vec>
-        constexpr auto calculatePitchesFromExtents(T_Vec const& extent)
-        {
-            constexpr auto dim = T_Vec::dim();
-            using type = typename T_Vec::type;
-            auto pitchBytes = typename T_Vec::UniVec{};
-            if constexpr(dim > 0)
-                pitchBytes.back() = static_cast<type>(sizeof(T_Elem));
-            if constexpr(dim > 1)
-                for(type i = dim - 1; i > 0; i--)
-                    pitchBytes[i - 1] = extent[i] * pitchBytes[i];
-            return pitchBytes;
-        }
-
-        //! Calculate the pitches purely from the extents.
-        template<typename T_Elem, alpaka::concepts::Vector T_Vec>
-        requires(T_Vec::dim() >= 2)
-        constexpr auto calculatePitches(T_Vec const& extent, typename T_Vec::type const& rowPitchBytes)
-        {
-            constexpr auto dim = T_Vec::dim();
-            using type = typename T_Vec::type;
-            auto pitchBytes = typename T_Vec::UniVec{};
-            pitchBytes.back() = static_cast<type>(sizeof(T_Elem));
-            if constexpr(dim > 1)
-                pitchBytes[dim - 2u] = rowPitchBytes;
-            if constexpr(dim > 2)
-                for(type i = dim - 2; i > 0; i--)
-                    pitchBytes[i - 1] = extent[i] * pitchBytes[i];
-            return pitchBytes;
-        }
-    } // namespace mem
-
     /** Life time managed view with contiguous data
      *
      * This managed view owns the data and will deallocate it when the view is destroyed.

--- a/tests/unit/algorithm/transformReduce.cpp
+++ b/tests/unit/algorithm/transformReduce.cpp
@@ -1,0 +1,209 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executeForEach.hpp>
+#include <alpaka/example/executors.hpp>
+#include <alpaka/meta/CartesianProduct.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <type_traits>
+
+using namespace alpaka;
+
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis))>;
+
+/** Stencil SIMD functor
+ *
+ * The stencil functor is getting a SimdPtr as input which allows to call the operator[] to change the index.
+ * In this test we do not shift the memory to avoid out of memory access.
+ * We cannot use generic lambdas with CUDA therefor we need to write a functor
+ */
+struct StencilAdd
+{
+    constexpr auto operator()(concepts::SimdPtr auto const& a, concepts::SimdPtr auto const& b) const
+    {
+        return a.load() + b.load();
+    }
+};
+
+struct StencilAddWithAcc
+{
+    constexpr auto operator()(
+        onAcc::concepts::Acc auto const&,
+        concepts::SimdPtr auto const& a,
+        concepts::SimdPtr auto const& b) const
+    {
+        return a.load() + b.load();
+    }
+};
+
+struct AddUpCastWithAcc
+{
+    constexpr auto operator()(
+        onAcc::concepts::Acc auto const&,
+        concepts::Simd auto const& a,
+        concepts::Simd auto const& b) const
+    {
+        return pCast<size_t>(a + b);
+    }
+};
+
+struct ScalarOpWithAcc
+{
+    constexpr auto operator()(onAcc::concepts::Acc auto const&, auto const& a, auto const& b) const
+    {
+        using ValueType = trait::GetValueType_t<ALPAKA_TYPEOF(a)>;
+        return a * ValueType{2} + b;
+    }
+};
+
+template<typename T_DataType>
+void executeTest(
+    concepts::Executor auto exec,
+    auto const& computeQueue,
+    auto const functorPair,
+    concepts::Vector auto extentMd)
+{
+    std::cout << "run func : " << core::demangledName(std::get<2>(functorPair).second) << std::endl;
+
+    auto computeDev = computeQueue.getDevice();
+    using DataType = T_DataType;
+    using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
+    onHost::ManagedView computeViewOut = onHost::alloc<OutDataType>(computeDev, extentMd.all(1));
+    onHost::ManagedView computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::ManagedView computeViewIn1 = onHost::allocMirror(computeDev, computeViewIn0);
+    onHost::ManagedView hostViewIota = onHost::allocHostMirror(computeViewIn0);
+    onHost::ManagedView hostViewOut = onHost::allocHostMirror(computeViewOut);
+
+    // initialize with the linearized index
+    DataType iotaCounter = 0;
+    for(auto& value : hostViewIota)
+    {
+        value = iotaCounter;
+        ++iotaCounter;
+    }
+
+    onHost::memcpy(computeQueue, computeViewIn0, hostViewIota);
+    onHost::memcpy(computeQueue, computeViewIn1, hostViewIota);
+
+    onHost::wait(computeQueue);
+    auto const beginT = std::chrono::high_resolution_clock::now();
+
+    onHost::transformReduce(
+        computeQueue,
+        exec,
+        std::get<0>(functorPair),
+        computeViewOut.data(),
+        std::get<1>(functorPair).first,
+        std::get<2>(functorPair).first,
+        computeViewIn0,
+        computeViewIn1);
+
+    onHost::wait(computeQueue);
+    auto const endT = std::chrono::high_resolution_clock::now();
+    std::cout << "Time for transform reduce: " << std::chrono::duration<double>(endT - beginT).count() << 's'
+              << " data size: " << hostViewIota.getExtents() << std::endl;
+
+    onHost::memcpy(computeQueue, hostViewOut, computeViewOut);
+    onHost::wait(computeQueue);
+
+    // validate without using the forward iterator
+    DataType refIotaCounter = 0;
+    auto result = std::get<0>(functorPair);
+    meta::ndLoopIncIdx(
+        extentMd,
+        [&](auto idx)
+        {
+            result = std::get<1>(functorPair)
+                         .second(result, std::get<2>(functorPair).second(refIotaCounter, refIotaCounter));
+            ++refIotaCounter;
+        });
+    CHECK(*hostViewOut.data() == result);
+};
+
+template<typename T_DataType>
+void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTuples)
+{
+    using DataType = T_DataType;
+
+    auto deviceSpec = cfg[object::deviceSpec];
+    alpaka::concepts::Executor auto exec = cfg[object::exec];
+
+    auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!computeDevSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device computeDev = computeDevSelector.makeDevice(0);
+
+    std::cout << "device spec: " << getName(deviceSpec) << std::endl;
+    std::cout << "device name: " << computeDev.getName() << std::endl;
+    std::cout << "executor   : " << exec.getName() << std::endl;
+
+    onHost::Queue computeQueue = computeDev.makeQueue();
+
+    // execute for each functor
+    std::apply(
+        [&](auto const&... functorPair) { (executeTest<DataType>(exec, computeQueue, functorPair, extentMd), ...); },
+        functorTuples);
+}
+
+TEMPLATE_LIST_TEST_CASE("transformReduce", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    using DataType = int;
+
+    // This list is not directly defined within the function `prepareTest()` due to nvcc compile issues.
+    auto functorList = std::make_tuple(
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(std::plus{}, std::plus{})),
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
+            std::make_pair(StencilFunc{StencilAdd{}}, std::plus{})),
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
+            std::make_pair(StencilFunc{StencilAddWithAcc{}}, std::plus{})),
+        std::make_tuple(
+            size_t{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(
+                AddUpCastWithAcc{},
+                [](DataType const& a, DataType const& b) { return static_cast<size_t>(a + b); })),
+        /* We can use a lambda function because the types are explicitly defined.
+         * Generic lambdas would not be supported for CUDA/HIP
+         * Wrapp the functor as ScalarFunc because math::min() cannot be executed on a Simd pack.
+         * This enforces that the functor is evaluated on scalar values and not SIMD packs.
+         * Memory loads and stores will be vectorized.
+         */
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(
+                ScalarFunc{[] ALPAKA_FN_ACC(DataType const& a, DataType const& b)
+                           { return math::min(a + DataType{1}, b); }},
+                [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); }))
+
+    );
+
+    // different extents for testing
+    auto extentMdList
+        = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
+
+    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, functorList), ...); }, extentMdList);
+}


### PR DESCRIPTION
- add `onHost::transformReduce()`
- add test case for transform reduce
- move `calculatePitchesFromExtents()` and `calculatePitches()` to file `DataPitches.hpp`

sneak in: fix for `Simd` and `Vec` constructor for 32byte aligned types (use const refence to silent gcc warning of changed behaviour in gcc 4.6