### PR TITLE
add `onHost::reduce()`

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -35,6 +35,7 @@
 #include "alpaka/onHost/DeviceSelector.hpp"
 #include "alpaka/onHost/Queue.hpp"
 #include "alpaka/onHost/algo/concurrent.hpp"
+#include "alpaka/onHost/algo/reduce.hpp"
 #include "alpaka/onHost/algo/transform.hpp"
 #include "alpaka/onHost/algo/transformReduce.hpp"
 #include "alpaka/onHost/mem/stdContainer.hpp"

--- a/include/alpaka/functor.hpp
+++ b/include/alpaka/functor.hpp
@@ -19,6 +19,8 @@ namespace alpaka
     template<typename T_Func>
     struct StencilFunc : T_Func
     {
+        using Functor = T_Func;
+
         constexpr StencilFunc(auto&& func) : T_Func{ALPAKA_FORWARD(func)}
         {
         }
@@ -35,6 +37,8 @@ namespace alpaka
     template<typename T_Func>
     struct ScalarFunc : T_Func
     {
+        using Functor = T_Func;
+
         constexpr ScalarFunc(auto&& func) : T_Func{ALPAKA_FORWARD(func)}
         {
         }

--- a/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
+++ b/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
@@ -12,6 +12,7 @@
 #include "alpaka/functor.hpp"
 #include "alpaka/mem/concepts.hpp"
 #include "alpaka/onAcc.hpp"
+#include "alpaka/onAcc/Acc.hpp"
 
 #include <cstdint>
 #include <new>
@@ -89,7 +90,7 @@ namespace alpaka::onAcc::internal
 
     private:
         template<alpaka::concepts::Alignment T_MemAlignment, uint32_t T_width>
-        ALPAKA_FN_INLINE static constexpr auto executeDoReduce(
+        ALPAKA_FN_INLINE static constexpr auto executeDoTransform(
             auto const& acc,
             auto const& dataIdx,
             auto&& func,
@@ -126,13 +127,13 @@ namespace alpaka::onAcc::internal
                     /* It is not possible to create a Simd{Simd} due to constructor issues. Therefore we need to define
                      * the type for the result explicit.
                      */
-                    using ComponentType = ALPAKA_TYPEOF(executeDoReduce<T_MemAlignment, T_width>(
+                    using ComponentType = ALPAKA_TYPEOF(executeDoTransform<T_MemAlignment, T_width>(
                         acc,
                         std::get<0>(std::make_tuple(dataIdx...)),
                         ALPAKA_FORWARD(func),
                         ALPAKA_FORWARD(data)...));
                     auto results = Simd<ComponentType, std::tuple_size_v<ALPAKA_TYPEOF(ids)>>{
-                        executeDoReduce<T_MemAlignment, T_width>(
+                        executeDoTransform<T_MemAlignment, T_width>(
                             acc,
                             dataIdx,
                             ALPAKA_FORWARD(func),
@@ -144,6 +145,67 @@ namespace alpaka::onAcc::internal
         }
 
     private:
+        template<onAcc::concepts::Acc T_Acc, typename T_ReduceOp>
+        struct ScalarReducer
+        {
+            // using a const reference here is fine because we control the lifetime
+            T_Acc const& m_acc;
+            T_ReduceOp const& m_reduceOp;
+
+            constexpr ScalarReducer(T_Acc const& acc, auto&& func) : m_acc(acc), m_reduceOp{ALPAKA_FORWARD(func)}
+            {
+            }
+
+            constexpr auto operator()(auto&& a, auto&& b) const
+                requires(alpaka::concepts::Simd<ALPAKA_TYPEOF(a)> && alpaka::concepts::Simd<ALPAKA_TYPEOF(b)>)
+            {
+                return loadAncExecuteScalarOp(
+                    std::make_integer_sequence<uint32_t, ALPAKA_TYPEOF(a)::dim()>{},
+                    [this](alpaka::concepts::CVector auto idx, auto const& acc, auto&& func, auto&&... data) constexpr
+                    {
+                        // recursively call until no Simd type is the result
+                        return operator()(data[idx.x()]...);
+                    },
+                    m_acc,
+                    m_reduceOp,
+                    a,
+                    b);
+            }
+
+            constexpr auto operator()(auto&& a, auto&& b) const
+                requires(!alpaka::concepts::Simd<ALPAKA_TYPEOF(a)> && !alpaka::concepts::Simd<ALPAKA_TYPEOF(b)>)
+            {
+                return m_reduceOp(a, b);
+            }
+
+        private:
+            template<uint32_t... T_idx>
+            ALPAKA_FN_INLINE ALPAKA_FN_ACC static constexpr auto loadAncExecuteScalarOp(
+                std::integer_sequence<uint32_t, T_idx...>,
+                auto&& op,
+                auto const& acc,
+                auto&& func,
+                auto&&... data)
+            {
+                return Simd{op(CVec<uint32_t, T_idx>{}, acc, ALPAKA_FORWARD(func), ALPAKA_FORWARD(data)...)...};
+            }
+        };
+
+        /** Get the reducer functor
+         *
+         * @return wrapped functor in case the input is @see ScalarFunc else the identity
+         */
+        ALPAKA_FN_INLINE constexpr auto getReducer(onAcc::concepts::Acc auto const&, auto&& reduceOp) const
+        {
+            return reduceOp;
+        }
+
+        ALPAKA_FN_INLINE constexpr auto getReducer(onAcc::concepts::Acc auto const& acc, auto&& reduceOp) const
+            requires(isSpecializationOf_v<ALPAKA_TYPEOF(reduceOp), ScalarFunc>)
+        {
+            return ScalarReducer<ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(reduceOp)>{acc, reduceOp};
+        }
+
         constexpr auto const& asParent() const
         {
             return static_cast<T_Parent const&>(*this);
@@ -154,11 +216,13 @@ namespace alpaka::onAcc::internal
             auto const& acc,
             alpaka::concepts::Vector auto numElements,
             auto const& neutralElement,
-            auto&& reduceFunc,
+            auto&& userReduceFunc,
             auto&& func,
             alpaka::concepts::MdSpan auto&& data0,
             alpaka::concepts::MdSpan auto&&... dataN) const
         {
+            auto reduceFunc = getReducer(acc, userReduceFunc);
+
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
             constexpr uint32_t simdWidthInByte = T_simdWidth * sizeof(ValueType);
             // number of simd packs fitting into the maxConcurrencyInByte

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -69,41 +69,17 @@ namespace alpaka::onHost::internal
                 {
                     auto allThreads = alpaka::onAcc::SimdAlgo{
                         alpaka::onAcc::WorkerGroup{frameIdx + elemIdxInFrame, frameDataExtent}};
-                    if constexpr(isSpecializationOf_v<ALPAKA_TYPEOF(reduceFunc), ScalarFunc>)
-                    {
-                        // reduce functor with for scalar values only
-                        callTransformFn(
-                            acc,
-                            allThreads,
-                            extentMd,
-                            neutralElement,
-                            tbSum[elemIdxInFrame],
-                            [&](auto&& a, auto&& b) constexpr
-                            {
-                                return loadAncExecuteScalarOp(
-                                    std::make_integer_sequence<uint32_t, ALPAKA_TYPEOF(a)::width()>{},
-                                    [&](alpaka::concepts::CVector auto idx, auto const& acc, auto&&... data) constexpr
-                                    { return reduceFunc(data[idx.x()]...); },
-                                    acc,
-                                    a,
-                                    b);
-                            },
-                            transformFunc,
-                            ALPAKA_FORWARD(inputs)...);
-                    }
-                    else
-                    {
-                        // reduce functor with simd package support
-                        callTransformFn(
-                            acc,
-                            allThreads,
-                            extentMd,
-                            neutralElement,
-                            tbSum[elemIdxInFrame],
-                            reduceFunc,
-                            transformFunc,
-                            ALPAKA_FORWARD(inputs)...);
-                    }
+
+                    // reduce functor with simd package support
+                    callTransformFn(
+                        acc,
+                        allThreads,
+                        extentMd,
+                        neutralElement,
+                        tbSum[elemIdxInFrame],
+                        reduceFunc,
+                        transformFunc,
+                        ALPAKA_FORWARD(inputs)...);
                 }
             }
 
@@ -137,8 +113,18 @@ namespace alpaka::onHost::internal
             // Atomic update of the global result
             if(laneIdInBlock == 0)
             {
-                using BinaryAtomicOp = onAcc::FunctorToAtomicOp_t<ALPAKA_TYPEOF(reduceFunc)>;
-                alpaka::onAcc::atomicOp<BinaryAtomicOp>(acc, output.data(), dynS[laneIdInBlock]);
+                if constexpr(requires { typename ALPAKA_TYPEOF(reduceFunc)::Functor; })
+                {
+                    // Handle wrapped reduce functors e.g. ScalarFunc
+                    using ReduceFunctor = typename ALPAKA_TYPEOF(reduceFunc)::Functor;
+                    using BinaryAtomicOp = onAcc::FunctorToAtomicOp_t<ReduceFunctor>;
+                    alpaka::onAcc::atomicOp<BinaryAtomicOp>(acc, output.data(), dynS[laneIdInBlock]);
+                }
+                else
+                {
+                    using BinaryAtomicOp = onAcc::FunctorToAtomicOp_t<ALPAKA_TYPEOF(reduceFunc)>;
+                    alpaka::onAcc::atomicOp<BinaryAtomicOp>(acc, output.data(), dynS[laneIdInBlock]);
+                }
             }
         }
 
@@ -162,7 +148,7 @@ namespace alpaka::onHost::internal
             auto& result,
             auto&& reduceFunc,
             auto&& transformFunc,
-            auto&&... inputs)
+            alpaka::concepts::MdSpan auto&&... inputs)
 
         {
             // Use the generic transformFunc and the variant reduceFunc

--- a/include/alpaka/onHost/algo/reduce.hpp
+++ b/include/alpaka/onHost/algo/reduce.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/trait.hpp"
+#include "alpaka/mem/concepts.hpp"
+#include "alpaka/onHost/algo/internal/transformReduce.hpp"
+
+namespace alpaka::onHost
+{
+    /** accumulate the results into a scalar value.
+     *
+     * @param queue The queue to execute the transformation.
+     * @param exec The executor to use for the kernel execution.
+     * @param neutralElement The neutral element in respect to binaryReduceFn.
+     * @param out MdSpan for the result. The value_type must be equal to neutralElement and the result of the binary
+     * reduce functor type. The result is written to the first element of the output data.
+     * @param binaryReduceFn Reduce binary functor, the functor operation must be transitive and commutative.
+     *   The atomic trait alpaka::onAcc::trait::FunctorToAtomicOp<> must be specialized.
+     *   The functor execution order is not specified.
+     *   The functor should support Simd packages, if not you can enforce the element wise execution by wrapping into
+     *   @see ScalarFunc.
+     * @param in The input data which should be reduced.
+     *
+     * @{
+     */
+    template<typename DataType, typename T_Device>
+    inline void reduce(
+        Queue<T_Device> const& queue,
+        alpaka::concepts::Executor auto const exec,
+        DataType const& neutralElement,
+        alpaka::concepts::MdSpan auto out,
+        auto&& binaryReduceFn,
+        auto&& in) requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
+    {
+        internal::transformReduce(
+            queue,
+            exec,
+            neutralElement,
+            out,
+            ALPAKA_FORWARD(binaryReduceFn),
+            std::identity{},
+            ALPAKA_FORWARD(in));
+    }
+
+    /**
+     * A available default executor will be selected automaticlally. The default executor is a executor with most
+     * parallelism/performance.
+     */
+    template<typename DataType, typename T_Device>
+    inline void reduce(
+        Queue<T_Device> const& queue,
+        DataType const& neutralElement,
+        alpaka::concepts::MdSpan auto out,
+        auto&& binaryReduceFn,
+        auto&& in) requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
+    {
+        auto executor = supportedMappings(queue.getDevice());
+        reduce(queue, std::get<0>(executor), neutralElement, out, ALPAKA_FORWARD(binaryReduceFn), ALPAKA_FORWARD(in));
+    }
+
+    /** @} */
+} // namespace alpaka::onHost

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -27,7 +27,9 @@ namespace alpaka::onHost
      * reduce functor type. The result is written to the first element of the output data.
      * @param binaryReduceFn Reduce binary functor, the functor operation must be transitive and commutative.
      *   The atomic trait alpaka::onAcc::trait::FunctorToAtomicOp<> must be specialized.
-     *   Currently only std::plus<> is supported. The functor execution order is not specified.
+     *   The functor execution order is not specified.
+     *   The functor should support Simd packages, if not you can enforce the element wise execution by wrapping into
+     *   @see ScalarFunc.
      * @param transformFn The function to apply to each element of the input data.
      *   The functor should support Simd packages. If not you can enforce the element wise execution by wrapping into
      * @see ScalarFunc. If you would like to support stencil executions wrapp fn into @see StencilFunc. StencilFunc is

--- a/tests/unit/algorithm/reduce.cpp
+++ b/tests/unit/algorithm/reduce.cpp
@@ -1,0 +1,158 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executeForEach.hpp>
+#include <alpaka/example/executors.hpp>
+#include <alpaka/meta/CartesianProduct.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <type_traits>
+
+using namespace alpaka;
+
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis))>;
+
+// This functor des not support Simd and must be wrapped by @see ScalarFunc
+struct MinValue
+{
+    constexpr auto operator()(auto const& a, auto const& b) const
+    {
+        return math::min(a, b);
+    }
+};
+
+template<>
+struct alpaka::onAcc::trait::FunctorToAtomicOp<MinValue>
+{
+    using type = alpaka::onAcc::AtomicMin;
+};
+
+// This functor des not support Simd and must be wrapped by @see ScalarFunc
+struct MaxValue
+{
+    constexpr auto operator()(auto const& a, auto const& b) const
+    {
+        return math::max(a, b);
+    }
+};
+
+template<>
+struct alpaka::onAcc::trait::FunctorToAtomicOp<MaxValue>
+{
+    using type = alpaka::onAcc::AtomicMax;
+};
+
+template<typename T_DataType>
+void executeTest(
+    concepts::Executor auto exec,
+    auto const& computeQueue,
+    auto const functorPair,
+    concepts::Vector auto extentMd)
+{
+    std::cout << "run func : " << core::demangledName(std::get<2>(functorPair)) << std::endl;
+
+    auto computeDev = computeQueue.getDevice();
+    using DataType = T_DataType;
+    using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
+    onHost::ManagedView computeViewOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd.all(1));
+    onHost::ManagedView computeViewIn = onHost::allocAsync<DataType>(computeQueue, extentMd);
+    onHost::ManagedView hostViewIota = onHost::allocHostLike(computeViewIn);
+    onHost::ManagedView hostViewOut = onHost::allocHostLike(computeViewOut);
+
+    // initialize with the linearized index
+    DataType iotaCounter = 0;
+    for(auto& value : hostViewIota)
+    {
+        value = iotaCounter;
+        ++iotaCounter;
+    }
+
+    onHost::memcpy(computeQueue, computeViewIn, hostViewIota);
+
+    onHost::wait(computeQueue);
+    auto const beginT = std::chrono::high_resolution_clock::now();
+
+    onHost::reduce(
+        computeQueue,
+        exec,
+        std::get<0>(functorPair),
+        computeViewOut,
+        std::get<1>(functorPair),
+        computeViewIn);
+
+    onHost::wait(computeQueue);
+    auto const endT = std::chrono::high_resolution_clock::now();
+    std::cout << "Time for reduction: " << std::chrono::duration<double>(endT - beginT).count() << 's'
+              << " data size: " << hostViewIota.getExtents() << std::endl;
+
+    onHost::memcpy(computeQueue, hostViewOut, computeViewOut);
+    onHost::wait(computeQueue);
+
+    // validate without using the forward iterator
+    DataType refIotaCounter = 0;
+    auto result = std::get<0>(functorPair);
+    meta::ndLoopIncIdx(
+        extentMd,
+        [&](auto idx)
+        {
+            result = std::get<2>(functorPair)(result, refIotaCounter);
+            ++refIotaCounter;
+        });
+
+    CHECK(*hostViewOut.data() == result);
+};
+
+template<typename T_DataType>
+void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTuples)
+{
+    using DataType = T_DataType;
+
+    auto deviceSpec = cfg[object::deviceSpec];
+    alpaka::concepts::Executor auto exec = cfg[object::exec];
+
+    auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!computeDevSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device computeDev = computeDevSelector.makeDevice(0);
+
+    std::cout << "device spec: " << getName(deviceSpec) << std::endl;
+    std::cout << "device name: " << computeDev.getName() << std::endl;
+    std::cout << "executor   : " << exec.getName() << std::endl;
+
+    onHost::Queue computeQueue = computeDev.makeQueue();
+
+    // execute for each functor
+    std::apply(
+        [&](auto const&... functorPair) { (executeTest<DataType>(exec, computeQueue, functorPair, extentMd), ...); },
+        functorTuples);
+}
+
+TEMPLATE_LIST_TEST_CASE("reduce", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    using DataType = int;
+
+    // This list is not directly defined within the function `prepareTest()` due to nvcc compile issues.
+    auto functorList = std::make_tuple(
+        std::make_tuple(DataType{0}, std::plus{}, std::plus{}),
+        std::make_tuple(std::numeric_limits<DataType>::max(), ScalarFunc{MinValue{}}, MinValue{}),
+        std::make_tuple(std::numeric_limits<DataType>::min(), ScalarFunc{MaxValue{}}, MaxValue{}));
+
+    // different extents for testing
+    auto extentMdList
+        = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
+
+    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, functorList), ...); }, extentMdList);
+}

--- a/tests/unit/algorithm/transformReduce.cpp
+++ b/tests/unit/algorithm/transformReduce.cpp
@@ -64,6 +64,21 @@ struct ScalarOpWithAcc
     }
 };
 
+// This functor des not support Simd and must be wrapped by @see ScalarFunc
+struct MinValue
+{
+    constexpr auto operator()(auto const& a, auto const& b) const
+    {
+        return math::min(a, b);
+    }
+};
+
+template<>
+struct alpaka::onAcc::trait::FunctorToAtomicOp<MinValue>
+{
+    using type = alpaka::onAcc::AtomicMin;
+};
+
 template<typename T_DataType>
 void executeTest(
     concepts::Executor auto exec,
@@ -71,7 +86,8 @@ void executeTest(
     auto const functorPair,
     concepts::Vector auto extentMd)
 {
-    std::cout << "run func : " << core::demangledName(std::get<2>(functorPair).second) << std::endl;
+    std::cout << "run reduce(func) : " << core::demangledName(std::get<1>(functorPair).second) << "("
+              << core::demangledName(std::get<2>(functorPair).second) << ")" << std::endl;
 
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
@@ -197,10 +213,12 @@ TEMPLATE_LIST_TEST_CASE("transformReduce", "", TestBackends)
             std::make_pair(
                 ScalarFunc{[] ALPAKA_FN_ACC(DataType const& a, DataType const& b)
                            { return math::min(a + DataType{1}, b); }},
-                [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); }))
-
-
-    );
+                [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); })),
+        std::make_tuple(
+            std::numeric_limits<DataType>::max(),
+            std::make_pair(ScalarFunc{MinValue{}}, MinValue{}),
+            // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
+            std::make_pair(std::plus{}, std::plus{})));
 
     // different extents for testing
     auto extentMdList

--- a/tests/unit/simd/simd.cpp
+++ b/tests/unit/simd/simd.cpp
@@ -177,6 +177,14 @@ struct CompileTimeKernelCompare2D
 
 struct CompileTimeKernelReduce
 {
+    struct MinValue
+    {
+        constexpr auto operator()(auto const& a, auto const& b) const
+        {
+            return a < b ? a : b;
+        }
+    };
+
     ALPAKA_FN_HOST_ACC void operator()() const
     {
         using namespace alpaka;
@@ -192,6 +200,13 @@ struct CompileTimeKernelReduce
         constexpr auto s3 = Simd{1, 2, 3, 4, 5};
         static_assert(120 == s3.reduce(std::multiplies{}));
         static_assert(120 == s3.product());
+
+        // check user provided functor
+        constexpr auto s4 = Simd{1, 2, 3, 4, 5};
+        static_assert(1 == s4.reduce(MinValue{}));
+
+        constexpr auto s5 = Simd{1, 2, 3, 4, 5, -10};
+        static_assert(-10 == s5.reduce(MinValue{}));
     }
 };
 


### PR DESCRIPTION
- add `onHost::reduce()`
  - add interfaces
  - add tests
- remove restriction of `onHost::reduceTransform()` that the reduce operator can only be `std::plus`
  - this was possible by adding support for `ScalarFunc` to `onAcc::internal::SimdTransformReduce`
  - test other reduce functor as `std::plus`