### PR TITLE
revert riscv simd width if no vector extension is available

### DIFF
--- a/include/alpaka/api/host/cpuArchSize.hpp
+++ b/include/alpaka/api/host/cpuArchSize.hpp
@@ -19,7 +19,8 @@ namespace alpaka::onHost::internal
 #elif defined(__riscv_vector)
             64u;
 #elif defined(__riscv)
-            32u;
+            // do not use vectors if the vector extension is not set
+            sizeof(T_Type);
         // ARM e.g. nvidia grace hopper
 #elif defined(__ARM_FEATURE_SVE) || defined(__ARM_FEATURE_SVE2_AES) || defined(__ARM_FEATURE_DOTPROD)
             64u;


### PR DESCRIPTION
Partly revert #212.

Increasing the vector length is not helpful if there are no vector units. Nevertheless we keep the macro definition to make clear that we distinguish between vector riscv and non-vector extension riscv.