### PR TITLE
add alpaka_cxx_std to cmake cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,8 @@ function(checkCompilerCXXSupport language min_cxx_standard)
     endif ()
 endfunction()
 
-set(alpaka_CXX_STANDARD 20)
+set(alpaka_CXX_STANDARD 20 CACHE STRING "C++ standard")
+
 checkCompilerCXXSupport(CXX ${alpaka_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD ${alpaka_CXX_STANDARD})
 


### PR DESCRIPTION
Currently the `alpaka_add_executable` macro tries to access this variable for the HIP backend but can't see it since it is in a different cmake file
I saw this error when trying to use alpaka3 in another project with HIP