### PR TITLE
fix simd alignment

### DIFF
--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -23,6 +23,7 @@
 #include <array>
 #include <bit>
 #include <concepts>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <iostream>
@@ -34,9 +35,14 @@ namespace alpaka
 {
     namespace detail
     {
-        template<typename T_ValueType, concepts::Alignment T_Alignment, uint32_t dataSizeInBytes>
+        template<typename T_ValueType, uint32_t T_numElements, concepts::Alignment T_Alignment>
         consteval uint32_t optimalAlignment()
         {
+            constexpr uint32_t currentTypeAlignment = static_cast<uint32_t>(alignof(T_ValueType));
+            if constexpr(T_numElements % 2 != 0u)
+                return currentTypeAlignment;
+
+            constexpr uint32_t dataSizeInBytes = static_cast<uint32_t>(sizeof(T_ValueType) * T_numElements);
             constexpr uint32_t alignment = std::min(T_Alignment::template get<T_ValueType>(), dataSizeInBytes);
             if constexpr(std::has_single_bit(alignment))
                 return alignment;
@@ -52,9 +58,7 @@ namespace alpaka
     struct Simd;
 
     template<typename T_Type, uint32_t T_dim, concepts::Alignment T_Alignment, typename T_Storage>
-    struct alignas(
-        alpaka::detail::optimalAlignment<T_Type, T_Alignment, static_cast<uint32_t>(sizeof(T_Type) * T_dim)>()) Simd
-        : private T_Storage
+    struct alignas(alpaka::detail::optimalAlignment<T_Type, T_dim, T_Alignment>()) Simd : private T_Storage
     {
         using Storage = T_Storage;
         using type = T_Type;

--- a/include/alpaka/mem/Alignment.hpp
+++ b/include/alpaka/mem/Alignment.hpp
@@ -29,12 +29,12 @@ namespace alpaka
                 return value;
         }
 
+    private:
         static consteval uint32_t get()
         {
             return value;
         }
 
-    private:
         static constexpr uint32_t value = T_byte;
     };
 

--- a/tests/unit/math/TestTemplate.hpp
+++ b/tests/unit/math/TestTemplate.hpp
@@ -229,7 +229,8 @@ namespace mathtest
 
                 if(!isApproxEqual(results(i), stdExpectedResult))
                 {
-                    INFO("Idx i: " << i << " computed : " << results(i) << " vs expected: " << stdExpectedResult);
+                    std::cerr << "Idx i: " << i << " computed : " << results(i)
+                              << " vs expected: " << stdExpectedResult << " arguments:" << args(i) << std::endl;
                 }
                 // Validate
                 REQUIRE(isApproxEqual(results(i), stdExpectedResult));

--- a/tests/unit/simd/alignment.cpp
+++ b/tests/unit/simd/alignment.cpp
@@ -30,14 +30,19 @@ struct SimdAlignment
 
         constexpr auto v1 = Vec{1.f, 2.f, 3.f};
         constexpr auto s3 = Simd{v1, v1, v1, v1};
+        static_assert(alignof(ALPAKA_TYPEOF(v1)) == 4u);
         static_assert(alignof(ALPAKA_TYPEOF(s3)) == 4u);
 
         constexpr auto v2 = Vec{1.f, 2.f};
         constexpr auto s4 = Simd{v2, v2, v2};
+        static_assert(alignof(ALPAKA_TYPEOF(v2)) == 4u);
         static_assert(alignof(ALPAKA_TYPEOF(s4)) == 4u);
 
         constexpr auto s5 = Simd{v2, v2, v2, v2};
         static_assert(alignof(ALPAKA_TYPEOF(s5)) == 32u);
+
+        constexpr auto s6 = Simd{v2, v2, v2, v2, v2};
+        static_assert(alignof(ALPAKA_TYPEOF(s6)) == 4u);
 
         struct Foo
         {
@@ -46,8 +51,8 @@ struct SimdAlignment
             char8_t c2;
         };
 
-        constexpr auto s6 = Simd{Foo{'a', 'b', 'c'}, Foo{'d', 'e', 'f'}, Foo{'g', 'h', 'i'}};
-        static_assert(alignof(ALPAKA_TYPEOF(s6)) == 1u);
+        constexpr auto s7 = Simd{Foo{'a', 'b', 'c'}, Foo{'d', 'e', 'f'}, Foo{'g', 'h', 'i'}};
+        static_assert(alignof(ALPAKA_TYPEOF(s7)) == 1u);
     }
 };
 


### PR DESCRIPTION
In cases where the number of elements in a SIMD was uneven the alignment
was wrong.
Error was only shown with icpx with OpenMpBlocks and the `kernelMd`
test.

- extend the unit test
- first commit is improving the math tests error message