### PR TITLE
refactor onHost::algo and bableStream

### DIFF
--- a/benchmark/babelstream/src/babelStreamCommon.hpp
+++ b/benchmark/babelstream/src/babelStreamCommon.hpp
@@ -167,14 +167,19 @@ namespace
     //! \tparam T Type of the values to compare.
     //! \param a First value to compare.
     //! \param b Second value to compare.
+    //! \param epsMultiplier Multiplier for the epsilon value used in floating-point comparisons. Default is 100.
     //! \return Returns true if the values are approximately equal (for floating-point types) or exactly equal (for
     //! integral types).
     template<typename T>
-    [[maybe_unused]] bool FuzzyEqual(T a, T b)
+    [[maybe_unused]] bool FuzzyEqual(T a, T b, T epsMultiplier = 100)
     {
         if constexpr(std::is_floating_point_v<T>)
         {
-            return std::fabs(a - b) < (std::numeric_limits<T>::epsilon() * static_cast<T>(100.0));
+            bool v = std::fabs(a - b) < (std::numeric_limits<T>::epsilon() * epsMultiplier);
+            if(!v)
+                std::cout << "FuzzyEqual: " << a << " != " << b << " with epsilon "
+                          << (std::numeric_limits<T>::epsilon() * epsMultiplier) << std::endl;
+            return v;
         }
         else if constexpr(std::is_integral_v<T>)
         {
@@ -282,7 +287,6 @@ namespace
         WorkDivAdd,
         WorkDivTriad,
         WorkDivMult,
-        WorkDivDot,
         WorkDivNStream,
         DeviceName,
         TimeUnit,
@@ -344,8 +348,6 @@ namespace
             return "WorkDivTriad";
         case BMInfoDataType::WorkDivMult:
             return "WorkDivMult ";
-        case BMInfoDataType::WorkDivDot:
-            return "WorkDivDot  ";
         case BMInfoDataType::WorkDivNStream:
             return "WorkDivNStream";
         default:
@@ -588,7 +590,6 @@ namespace
             addItemValueToSS(BMInfoDataType::WorkDivMult);
             addItemValueToSS(BMInfoDataType::WorkDivAdd);
             addItemValueToSS(BMInfoDataType::WorkDivTriad);
-            addItemValueToSS(BMInfoDataType::WorkDivDot);
             addItemValueToSS(BMInfoDataType::WorkDivNStream);
             addItemValueToSS(BMInfoDataType::CopyTimeFromAccToHost);
 

--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -133,97 +133,11 @@ struct SimdNStreamOp
     }
 };
 
-//! Dot product of two vectors. The result is not a scalar but a vector of block-level dot products. For the
-//! BabelStream implementation and documentation: https://github.com/UoB-HPC
-struct DotKernel
+struct DotMultiplication
 {
-    //! The kernel entry point
-    //! \tparam TAcc The accelerator environment to be executed on.
-    //! \tparam T The data type
-    //! \param acc The accelerator to be executed on.
-    //! \param a MdSpan for vector a
-    //! \param b MdSpan for vector b
-    //! \param sum Pointer for result vector consisting sums of blocks
-    //! \param arraySize the size of the array
-    template<typename TAcc>
-    ALPAKA_FN_ACC void operator()(
-        TAcc const& acc,
-        alpaka::concepts::MdSpan auto const a,
-        alpaka::concepts::MdSpan auto const b,
-        auto sum,
-        auto arraySize) const
+    constexpr auto operator()(concepts::Simd auto&& simdA, concepts::Simd auto&& simdB) const
     {
-        using T = trait::GetValueType_t<ALPAKA_TYPEOF(sum)>;
-        auto tbSum = onAcc::declareSharedMdArray<T, uniqueId()>(acc, CVec<uint32_t, blockThreadExtentMain>{});
-#if 1
-        auto numFrames = acc[frame::count];
-        auto frameExtent = acc[frame::extent];
-
-        auto traverseInFrame = onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{frameExtent});
-        /* init shared memory
-         * no need to synchronize because after the loop because the same index map will be used to access the shared
-         * memory in the tribble loop.
-         */
-        for(auto [elemIdxInFrame] : traverseInFrame)
-        {
-            tbSum[elemIdxInFrame] = T{0};
-        }
-
-        auto const frameDataExtent = numFrames * frameExtent;
-        auto traverseOverFrames = onAcc::makeIdxMap(
-            acc,
-            onAcc::worker::blocksInGrid,
-            IdxRange{alpaka::CVec<uint32_t, 0u>{}, frameDataExtent, frameExtent});
-
-        for(auto frameIdx : traverseOverFrames)
-        {
-            for(auto elemIdxInFrame : traverseInFrame)
-            {
-                auto allThreads = onAcc::SimdAlgo{onAcc::WorkerGroup{frameIdx + elemIdxInFrame, frameDataExtent}};
-                auto reducedValue = allThreads.transformReduce(
-                    acc,
-                    alpaka::Vec{arraySize},
-                    T{0},
-                    std::plus{},
-                    [&](auto const&, auto&& simdA, auto&& simdB) constexpr { return simdA.load() * simdB.load(); },
-                    a,
-                    b);
-
-                tbSum[elemIdxInFrame] += reducedValue;
-            }
-        }
-        // sync is required because we do not know which thread wrote whcih value
-        alpaka::onAcc::syncBlockThreads(acc);
-        // aggregate for each thread but skip the first shared memory slot
-        for(auto [elemIdxInFrame] :
-            onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{acc[layer::thread].count(), frameExtent}))
-        {
-            tbSum[acc[layer::thread].idx()] += tbSum[elemIdxInFrame];
-        }
-
-#else
-        // this version is shorter in code but runs into floating point stability issues due to to long aggregation of
-        // value by a single thread
-        auto threadSum = T{0};
-        for(auto [i] : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{arraySize}))
-        {
-            threadSum += a[i] * b[i];
-        }
-        for(auto [local_i] : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, onAcc::range::threadsInBlock))
-        {
-            tbSum[local_i] = threadSum;
-        }
-#endif
-        auto const [local_i] = acc[layer::thread].idx();
-        auto const [blockSize] = acc[layer::thread].count();
-        for(auto offset = blockSize / 2; offset > 0; offset /= 2)
-        {
-            alpaka::onAcc::syncBlockThreads(acc);
-            if(local_i < offset)
-                tbSum[local_i] += tbSum[local_i + offset];
-        }
-        if(local_i == 0)
-            onAcc::atomicAdd(acc, &sum[0], tbSum[local_i]);
+        return simdA * simdB;
     }
 };
 
@@ -416,13 +330,6 @@ void testKernels(auto const deviceSpec, auto const exec)
         }
         if(kernelsToBeExecuted == KernelsToRun::All)
         {
-            uint32_t elementsPerFrameItem = getNumElemPerThread<DataType>(queue);
-            auto numFrames = std::min(
-                static_cast<Idx>(dotGridBlockExtent),
-                alpaka::divExZero(arraySize, (static_cast<Idx>(blockThreadExtentMain) * elementsPerFrameItem)));
-
-            auto dataBlockingDot = onHost::FrameSpec{numFrames, static_cast<Idx>(blockThreadExtentMain)};
-
             // Vector of sums of each block
             auto bufAccSumPerBlock = onHost::alloc<DataType>(devAcc, 1u);
             auto bufHostSumPerBlock = onHost::allocHostMirror(bufAccSumPerBlock);
@@ -431,25 +338,20 @@ void testKernels(auto const deviceSpec, auto const exec)
             measureKernelExec(
                 [&]()
                 {
-                    // set initial value of the sum to 0
-                    onHost::memset(queue, bufAccSumPerBlock, 0);
-                    queue.enqueue(
+                    onHost::transformReduce(
+                        queue,
                         exec,
-                        dataBlockingDot,
-                        KernelBundle{
-                            DotKernel(), // Dot kernel
-                            bufAccInputA,
-                            bufAccInputB,
-                            bufAccSumPerBlock,
-                            arraySize});
+                        DataType{0},
+                        bufAccSumPerBlock,
+                        std::plus{},
+                        DotMultiplication{},
+                        bufAccInputA,
+                        bufAccInputB);
                     onHost::memcpy(queue, bufHostSumPerBlock, bufAccSumPerBlock);
                     onHost::wait(queue);
                     resultDot = bufHostSumPerBlock[0u];
                 },
                 "DotKernel");
-
-            // Add workdiv to the list of workdivs to print later
-            metaData.setItem(BMInfoDataType::WorkDivDot, dataBlockingDot);
         }
         // NStream kernel is run only for one command line argument
         if(kernelsToBeExecuted == KernelsToRun::NStream)
@@ -520,9 +422,17 @@ void testKernels(auto const deviceSpec, auto const exec)
 
         // Verify Dot kernel
         DataType const expectedSum = static_cast<DataType>(arraySize) * expectedA * expectedB;
+
+        // allow a summation error of 100 epsilon per 32 mega elements
+        // The original bablesteam is always checking 8 digits only.
+        Idx presicionBaseArraySize = 32 * 1024 * 1024;
+        DataType epsScaling = divExZero(arraySize, presicionBaseArraySize);
         //  Dot product should be identical to arraySize*valA*valB
-        //  Use a different equality check if floating point errors exceed precision of FuzzyEqual function
-        REQUIRE(FuzzyEqual(static_cast<float>(std::fabs(resultDot - expectedSum) / expectedSum), 0.0f));
+        //  Use a different equality check if floating point errors exceed the precision of FuzzyEqual function
+        REQUIRE(FuzzyEqual<DataType>(
+            std::fabs(resultDot - expectedSum) / expectedSum,
+            static_cast<DataType>(0.0),
+            static_cast<DataType>(100.0) * epsScaling));
 
         // Set workdivs of benchmark metadata to be displayed at the end
         metaData.setItem(BMInfoDataType::WorkDivInit, dataBlocking);

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -113,6 +113,11 @@ namespace alpaka::onHost
         {
             return internal::GetDeviceProperties::Op<ALPAKA_TYPEOF(*m_device.get())>{}(*m_device.get());
         }
+
+        constexpr auto getDeviceKind() const
+        {
+            return T_DeviceKind{};
+        }
     };
 
     namespace concepts

--- a/include/alpaka/onHost/algo/concurrent.hpp
+++ b/include/alpaka/onHost/algo/concurrent.hpp
@@ -16,7 +16,7 @@ namespace alpaka::onHost
      *
      * @param queue The queue to execute the transformation.
      * @param exec The executor to use for the kernel execution.
-     * @param extentMd multi dimensional number of elements
+     * @param extents multi dimensional or scalar number of elements
      * @param fn The function to apply to each element of the input data.
      *   The functor should support @see SimdPtr and therefore can be used for stencil evaluations.
      *   It is not required to wrapp the functor with @see StencilFunc.
@@ -45,11 +45,11 @@ namespace alpaka::onHost
     inline void concurrent(
         Queue<T_Device> const& queue,
         alpaka::concepts::Executor auto const exec,
-        alpaka::concepts::Vector auto const& extentMd,
+        alpaka::concepts::VectorOrScalar auto const& extents,
         auto&& fn,
         auto&&... inOut)
     {
-        internal::concurrent<T_DataType>(queue, exec, extentMd, ALPAKA_FORWARD(fn), ALPAKA_FORWARD(inOut)...);
+        internal::concurrent<T_DataType>(queue, exec, extents, ALPAKA_FORWARD(fn), ALPAKA_FORWARD(inOut)...);
     }
 
     /**
@@ -59,7 +59,7 @@ namespace alpaka::onHost
     template<typename T_DataType, typename T_Device>
     inline void transform(
         Queue<T_Device> const& queue,
-        alpaka::concepts::Vector auto const& extentMd,
+        alpaka::concepts::VectorOrScalar auto const& extents,
         auto&& fn,
         auto&&... inOut)
     {
@@ -67,7 +67,7 @@ namespace alpaka::onHost
         internal::concurrent<T_DataType>(
             queue,
             std::get<0>(executor),
-            extentMd,
+            extents,
             ALPAKA_FORWARD(fn),
             ALPAKA_FORWARD(inOut)...);
     }

--- a/include/alpaka/onHost/algo/internal/concurrent.hpp
+++ b/include/alpaka/onHost/algo/internal/concurrent.hpp
@@ -21,10 +21,11 @@ namespace alpaka::onHost::internal
     {
         ALPAKA_FN_ACC void operator()(
             onAcc::concepts::Acc auto const& acc,
-            alpaka::concepts::Vector auto const& extentMd,
+            alpaka::concepts::VectorOrScalar auto const& extents,
             auto const& func,
             alpaka::concepts::MdSpan auto&&... inputs) const
         {
+            Vec const extentMd = extents;
             auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
 
             return simdGrid.concurrent(
@@ -45,10 +46,11 @@ namespace alpaka::onHost::internal
     inline void concurrent(
         auto const& queue,
         alpaka::concepts::Executor auto const exec,
-        alpaka::concepts::Vector auto const& extentMd,
+        alpaka::concepts::VectorOrScalar auto const& extents,
         auto&& fn,
         auto&&... in)
     {
+        Vec const extentMd = extents;
         auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), extentMd);
 
         queue.enqueue(

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -7,6 +7,7 @@
 
 #include "alpaka/Simd.hpp"
 #include "alpaka/Vec.hpp"
+#include "alpaka/api/util.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/functor.hpp"
 #include "alpaka/mem/MdSpan.hpp"
@@ -230,8 +231,30 @@ namespace alpaka::onHost::internal
         auto&&... in)
     {
         auto extentMd = onHost::getExtents(in0);
+        using IndexType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(extentMd)>;
         auto frameSpec = getFrameSpec<DataType>(queue.getDevice(), extentMd);
 
+        /* Adjust the number of frames to a maximum based on the number of multiprocessors of the device.
+         * The number of frames is kept as low as possible to reduce numerical issue due to long chains of reductions.
+         * Each frame is using an atomic operation to reduce the value of the full frame.
+         */
+        {
+            IndexType multiprocessorScaling = 1u;
+            if constexpr(!std::is_same_v<ALPAKA_TYPEOF(queue.getDevice().getDeviceKind()), deviceKind::Cpu>)
+            {
+                // For non-CPU devices, we scale the number of frames based on an arbitrary number derived from
+                // testing with the dot kernel of the bablestream benchmark.
+                multiprocessorScaling = 32u;
+            }
+
+            auto const numMultiProcessors = queue.getDevice().getDeviceProperties().m_multiProcessorCount;
+            auto adjsutedNumFrames = alpaka::api::util::adjustToLimit(
+                frameSpec.m_numFrames,
+                static_cast<IndexType>(numMultiProcessors * multiprocessorScaling));
+            frameSpec = FrameSpec{adjsutedNumFrames, frameSpec.m_frameExtent};
+        }
+
+        std::cout << frameSpec << std::endl;
         auto kernelFn
             = SimdTransformReduceKernel{static_cast<uint32_t>(frameSpec.m_frameExtent.product() * sizeof(DataType))};
 


### PR DESCRIPTION
- add support for scalar extents
- adjust number of frames used for `onHost::transFormReduce()` for better numerical stability
- use `onHost::transformReduce()` instead of a handcrafted dot kernel
- refactor `FuzzyEqual` to select the precision for the dot result to take the problem size into account.