### PR TITLE
host task enqueue for all backends

### DIFF
--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -111,7 +111,7 @@ namespace alpaka::onHost::internal
     struct internal::Fill::Op<syclGeneric::Queue<T_Device>, T_Dest, T_Value, T_Extents>
     {
         void operator()(
-            syclGeneric::Queue<T_Device> queue,
+            syclGeneric::Queue<T_Device>& queue,
             auto&& dest,
             T_Value elementValue,
             T_Extents const& extents) const

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -10,6 +10,7 @@
 
 #    include "alpaka/api/syclGeneric/onAcc.hpp"
 #    include "alpaka/api/util.hpp"
+#    include "alpaka/core/CallbackThread.hpp"
 #    include "alpaka/interface.hpp"
 #    include "alpaka/internal.hpp"
 #    include "alpaka/onAcc/Acc.hpp"
@@ -115,10 +116,32 @@ namespace alpaka::onHost
             Handle<T_Device> m_device;
             uint32_t m_idx = 0u;
             sycl::queue m_queue;
+            core::CallbackThread m_callBackThread;
         };
 
 
     } // namespace syclGeneric
+
+    template<typename T_Device, typename T_Task>
+    struct internal::Enqueue::Task<syclGeneric::Queue<T_Device>, T_Task>
+    {
+        /** It is not allowed to execute sycl methods within a SYCL host_task therefore we use a callback host thread
+         * to execute the host function which is allowing to use sycl methods.
+         */
+        static void callHostTask(syclGeneric::Queue<T_Device>& queue, T_Task task)
+        {
+            auto f = queue.m_callBackThread.submit([t = std::move(task)] { t(); });
+            f.wait();
+        }
+
+        void operator()(syclGeneric::Queue<T_Device>& queue, T_Task const& task) const
+        {
+            // using the queue by reference is fine here, because the queue is not destroyed while the task is
+            // executed.
+            queue.m_queue.submit([&queue, task](sycl::handler& cgh)
+                                 { cgh.host_task([&queue, task]() { callHostTask(queue, task); }); });
+        }
+    };
 
     template<typename T_Device, typename T_Dest, typename T_Extents>
     requires(alpaka::trait::getDim_v<T_Extents> == 1u)
@@ -219,6 +242,7 @@ namespace alpaka::onHost
 } // namespace alpaka::onHost
 
 namespace alpaka::internal
+
 {
     template<typename T_Device>
     struct GetApi::Op<alpaka::onHost::syclGeneric::Queue<T_Device>>

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -18,6 +18,7 @@
 #    include "alpaka/api/unifiedCudaHip/concepts.hpp"
 #    include "alpaka/api/util.hpp"
 #    include "alpaka/core/ApiCudaRt.hpp"
+#    include "alpaka/core/CallbackThread.hpp"
 #    include "alpaka/core/UniformCudaHip.hpp"
 #    include "alpaka/internal.hpp"
 #    include "alpaka/onAcc/Acc.hpp"
@@ -85,6 +86,7 @@ namespace alpaka::onHost
             Handle<T_Device> m_device;
             uint32_t m_idx = 0u;
             typename ApiInterface::Stream_t m_UniformCudaHipQueue;
+            core::CallbackThread m_callBackThread;
 
             friend struct alpaka::internal::GetName;
 
@@ -299,6 +301,41 @@ namespace alpaka::onHost
 {
     namespace internal
     {
+        template<typename T_Device, typename T_Task>
+        struct Enqueue::Task<unifiedCudaHip::Queue<T_Device>, T_Task>
+        {
+            struct HostFuncData
+            {
+                // We don't need to keep the queue alive, because in it's dtor it will synchronize with the CUDA/HIP
+                // stream and wait until all host functions and the CallbackThread are done. It's actually an error to
+                // copy the queue into the host function. Destroying it here would call CUDA/HIP APIs from the host
+                // function. Passing it further to the Callback thread, would make the Callback thread hold a task
+                // containing the queue with the CallbackThread itself. Destroying the task if no other queue instance
+                // exists will make the CallbackThread join itself and crash.
+                unifiedCudaHip::Queue<T_Device>& q;
+                T_Task t;
+            };
+
+            static void uniformCudaHipRtHostFunc(void* arg)
+            {
+                auto data = std::unique_ptr<HostFuncData>(reinterpret_cast<HostFuncData*>(arg));
+                auto& queue = data->q;
+                auto f = queue.m_callBackThread.submit([d = std::move(data)] { d->t(); });
+                f.wait();
+            }
+
+            void operator()(unifiedCudaHip::Queue<T_Device>& queue, T_Task const& task) const
+            {
+                using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
+
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::launchHostFunc(
+                        queue.getNativeHandle(),
+                        uniformCudaHipRtHostFunc,
+                        new HostFuncData{queue, task}));
+            }
+        };
 
         template<
             typename T_Device,

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 René Widera
+/* Copyright 2023 Axel Hübl, Benjamin Worpitz, Bernhard Manfred Gruber, Jan Stephan, René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -368,4 +368,149 @@ TEMPLATE_LIST_TEST_CASE("memcpy", "", TestApis)
 
     // validate without using the forward iterator
     meta::ndLoopIncIdx(problemSize, [&](auto idx) { CHECK(hBuff[idx] == size_t{0}); });
+}
+
+TEMPLATE_LIST_TEST_CASE("host task callback", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    std::cout << deviceSpec.getApi().getName() << std::endl;
+    onHost::Device device = devSelector.makeDevice(0);
+
+    std::cout << device.getName() << std::endl;
+
+    onHost::Queue queue = device.makeQueue();
+
+    std::promise<bool> promise;
+
+    queue.enqueue(
+        [&]()
+        {
+            std::cout << "Host Callback executed!" << std::endl;
+            promise.set_value(true);
+        });
+
+    CHECK(promise.get_future().get());
+}
+
+TEMPLATE_LIST_TEST_CASE("host task", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    std::cout << deviceSpec.getApi().getName() << std::endl;
+    onHost::Device device = devSelector.makeDevice(0);
+
+    std::cout << device.getName() << std::endl;
+
+    onHost::Queue queue = device.makeQueue();
+
+    bool flag = false;
+    auto task = [&] { flag = true; };
+    queue.enqueue(task); // lvalue
+    onHost::wait(queue);
+    CHECK(flag == true);
+
+    flag = false;
+    queue.enqueue(std::move(task)); // xvalue
+    onHost::wait(queue);
+    CHECK(flag == true);
+
+    flag = false;
+    queue.enqueue([&] { flag = true; }); // prvalue
+    onHost::wait(queue);
+    CHECK(flag == true);
+}
+
+TEMPLATE_LIST_TEST_CASE("queue wait should work", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    std::cout << deviceSpec.getApi().getName() << std::endl;
+    onHost::Device device = devSelector.makeDevice(0);
+
+    std::cout << device.getName() << std::endl;
+
+    onHost::Queue queue = device.makeQueue();
+
+    std::atomic<bool> callbackFinished{false};
+    queue.enqueue(
+        [&callbackFinished]() noexcept
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100u));
+            callbackFinished = true;
+        });
+
+    onHost::wait(queue);
+    CHECK(callbackFinished.load() == true);
+}
+
+TEMPLATE_LIST_TEST_CASE("task is destroyed after execution", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    std::cout << deviceSpec.getApi().getName() << std::endl;
+    onHost::Device device = devSelector.makeDevice(0);
+
+    std::cout << device.getName() << std::endl;
+
+    onHost::Queue queue = device.makeQueue();
+
+    struct Task
+    {
+        std::atomic<bool>* destroyed;
+
+        explicit Task(std::atomic<bool>& a) : destroyed(&a)
+        {
+        }
+
+        Task(Task const&) = default;
+
+        ~Task()
+        {
+            *destroyed = true;
+        }
+
+        void operator()() const
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1u));
+        }
+    };
+
+    std::atomic<bool> destroyed{false};
+    queue.enqueue(Task{destroyed});
+
+    onHost::wait(queue);
+    CHECK(destroyed == true);
 }


### PR DESCRIPTION
- add host task support for CUDA, HIP and OneApi.
- add tests from alpaka mainline to check the feature