### PR TITLE
riscv: updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,26 @@ You can benchmark bableStream for different number of elements e.g. with a simpl
 for((i=1;i<10;++i)) ; do  ./benchmark/babelstream/babelstream --array-size=$((33554432 * $i)) --number-runs=100; done
 ```
 
+### cross compile on x86 for riscv
+
+Tested on https://riscv.epcc.ed.ac.uk/
+
+```bash
+module load riscv64-linux/gnu-12.2
+# download the latest CMake 3.3X and set it to your environment PATH variable
+export RISCV_GNU_INSTALL_ROOT=/usr/local/share/riscv-compiler/gnu-12.2/build/rv64gc-linux/
+# Some tests failing to compile, not because of C++ the compile or linker runs into parsing issues.
+# Therefore tests are disabled by default.
+cmake -Dalpaka_BENCHMARKS=ON  -Dalpaka_EXAMPLES=ON -Dalpaka_EXEC_CpuOmpBlocksAndThreads=OFF ../alpaka -DCMAKE_CXX_FLAGS="-march=rv64gc -mabi=lp64d -fopenmp" -DCMAKE_EXE_LINKER_FLAGS="-lpthread -fopenmp" -DCMAKE_TOOLCHAIN_FILE=../alpaka/cmake/riscv64-gnu.toolchain.cmake  -DCMAKE_EXE_LINKER_FLAGS=-fopenmp -DCMAKE_BUILD_TYPE=Release
+make -j
+# one of the Milk-V Pionee nodes
+srun -n 1 --nodelist=rvc24 --time=00:30:00 --cpu-bind=none --cpus-per-task=64 -q riscv --pty bash
+export OMP_NUM_THREADS=64
+export OMP_PROC_BIND=spread
+export OMP_PLACES=cores
+ctest --output-on-failure
+```
+
 Coding
 ------
 

--- a/cmake/riscv64-clang.toolchain.cmake
+++ b/cmake/riscv64-clang.toolchain.cmake
@@ -1,0 +1,39 @@
+#
+# Copyright 2025 René Widera
+# SPDX-License-Identifier: ISC
+#
+
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+if(DEFINED ENV{RISCV_CLANG_INSTALL_ROOT} AND NOT DEFINED RISCV_CLANG_INSTALL_ROOT)
+    set(RISCV_CLANG_INSTALL_ROOT "$ENV{RISCV_CLANG_INSTALL_ROOT}" CACHE PATH "Path to CLANG for RISC-V cross compiler installation directory")
+else()
+    set(RISCV_CLANG_INSTALL_ROOT /opt/riscv CACHE PATH "Path to CLANG for RISC-V cross compiler installation directory")
+endif()
+set(RISCV_GCC_INSTALL_ROOT "${RISCV_CLANG_INSTALL_ROOT}" CACHE PATH "Path to GCC for RISC-V cross compiler installation directory")
+set(CMAKE_SYSROOT ${RISCV_GCC_INSTALL_ROOT}/sysroot CACHE PATH "RISC-V sysroot")
+
+set(CLANG_TARGET_TRIPLE "riscv64-unknown-linux-gnu")
+
+set(CMAKE_C_COMPILER ${RISCV_CLANG_INSTALL_ROOT}/bin/clang)
+set(CMAKE_C_COMPILER_TARGET ${CLANG_TARGET_TRIPLE})
+set(CMAKE_CXX_COMPILER ${RISCV_CLANG_INSTALL_ROOT}/bin/clang++)
+set(CMAKE_CXX_COMPILER_TARGET ${CLANG_TARGET_TRIPLE})
+set(CMAKE_ASM_COMPILER ${RISCV_CLANG_INSTALL_ROOT}/bin/clang)
+set(CMAKE_ASM_COMPILER_TARGET ${CLANG_TARGET_TRIPLE})
+
+
+# Avoids running the linker for source files passed to add_executable because cross-compiling required special
+# linker flags.
+# Attention, this can create issues during static MPI linking.
+# A workaround is to pass linker option via `CMAKE_EXE_LINKER_FLAGS` and link this CMake variable
+# explicit to target.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+# prefer static libraries
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+set(BUILD_SHARED_LIBRARIES OFF)
+
+list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/cmake/riscv64-gnu.toolchain.cmake
+++ b/cmake/riscv64-gnu.toolchain.cmake
@@ -1,0 +1,36 @@
+#
+# Copyright 2025 René Widera
+# SPDX-License-Identifier: ISC
+#
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+if(DEFINED ENV{RISCV_GNU_INSTALL_ROOT} AND NOT DEFINED RISCV_GNU_INSTALL_ROOT)
+    set(RISCV_GNU_INSTALL_ROOT "$ENV{RISCV_GNU_INSTALL_ROOT}" CACHE PATH "Path to GNU for RISC-V cross compiler installation directory")
+else()
+    set(RISCV_GNU_INSTALL_ROOT /opt/riscv CACHE PATH "Path to GNU for RISC-V cross compiler installation directory")
+endif()
+set(CMAKE_SYSROOT ${RISCV_GNU_INSTALL_ROOT}/sysroot CACHE PATH "RISC-V sysroot")
+
+set(GNU_TARGET_TRIPLE riscv64-unknown-linux-gnu)
+
+set(CMAKE_C_COMPILER ${RISCV_GNU_INSTALL_ROOT}/bin/riscv64-unknown-linux-gnu-gcc)
+set(CMAKE_C_COMPILER_TARGET ${GNU_TARGET_TRIPLE})
+set(CMAKE_CXX_COMPILER ${RISCV_GNU_INSTALL_ROOT}/bin/riscv64-unknown-linux-gnu-g++)
+set(CMAKE_CXX_COMPILER_TARGET ${GNU_TARGET_TRIPLE})
+set(CMAKE_ASM_COMPILER ${RISCV_GNU_INSTALL_ROOT}/bin/riscv64-unknown-linux-gnu-as)
+set(CMAKE_ASM_COMPILER_TARGET ${GNU_TARGET_TRIPLE})
+
+# Avoids running the linker for source files passed to add_executable because cross-compiling required special
+# linker flags.
+# Attention, this can create issues during static MPI linking.
+# A workaround is to pass linker option via `CMAKE_EXE_LINKER_FLAGS` and link this CMake variable
+# explicit to target.
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+# prefer static libraries
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+set(BUILD_SHARED_LIBRARIES OFF)
+
+list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/include/alpaka/api/host/cpuArchSize.hpp
+++ b/include/alpaka/api/host/cpuArchSize.hpp
@@ -18,6 +18,8 @@ namespace alpaka::onHost::internal
             64u;
 #elif defined(__riscv_vector)
             64u;
+#elif defined(__riscv)
+            32u;
         // ARM e.g. nvidia grace hopper
 #elif defined(__ARM_FEATURE_SVE) || defined(__ARM_FEATURE_SVE2_AES) || defined(__ARM_FEATURE_DOTPROD)
             64u;


### PR DESCRIPTION
- add cmake toolchains to support crosscompiling for riscv
- add short description and example how to cross compile for riscv
- update `getCPUSimdWidth()` for riscv without vector extensions