### PR TITLE
add `onHost::allocAsync()`,  `onHost::allocLikeAsync()` and `addDestructorAction()` to `ManagedView`

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -331,7 +331,7 @@ void testKernels(auto const deviceSpec, auto const exec)
         if(kernelsToBeExecuted == KernelsToRun::All)
         {
             // Vector of sums of each block
-            auto bufAccSumPerBlock = onHost::alloc<DataType>(devAcc, 1u);
+            auto bufAccSumPerBlock = onHost::allocAsync<DataType>(queue, 1u);
             auto bufHostSumPerBlock = onHost::allocHostLike(bufAccSumPerBlock);
 
             // Test Dot kernel with specific blocksize which is larger than one

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -105,6 +105,7 @@ namespace alpaka::onHost
             friend struct alpaka::internal::GetApi;
             friend struct internal::GetDeviceProperties;
             friend struct internal::AdjustThreadSpec;
+            friend struct internal::AllocAsync;
         };
     } // namespace cpu
 

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -10,6 +10,7 @@
 #include "alpaka/api/host/exec/OmpThreads.hpp"
 #include "alpaka/api/host/exec/Serial.hpp"
 #include "alpaka/core/CallbackThread.hpp"
+#include "alpaka/core/alignedAlloc.hpp"
 #include "alpaka/interface.hpp"
 #include "alpaka/internal.hpp"
 #include "alpaka/meta/NdLoop.hpp"
@@ -17,6 +18,7 @@
 #include "alpaka/onHost/FrameSpec.hpp"
 #include "alpaka/onHost/Handle.hpp"
 #include "alpaka/onHost/internal.hpp"
+#include "alpaka/onHost/mem/ManagedView.hpp"
 
 #include <cstdint>
 #include <cstring>
@@ -28,7 +30,7 @@ namespace alpaka::onHost
     namespace cpu
     {
         template<typename T_Device>
-        struct Queue
+        struct Queue : std::enable_shared_from_this<Queue<T_Device>>
         {
         public:
             Queue(internal::concepts::DeviceHandle auto device, uint32_t const idx)
@@ -137,12 +139,18 @@ namespace alpaka::onHost
                 return m_device;
             }
 
+            std::shared_ptr<Queue> getSharedPtr()
+            {
+                return this->shared_from_this();
+            }
+
             friend struct onHost::internal::GetDevice;
 
             friend struct internal::Wait;
             friend struct internal::Memcpy;
             friend struct internal::Memset;
             friend struct alpaka::internal::GetApi;
+            friend struct internal::AllocAsync;
         };
     } // namespace cpu
 
@@ -281,6 +289,92 @@ namespace alpaka::onHost
                     std::get<0>(executors),
                     dataView.getSubView(extents),
                     elementValue);
+            }
+        };
+
+        /** The code is a copy of the Alloc::Op with the difference that the memory is allocated and freed
+         * asynchronously
+         *
+         * @todo check if we can reduce the duplication by having a common function for the computation of the extents
+         * and pitches and seperate the View creation.
+         */
+        template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
+        struct AllocAsync::Op<T_Type, cpu::Queue<T_Device>, T_Extents>
+        {
+            static consteval uint32_t highestPowerOfTwo(uint32_t value)
+            {
+                uint32_t result = 1u;
+                while((result << 1u) <= value)
+                {
+                    result <<= 1u;
+                }
+                return result;
+            }
+
+            auto operator()(cpu::Queue<T_Device>& queue, T_Extents const& extents) const
+            {
+                using IdxType = typename T_Extents::type;
+
+                constexpr uint32_t typeAlignmentBytes = alignof(T_Type);
+                constexpr uint32_t simdPackBytes = alpaka::getArchSimdWidth<T_Type>(
+                                                       ALPAKA_TYPEOF(getApi(queue)){},
+                                                       ALPAKA_TYPEOF(getDeviceKind(queue)){})
+                                                   * sizeof(T_Type);
+                constexpr uint32_t bestSimdPackBytes = highestPowerOfTwo(simdPackBytes);
+                constexpr IdxType alignment = std::max(bestSimdPackBytes, typeAlignmentBytes);
+
+                constexpr auto dim = T_Extents::dim();
+
+                auto deviceDependency = onHost::Device{queue.getDevice()->getSharedPtr()};
+                auto queueDependency = onHost::Queue{queue.getSharedPtr()};
+
+                if constexpr(dim == 1u)
+                {
+                    auto* ptr = reinterpret_cast<T_Type*>(
+                        alpaka::core::alignedAlloc(alignment, extents.x() * sizeof(T_Type)));
+                    // queueDependency is captured to keep the device alive until the memory is deleted
+                    auto deleter = [ptr, queueDependency]()
+                    {
+                        internal::enqueue(
+                            *queueDependency.get(),
+                            [ptr, queueDependency]() { alpaka::core::alignedFree(alignment, ptr); });
+                    };
+
+                    auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
+                    auto buffer = onHost::ManagedView{
+                        deviceDependency,
+                        ptr,
+                        extents,
+                        pitches,
+                        std::move(deleter),
+                        Alignment<alignment>{}};
+                    return buffer;
+                }
+                else
+                {
+                    IdxType rowExtentInBytes = extents.x() * static_cast<IdxType>(sizeof(T_Type));
+                    IdxType rowPitchInBytes = divCeil(rowExtentInBytes, alignment) * alignment;
+                    auto pitches = alpaka::mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
+
+                    size_t memSizeInByte = pCast<size_t>(pitches)[0] * static_cast<size_t>(extents[0]);
+
+                    auto* ptr = reinterpret_cast<T_Type*>(alpaka::core::alignedAlloc(alignment, memSizeInByte));
+                    auto deleter = [ptr, queueDependency]()
+                    {
+                        internal::enqueue(
+                            *queueDependency.get(),
+                            [ptr, queueDependency]() { alpaka::core::alignedFree(alignment, ptr); });
+                    };
+
+                    auto buffer = onHost::ManagedView{
+                        deviceDependency,
+                        ptr,
+                        extents,
+                        pitches,
+                        std::move(deleter),
+                        Alignment<alignment>{}};
+                    return buffer;
+                }
             }
         };
     } // namespace internal

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -212,7 +212,7 @@ namespace alpaka::onHost::internal
                 = std::max(u_int32_t(1), onHost::getDynSharedMemBytes(executor, threadBlocking, kernelBundle));
             assert(
                 st_shared_mem_bytes + blockDynSharedMemBytes
-                <= m_device->getNativeHandle().first.template get_info<sycl::info::device::local_mem_size>());
+                <= queue.m_device->getNativeHandle().first.template get_info<sycl::info::device::local_mem_size>());
 
             queue.m_queue.submit(
                 [threadBlocking, kernelBundle, blockDynSharedMemBytes](sycl::handler& cgh)
@@ -286,7 +286,7 @@ namespace alpaka::onHost::internal
 
             assert(
                 st_shared_mem_bytes + blockDynSharedMemBytes
-                <= m_device->getNativeHandle().first.template get_info<sycl::info::device::local_mem_size>());
+                <= queue.m_device->getNativeHandle().first.template get_info<sycl::info::device::local_mem_size>());
 
             queue.m_queue.submit(
                 [threadBlocking, frameSpec, kernelBundle, blockDynSharedMemBytes](sycl::handler& cgh)

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -79,6 +79,7 @@ namespace alpaka::onHost
             friend struct alpaka::internal::GetApi;
             friend struct internal::GetDeviceProperties;
             friend struct internal::AdjustThreadSpec;
+            friend struct onHost::internal::AllocAsync;
         };
     } // namespace syclGeneric
 

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -14,6 +14,8 @@
 #    include "alpaka/onAcc/Acc.hpp"
 #    include "alpaka/onHost.hpp"
 #    include "alpaka/onHost/concepts.hpp"
+#    include "alpaka/onHost/internal.hpp"
+#    include "alpaka/onHost/mem/ManagedView.hpp"
 #    include "alpaka/onHost/trait.hpp"
 
 #    include <sycl/sycl.hpp>
@@ -90,6 +92,7 @@ namespace alpaka::onHost
         private:
             friend struct alpaka::internal::GetDeviceType;
             friend struct alpaka::onHost::internal::Enqueue;
+            friend struct onHost::internal::AllocAsync;
 
             auto getDeviceKind() const
             {
@@ -160,6 +163,80 @@ namespace alpaka::onHost
         {
             sycl::queue sycl_queue = queue.getNativeHandle();
             sycl_queue.fill(internal::Data::data(dest), elementValue, extents.x());
+        }
+    };
+
+    /** The code is a copy of the Alloc::Op with the difference that the memory is allocated and freed
+     * asynchronously
+     *
+     * @todo check if we can reduce the duplication by having a common function for the computation of the extents
+     * and pitches and seperate the View creation.
+     */
+    template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
+    struct internal::AllocAsync::Op<T_Type, syclGeneric::Queue<T_Device>, T_Extents>
+    {
+        static consteval uint32_t highestPowerOfTwo(uint32_t value)
+        {
+            uint32_t result = 1u;
+            while((result << 1u) <= value)
+            {
+                result <<= 1u;
+            }
+            return result;
+        }
+
+        auto operator()(syclGeneric::Queue<T_Device>& queue, T_Extents const& extents) const
+        {
+            using IdxType = typename T_Extents::type;
+
+            constexpr uint32_t typeAlignmentBytes = alignof(T_Type);
+            constexpr uint32_t simdPackBytes = alpaka::getArchSimdWidth<T_Type>(
+                                                   ALPAKA_TYPEOF(getApi(queue)){},
+                                                   ALPAKA_TYPEOF(getDeviceKind(queue)){})
+                                               * sizeof(T_Type);
+            constexpr uint32_t bestSimdPackBytes = highestPowerOfTwo(simdPackBytes);
+            constexpr IdxType alignment = std::max(bestSimdPackBytes, typeAlignmentBytes);
+
+            auto deviceDependency = onHost::Device{queue.getDevice()->getSharedPtr()};
+            sycl::queue sycl_queue = queue.getNativeHandle();
+
+            constexpr auto dim = T_Extents::dim();
+            if constexpr(dim == 1u)
+            {
+                T_Type* ptr = reinterpret_cast<T_Type*>(
+                    sycl::aligned_alloc_device(alignment, extents.x() * sizeof(T_Type), sycl_queue));
+                auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
+                auto deleter = [queue, ptr]() { sycl::free(ptr, queue.getNativeHandle()); };
+
+                auto buffer = onHost::ManagedView{
+                    deviceDependency,
+                    ptr,
+                    extents,
+                    pitches,
+                    std::move(deleter),
+                    Alignment<alignment>{}};
+                return buffer;
+            }
+            else
+            {
+                IdxType rowExtentInBytes = extents.x() * static_cast<IdxType>(sizeof(T_Type));
+                IdxType rowPitchInBytes = divCeil(rowExtentInBytes, alignment) * alignment;
+                auto pitches = alpaka::mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
+
+                size_t memSizeInByte = pCast<size_t>(pitches)[0] * static_cast<size_t>(extents[0]);
+                T_Type* ptr
+                    = reinterpret_cast<T_Type*>(sycl::aligned_alloc_device(alignment, memSizeInByte, sycl_queue));
+                auto deleter = [queue, ptr]() { sycl::free(ptr, queue.getNativeHandle()); };
+
+                auto buffer = onHost::ManagedView{
+                    deviceDependency,
+                    ptr,
+                    extents,
+                    pitches,
+                    std::move(deleter),
+                    Alignment<alignment>{}};
+                return buffer;
+            }
         }
     };
 } // namespace alpaka::onHost

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -108,6 +108,7 @@ namespace alpaka::onHost
             }
 
             friend struct onHost::internal::Alloc;
+            friend struct onHost::internal::AllocAsync;
             friend struct alpaka::internal::GetApi;
             friend struct internal::GetDeviceProperties;
             friend struct internal::AdjustThreadSpec;

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -24,6 +24,7 @@
 #    include "alpaka/onHost/FrameSpec.hpp"
 #    include "alpaka/onHost/Handle.hpp"
 #    include "alpaka/onHost/internal.hpp"
+#    include "alpaka/onHost/mem/ManagedView.hpp"
 
 #    include <cstdint>
 #    include <sstream>
@@ -35,7 +36,7 @@ namespace alpaka::onHost
         struct CallKernel;
 
         template<typename T_Device>
-        struct Queue
+        struct Queue : std::enable_shared_from_this<Queue<T_Device>>
         {
             using ApiInterface = typename T_Device::ApiInterface;
 
@@ -119,11 +120,17 @@ namespace alpaka::onHost
                 return m_device;
             }
 
+            std::shared_ptr<Queue> getSharedPtr()
+            {
+                return this->shared_from_this();
+            }
+
             friend struct onHost::internal::GetDevice;
 
             friend struct alpaka::internal::GetApi;
             friend struct onHost::internal::Memcpy;
             friend struct onHost::internal::Memset;
+            friend struct onHost::internal::AllocAsync;
             friend struct CallKernel;
         };
 
@@ -512,6 +519,75 @@ namespace alpaka::onHost
                     std::get<0>(executors),
                     dataView.getSubView(extents),
                     elementValue);
+            }
+        };
+
+        /** The code is a copy of the Alloc::Op with the difference that the memory is allocated and freed
+         * asynchronously
+         *
+         * @todo check if we can reduce the duplication by having a common function for the computation of the extents
+         * and pitches and seperate the View creation.
+         */
+        template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
+        struct AllocAsync::Op<T_Type, unifiedCudaHip::Queue<T_Device>, T_Extents>
+        {
+            auto operator()(unifiedCudaHip::Queue<T_Device>& queue, T_Extents const& extents) const
+            {
+                using ApiInterface = typename T_Device::ApiInterface;
+
+                /** Each CUDA/HIP allocation is aligned to at least 128 byte but typically to 256byte
+                 *
+                 * @todo check if this value can be derived from the device properties
+                 * @todo validate if memory is always aligtne dto 256 byte
+                 */
+                constexpr uint32_t alignment = 128u;
+
+                T_Type* ptr = nullptr;
+                auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
+
+                using Idx = typename T_Extents::type;
+
+                constexpr auto dim = T_Extents::dim();
+                if constexpr(dim == 1u)
+                {
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ApiInterface,
+                        ApiInterface::mallocAsync(
+                            (void**) &ptr,
+                            static_cast<std::size_t>(extents.x()) * sizeof(T_Type),
+                            queue.getNativeHandle()));
+                }
+                else if constexpr(dim >= 2u)
+                {
+                    Idx rowExtentInBytes = extents.x() * static_cast<Idx>(sizeof(T_Type));
+                    Idx rowPitchInBytes = divCeil(rowExtentInBytes, static_cast<Idx>(alignment)) * alignment;
+                    pitches = alpaka::mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
+
+                    size_t memSizeInByte = pCast<size_t>(pitches)[0] * static_cast<size_t>(extents[0]);
+
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ApiInterface,
+                        ApiInterface::mallocAsync((void**) &ptr, memSizeInByte, queue.getNativeHandle()));
+                }
+
+                auto deviceDependency = onHost::Device{queue.getDevice()->getSharedPtr()};
+                auto queueDependency = onHost::Queue{queue.getSharedPtr()};
+
+                auto deleter = [ptr, queueDependency]()
+                {
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+                        ApiInterface,
+                        ApiInterface::freeAsync(ptr, queueDependency.getNativeHandle()));
+                };
+
+                auto buffer = onHost::ManagedView{
+                    deviceDependency,
+                    ptr,
+                    extents,
+                    pitches,
+                    std::move(deleter),
+                    Alignment<alignment>{}};
+                return buffer;
             }
         };
     } // namespace internal

--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -164,14 +164,9 @@ namespace alpaka
             return ::cudaFree(devPtr);
         }
 
-        static inline Error_t freeAsync([[maybe_unused]] void* devPtr, [[maybe_unused]] Stream_t stream)
+        static inline Error_t freeAsync(void* devPtr, Stream_t stream)
         {
-#    if CUDART_VERSION >= 11020
             return ::cudaFreeAsync(devPtr, stream);
-#    else
-            // Not implemented.
-            return errorUnknown;
-#    endif
         }
 
         static inline Error_t funcGetAttributes(FuncAttributes_t* attr, void const* func)

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -180,10 +180,8 @@ namespace alpaka
             return ::hipFree(devPtr);
         }
 
-        static inline Error_t freeAsync([[maybe_unused]] void* devPtr, [[maybe_unused]] Stream_t stream)
+        static inline Error_t freeAsync(void* devPtr, Stream_t stream)
         {
-            // stream-ordered memory operations are fully implemented only in ROCm 5.3.0 and later.
-#    if HIP_VERSION >= 50'300'000
             // hipFreeAsync fails on a null pointer deallocation
             if(devPtr)
             {
@@ -193,10 +191,6 @@ namespace alpaka
             {
                 return ::hipSuccess;
             }
-#    else
-            // Not implemented.
-            return errorUnknown;
-#    endif
         }
 
         static inline Error_t funcGetAttributes(FuncAttributes_t* attr, void const* func)

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -264,4 +264,45 @@ namespace alpaka::onHost
     Queue(Handle<T_Queue>&&) -> Queue<Device<
         ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Queue>())),
         ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Queue>()))>>;
+
+    /** allocate memory asynchronously in the given queue
+     *
+     * @attention It is allowed that the function is blocking the caller until the memory is created.
+     *
+     * The memory is allowed to be used in other queues too.
+     * To avoid that a view to the memory is still in use during the deallocation you can use @see
+     * addDestructorAction() and wait for a queue if it differs to the queue used for the allocation.
+     *
+     * @tparam T_Type type of the data elements
+     * @param queue queue handle
+     * @return Memory owning view to the allocated memory. You are not allowed to derefence the view to access the
+     * memory before the allocation within the queue is finished. The view will be freed after the last instance to the
+     * memory is destroyed. The deallocation is asynchronous performed in the the queue which is used for the
+     * allocation.
+     *
+     * @{
+     */
+
+    /**
+     * @param extents number of elements for each dimension
+     */
+    template<typename T_Type, typename T_Device>
+    inline auto allocAsync(Queue<T_Device> const& queue, alpaka::concepts::VectorOrScalar auto const& extents)
+    {
+        Vec const extentsVec = extents;
+        return internal::AllocAsync::Op<T_Type, std::decay_t<decltype(*queue.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
+            *queue.get(),
+            extentsVec);
+    }
+
+    /**
+     * @param view other memory where the extents will be derived from
+     */
+    template<typename T_Device>
+    inline auto allocLikeAsync(Queue<T_Device> const& queue, auto const& view)
+    {
+        return allocAsync<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(queue, getExtents(view));
+    }
+
+    /** @} */
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -254,7 +254,6 @@ namespace alpaka::onHost::internal
             frameSpec = FrameSpec{adjsutedNumFrames, frameSpec.m_frameExtent};
         }
 
-        std::cout << frameSpec << std::endl;
         auto kernelFn
             = SimdTransformReduceKernel{static_cast<uint32_t>(frameSpec.m_frameExtent.product() * sizeof(DataType))};
 

--- a/include/alpaka/onHost/internal.hpp
+++ b/include/alpaka/onHost/internal.hpp
@@ -225,6 +225,15 @@ namespace alpaka::onHost
             };
         };
 
+        struct AllocAsync
+        {
+            template<typename T_Type, typename T_Any, typename T_Extents>
+            struct Op
+            {
+                void operator()(T_Any& any, T_Extents const&) const;
+            };
+        };
+
         struct Memcpy
         {
             template<typename T_Queue, typename T_Dest, typename T_Source, typename T_Extents>

--- a/include/alpaka/onHost/mem/ManagedView.hpp
+++ b/include/alpaka/onHost/mem/ManagedView.hpp
@@ -119,6 +119,24 @@ namespace alpaka::onHost
             return ManagedView{T_Api{}, shiftedPtr, extents, this->getPitches(), Alignment<>{}};
         }
 
+        /** Adds a destructor action to the managed view
+         *
+         * The action will be executed when the managed view is destroyed.
+         * This can be used to add additional cleanup actions e.g. waiting on a specific queue.
+         * Actions are executed in FIFO order.
+         *
+         * @param action callable to execute on destruction
+         */
+        void addDestructorAction(std::function<void()>&& action)
+        {
+            m_deleter->addAction(ALPAKA_FORWARD(action));
+        }
+
+        void destructorWaitFor(auto const& any)
+        {
+            addDestructorAction([any]() { onHost::wait(any); });
+        }
+
     private:
         /** @todo move this to trais or somewhere else that it can be used everywhere */
         template<alpaka::concepts::IsPointer T>

--- a/include/alpaka/onHost/mem/ManagedView.hpp
+++ b/include/alpaka/onHost/mem/ManagedView.hpp
@@ -132,6 +132,10 @@ namespace alpaka::onHost
             m_deleter->addAction(ALPAKA_FORWARD(action));
         }
 
+        /** Add an action to be executed when the shared_ptr is destroyed.
+         *
+         * @param action Callable to execute on destruction.
+         */
         void destructorWaitFor(auto const& any)
         {
             addDestructorAction([any]() { onHost::wait(any); });

--- a/include/alpaka/onHost/mem/MangedDealloc.hpp
+++ b/include/alpaka/onHost/mem/MangedDealloc.hpp
@@ -47,7 +47,7 @@ namespace alpaka::onHost::mem
         void addAction(std::function<void()> action)
         {
             std::lock_guard<std::mutex> lock{actionGuard};
-            actions.push_back(std::move(action));
+            actions.emplace_back(std::move(action));
         }
 
         std::shared_ptr<ManagedDealloc> getSharedPtr()

--- a/include/alpaka/onHost/mem/MangedDealloc.hpp
+++ b/include/alpaka/onHost/mem/MangedDealloc.hpp
@@ -18,11 +18,9 @@ namespace alpaka::onHost::mem
      */
     struct ManagedDealloc : std::enable_shared_from_this<ManagedDealloc>
     {
-        std::function<void()> freeOp;
-
         /**
          * Constructor
-         * @param freeOp Function to be called when the shared_ptr is destroyed.
+         * @param freeOp Function to be called when the shared_ptr is destroyed after all actions are executed.
          *               All dependencies required to deallocate the memory must be holed by freeOp.
          */
         ManagedDealloc(std::function<void()> freeOp) : freeOp{std::move(freeOp)}
@@ -31,12 +29,35 @@ namespace alpaka::onHost::mem
 
         ~ManagedDealloc()
         {
+            // Execute all actions before freeing the memory
+            {
+                std::lock_guard<std::mutex> lock{actionGuard};
+                for(auto& action : actions)
+                {
+                    action();
+                }
+            }
             freeOp();
+        }
+
+        /** Add an action to be executed when the shared_ptr is destroyed.
+         *
+         * @param action Callable to execute on destruction.
+         */
+        void addAction(std::function<void()> action)
+        {
+            std::lock_guard<std::mutex> lock{actionGuard};
+            actions.push_back(std::move(action));
         }
 
         std::shared_ptr<ManagedDealloc> getSharedPtr()
         {
             return this->shared_from_this();
         }
+
+    private:
+        std::function<void()> freeOp;
+        std::mutex actionGuard;
+        std::vector<std::function<void()>> actions;
     };
 } // namespace alpaka::onHost::mem

--- a/tests/unit/algorithm/transform.cpp
+++ b/tests/unit/algorithm/transform.cpp
@@ -76,9 +76,9 @@ void executeTest(
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
     using OutDataType = decltype(functorPair.second(std::declval<DataType>(), std::declval<DataType>()));
-    onHost::ManagedView computeViewOut = onHost::alloc<OutDataType>(computeDev, extentMd);
-    onHost::ManagedView computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::ManagedView computeViewIn1 = onHost::allocLike(computeDev, computeViewIn0);
+    onHost::ManagedView computeViewOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd);
+    onHost::ManagedView computeViewIn0 = onHost::allocAsync<DataType>(computeQueue, extentMd);
+    onHost::ManagedView computeViewIn1 = onHost::allocLikeAsync(computeQueue, computeViewIn0);
     onHost::ManagedView hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
     onHost::ManagedView hostViewOut = onHost::allocLike(onHost::makeHostDevice(), computeViewOut);
 


### PR DESCRIPTION
- add `onHost::allocAsync()`,  `onHost::allocLikeAsync()
  - Use new asynchronous allocation for the accumulation result of the dot kernel.
  - Use asynchronous allocation in the transform test.
- `addDestructorAction()` and ` destructorWaitFor()` to `ManagedView`
  - Registering an action is very useful to guarantee that asynchronously allocated memory is not destroyed before all operations in a queue different from the allocation queue are finished.