### PR TITLE
add `onHost::allocManaged()`

### DIFF
--- a/include/alpaka/api/cuda/Device.hpp
+++ b/include/alpaka/api/cuda/Device.hpp
@@ -8,6 +8,7 @@
 
 #if ALPAKA_LANG_CUDA
 #    include "alpaka/api/unifiedCudaHip/Device.hpp"
+#    include "alpaka/core/ApiCudaRt.hpp"
 #    include "alpaka/onHost/trait.hpp"
 
 #    include <type_traits>
@@ -22,5 +23,28 @@ namespace alpaka::onHost
         };
     } // namespace trait
 } // namespace alpaka::onHost
+
+namespace alpaka::onHost::internal
+{
+    template<alpaka::deviceKind::concepts::DeviceKind T_DeviceKind, typename T_Any>
+    struct IsDataAccessible::SecondPath<api::Cuda, T_DeviceKind, T_Any>
+    {
+        bool operator()(api::Cuda usedApi, T_DeviceKind deviceKind, T_Any const& view) const
+        {
+            using ApiInterface = ApiCudaRt;
+            typename ApiInterface::PointerAttr_t ptrAttributes;
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                ApiInterface,
+                ApiInterface::pointerGetAttributes(&ptrAttributes, onHost::data(view)));
+
+            if(ptrAttributes.type == ApiInterface::memoryTypeManaged)
+                return true;
+            if(ptrAttributes.type == ApiInterface::memoryTypeHost && std::is_same_v<T_DeviceKind, deviceKind::Cpu>)
+                return true;
+
+            return false;
+        }
+    };
+} // namespace alpaka::onHost::internal
 
 #endif

--- a/include/alpaka/api/hip/Device.hpp
+++ b/include/alpaka/api/hip/Device.hpp
@@ -8,6 +8,7 @@
 
 #if ALPAKA_LANG_HIP
 #    include "alpaka/api/unifiedCudaHip/Device.hpp"
+#    include "alpaka/core/ApiHipRt.hpp"
 #    include "alpaka/onHost/trait.hpp"
 
 #    include <type_traits>
@@ -22,5 +23,28 @@ namespace alpaka::onHost
         };
     } // namespace trait
 } // namespace alpaka::onHost
+
+namespace alpaka::onHost::internal
+{
+    template<alpaka::deviceKind::concepts::DeviceKind T_DeviceKind, typename T_Any>
+    struct IsDataAccessible::SecondPath<api::Hip, T_DeviceKind, T_Any>
+    {
+        bool operator()(api::Hip usedApi, T_DeviceKind deviceKind, T_Any const& view) const
+        {
+            using ApiInterface = ApiHipRt;
+            typename ApiInterface::PointerAttr_t ptrAttributes;
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                ApiInterface,
+                ApiInterface::pointerGetAttributes(&ptrAttributes, onHost::data(view)));
+
+            if(ptrAttributes.type == ApiInterface::memoryTypeManaged)
+                return true;
+            if(ptrAttributes.type == ApiInterface::memoryTypeHost && std::is_same_v<T_DeviceKind, deviceKind::Cpu>)
+                return true;
+
+            return false;
+        }
+    };
+} // namespace alpaka::onHost::internal
 
 #endif

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -106,6 +106,7 @@ namespace alpaka::onHost
             friend struct internal::GetDeviceProperties;
             friend struct internal::AdjustThreadSpec;
             friend struct internal::AllocAsync;
+            friend struct internal::AllocManaged;
         };
     } // namespace cpu
 
@@ -197,6 +198,29 @@ namespace alpaka::onHost
                         Alignment<alignment>{}};
                     return buffer;
                 }
+            }
+        };
+
+        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
+        struct AllocManaged::Op<T_Type, cpu::Device<T_Platform>, T_Extents>
+        {
+            auto operator()(cpu::Device<T_Platform>& device, T_Extents const& extents) const
+            {
+                return Alloc::Op<T_Type, cpu::Device<T_Platform>, T_Extents>{}(device, extents);
+            }
+        };
+
+        template<typename T_Platform, typename T_Any>
+        struct IsDataAccessible::FirstPath<cpu::Device<T_Platform>, T_Any>
+        {
+            bool operator()(cpu::Device<T_Platform>& device, T_Any const& view) const
+            {
+                if constexpr(
+                    std::is_same_v<ALPAKA_TYPEOF(getApi(view)), api::Host>
+                    && std::is_same_v<ALPAKA_TYPEOF(getDeviceKind(device)), deviceKind::Cpu>)
+                    return true;
+                else
+                    return false;
             }
         };
 

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -289,11 +289,18 @@ namespace alpaka::onHost
                 // avoid that we pass a ManagedView and convert non alpaka data views
                 alpaka::concepts::MdSpan<T_Value> auto dataView = makeView(dest);
 
-                alpaka::internal::generic::fill(
-                    queue,
-                    std::get<0>(executors),
-                    dataView.getSubView(extents),
-                    elementValue);
+                if constexpr(std::tuple_size_v<ALPAKA_TYPEOF(executors)> >= 1u)
+                    alpaka::internal::generic::fill(
+                        queue,
+                        std::get<0>(executors),
+                        dataView.getSubView(extents),
+                        elementValue);
+                else
+                    alpaka::internal::generic::fill(
+                        queue,
+                        exec::cpuSerial,
+                        dataView.getSubView(extents),
+                        elementValue);
             }
         };
 

--- a/include/alpaka/api/oneApi/Platform.hpp
+++ b/include/alpaka/api/oneApi/Platform.hpp
@@ -9,6 +9,9 @@
 #if ALPAKA_LANG_ONEAPI
 #    include "alpaka/api/oneApi/Api.hpp"
 #    include "alpaka/api/syclGeneric/Platform.hpp"
+#    include "alpaka/example/executors.hpp"
+#    include "alpaka/internal.hpp"
+#    include "alpaka/onHost/internal.hpp"
 #    include "alpaka/tag.hpp"
 
 namespace alpaka
@@ -98,5 +101,48 @@ namespace alpaka
         };
     } // namespace internal
 } // namespace alpaka
+
+namespace alpaka::onHost::internal
+{
+    template<alpaka::deviceKind::concepts::DeviceKind T_DeviceKind, typename T_Any>
+    struct IsDataAccessible::SecondPath<api::OneApi, T_DeviceKind, T_Any>
+    {
+        static void getPtrType(auto const& platform, auto& sycl_data_alloc_type, auto const& view)
+        {
+            auto sycl_context = platform->getContext();
+            auto sycl_alloc_type = get_pointer_type(Data::data(view), sycl_context);
+
+            if(sycl_alloc_type != sycl::usm::alloc::unknown)
+                sycl_data_alloc_type = sycl_alloc_type;
+        }
+
+        bool operator()(api::OneApi usedApi, T_DeviceKind deviceKind, T_Any const& view) const
+        {
+            auto deviceKindList = onHost::supportedDevices(usedApi);
+            auto sycl_data_alloc_type = sycl::usm::alloc::unknown;
+            alpaka::apply(
+                [&sycl_data_alloc_type, &view](auto... devKind)
+                {
+                    (getPtrType(
+                         onHost::make_sharedSingleton<syclGeneric::Platform<api::OneApi, ALPAKA_TYPEOF(devKind)>>(),
+                         sycl_data_alloc_type,
+                         view),
+                     ...);
+                },
+                deviceKindList);
+
+            if(std::is_same_v<T_DeviceKind, deviceKind::Cpu>)
+            {
+                /* If the device kind is not CPU and usm alloc type is shared, we do not know if the memory is shared
+                 * within the same sycl context. Therefor only know we mark only shared and host alloced memory
+                 * accessible in case the device kind is CPU.
+                 */
+                if(sycl_data_alloc_type == sycl::usm::alloc::shared || sycl_data_alloc_type == sycl::usm::alloc::host)
+                    return true;
+            }
+            return false;
+        }
+    };
+} // namespace alpaka::onHost::internal
 
 #endif

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -80,6 +80,8 @@ namespace alpaka::onHost
             friend struct internal::GetDeviceProperties;
             friend struct internal::AdjustThreadSpec;
             friend struct onHost::internal::AllocAsync;
+            friend struct onHost::internal::AllocManaged;
+            friend struct onHost::internal::IsDataAccessible;
         };
     } // namespace syclGeneric
 
@@ -153,6 +155,124 @@ namespace alpaka::onHost
                         Alignment<alignment>{}};
                     return buffer;
                 }
+            }
+        };
+
+        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
+        struct AllocManaged::Op<T_Type, syclGeneric::Device<T_Platform>, T_Extents>
+        {
+            static consteval uint32_t highestPowerOfTwo(uint32_t value)
+            {
+                uint32_t result = 1u;
+                while((result << 1u) <= value)
+                {
+                    result <<= 1u;
+                }
+                return result;
+            }
+
+            auto operator()(syclGeneric::Device<T_Platform>& device, T_Extents const& extents) const
+            {
+                using IdxType = typename T_Extents::type;
+
+                constexpr uint32_t typeAlignmentBytes = alignof(T_Type);
+                constexpr uint32_t simdPackBytes = alpaka::getArchSimdWidth<T_Type>(
+                                                       ALPAKA_TYPEOF(getApi(device)){},
+                                                       ALPAKA_TYPEOF(getDeviceKind(device)){})
+                                                   * sizeof(T_Type);
+                constexpr uint32_t bestSimdPackBytes = highestPowerOfTwo(simdPackBytes);
+                constexpr IdxType alignment = std::max(bestSimdPackBytes, typeAlignmentBytes);
+
+                auto [sycl_device, sycl_context] = device.getNativeHandle();
+
+                bool isManagedMemorySupported = sycl_device.has(sycl::aspect::usm_shared_allocations);
+                if(!isManagedMemorySupported)
+                {
+                    throw std::runtime_error("Sycl device does not support managed memory allocations.");
+                }
+
+                constexpr auto dim = T_Extents::dim();
+                if constexpr(dim == 1u)
+                {
+                    T_Type* ptr = reinterpret_cast<T_Type*>(sycl::aligned_alloc_shared(
+                        alignment,
+                        extents.x() * sizeof(T_Type),
+                        sycl_device,
+                        sycl_context));
+                    auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
+                    auto deleter = [ctx = sycl_context, ptr]() { sycl::free(ptr, ctx); };
+
+                    auto buffer = onHost::ManagedView{
+                        onHost::Device{device.getSharedPtr()},
+                        ptr,
+                        extents,
+                        pitches,
+                        std::move(deleter),
+                        Alignment<alignment>{}};
+                    return buffer;
+                }
+                else
+                {
+                    IdxType rowExtentInBytes = extents.x() * static_cast<IdxType>(sizeof(T_Type));
+                    IdxType rowPitchInBytes = divCeil(rowExtentInBytes, alignment) * alignment;
+                    auto pitches = alpaka::mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
+
+                    size_t memSizeInByte = pCast<size_t>(pitches)[0] * static_cast<size_t>(extents[0]);
+                    T_Type* ptr = reinterpret_cast<T_Type*>(
+                        sycl::aligned_alloc_shared(alignment, memSizeInByte, sycl_device, sycl_context));
+                    auto deleter = [ctx = sycl_context, ptr]() { sycl::free(ptr, ctx); };
+
+                    auto buffer = onHost::ManagedView{
+                        onHost::Device{device.getSharedPtr()},
+                        ptr,
+                        extents,
+                        pitches,
+                        std::move(deleter),
+                        Alignment<alignment>{}};
+                    return buffer;
+                }
+            }
+        };
+
+        template<typename T_Platform, typename T_Any>
+        struct IsDataAccessible::FirstPath<syclGeneric::Device<T_Platform>, T_Any>
+        {
+            bool operator()(syclGeneric::Device<T_Platform>& device, T_Any const& view) const
+            {
+                auto [sycl_device, sycl_context] = device.getNativeHandle();
+                auto sycl_alloc_type = sycl::get_pointer_type(data(view), sycl_context);
+
+                if(sycl_alloc_type != sycl::usm::alloc::unknown)
+                {
+                    try
+                    {
+                        sycl::device deviceAssiciatedWithData = sycl::get_pointer_device(data(view), sycl_context);
+                        if(deviceAssiciatedWithData == sycl_device)
+                        {
+                            // sycl device allocated the memory
+                            return true;
+                        }
+                    }
+                    catch(...)
+                    {
+                    }
+                }
+
+                if(sycl_alloc_type == sycl::usm::alloc::shared)
+                {
+                    // is shared within the device context
+                    return true;
+                }
+                else if(sycl_alloc_type == sycl::usm::alloc::unknown)
+                {
+                    // assume that a sycl cpu device can always access host memory
+                    if constexpr(
+                        std::is_same_v<ALPAKA_TYPEOF(getApi(view)), api::Host>
+                        && std::is_same_v<ALPAKA_TYPEOF(getDeviceKind(device)), deviceKind::Cpu>)
+                        return true;
+                }
+
+                return false;
             }
         };
 

--- a/include/alpaka/api/syclGeneric/Platform.hpp
+++ b/include/alpaka/api/syclGeneric/Platform.hpp
@@ -174,6 +174,8 @@ namespace alpaka
                 friend struct internal::GetDeviceProperties::Op<syclGeneric::Platform<T_ApiInterface, T_DeviceKind>>;
 
             private:
+                friend struct onHost::internal::IsDataAccessible;
+
                 std::shared_ptr<alpaka::detail::Context> contextManager;
                 sycl::platform platform;
                 std::vector<std::weak_ptr<syclGeneric::Device<Platform<T_ApiInterface, T_DeviceKind>>>> devices;

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -109,9 +109,11 @@ namespace alpaka::onHost
 
             friend struct onHost::internal::Alloc;
             friend struct onHost::internal::AllocAsync;
+            friend struct onHost::internal::AllocManaged;
             friend struct alpaka::internal::GetApi;
             friend struct internal::GetDeviceProperties;
             friend struct internal::AdjustThreadSpec;
+            friend struct onHost::internal::IsDataAccessible;
         };
     } // namespace unifiedCudaHip
 } // namespace alpaka::onHost
@@ -200,6 +202,96 @@ namespace alpaka::onHost
                     std::move(deleter),
                     Alignment<alignment>{}};
                 return buffer;
+            }
+        };
+
+        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
+        struct AllocManaged::Op<T_Type, unifiedCudaHip::Device<T_Platform>, T_Extents>
+        {
+            static consteval uint32_t highestPowerOfTwo(uint32_t value)
+            {
+                uint32_t result = 1u;
+                while((result << 1u) <= value)
+                {
+                    result <<= 1u;
+                }
+                return result;
+            }
+
+            auto operator()(unifiedCudaHip::Device<T_Platform>& device, T_Extents const& extents) const
+            {
+                using IdxType = typename T_Extents::type;
+
+                /** Each CUDA/HIP allocation is aligned to at least 128 byte but typically to 256byte
+                 *
+                 * @todo check if this value can be derived from the device properties
+                 * @todo validate if memory is always aligtne dto 256 byte
+                 */
+                constexpr IdxType alignment = 128u;
+
+                using ApiInterface = typename T_Platform::ApiInterface;
+
+                T_Type* ptr = nullptr;
+                auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
+
+                constexpr auto dim = T_Extents::dim();
+                if constexpr(dim == 1u)
+                {
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ApiInterface,
+                        ApiInterface::mallocManaged(
+                            (void**) &ptr,
+                            static_cast<std::size_t>(extents.x()) * sizeof(T_Type)));
+                }
+                else
+                {
+                    IdxType rowExtentInBytes = extents.x() * static_cast<IdxType>(sizeof(T_Type));
+                    IdxType rowPitchInBytes = divCeil(rowExtentInBytes, alignment) * alignment;
+                    auto pitches = alpaka::mem::calculatePitches<T_Type>(extents, rowPitchInBytes);
+
+                    size_t memSizeInByte = pCast<size_t>(pitches)[0] * static_cast<size_t>(extents[0]);
+
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ApiInterface,
+                        ApiInterface::mallocManaged((void**) &ptr, static_cast<std::size_t>(memSizeInByte)));
+                }
+
+                auto deviceDependency = onHost::Device{device.getSharedPtr()};
+
+                auto deleter = [ptr, deviceDependency]()
+                { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::free(ptr)); };
+
+                auto buffer = onHost::ManagedView{
+                    deviceDependency,
+                    ptr,
+                    extents,
+                    pitches,
+                    std::move(deleter),
+                    Alignment<alignment>{}};
+                return buffer;
+            }
+        };
+
+        template<typename T_Platform, typename T_Any>
+        struct IsDataAccessible::FirstPath<unifiedCudaHip::Device<T_Platform>, T_Any>
+        {
+            bool operator()(unifiedCudaHip::Device<T_Platform>& device, T_Any const& view) const
+            {
+                using ApiInterface = typename T_Platform::ApiInterface;
+                typename ApiInterface::PointerAttr_t ptrAttributes;
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::pointerGetAttributes(&ptrAttributes, onHost::data(view)));
+
+                auto deviceHandle = device.getNativeHandle();
+
+                // pointer is owned by the device itself
+                if(deviceHandle == ptrAttributes.device)
+                    return true;
+                if(ptrAttributes.type == ApiInterface::memoryTypeManaged)
+                    return true;
+
+                return false;
             }
         };
 

--- a/include/alpaka/concepts.hpp
+++ b/include/alpaka/concepts.hpp
@@ -69,6 +69,14 @@ namespace alpaka
         template<typename T>
         concept IsPointer = std::is_pointer_v<T>;
 
+
+        template<typename T, typename T_ValueType = alpaka::NotRequired>
+        concept View = MdSpan<T, T_ValueType> && requires(T t) {
+            {
+                getApi(t)
+            } -> alpaka::concepts::Api;
+        };
+
     } // namespace concepts
 
     namespace internal

--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -19,6 +19,8 @@ namespace alpaka
 
         // Types
         using DeviceAttr_t = ::cudaDeviceAttr;
+        using PointerAttr_t = ::cudaPointerAttributes;
+        using Memory_t = ::cudaMemoryType;
         using DeviceProp_t = ::cudaDeviceProp;
         using Error_t = ::cudaError_t;
         using Event_t = ::cudaEvent_t;
@@ -77,6 +79,11 @@ namespace alpaka
         static constexpr DeviceAttr_t deviceAttributeMultiprocessorCount = ::cudaDevAttrMultiProcessorCount;
         static constexpr DeviceAttr_t deviceAttributeWarpSize = ::cudaDevAttrWarpSize;
 
+        static constexpr Memory_t memoryTypeUnregistered = ::cudaMemoryTypeUnregistered;
+        static constexpr Memory_t memoryTypeHost = ::cudaMemoryTypeHost;
+        static constexpr Memory_t memoryTypeDevice = ::cudaMemoryTypeDevice;
+        static constexpr Memory_t memoryTypeManaged = ::cudaMemoryTypeManaged;
+
         static constexpr Limit_t limitPrintfFifoSize = ::cudaLimitPrintfFifoSize;
         static constexpr Limit_t limitMallocHeapSize = ::cudaLimitMallocHeapSize;
 
@@ -107,6 +114,11 @@ namespace alpaka
         static inline Error_t deviceGetAttribute(int* value, DeviceAttr_t attr, int device)
         {
             return ::cudaDeviceGetAttribute(value, attr, device);
+        }
+
+        static inline Error_t pointerGetAttributes(PointerAttr_t* attr, void const* ptr)
+        {
+            return ::cudaPointerGetAttributes(attr, ptr);
         }
 
         static inline Error_t deviceGetLimit(size_t* pValue, Limit_t limit)
@@ -262,6 +274,11 @@ namespace alpaka
         static inline Error_t malloc(void** devPtr, size_t size)
         {
             return ::cudaMalloc(devPtr, size);
+        }
+
+        static inline Error_t mallocManaged(void** devPtr, size_t size)
+        {
+            return ::cudaMallocManaged(devPtr, size);
         }
 
         static inline Error_t malloc3D(PitchedPtr_t* pitchedDevPtr, Extent_t extent)

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -21,6 +21,8 @@ namespace alpaka
 
         // Types
         using DeviceAttr_t = ::hipDeviceAttribute_t;
+        using PointerAttr_t = ::hipPointerAttribute_t;
+        using Memory_t = ::hipMemoryType;
         using DeviceProp_t = ::hipDeviceProp_t;
         using Error_t = ::hipError_t;
         using Event_t = ::hipEvent_t;
@@ -80,6 +82,11 @@ namespace alpaka
         static constexpr DeviceAttr_t deviceAttributeMultiprocessorCount = ::hipDeviceAttributeMultiprocessorCount;
         static constexpr DeviceAttr_t deviceAttributeWarpSize = ::hipDeviceAttributeWarpSize;
 
+        static constexpr Memory_t memoryTypeUnregistered = ::hipMemoryTypeUnregistered;
+        static constexpr Memory_t memoryTypeHost = ::hipMemoryTypeHost;
+        static constexpr Memory_t memoryTypeDevice = ::hipMemoryTypeDevice;
+        static constexpr Memory_t memoryTypeManaged = ::hipMemoryTypeManaged;
+
 #    if HIP_VERSION >= 40'500'000
         static constexpr Limit_t limitPrintfFifoSize = ::hipLimitPrintfFifoSize;
 #    else
@@ -115,6 +122,11 @@ namespace alpaka
         static inline Error_t deviceGetAttribute(int* value, DeviceAttr_t attr, int device)
         {
             return ::hipDeviceGetAttribute(value, attr, device);
+        }
+
+        static inline Error_t pointerGetAttributes(PointerAttr_t* attr, void const* ptr)
+        {
+            return ::hipPointerGetAttributes(attr, ptr);
         }
 
         static inline Error_t deviceGetLimit(size_t* pValue, Limit_t limit)
@@ -287,6 +299,11 @@ namespace alpaka
         static inline Error_t malloc(void** devPtr, size_t size)
         {
             return ::hipMalloc(devPtr, size);
+        }
+
+        static inline Error_t mallocManaged(void** devPtr, size_t size)
+        {
+            return ::hipMallocManaged(devPtr, size);
         }
 
         static inline Error_t malloc3D(PitchedPtr_t* pitchedDevPtr, Extent_t extent)

--- a/include/alpaka/internal.hpp
+++ b/include/alpaka/internal.hpp
@@ -58,6 +58,12 @@ namespace alpaka
             return GetApi::Op<std::decay_t<decltype(any)>>{}(any);
         }
 
+        template<typename T_Any>
+        inline constexpr auto getApi(onHost::Handle<T_Any>&& anyHandle)
+        {
+            return GetApi::Op<ALPAKA_TYPEOF(*anyHandle.get())>{}(*anyHandle.get());
+        }
+
         struct GetDeviceType
         {
             template<typename T_Any>

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -148,6 +148,87 @@ namespace alpaka::onHost
             extentsVec);
     }
 
+    /** allocate memory on the given device with unified virtual memory
+     *
+     * This memory can be accessed from all devices with the same Api and device kind. Depending of the backend e.g.
+     * OneApi memory can be accessed by other device kind devices if they are using the same native context. It is not
+     * allowed to access the data on two devices at the same time, this must be avoided by explicit synchronizations.
+     * Managed memory follows the rules of UVM memory of the device backend e.g. CUDA, HIP, ...
+     *
+     * @tparam T_Type type of the data elements
+     * @param extents number of elements for each dimension
+     * @return Managed view to the allocated memory
+     *
+     * @{
+     */
+
+    /**
+     * @param device device handle
+     */
+    template<typename T_Type>
+    inline auto allocManaged(concepts::Device auto const& device, alpaka::concepts::VectorOrScalar auto const& extents)
+    {
+        Vec const extentsVec = extents;
+        return internal::AllocManaged::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
+            *device.get(),
+            extentsVec);
+    }
+
+    /** Allocates managed memory on the device associated with the given queue.
+     *
+     * @param queue queue handle
+     */
+    template<typename T_Type, typename T_Device>
+    inline auto allocManaged(Queue<T_Device> const& queue, alpaka::concepts::VectorOrScalar auto const& extents)
+    {
+        Vec const extentsVec = extents;
+        return internal::AllocManaged::
+            Op<T_Type, std::decay_t<decltype(*queue.getDevice().get())>, ALPAKA_TYPEOF(extentsVec)>{}(
+                *queue.getDevice().get(),
+                extentsVec);
+    }
+
+    /** @} */
+
+    /** check if the given view is accessible on the given device
+     *
+     * @param device device handle
+     * @param view memory where properties will be derived from
+     * @return true if the view is accessible on the device, false otherwise.
+     * alpaka can not detect all memory access types therefore the result can be false even if the memory is accessible
+     * because the view was allocated with a UVM allocator.
+     *
+     * @{
+     */
+    inline bool isDataAccessible(concepts::Device auto const& device, alpaka::concepts::View auto const& view)
+    {
+        return internal::IsDataAccessible::FirstPath<ALPAKA_TYPEOF(*device.get()), ALPAKA_TYPEOF(view)>{}(
+                   *device.get(),
+                   view)
+               || internal::IsDataAccessible::SecondPath<
+                   ALPAKA_TYPEOF(getApi(view)),
+                   ALPAKA_TYPEOF(getDeviceKind(device)),
+                   ALPAKA_TYPEOF(view)>{}(getApi(view), getDeviceKind(device), view);
+    }
+
+    /** check if the given view is accessible on the given device of the queue.
+     *
+     * @param queue queue handle
+     */
+    template<typename T_Device>
+    inline bool isDataAccessible(Queue<T_Device> const& queue, alpaka::concepts::View auto const& view)
+    {
+        return internal::IsDataAccessible::FirstPath<ALPAKA_TYPEOF(*queue.getDevice().get()), ALPAKA_TYPEOF(view)>{}(
+                   *queue.getDevice().get(),
+                   view)
+               || internal::IsDataAccessible::SecondPath<
+                   ALPAKA_TYPEOF(getApi(view)),
+                   ALPAKA_TYPEOF(getDeviceKind(queue.getDevice())),
+                   ALPAKA_TYPEOF(view)>{}(getApi(view), getDeviceKind(queue.getDevice()), view);
+    }
+
+    /** @} */
+
     /** allocate memory on the given device based on a view
      *
      * Derives type and extents of the memory from the view.

--- a/include/alpaka/onHost/internal.hpp
+++ b/include/alpaka/onHost/internal.hpp
@@ -214,6 +214,12 @@ namespace alpaka::onHost
             {
                 return Op<std::decay_t<decltype(any)>>{}(any);
             }
+
+            template<typename T_Any>
+            static decltype(auto) data(Handle<T_Any>&& anyHandle)
+            {
+                return Op<std::decay_t<decltype(*anyHandle.get())>>{}(*anyHandle.get());
+            }
         };
 
         struct Alloc
@@ -231,6 +237,41 @@ namespace alpaka::onHost
             struct Op
             {
                 void operator()(T_Any& any, T_Extents const&) const;
+            };
+        };
+
+        struct AllocManaged
+        {
+            template<typename T_Type, typename T_Any, typename T_Extents>
+            struct Op
+            {
+                void operator()(T_Any& any, T_Extents const&) const;
+            };
+        };
+
+        /** checks if a view can be accessed from the given device
+         *
+         * There are two paths to check if a view is accessible:
+         *   - first: Try to validate the view in the scope of the device.
+         *   - second: Try to validate based on soft criteria in the scope of the view's API.
+         *             This path is required because the host API does not know about view data locations.
+         *             The second path is optionally and will return always false if not specialized.
+         */
+        struct IsDataAccessible
+        {
+            template<typename T_Device, typename T_Any>
+            struct FirstPath
+            {
+                bool operator()(T_Device& device, T_Any const& any) const;
+            };
+
+            template<typename T_DataApi, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind, typename T_Any>
+            struct SecondPath
+            {
+                bool operator()(T_DataApi, T_DeviceKind, T_Any const& any) const
+                {
+                    return false;
+                }
             };
         };
 
@@ -316,5 +357,12 @@ namespace alpaka::onHost
         {
             return GetPitches::Op<std::decay_t<decltype(any)>>{}(any);
         }
+
+        template<typename T_Any>
+        inline auto getPitches(Handle<T_Any>&& any)
+        {
+            return GetPitches::Op<ALPAKA_TYPEOF(*any.get())>{}(*any.get());
+        }
+
     } // namespace internal
 } // namespace alpaka::onHost

--- a/tests/unit/mem/alloc.cpp
+++ b/tests/unit/mem/alloc.cpp
@@ -1,0 +1,109 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executeForEach.hpp>
+#include <alpaka/example/executors.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <iostream>
+
+using namespace alpaka;
+
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis))>;
+
+struct IotaValidate
+{
+    ALPAKA_FN_ACC void operator()(auto const& acc, concepts::MdSpan<int> auto success, concepts::MdSpan auto in) const
+    {
+        for(auto [i] : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange(in.getExtents())))
+        {
+            if(in[i] != i)
+                // set to false
+                onAcc::atomicExch(acc, &success[0], 0);
+        }
+    }
+};
+
+void validateAccess(auto device, alpaka::concepts::Executor auto exec, concepts::MdSpan auto deviceAccessibleData)
+{
+    auto deviceStatus = onHost::alloc<int>(device, 1);
+    auto hostStatus = onHost::allocHostLike(deviceStatus);
+    auto deviceQueue = device.makeQueue();
+    REQUIRE(onHost::isDataAccessible(deviceQueue, deviceAccessibleData) == true);
+    onHost::fill(deviceQueue, deviceStatus, 1);
+    deviceQueue.enqueue(
+        exec,
+        getFrameSpec<float>(deviceQueue.getDevice(), deviceAccessibleData.getExtents()),
+        KernelBundle{IotaValidate{}, deviceStatus, deviceAccessibleData});
+    onHost::memcpy(deviceQueue, hostStatus, deviceStatus);
+    onHost::wait(deviceQueue);
+    REQUIRE(hostStatus[0] == 1);
+}
+
+void allocAsyncImplicitWait(auto device, alpaka::concepts::Executor auto exec)
+{
+    onHost::Queue queue0 = device.makeQueue();
+
+    auto hostDevice = onHost::makeHostDevice();
+
+    int dataSize = 42;
+
+    auto hostView = onHost::allocHost<int>(dataSize);
+    auto deviceView = onHost::alloc<int>(device, dataSize);
+    auto managedView = onHost::allocManaged<int>(device, dataSize);
+
+    REQUIRE(onHost::isDataAccessible(hostDevice, hostView) == true);
+    REQUIRE(onHost::isDataAccessible(hostDevice, managedView) == true);
+    for(int i = 0; i < hostView.getExtents().x(); ++i)
+    {
+        hostView[i] = i;
+        // managed memory must be accessible on the host
+        managedView[i] = i;
+    }
+
+    auto deviceQueue = device.makeQueue();
+    // check that we can copy from managed memory to device memory
+    onHost::memcpy(deviceQueue, deviceView, managedView);
+    onHost::wait(deviceQueue);
+
+    if(std::is_same_v<ALPAKA_TYPEOF(getDeviceKind(device)), deviceKind::Cpu>)
+    {
+        REQUIRE(onHost::isDataAccessible(device, hostView) == true);
+        validateAccess(device, exec, hostView);
+    }
+    else
+        REQUIRE(onHost::isDataAccessible(device, hostView) == false);
+
+    REQUIRE(onHost::isDataAccessible(device, managedView) == true);
+    validateAccess(device, exec, managedView);
+
+    REQUIRE(onHost::isDataAccessible(device, deviceView) == true);
+    validateAccess(device, exec, deviceView);
+
+    REQUIRE(onHost::isDataAccessible(hostDevice, managedView) == true);
+    validateAccess(hostDevice, exec::cpuSerial, managedView);
+}
+
+TEMPLATE_LIST_TEST_CASE("alloc", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+
+    std::cout << deviceSpec.getApi().getName() << "on " << device.getName() << std::endl;
+
+    allocAsyncImplicitWait(device, exec);
+}


### PR DESCRIPTION
- add support for managed memory
- tiny fixes for algorithms called without an executor in case `cpuSerial` is disabled in CMake.


Note: for allocation, there is a lot of copy past code between different methods of allocation to map multi dimensional memory to a one dimensional data blob. This will be refactored later to shrink the code base and avoid to much maintenance overhead and implementation mistakes.