### PR TITLE
fix CATCH2 v3 signal handling

### DIFF
--- a/cmake/buildDependencies.cmake
+++ b/cmake/buildDependencies.cmake
@@ -11,10 +11,13 @@ function(alpaka_install_catch2)
     if(NOT TARGET Catch2::Catch2)
         if(alpaka_SYSTEM_CATCH2)
             message(STATUS "use System Catch2")
+            message(WARNING "Your System version of CATCH2 V3 should have set '-DCATCH_CONFIG_NO_POSIX_SIGNALS=ON', else some tests e.g. with managed memory can fail.")
             find_package(Catch2 3.5.3 REQUIRED)
             include(Catch)
         else()
             message(STATUS "download and install Catch2 locally")
+            # bug with SYCL alloc_shared and Catch2 V3 https://github.com/intel/llvm/issues/6720#issuecomment-1882988322
+            set(CATCH_CONFIG_NO_POSIX_SIGNALS ON)
             # get Catch2 v3 and build it from source with the same C++ standard as the tests
             Include(FetchContent)
             FetchContent_Declare(Catch2 GIT_REPOSITORY https://github.com/catchorg/Catch2.git GIT_TAG v3.5.3)


### PR DESCRIPTION
Disable CATCH2 signal handling else SYCL `alloc_shared()` will fail if you execute more than one test which is using managed memory.