### PR TITLE
Use remove_cv before freeing to allow pointers to volatile memory

### DIFF
--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -104,7 +104,12 @@ namespace alpaka::onHost
 
                 T_Type* ptr = reinterpret_cast<T_Type*>(
                     sycl::aligned_alloc_device(alignment, memSizeInByte, sycl_device, sycl_context));
-                auto deleter = [ctx = sycl_context, ptr]() { sycl::free(ptr, ctx); };
+                auto deleter = [ctx = sycl_context, ptr]()
+                {
+                    void* ptrToFree
+                        = reinterpret_cast<void*>(const_cast<std::remove_volatile_t<ALPAKA_TYPEOF(ptr)>>(ptr));
+                    sycl::free(ptrToFree, ctx);
+                };
 
                 auto managedView = onHost::ManagedView{
                     deviceDependency,
@@ -138,7 +143,12 @@ namespace alpaka::onHost
 
                 T_Type* ptr = reinterpret_cast<T_Type*>(
                     sycl::aligned_alloc_shared(alignment, memSizeInByte, sycl_device, sycl_context));
-                auto deleter = [ctx = sycl_context, ptr]() { sycl::free(ptr, ctx); };
+                auto deleter = [ctx = sycl_context, ptr]()
+                {
+                    void* ptrToFree
+                        = reinterpret_cast<void*>(const_cast<std::remove_volatile_t<ALPAKA_TYPEOF(ptr)>>(ptr));
+                    sycl::free(ptrToFree, ctx);
+                };
 
                 auto managedView = onHost::ManagedView{
                     deviceDependency,
@@ -166,7 +176,12 @@ namespace alpaka::onHost
 
                 T_Type* ptr
                     = reinterpret_cast<T_Type*>(sycl::aligned_alloc_host(alignment, memSizeInByte, sycl_context));
-                auto deleter = [ctx = sycl_context, ptr]() { sycl::free(ptr, ctx); };
+                auto deleter = [ctx = sycl_context, ptr]()
+                {
+                    void* ptrToFree
+                        = reinterpret_cast<void*>(const_cast<std::remove_volatile_t<ALPAKA_TYPEOF(ptr)>>(ptr));
+                    sycl::free(ptrToFree, ctx);
+                };
 
                 auto managedView = onHost::ManagedView{
                     deviceDependency,

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -203,7 +203,8 @@ namespace alpaka::onHost
                  * managed handle is running out of a scope.
                  */
                 internal::wait(*queueDep.get());
-                sycl::free(ptr, queueDep->getNativeHandle());
+                void* ptrToFree = reinterpret_cast<void*>(const_cast<std::remove_volatile_t<ALPAKA_TYPEOF(ptr)>>(ptr));
+                sycl::free(ptrToFree, queueDep->getNativeHandle());
             };
 
             auto managedView = onHost::ManagedView{

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -186,7 +186,11 @@ namespace alpaka::onHost
                 auto deviceDependency = onHost::Device{device.getSharedPtr()};
 
                 auto deleter = [ptr, deviceDependency]()
-                { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::free(ptr)); };
+                {
+                    void* ptrToFree
+                        = reinterpret_cast<void*>(const_cast<std::remove_volatile_t<ALPAKA_TYPEOF(ptr)>>(ptr));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::free(ptrToFree));
+                };
 
                 /** Each CUDA/HIP allocation is aligned to at least 128 byte but typically to 256byte
                  *
@@ -229,7 +233,11 @@ namespace alpaka::onHost
                     ApiInterface::mallocManaged((void**) &ptr, memSizeInByte));
 
                 auto deleter = [ptr, deviceDependency]()
-                { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::free(ptr)); };
+                {
+                    void* ptrToFree
+                        = reinterpret_cast<void*>(const_cast<std::remove_volatile_t<ALPAKA_TYPEOF(ptr)>>(ptr));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::free(ptrToFree));
+                };
 
                 auto managedView = onHost::ManagedView{
                     deviceDependency,
@@ -268,7 +276,11 @@ namespace alpaka::onHost
                         ApiInterface::hostMallocMapped | ApiInterface::hostMallocPortable));
 
                 auto deleter = [ptr, deviceDependency]()
-                { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::hostFree(ptr)); };
+                {
+                    void* ptrToFree
+                        = reinterpret_cast<void*>(const_cast<std::remove_volatile_t<ALPAKA_TYPEOF(ptr)>>(ptr));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::hostFree(ptrToFree));
+                };
 
                 auto managedView = onHost::ManagedView{
                     deviceDependency,

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -554,9 +554,11 @@ namespace alpaka::onHost
 
                 auto deleter = [ptr, queueDependency]()
                 {
+                    void* ptrToFree
+                        = reinterpret_cast<void*>(const_cast<std::remove_volatile_t<ALPAKA_TYPEOF(ptr)>>(ptr));
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
                         ApiInterface,
-                        ApiInterface::freeAsync(ptr, queueDependency.getNativeHandle()));
+                        ApiInterface::freeAsync(ptrToFree, queueDependency.getNativeHandle()));
                 };
 
                 auto managedView = onHost::ManagedView{

--- a/include/alpaka/core/alignedAlloc.hpp
+++ b/include/alpaka/core/alignedAlloc.hpp
@@ -24,9 +24,13 @@ namespace alpaka::core
         }
     }
 
-    ALPAKA_FN_INLINE ALPAKA_FN_HOST void alignedFree(size_t alignment, void* ptr)
+    ALPAKA_FN_INLINE ALPAKA_FN_HOST void alignedFree(size_t alignment, auto ptr)
+        requires(std::is_pointer_v<ALPAKA_TYPEOF(ptr)>)
     {
         if(ptr != nullptr)
-            ::operator delete(ptr, std::align_val_t{alignment});
+        {
+            void* ptrToFree = reinterpret_cast<void*>(const_cast<std::remove_volatile_t<ALPAKA_TYPEOF(ptr)>>(ptr));
+            ::operator delete(ptrToFree, std::align_val_t{alignment});
+        }
     }
 } // namespace alpaka::core


### PR DESCRIPTION
Opened from https://github.com/alpaka-group/alpaka3/pull/157#discussion_r2171318420