### PR TITLE
fix `onHost::allocAsync()`

### DIFF
--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -122,6 +122,11 @@ namespace alpaka::onHost
                     });
             }
 
+            /** execute a task in the queue
+             *
+             * @attention Do NOT enqueue a task which captures the queue internally to keep the queue alive as
+             * dependency. In this case the destructure of the queue is not called.
+             */
             void enqueue(auto const& task)
             {
                 m_workerThread.submit([task]() { task(); });
@@ -326,19 +331,15 @@ namespace alpaka::onHost
                 constexpr auto dim = T_Extents::dim();
 
                 auto deviceDependency = onHost::Device{queue.getDevice()->getSharedPtr()};
-                auto queueDependency = onHost::Queue{queue.getSharedPtr()};
+                auto queueDependency = queue.getSharedPtr();
 
                 if constexpr(dim == 1u)
                 {
                     auto* ptr = reinterpret_cast<T_Type*>(
                         alpaka::core::alignedAlloc(alignment, extents.x() * sizeof(T_Type)));
                     // queueDependency is captured to keep the device alive until the memory is deleted
-                    auto deleter = [ptr, queueDependency]()
-                    {
-                        internal::enqueue(
-                            *queueDependency.get(),
-                            [ptr, queueDependency]() { alpaka::core::alignedFree(alignment, ptr); });
-                    };
+                    auto deleter = [ptr, queueDep = std::move(queueDependency)]()
+                    { internal::enqueue(*queueDep.get(), [ptr]() { alpaka::core::alignedFree(alignment, ptr); }); };
 
                     auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
                     auto buffer = onHost::ManagedView{
@@ -359,12 +360,8 @@ namespace alpaka::onHost
                     size_t memSizeInByte = pCast<size_t>(pitches)[0] * static_cast<size_t>(extents[0]);
 
                     auto* ptr = reinterpret_cast<T_Type*>(alpaka::core::alignedAlloc(alignment, memSizeInByte));
-                    auto deleter = [ptr, queueDependency]()
-                    {
-                        internal::enqueue(
-                            *queueDependency.get(),
-                            [ptr, queueDependency]() { alpaka::core::alignedFree(alignment, ptr); });
-                    };
+                    auto deleter = [ptr, queueDep = std::move(queueDependency)]()
+                    { internal::enqueue(*queueDep.get(), [ptr]() { alpaka::core::alignedFree(alignment, ptr); }); };
 
                     auto buffer = onHost::ManagedView{
                         deviceDependency,

--- a/include/alpaka/api/syclGeneric/Platform.hpp
+++ b/include/alpaka/api/syclGeneric/Platform.hpp
@@ -10,6 +10,7 @@
 
 #    include "Device.hpp"
 #    include "alpaka/core/Dict.hpp"
+#    include "alpaka/core/Sycl.hpp"
 #    include "alpaka/internal.hpp"
 
 #    include <sycl/sycl.hpp>

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -71,6 +71,11 @@ namespace alpaka::onHost
                 }
             }
 
+            std::shared_ptr<Queue> getSharedPtr()
+            {
+                return this->shared_from_this();
+            }
+
             [[nodiscard]] auto getNativeHandle() const noexcept
             {
                 return m_queue;
@@ -154,7 +159,7 @@ namespace alpaka::onHost
     struct internal::Fill::Op<syclGeneric::Queue<T_Device>, T_Dest, T_Value, T_Extents>
     {
         void operator()(
-            syclGeneric::Queue<T_Device> queue,
+            syclGeneric::Queue<T_Device>& queue,
             auto&& dest,
             T_Value elementValue,
             T_Extents const& extents) const
@@ -199,6 +204,7 @@ namespace alpaka::onHost
 
             auto deviceDependency = onHost::Device{queue.getDevice()->getSharedPtr()};
             sycl::queue sycl_queue = queue.getNativeHandle();
+            auto queueDependency = queue.getSharedPtr();
 
             constexpr auto dim = T_Extents::dim();
             if constexpr(dim == 1u)
@@ -206,7 +212,16 @@ namespace alpaka::onHost
                 T_Type* ptr = reinterpret_cast<T_Type*>(
                     sycl::aligned_alloc_device(alignment, extents.x() * sizeof(T_Type), sycl_queue));
                 auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
-                auto deleter = [queue, ptr]() { sycl::free(ptr, queue.getNativeHandle()); };
+
+                auto deleter = [queueDep = std::move(queueDependency), ptr]()
+                {
+                    /* @todo: validate if this is still required
+                     * This wait is a workaround because SYCL is not enqueuing the deallocation in a queue and
+                     * therefore the free is executed during it is still in use e.g. in a kernel
+                     */
+                    internal::wait(*queueDep.get());
+                    sycl::free(ptr, queueDep->getNativeHandle());
+                };
 
                 auto buffer = onHost::ManagedView{
                     deviceDependency,
@@ -226,7 +241,16 @@ namespace alpaka::onHost
                 size_t memSizeInByte = pCast<size_t>(pitches)[0] * static_cast<size_t>(extents[0]);
                 T_Type* ptr
                     = reinterpret_cast<T_Type*>(sycl::aligned_alloc_device(alignment, memSizeInByte, sycl_queue));
-                auto deleter = [queue, ptr]() { sycl::free(ptr, queue.getNativeHandle()); };
+
+                auto deleter = [queueDep = std::move(queueDependency), ptr]()
+                {
+                    /* @todo: validate if this is still required
+                     * This wait is a workaround because SYCL is not enqueuing the deallocation in a queue and
+                     * therefore the free is executed during it is still in use e.g. in a kernel
+                     */
+                    internal::wait(*queueDep.get());
+                    sycl::free(ptr, queueDep->getNativeHandle());
+                };
 
                 auto buffer = onHost::ManagedView{
                     deviceDependency,

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -38,7 +38,7 @@ namespace alpaka::onHost
         {
         }
 
-        auto get() const
+        auto* get() const
         {
             return m_queue.get();
         }

--- a/include/alpaka/onHost/algo/concurrent.hpp
+++ b/include/alpaka/onHost/algo/concurrent.hpp
@@ -57,7 +57,7 @@ namespace alpaka::onHost
      * parallelism/performance.
      */
     template<typename T_DataType, typename T_Device>
-    inline void transform(
+    inline void concurrent(
         Queue<T_Device> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents,
         auto&& fn,

--- a/tests/unit/mem/allocAsync.cpp
+++ b/tests/unit/mem/allocAsync.cpp
@@ -1,0 +1,76 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executeForEach.hpp>
+#include <alpaka/example/executors.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <iostream>
+
+using namespace alpaka;
+
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis))>;
+
+struct RaceCheckKErnel
+{
+    ALPAKA_FN_ACC void operator()(auto const& acc, concepts::MdSpan<int> auto success, concepts::MdSpan auto in) const
+    {
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange(in.getExtents())))
+        {
+            if(in[i] != 3.14159265f)
+                // set to false
+                onAcc::atomicExch(acc, &success[0], 0);
+        }
+    }
+};
+
+void runTestApis(auto cfg)
+{
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+    std::cout << deviceSpec.getApi().getName() << std::endl;
+
+    onHost::Device device = devSelector.makeDevice(0);
+
+    std::cout << device.getName() << std::endl;
+
+    onHost::Queue queue0 = device.makeQueue();
+
+    auto hViewResults = onHost::allocHost<int>(1u);
+    auto dViewResults = onHost::allocLike(device, hViewResults);
+
+    onHost::fill(queue0, dViewResults, 1);
+    {
+        auto managedView = onHost::allocAsync<float>(queue0, 10ul);
+        // managedView.destructorWaitFor(queue0);
+        onHost::fill(queue0, managedView, 3.14159265f);
+        queue0.enqueue(
+            exec,
+            getFrameSpec<float>(queue0.getDevice(), managedView.getExtents()),
+            KernelBundle{RaceCheckKErnel{}, dViewResults, managedView});
+    }
+
+    onHost::memcpy(queue0, hViewResults, dViewResults);
+    onHost::wait(queue0);
+    REQUIRE(hViewResults[0] == 1);
+}
+
+TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    // repeat the test multiple times to increase the change to trigger data races
+    constexpr int testRounds = 10;
+    for(int i = 0; i < testRounds; ++i)
+        runTestApis(cfg);
+}

--- a/tests/unit/mem/allocAsync.cpp
+++ b/tests/unit/mem/allocAsync.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 René Widera
+/* Copyright 2025 René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -15,7 +15,7 @@ using namespace alpaka;
 
 using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis))>;
 
-struct RaceCheckKErnel
+struct RaceCheckKernel
 {
     ALPAKA_FN_ACC void operator()(auto const& acc, concepts::MdSpan<int> auto success, concepts::MdSpan auto in) const
     {
@@ -28,8 +28,76 @@ struct RaceCheckKErnel
     }
 };
 
-void runTestApis(auto cfg)
+void allocAsyncImplicitWait(auto device, auto exec)
 {
+    onHost::Queue queue0 = device.makeQueue();
+
+    auto hViewResults = onHost::allocHost<int>(1u);
+    auto dViewResults = onHost::allocLike(device, hViewResults);
+
+    onHost::fill(queue0, dViewResults, 1);
+    onHost::wait(queue0);
+    {
+        // Asynchronous allocation memory is in the destructor waiting for all work enqueued in the creator queue.
+        auto managedView = onHost::allocAsync<float>(queue0, 10ul);
+        onHost::fill(queue0, managedView, 3.14159265f);
+        queue0.enqueue(
+            exec,
+            getFrameSpec<float>(queue0.getDevice(), managedView.getExtents()),
+            KernelBundle{RaceCheckKernel{}, dViewResults, managedView});
+        /* managedView is detroyed here before the kernel is finshed.
+         * If the view is not waiting for all work in the queue enqueued before the destructor of the view is called,
+         * the application should crash with invalid memory access or the validation in the kernel should fail.
+         * Typically, the kernel is reading zero's if the synchronization is missing.
+         */
+    }
+    {
+        auto managedView = onHost::allocAsync<float>(queue0, 10ul);
+        onHost::fill(queue0, managedView, 42.0f);
+    }
+
+    onHost::memcpy(queue0, hViewResults, dViewResults);
+    onHost::wait(queue0);
+    REQUIRE(hViewResults[0] == 1);
+}
+
+void allocAsyncExplicitWait(auto device, auto exec)
+{
+    onHost::Queue queue0 = device.makeQueue();
+    onHost::Queue queue1 = device.makeQueue();
+
+    auto hViewResults = onHost::allocHost<int>(1u);
+    auto dViewResults = onHost::allocLike(device, hViewResults);
+
+    onHost::fill(queue0, dViewResults, 1);
+    onHost::wait(queue0);
+    {
+        auto managedView = onHost::allocAsync<float>(queue1, 10ul);
+        // set an action that the destructor is waiting for all work enqueued in queue0
+        managedView.destructorWaitFor(queue0);
+        // wait for the allocation
+        onHost::wait(queue1);
+
+        onHost::fill(queue0, managedView, 3.14159265f);
+        queue0.enqueue(
+            exec,
+            getFrameSpec<float>(queue0.getDevice(), managedView.getExtents()),
+            KernelBundle{RaceCheckKernel{}, dViewResults, managedView});
+        /* managedView is detroyed here before the kernel is finshed.
+         * If the view is not waiting for all work in the queue enqueued before the destructor of the view is called,
+         * the application should crash with invalid memory access or the validation in the kernel should fail.
+         * Typically, the kernel is reading zero's if the synchronization is missing.
+         */
+    }
+
+    onHost::memcpy(queue0, hViewResults, dViewResults);
+    onHost::wait(queue0);
+    REQUIRE(hViewResults[0] == 1);
+}
+
+TEMPLATE_LIST_TEST_CASE("allocAsync", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
     auto deviceSpec = cfg[object::deviceSpec];
     auto exec = cfg[object::exec];
 
@@ -39,38 +107,16 @@ void runTestApis(auto cfg)
         std::cout << "No device available for " << deviceSpec.getName() << std::endl;
         return;
     }
-    std::cout << deviceSpec.getApi().getName() << std::endl;
 
     onHost::Device device = devSelector.makeDevice(0);
 
-    std::cout << device.getName() << std::endl;
+    std::cout << deviceSpec.getApi().getName() << "on " << device.getName() << std::endl;
 
-    onHost::Queue queue0 = device.makeQueue();
-
-    auto hViewResults = onHost::allocHost<int>(1u);
-    auto dViewResults = onHost::allocLike(device, hViewResults);
-
-    onHost::fill(queue0, dViewResults, 1);
-    {
-        auto managedView = onHost::allocAsync<float>(queue0, 10ul);
-        // managedView.destructorWaitFor(queue0);
-        onHost::fill(queue0, managedView, 3.14159265f);
-        queue0.enqueue(
-            exec,
-            getFrameSpec<float>(queue0.getDevice(), managedView.getExtents()),
-            KernelBundle{RaceCheckKErnel{}, dViewResults, managedView});
-    }
-
-    onHost::memcpy(queue0, hViewResults, dViewResults);
-    onHost::wait(queue0);
-    REQUIRE(hViewResults[0] == 1);
-}
-
-TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
-{
-    auto cfg = TestType::makeDict();
     // repeat the test multiple times to increase the change to trigger data races
     constexpr int testRounds = 10;
     for(int i = 0; i < testRounds; ++i)
-        runTestApis(cfg);
+        allocAsyncImplicitWait(device, exec);
+
+    for(int i = 0; i < testRounds; ++i)
+        allocAsyncExplicitWait(device, exec);
 }


### PR DESCRIPTION
- SYCL: fix that asynchronious deallocation is not executed queue
  dependent
- Host: fix that queue destructor was not called
   - it is not allowed to capture the queue in a lambda function and enqueue this lambda into the queue itself.
- add unit test for `allocAsync()`


Sneak in fix of `onHost:.concurrent() ` in the first commit.