### PR TITLE
fix example generators

### DIFF
--- a/include/alpaka/example/executeForEach.hpp
+++ b/include/alpaka/example/executeForEach.hpp
@@ -48,4 +48,21 @@ namespace alpaka
         // Pass the tag as first argument to the callable.
         return std::apply([=](auto const&... backends) { return (exe(backends) || ...); }, tupleOfBackends);
     }
+
+    template<onHost::concepts::DeviceSpec... T_DeviceSpecs>
+    inline auto executeForEachIfHasDevice(auto&& callable, std::tuple<T_DeviceSpecs...> const& tupleOfDeviceSpecs)
+    {
+        auto exe = [=](auto const& devSpec)
+        {
+            auto devSelector = onHost::makeDeviceSelector(devSpec);
+            if(devSelector.isAvailable())
+            {
+                callable(devSpec);
+            }
+            return EXIT_SUCCESS;
+        };
+        // Execute the callable once for each enabled accelerator.
+        // Pass the tag as first argument to the callable.
+        return std::apply([=](auto const&... devSpecs) { return (exe(devSpecs) || ...); }, tupleOfDeviceSpecs);
+    }
 } // namespace alpaka

--- a/include/alpaka/example/executors.hpp
+++ b/include/alpaka/example/executors.hpp
@@ -22,6 +22,11 @@ namespace alpaka::onHost
         return AutoDeviceMappings{};
     }
 
+    /** Get alist of supported device specifications
+     *
+     * @param api a single api
+     * @return tuple of device specifications
+     */
     constexpr auto getDeviceSpecsFor(auto const api)
     {
         return std::apply(
@@ -29,6 +34,17 @@ namespace alpaka::onHost
                 return std::make_tuple(DeviceSpec{api, devType}...);
             },
             supportedDevices(api));
+    }
+
+    /** Get alist of supported device specifications
+     *
+     * @param apiList a tuple with APIs
+     * @return tuple of device specifications
+     */
+    template<alpaka::concepts::Api... T_Apis>
+    constexpr auto getDeviceSpecsFor(std::tuple<T_Apis...> const apiList)
+    {
+        return std::apply([](auto... api) constexpr { return std::tuple_cat(getDeviceSpecsFor(api)...); }, apiList);
     }
 
     constexpr auto createBackendsFor(auto const deviceSpec)

--- a/include/alpaka/onHost/DeviceSelector.hpp
+++ b/include/alpaka/onHost/DeviceSelector.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/api/host/Api.hpp"
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/tag.hpp"
+#include "alpaka/utility.hpp"
 
 namespace alpaka::onHost
 {
@@ -106,5 +107,11 @@ namespace alpaka::onHost
             deviceKind::cpu}
             .makeDevice(0);
     }
+
+    namespace concepts
+    {
+        template<typename T>
+        concept DeviceSpec = isSpecializationOf_v<T, onHost::DeviceSpec>;
+    } // namespace concepts
 
 } // namespace alpaka::onHost


### PR DESCRIPTION
- fix `getDeviceSpecsFor()` for a list of APIs
- fix `executeForEachIfHasDevice()` if called with device specs

Some examples were not executed for all APIs due to a wrong interface usage.