### PR TITLE
disable copy and move

### DIFF
--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -37,7 +37,10 @@ namespace alpaka::onHost
             }
 
             Device(Device const&) = delete;
+            Device& operator=(Device const&) = delete;
+
             Device(Device&&) = delete;
+            Device& operator=(Device&&) = delete;
 
             bool operator==(Device const& other) const
             {

--- a/include/alpaka/api/host/Platform.hpp
+++ b/include/alpaka/api/host/Platform.hpp
@@ -26,7 +26,10 @@ namespace alpaka::onHost
             Platform() = default;
 
             Platform(Platform const&) = delete;
+            Platform& operator=(Platform const&) = delete;
+
             Platform(Platform&&) = delete;
+            Platform& operator=(Platform&&) = delete;
 
         private:
             void _()

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -46,7 +46,10 @@ namespace alpaka::onHost
             }
 
             Queue(Queue const&) = delete;
+            Queue& operator=(Queue const&) = delete;
+
             Queue(Queue&&) = delete;
+            Queue& operator=(Queue&&) = delete;
 
             bool operator==(Queue const& other) const
             {

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -31,6 +31,12 @@ namespace alpaka::onHost
             {
             }
 
+            Device(Device const&) = delete;
+            Device& operator=(Device const&) = delete;
+
+            Device(Device&&) = delete;
+            Device& operator=(Device&&) = delete;
+
             auto getName() const
             {
                 return m_sycl_dev.get_info<sycl::info::device::name>();

--- a/include/alpaka/api/syclGeneric/Platform.hpp
+++ b/include/alpaka/api/syclGeneric/Platform.hpp
@@ -115,7 +115,10 @@ namespace alpaka
                 }
 
                 Platform(Platform const&) = delete;
+                Platform& operator=(Platform const&) = delete;
+
                 Platform(Platform&&) = delete;
+                Platform& operator=(Platform&&) = delete;
 
                 std::shared_ptr<Platform<T_ApiInterface, T_DeviceKind>> getSharedPtr()
                 {

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -55,6 +55,12 @@ namespace alpaka::onHost
             {
             }
 
+            Queue(Queue const&) = delete;
+            Queue& operator=(Queue const&) = delete;
+
+            Queue(Queue&&) = delete;
+            Queue& operator=(Queue&&) = delete;
+
             ~Queue()
             {
                 try

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -45,7 +45,10 @@ namespace alpaka::onHost
             }
 
             Device(Device const&) = delete;
+            Device& operator=(Device const&) = delete;
+
             Device(Device&&) = delete;
+            Device& operator=(Device&&) = delete;
 
             bool operator==(Device const& other) const
             {

--- a/include/alpaka/api/unifiedCudaHip/Platform.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Platform.hpp
@@ -33,7 +33,10 @@ namespace alpaka::onHost
             Platform() = default;
 
             Platform(Platform const&) = delete;
+            Platform& operator=(Platform const&) = delete;
+
             Platform(Platform&&) = delete;
+            Platform& operator=(Platform&&) = delete;
 
         private:
             void _()

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -65,7 +65,10 @@ namespace alpaka::onHost
             }
 
             Queue(Queue const&) = delete;
+            Queue& operator=(Queue const&) = delete;
+
             Queue(Queue&&) = delete;
+            Queue& operator=(Queue&&) = delete;
 
             bool operator==(Queue const& other) const
             {


### PR DESCRIPTION
Disable copy, move, copy assign and move assign for internel devices, queues and platforms.