### PR TITLE
add event support

### DIFF
--- a/include/alpaka/api/cpu.hpp
+++ b/include/alpaka/api/cpu.hpp
@@ -6,6 +6,7 @@
 
 #include "alpaka/api/host/Api.hpp"
 #include "alpaka/api/host/Device.hpp"
+#include "alpaka/api/host/Event.hpp"
 #include "alpaka/api/host/Platform.hpp"
 #include "alpaka/api/host/Queue.hpp"
 #include "alpaka/api/host/atomic.hpp"

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/api/host/Api.hpp"
+#include "alpaka/api/host/Event.hpp"
 #include "alpaka/api/host/Queue.hpp"
 #include "alpaka/api/util.hpp"
 #include "alpaka/core/alignedAlloc.hpp"
@@ -62,6 +63,7 @@ namespace alpaka::onHost
             uint32_t m_idx = 0u;
             DeviceProperties m_properties;
             std::vector<std::weak_ptr<cpu::Queue<Device>>> queues;
+            std::vector<std::weak_ptr<cpu::Event<Device>>> events;
             std::mutex queuesGuard;
 
             std::shared_ptr<Device> getSharedPtr()
@@ -93,6 +95,18 @@ namespace alpaka::onHost
 
                 queues.emplace_back(newQueue);
                 return newQueue;
+            }
+
+            friend struct internal::MakeEvent;
+
+            Handle<cpu::Event<Device>> makeEvent()
+            {
+                auto thisHandle = this->getSharedPtr();
+                std::lock_guard<std::mutex> lk{queuesGuard};
+                auto newEvent = std::make_shared<cpu::Event<Device>>(std::move(thisHandle), queues.size());
+
+                events.emplace_back(newEvent);
+                return newEvent;
             }
 
             friend struct alpaka::internal::GetDeviceType;

--- a/include/alpaka/api/host/Event.hpp
+++ b/include/alpaka/api/host/Event.hpp
@@ -1,0 +1,153 @@
+/* Copyright 2023 Axel Hübl, Benjamin Worpitz, Matthias Werner, René Widera, Jan Stephan, Bernhard Manfred Gruber
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+
+#include "alpaka/api/host/Api.hpp"
+#include "alpaka/interface.hpp"
+#include "alpaka/internal.hpp"
+#include "alpaka/onHost/Handle.hpp"
+#include "alpaka/onHost/internal.hpp"
+
+#include <cstdint>
+#include <cstring>
+#include <future>
+#include <sstream>
+
+namespace alpaka::onHost
+{
+    namespace cpu
+    {
+        template<typename T_Device>
+        struct Event : std::enable_shared_from_this<Event<T_Device>>
+        {
+        public:
+            Event(internal::concepts::DeviceHandle auto device, uint32_t const idx)
+                : m_device(std::move(device))
+                , m_idx(idx)
+            {
+            }
+
+            ~Event()
+            {
+                internal::wait(*this);
+            }
+
+            Event(Event const&) = delete;
+            Event& operator=(Event const&) = delete;
+
+            Event(Event&&) = delete;
+            Event& operator=(Event&&) = delete;
+
+            bool operator==(Event const& other) const
+            {
+                return m_idx == other.m_idx && m_device == other.m_device;
+            }
+
+            bool operator!=(Event const& other) const
+            {
+                return !(*this == other);
+            }
+
+        private:
+            Handle<T_Device> m_device;
+            uint32_t m_idx = 0u;
+
+            //!< The mutex used to synchronize access to the event.
+            std::mutex mutable m_mutex;
+            //!< The future signaling the event completion.
+            std::shared_future<void> m_future;
+            //!< The number of times this event has been enqueued.
+            std::size_t m_enqueueCount = 0u;
+            //!< The time this event has been ready the last time.
+            //!< Ready means that the event was not waiting within a queue
+            //!< (not enqueued or already completed). If m_enqueueCount ==
+            //!< m_LastReadyEnqueueCount, the event is currently not enqueued
+            std::size_t m_LastReadyEnqueueCount = 0u;
+
+            friend struct alpaka::internal::GetName;
+
+            std::string getName() const
+            {
+                return std::string("host::Event id=") + std::to_string(m_idx);
+            }
+
+            friend struct internal::GetNativeHandle;
+            friend struct internal::Enqueue;
+            friend struct alpaka::internal::GetDeviceType;
+
+            auto getDeviceKind() const
+            {
+                return alpaka::internal::getDeviceKind(*m_device.get());
+            }
+
+            auto getDevice() const
+            {
+                return m_device;
+            }
+
+            std::shared_ptr<Event> getSharedPtr()
+            {
+                return this->shared_from_this();
+            }
+
+            friend struct onHost::internal::GetDevice;
+
+            friend struct internal::IsEventComplete;
+
+            /** Check if the event is ready.
+             *
+             * @return true if the event is ready, false otherwise
+             */
+            bool isReady() noexcept
+            {
+                return (m_LastReadyEnqueueCount == m_enqueueCount);
+            }
+
+            /** Check if the event is complete.
+             *
+             * @attention Should not be called if the event lock is acquired, because it could lead to a deadlock.
+             *
+             * @return true if the event is complete, false otherwise
+             */
+            bool isEventComplete() noexcept
+            {
+                std::lock_guard<std::mutex> lk(m_mutex);
+                return isReady();
+            }
+
+            friend struct internal::WaitFor;
+            friend struct internal::Wait;
+
+            void wait()
+            {
+                std::unique_lock<std::mutex> lk(m_mutex);
+                size_t enqueueCount = m_enqueueCount;
+
+                while(enqueueCount > m_LastReadyEnqueueCount)
+                {
+                    auto future = m_future;
+                    lk.unlock();
+                    future.get();
+                    lk.lock();
+                }
+            }
+
+            friend struct alpaka::internal::GetApi;
+        };
+    } // namespace cpu
+} // namespace alpaka::onHost
+
+namespace alpaka::internal
+{
+    template<typename T_Device>
+    struct GetApi::Op<onHost::cpu::Event<T_Device>>
+    {
+        inline constexpr auto operator()(auto&& event) const
+        {
+            return alpaka::getApi(event.m_device);
+        }
+    };
+} // namespace alpaka::internal

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -6,6 +6,7 @@
 
 #include "alpaka/api/generic.hpp"
 #include "alpaka/api/host/Api.hpp"
+#include "alpaka/api/host/Event.hpp"
 #include "alpaka/api/host/exec/OmpBlocks.hpp"
 #include "alpaka/api/host/exec/OmpThreads.hpp"
 #include "alpaka/api/host/exec/Serial.hpp"
@@ -82,7 +83,7 @@ namespace alpaka::onHost
 
             [[nodiscard]] auto getNativeHandle() const noexcept
             {
-                return 0;
+                return m_idx;
             }
 
             friend struct internal::Enqueue;
@@ -162,6 +163,7 @@ namespace alpaka::onHost
             friend struct onHost::internal::GetDevice;
 
             friend struct internal::Wait;
+            friend struct internal::WaitFor;
             friend struct internal::Memcpy;
             friend struct internal::Memset;
             friend struct alpaka::internal::GetApi;
@@ -181,6 +183,55 @@ namespace alpaka::onHost
                 internal::enqueue(queue, [&p]() { p.set_value(); });
 
                 f.wait();
+            }
+        };
+
+        template<typename T_Device, typename T_Event>
+        struct Enqueue::Event<cpu::Queue<T_Device>, T_Event>
+        {
+            void operator()(cpu::Queue<T_Device>& queue, T_Event& event) const
+            {
+                auto sharedEvent = event.getSharedPtr();
+
+                // Setting the event state and enqueuing it has to be atomic.
+                std::lock_guard<std::mutex> lk(event.m_mutex);
+
+                ++event.m_enqueueCount;
+
+                auto const enqueueCount = event.m_enqueueCount;
+
+                // Enqueue a task that only resets the events flag if it is completed.
+                event.m_future = queue.m_workerThread.submit(
+                    [sharedEvent, enqueueCount]() mutable
+                    {
+                        std::unique_lock<std::mutex> lk2(sharedEvent->m_mutex);
+
+                        // Nothing to do if it has been re-enqueued to a later position in the queue.
+                        if(enqueueCount == sharedEvent->m_enqueueCount)
+                        {
+                            sharedEvent->m_LastReadyEnqueueCount
+                                = std::max(enqueueCount, sharedEvent->m_LastReadyEnqueueCount);
+                        }
+                    });
+            }
+        };
+
+        template<typename T_Device, typename T_Event>
+        struct WaitFor::Op<cpu::Queue<T_Device>, T_Event>
+        {
+            void operator()(cpu::Queue<T_Device>& queue, cpu::Event<T_Device>& event) const
+            {
+                // Setting the event state and enqueuing it has to be atomic.
+                std::lock_guard<std::mutex> lk(event.m_mutex);
+
+                if(!event.isReady())
+                {
+                    auto sharedEvent = event.getSharedPtr();
+                    auto oldFuture = event.m_future;
+
+                    // Enqueue a task that waits for the given future of the event.
+                    queue.m_workerThread.submit([sharedEvent, oldFuture]() { oldFuture.get(); });
+                }
             }
         };
 

--- a/include/alpaka/api/oneApi.hpp
+++ b/include/alpaka/api/oneApi.hpp
@@ -10,5 +10,6 @@
 #include "alpaka/api/oneApi/Queue.hpp"
 #include "alpaka/api/oneApi/executor.hpp"
 #include "alpaka/api/oneApi/math.hpp"
+#include "alpaka/api/syclGeneric/Event.hpp"
 #include "alpaka/api/syclGeneric/atomic.hpp"
 #include "alpaka/api/syclGeneric/math.hpp"

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Simeon Ehrig
+/* Copyright 2025 Simeon Ehrig, René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -10,6 +10,8 @@
 
 #    include "Queue.hpp"
 #    include "alpaka/Vec.hpp"
+#    include "alpaka/api/syclGeneric/Event.hpp"
+#    include "alpaka/api/syclGeneric/Queue.hpp"
 #    include "alpaka/api/util.hpp"
 #    include "alpaka/onHost/mem/ManagedView.hpp"
 
@@ -50,7 +52,7 @@ namespace alpaka::onHost
             [[nodiscard]] Handle<syclGeneric::Queue<Device>> makeQueue()
             {
                 auto thisHandle = this->getSharedPtr();
-                std::lock_guard<std::mutex> lk{queuesGuard};
+                std::lock_guard<std::mutex> lk{m_writeGuard};
                 auto newQueue = std::make_shared<syclGeneric::Queue<Device>>(std::move(thisHandle), queues.size());
 
                 queues.emplace_back(newQueue);
@@ -63,6 +65,18 @@ namespace alpaka::onHost
             }
 
         private:
+            friend struct internal::MakeEvent;
+
+            Handle<syclGeneric::Event<Device>> makeEvent()
+            {
+                auto thisHandle = this->getSharedPtr();
+                std::lock_guard<std::mutex> lk{m_writeGuard};
+                auto newEvent = std::make_shared<syclGeneric::Event<Device>>(std::move(thisHandle), events.size());
+
+                events.emplace_back(newEvent);
+                return newEvent;
+            }
+
             void _()
             {
                 static_assert(internal::concepts::Device<Device>);
@@ -79,7 +93,8 @@ namespace alpaka::onHost
             uint32_t m_idx = 0u;
             sycl::device m_sycl_dev;
             std::vector<std::weak_ptr<syclGeneric::Queue<Device>>> queues;
-            std::mutex queuesGuard;
+            std::vector<std::weak_ptr<syclGeneric::Event<Device>>> events;
+            std::mutex m_writeGuard;
             DeviceProperties m_properties;
 
             friend struct alpaka::internal::GetApi;

--- a/include/alpaka/api/syclGeneric/Event.hpp
+++ b/include/alpaka/api/syclGeneric/Event.hpp
@@ -1,0 +1,145 @@
+/* Copyright 2025 Simeon Ehrig
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/config.hpp"
+
+#if ALPAKA_LANG_SYCL
+
+#    include "alpaka/api/util.hpp"
+#    include "alpaka/core/CallbackThread.hpp"
+#    include "alpaka/interface.hpp"
+#    include "alpaka/internal.hpp"
+#    include "alpaka/onHost/concepts.hpp"
+#    include "alpaka/onHost/internal.hpp"
+
+#    include <sycl/sycl.hpp>
+
+#    include <algorithm>
+#    include <sstream>
+
+namespace alpaka::onHost
+{
+    namespace syclGeneric
+    {
+        template<typename T_Device>
+        struct Event : std::enable_shared_from_this<Event<T_Device>>
+        {
+        private:
+            friend struct alpaka::internal::GetApi;
+
+        public:
+            Event(internal::concepts::DeviceHandle auto device, uint32_t const idx)
+                : m_device(std::move(device))
+                , m_idx(idx)
+            {
+            }
+
+            Event(Event const&) = delete;
+            Event& operator=(Event const&) = delete;
+
+            Event(Event&&) = delete;
+            Event& operator=(Event&&) = delete;
+
+            ~Event()
+            {
+                try
+                {
+                    m_event.wait_and_throw();
+                }
+                catch(sycl::exception const& err)
+                {
+                    std::cerr << "Caught SYCL exception while destructing a SYCL event: " << err.what() << " ("
+                              << err.code() << ')' << std::endl;
+                }
+                catch(std::exception const& err)
+                {
+                    std::cerr << "The following runtime error(s) occurred while destructing a SYCL event:"
+                              << err.what() << std::endl;
+                }
+            }
+
+            std::shared_ptr<Event> getSharedPtr()
+            {
+                return this->shared_from_this();
+            }
+
+            [[nodiscard]] auto getNativeHandle() const noexcept
+            {
+                return m_event;
+            }
+
+            void wait()
+            {
+                m_event.wait_and_throw();
+            }
+
+            std::string getName() const
+            {
+                std::stringstream ss;
+                ss << "Queue<" << getApi(m_device).getName() << ">";
+                ss << " id=" << m_idx;
+                return ss.str();
+            }
+
+        private:
+            friend struct alpaka::internal::GetDeviceType;
+            friend struct alpaka::onHost::internal::Enqueue;
+
+            auto getDeviceKind() const
+            {
+                return alpaka::internal::getDeviceKind(*m_device.get());
+            }
+
+            auto getDevice() const
+            {
+                return m_device;
+            }
+
+            friend struct onHost::internal::GetDevice;
+
+            friend struct onHost::internal::IsEventComplete;
+
+            /** Check if the event is complete.
+             *
+             * @return true if the event is complete, false otherwise
+             */
+            bool isEventComplete() noexcept
+            {
+                auto const status = m_event.template get_info<sycl::info::event::command_execution_status>();
+                return (status == sycl::info::event_command_status::complete);
+            }
+
+            friend struct internal::WaitFor;
+            friend struct internal::Wait;
+
+            void setEvent(sycl::event const& event)
+            {
+                m_event = event;
+            }
+
+            Handle<T_Device> m_device;
+            sycl::event m_event{};
+            uint32_t m_idx = 0u;
+        };
+
+
+    } // namespace syclGeneric
+} // namespace alpaka::onHost
+
+namespace alpaka::internal
+
+{
+    template<typename T_Device>
+    struct GetApi::Op<alpaka::onHost::syclGeneric::Event<T_Device>>
+    {
+        inline constexpr auto operator()(auto&& event) const
+        {
+            return alpaka::getApi(event.m_device);
+        }
+    };
+} // namespace alpaka::internal
+
+#endif

--- a/include/alpaka/api/syclGeneric/Event.hpp
+++ b/include/alpaka/api/syclGeneric/Event.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Simeon Ehrig
+/* Copyright 2025 René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Simeon Ehrig
+/* Copyright 2025 Simeon Ehrig, René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -8,6 +8,7 @@
 
 #if ALPAKA_LANG_SYCL
 
+#    include "alpaka/api/syclGeneric//Event.hpp"
 #    include "alpaka/api/syclGeneric/onAcc.hpp"
 #    include "alpaka/api/util.hpp"
 #    include "alpaka/core/CallbackThread.hpp"
@@ -119,6 +120,14 @@ namespace alpaka::onHost
 
             friend struct onHost::internal::GetDevice;
 
+            friend struct alpaka::onHost::internal::WaitFor;
+
+            void waitFor(syclGeneric::Event<T_Device>& event)
+            {
+                sycl::event sycl_event = event.getNativeHandle();
+                m_queue.submit([sycl_event](sycl::handler& cgh) { cgh.depends_on(sycl_event); });
+            }
+
             Handle<T_Device> m_device;
             uint32_t m_idx = 0u;
             sycl::queue m_queue;
@@ -130,9 +139,10 @@ namespace alpaka::onHost
 
     template<typename T_Device, typename T_Task>
     struct internal::Enqueue::Task<syclGeneric::Queue<T_Device>, T_Task>
+
     {
-        /** It is not allowed to execute sycl methods within a SYCL host_task therefore we use a callback host thread
-         * to execute the host function which is allowing to use sycl methods.
+        /** It is not allowed to execute sycl methods within a SYCL host_task therefore we use a callback host
+         * thread to execute the host function which is allowing to use sycl methods.
          */
         static void callHostTask(syclGeneric::Queue<T_Device>& queue, T_Task task)
         {
@@ -146,6 +156,16 @@ namespace alpaka::onHost
             // executed.
             queue.m_queue.submit([&queue, task](sycl::handler& cgh)
                                  { cgh.host_task([&queue, task]() { callHostTask(queue, task); }); });
+        }
+    };
+
+    template<typename T_Device, typename T_Event>
+    struct internal::Enqueue::Event<syclGeneric::Queue<T_Device>, T_Event>
+    {
+        void operator()(syclGeneric::Queue<T_Device>& queue, T_Event& event) const
+        {
+            sycl::event emulatedEvent = queue.m_queue.submit([](sycl::handler& cgh) { cgh.single_task([]() {}); });
+            event.setEvent(emulatedEvent);
         }
     };
 

--- a/include/alpaka/api/unifiedCudaHip.hpp
+++ b/include/alpaka/api/unifiedCudaHip.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/api/cuda.hpp"
 #include "alpaka/api/hip.hpp"
 #include "alpaka/api/unifiedCudaHip/Device.hpp"
+#include "alpaka/api/unifiedCudaHip/Event.hpp"
 #include "alpaka/api/unifiedCudaHip/Platform.hpp"
 #include "alpaka/api/unifiedCudaHip/Queue.hpp"
 #include "alpaka/api/unifiedCudaHip/atomic.hpp"

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/core/config.hpp"
 
 #if ALPAKA_LANG_CUDA || ALPAKA_LANG_HIP
+#    include "alpaka/api/unifiedCudaHip/Event.hpp"
 #    include "alpaka/api/unifiedCudaHip/Queue.hpp"
 #    include "alpaka/api/util.hpp"
 #    include "alpaka/core/UniformCudaHip.hpp"
@@ -70,7 +71,8 @@ namespace alpaka::onHost
             uint32_t m_idx = 0u;
             DeviceProperties m_properties;
             std::vector<std::weak_ptr<unifiedCudaHip::Queue<Device>>> queues;
-            std::mutex queuesGuard;
+            std::vector<std::weak_ptr<unifiedCudaHip::Event<Device>>> events;
+            std::mutex m_writeGuard;
 
             std::shared_ptr<Device> getSharedPtr()
             {
@@ -96,11 +98,23 @@ namespace alpaka::onHost
             Handle<unifiedCudaHip::Queue<Device>> makeQueue()
             {
                 auto thisHandle = this->getSharedPtr();
-                std::lock_guard<std::mutex> lk{queuesGuard};
+                std::lock_guard<std::mutex> lk{m_writeGuard};
                 auto newQueue = std::make_shared<unifiedCudaHip::Queue<Device>>(std::move(thisHandle), queues.size());
 
                 queues.emplace_back(newQueue);
                 return newQueue;
+            }
+
+            friend struct onHost::internal::MakeEvent;
+
+            Handle<unifiedCudaHip::Event<Device>> makeEvent()
+            {
+                auto thisHandle = this->getSharedPtr();
+                std::lock_guard<std::mutex> lk{m_writeGuard};
+                auto newEvent = std::make_shared<unifiedCudaHip::Event<Device>>(std::move(thisHandle), events.size());
+
+                events.emplace_back(newEvent);
+                return newEvent;
             }
 
             friend struct alpaka::internal::GetDeviceType;

--- a/include/alpaka/api/unifiedCudaHip/Event.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Event.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 René Widera
+/* Copyright 2025 René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/include/alpaka/api/unifiedCudaHip/Event.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Event.hpp
@@ -1,0 +1,168 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+#pragma once
+
+#pragma once
+
+#include "alpaka/core/config.hpp"
+
+#if ALPAKA_LANG_CUDA || ALPAKA_LANG_HIP
+#    include "alpaka/api/cuda/IdxLayer.hpp"
+#    include "alpaka/api/generic.hpp"
+#    include "alpaka/api/hip/IdxLayer.hpp"
+#    include "alpaka/api/unifiedCudaHip/ComputeApi.hpp"
+#    include "alpaka/api/unifiedCudaHip/MemcpyKind.hpp"
+#    include "alpaka/api/unifiedCudaHip/concepts.hpp"
+#    include "alpaka/api/util.hpp"
+#    include "alpaka/core/ApiCudaRt.hpp"
+#    include "alpaka/core/CallbackThread.hpp"
+#    include "alpaka/core/UniformCudaHip.hpp"
+#    include "alpaka/internal.hpp"
+#    include "alpaka/onAcc/Acc.hpp"
+#    include "alpaka/onHost.hpp"
+#    include "alpaka/onHost/FrameSpec.hpp"
+#    include "alpaka/onHost/Handle.hpp"
+#    include "alpaka/onHost/internal.hpp"
+#    include "alpaka/onHost/mem/ManagedView.hpp"
+
+#    include <cstdint>
+#    include <sstream>
+
+namespace alpaka::onHost
+{
+    namespace unifiedCudaHip
+    {
+        template<typename T_Device>
+        struct Event : std::enable_shared_from_this<Event<T_Device>>
+        {
+            using ApiInterface = typename T_Device::ApiInterface;
+
+        public:
+            Event(internal::concepts::DeviceHandle auto device, uint32_t const idx)
+                : m_device(std::move(device))
+                , m_idx(idx)
+            {
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::setDevice(internal::getNativeHandle(*m_device.get())));
+
+                // Create the event on the current device with the specified flags. Valid flags include:
+                // - cuda/hip-EventDefault: Default event creation flag.
+                // - cuda/hip-EventBlockingSync : Specifies that event should use blocking synchronization.
+                //   A host thread that uses cuda/hip-EventSynchronize() to wait on an event created with this flag
+                //   will block until the event actually completes. (currently not used, @todo: check if this is
+                //   required, in mainline alpaka this is configuable in the constructor.
+                // - cuda/hip-EventDisableTiming : Specifies that the created event does not need to record timing
+                // data.
+                //   Events created with this flag specified and the cuda/hip-EventBlockingSync flag not specified
+                //   will provide the best performance when used with cudaStreamWaitEvent() and cudaEventQuery().
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::eventCreateWithFlags(
+                        &m_nativeEvent,
+                        ApiInterface::eventDefault | ApiInterface::eventDisableTiming));
+            }
+
+            ~Event()
+            {
+                onHost::internal::wait(*this);
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::eventDestroy(getNativeHandle()));
+            }
+
+            Event(Event const&) = delete;
+            Event& operator=(Event const&) = delete;
+
+            Event(Event&&) = delete;
+            Event& operator=(Event&&) = delete;
+
+            bool operator==(Event const& other) const
+            {
+                return m_idx == other.m_idx && m_device == other.m_device;
+            }
+
+            bool operator!=(Event const& other) const
+            {
+                return !(*this == other);
+            }
+
+        private:
+            Handle<T_Device> m_device;
+            uint32_t m_idx = 0u;
+            typename ApiInterface::Event_t m_nativeEvent;
+
+            friend struct alpaka::internal::GetName;
+
+            std::string getName() const
+            {
+                return std::string("unifiedCudaHip::Event id=") + std::to_string(m_idx);
+            }
+
+            friend struct onHost::internal::GetNativeHandle;
+
+            [[nodiscard]] auto getNativeHandle() const noexcept
+            {
+                return m_nativeEvent;
+            }
+
+            friend struct onHost::internal::Enqueue;
+
+            friend struct onHost::internal::Wait;
+
+            void wait() const
+            {
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::eventSynchronize(getNativeHandle()));
+            }
+
+            friend struct alpaka::internal::GetDeviceType;
+
+            auto getDeviceKind() const
+            {
+                return alpaka::internal::getDeviceKind(*m_device.get());
+            }
+
+            auto getDevice() const
+            {
+                return m_device;
+            }
+
+            std::shared_ptr<Event> getSharedPtr()
+            {
+                return this->shared_from_this();
+            }
+
+            friend struct onHost::internal::IsEventComplete;
+
+            bool isEventComplete() noexcept
+            {
+                typename ApiInterface::Error_t ret = ApiInterface::success;
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
+                    ApiInterface,
+                    ret = ApiInterface::eventQuery(m_nativeEvent),
+                    ApiInterface::errorNotReady);
+                return (ret == ApiInterface::success);
+            }
+
+            friend struct onHost::internal::GetDevice;
+
+            friend struct alpaka::internal::GetApi;
+        };
+
+    } // namespace unifiedCudaHip
+} // namespace alpaka::onHost
+
+namespace alpaka::internal
+{
+    template<typename T_Device>
+    struct GetApi::Op<onHost::unifiedCudaHip::Event<T_Device>>
+    {
+        inline constexpr auto operator()(auto&& queue) const
+        {
+            return getApi(queue.m_device);
+        }
+    };
+} // namespace alpaka::internal
+#endif

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -14,6 +14,7 @@
 #    include "alpaka/api/generic.hpp"
 #    include "alpaka/api/hip/IdxLayer.hpp"
 #    include "alpaka/api/unifiedCudaHip/ComputeApi.hpp"
+#    include "alpaka/api/unifiedCudaHip/Event.hpp"
 #    include "alpaka/api/unifiedCudaHip/MemcpyKind.hpp"
 #    include "alpaka/api/unifiedCudaHip/concepts.hpp"
 #    include "alpaka/api/util.hpp"

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -58,7 +58,6 @@ namespace alpaka::onHost
             ~Queue()
             {
                 onHost::internal::wait(*this);
-                // setDevice is not required because wait() is setting the device
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
                     ApiInterface,
                     ApiInterface::streamDestroy(getNativeHandle()));
@@ -129,6 +128,15 @@ namespace alpaka::onHost
             std::shared_ptr<Queue> getSharedPtr()
             {
                 return this->shared_from_this();
+            }
+
+            friend struct alpaka::onHost::internal::WaitFor;
+
+            void waitFor(unifiedCudaHip::Event<T_Device>& event)
+            {
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::streamWaitEvent(getNativeHandle(), internal::getNativeHandle(event), 0));
             }
 
             friend struct onHost::internal::GetDevice;
@@ -337,6 +345,19 @@ namespace alpaka::onHost
                         queue.getNativeHandle(),
                         uniformCudaHipRtHostFunc,
                         new HostFuncData{queue, task}));
+            }
+        };
+
+        template<typename T_Device, typename T_Event>
+        struct internal::Enqueue::Event<unifiedCudaHip::Queue<T_Device>, T_Event>
+        {
+            void operator()(unifiedCudaHip::Queue<T_Device>& queue, T_Event& event) const
+            {
+                using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
+
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::eventRecord(event.getNativeHandle(), queue.getNativeHandle()));
             }
         };
 

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -6,6 +6,7 @@
 
 #include "Handle.hpp"
 #include "alpaka/interface.hpp"
+#include "alpaka/onHost/Event.hpp"
 #include "alpaka/onHost/Queue.hpp"
 #include "alpaka/onHost/concepts.hpp"
 #include "alpaka/onHost/internal.hpp"
@@ -82,6 +83,11 @@ namespace alpaka::onHost
         auto makeQueue()
         {
             return Queue{internal::MakeQueue::Op<std::decay_t<decltype(*m_device.get())>>{}(*m_device.get())};
+        }
+
+        auto makeEvent()
+        {
+            return Event{internal::MakeEvent::Op<std::decay_t<decltype(*m_device.get())>>{}(*m_device.get())};
         }
 
         /** blocks the caller until the given handle executes all work

--- a/include/alpaka/onHost/Event.hpp
+++ b/include/alpaka/onHost/Event.hpp
@@ -1,0 +1,90 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "Handle.hpp"
+#include "alpaka/api/trait.hpp"
+#include "alpaka/onHost/internal.hpp"
+
+#include <memory>
+
+namespace alpaka::onHost
+{
+    template<typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    struct Device;
+
+    template<typename T_Device>
+    struct Event;
+
+    template<typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    struct Event<Device<T_Api, T_DeviceKind>>
+    {
+    private:
+        using DeviceInterface = Device<T_Api, T_DeviceKind>;
+        using EventHandle
+            = ALPAKA_TYPEOF(internal::MakeEvent::Op<ALPAKA_TYPEOF(*std::declval<DeviceInterface>().get())>{}(
+                *std::declval<DeviceInterface>().get()));
+
+        EventHandle m_event;
+
+    public:
+        using element_type = typename EventHandle::element_type;
+
+        template<typename T_Event>
+        Event(Handle<T_Event>&& event) : m_event{std::forward<Handle<T_Event>>(event)}
+        {
+        }
+
+        auto* get() const
+        {
+            return m_event.get();
+        }
+
+        constexpr auto getApi() const
+        {
+            return alpaka::internal::getApi(*m_event.get());
+        }
+
+        std::string getName() const
+        {
+            return alpaka::internal::GetName::Op<std::decay_t<decltype(*m_event.get())>>{}(*m_event.get());
+        }
+
+        [[nodiscard]] auto getNativeHandle() const
+        {
+            return internal::getNativeHandle(*m_event.get());
+        }
+
+        bool operator==(Event const& other) const
+        {
+            return this->get() == other.get();
+        }
+
+        bool operator!=(Event const& other) const
+        {
+            return this->get() != other.get();
+        }
+
+        /** Get the device of this event
+         *
+         * @return the device of this event
+         */
+        auto getDevice() const
+        {
+            return Device<T_Api, T_DeviceKind>{internal::getDevice(*m_event.get())};
+        }
+
+        bool isComplete() const
+        {
+            return alpaka::onHost::internal::isEventComplete(*m_event.get());
+        }
+    };
+
+    template<typename T_Event>
+    Event(Handle<T_Event>&&) -> Event<Device<
+        ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Event>())),
+        ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Event>()))>>;
+
+} // namespace alpaka::onHost

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -6,6 +6,7 @@
 
 #include "Handle.hpp"
 #include "alpaka/api/trait.hpp"
+#include "alpaka/onHost/Event.hpp"
 #include "alpaka/onHost/concepts.hpp"
 #include "alpaka/onHost/internal.hpp"
 
@@ -150,6 +151,18 @@ namespace alpaka::onHost
             return internal::Enqueue::Task<std::decay_t<decltype(*m_queue.get())>, std::decay_t<decltype(task)>>{}(
                 *m_queue.get(),
                 task);
+        }
+
+        void enqueue(Event<Device<T_Api, T_DeviceKind>> const& event) const
+        {
+            return internal::Enqueue::Event<ALPAKA_TYPEOF(*m_queue.get()), ALPAKA_TYPEOF(*event.get())>{}(
+                *m_queue.get(),
+                *event.get());
+        }
+
+        void waitFor(Event<Device<T_Api, T_DeviceKind>> const& event) const
+        {
+            return internal::waitFor(*m_queue.get(), *event.get());
         }
     };
 

--- a/include/alpaka/onHost/concepts.hpp
+++ b/include/alpaka/onHost/concepts.hpp
@@ -20,9 +20,11 @@ namespace alpaka::onHost
             {
                 alpaka::internal::GetName::Op<T>{}(device)
             } -> std::convertible_to<std::string>;
-
             {
                 internal::MakeQueue::Op<T>{}(device)
+            };
+            {
+                internal::MakeEvent::Op<T>{}(device)
             };
             {
                 internal::GetNativeHandle::Op<T>{}(device)

--- a/include/alpaka/onHost/internal.hpp
+++ b/include/alpaka/onHost/internal.hpp
@@ -83,7 +83,7 @@ namespace alpaka::onHost
             };
         };
 
-        static auto getNativeHandle(auto&& any)
+        inline auto getNativeHandle(auto&& any)
         {
             return GetNativeHandle::Op<std::decay_t<decltype(any)>>{}(any);
         }
@@ -96,6 +96,18 @@ namespace alpaka::onHost
                 auto operator()(T_Device& device) const
                 {
                     return device.makeQueue();
+                }
+            };
+        };
+
+        struct MakeEvent
+        {
+            template<typename T_Device>
+            struct Op
+            {
+                auto operator()(T_Device& device) const
+                {
+                    return device.makeEvent();
                 }
             };
         };
@@ -114,7 +126,41 @@ namespace alpaka::onHost
 
         inline void wait(auto&& any)
         {
-            return Wait::Op<std::decay_t<decltype(any)>>{}(any);
+            Wait::Op<std::decay_t<decltype(any)>>{}(any);
+        }
+
+        struct WaitFor
+        {
+            template<typename T_Queue, typename T_Event>
+            struct Op
+            {
+                void operator()(T_Queue& queue, T_Event& event)
+                {
+                    queue.waitFor(event);
+                }
+            };
+        };
+
+        inline void waitFor(auto& queue, auto& event)
+        {
+            WaitFor::Op<ALPAKA_TYPEOF(queue), ALPAKA_TYPEOF(event)>{}(queue, event);
+        }
+
+        struct IsEventComplete
+        {
+            template<typename T_Any>
+            struct Op
+            {
+                bool operator()(T_Any& any)
+                {
+                    return any.isEventComplete();
+                }
+            };
+        };
+
+        inline bool isEventComplete(auto&& any)
+        {
+            return IsEventComplete::Op<ALPAKA_TYPEOF(any)>{}(any);
         }
 
         struct Enqueue
@@ -142,6 +188,15 @@ namespace alpaka::onHost
                 void operator()(T_Queue& queue, T_Task const& task) const
                 {
                     queue.enqueue(task);
+                }
+            };
+
+            template<typename T_Queue, typename T_Event>
+            struct Event
+            {
+                void operator()(T_Queue& queue, T_Event& event) const
+                {
+                    queue.enqueue(event);
                 }
             };
         };

--- a/tests/unit/event/event.cpp
+++ b/tests/unit/event/event.cpp
@@ -1,0 +1,673 @@
+/* Copyright 2023 Axel Hübl, Benjamin Worpitz, Bernhard Manfred Gruber, Jan Stephan, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include "eventHelper.hpp"
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executeForEach.hpp>
+#include <alpaka/example/executors.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <iostream>
+
+/** @file
+ *
+ * This tests evaluated if events in a queue follows a defined behaviour. Events used to describe dependencies
+ * between queues need to guarantee that tasks not start to early.
+ * If a event is re-enqueued and used again the event is not allowed to be complete before the last enqueue of the
+ * event is executed on the device.
+ *
+ * @attention: Compared to older alpaka version the tests not using a special implementation of a emulated kernel which
+ * can be triggered from the host side. For CUDA in the past a driver method `cuStreamWaitValue32()` was used and for
+ * CPU there wars a different implementation. Sycl was not tested at all. This implementation is providing now a
+ * unified emulated kernel which is using mapped memory to signal that a kernel which is perfroming a bussy waiting on
+ * the device kernel should finish.
+ * If the usage of mapped memory is making issues at some point we should switch back to the old implementation.
+ *
+ * For OneApi and Intel GPUs some tests will not be performed. The GPU Arc770 used for testing provides most likly only
+ * a single hardware queue and therefore kernel whcih has no dependencies are not executed. Most test assumes that
+ * queues can run tasks concurrently even if there is already a running kernel.
+ */
+
+using namespace alpaka;
+using namespace alpaka::test::event;
+
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis))>;
+
+/** This test takes care that kernel in different queues can run concurrent and if we can communicate between host and
+ * the device via mapped memory. Even if the concurrent queue test says true it could be that kernels can run under the
+ * condition we test concurrent but if to many blocking kernel are enqueued they can not run concurrent.
+ */
+TEMPLATE_LIST_TEST_CASE("device analysis", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+
+    bool hasCQueue = detectConcurrentQueue(device);
+    std::cout << "Concurrent kernel queue detected: " << (hasCQueue ? "yes" : "no") << std::endl;
+
+    bool supportMappedMemTrigger = mappedMemTriggerDetection(device);
+    std::cout << "Can trigger via mapped memory: " << (supportMappedMemTrigger ? "yes" : "no") << std::endl;
+}
+
+TEMPLATE_LIST_TEST_CASE("event creation and enqueue", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+
+    onHost::Queue queue = device.makeQueue();
+    onHost::Event ev = device.makeEvent();
+    queue.enqueue(ev);
+    onHost::wait(ev);
+    CHECK(ev.isComplete() == true);
+}
+
+TEMPLATE_LIST_TEST_CASE("basic queue wait for event", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+
+    onHost::Queue queue0 = device.makeQueue();
+    onHost::Queue queue1 = device.makeQueue();
+    onHost::Event ev = device.makeEvent();
+    CHECK(ev.isComplete() == true);
+    queue0.enqueue(ev);
+    onHost::wait(ev);
+    CHECK(ev.isComplete() == true);
+    queue0.enqueue([]() { std::this_thread::sleep_for(std::chrono::milliseconds(100u)); });
+    queue0.enqueue(ev);
+    queue1.waitFor(ev);
+    onHost::wait(queue1);
+    CHECK(ev.isComplete() == true);
+}
+
+TEMPLATE_LIST_TEST_CASE("test trigger event", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+
+    bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
+    if(!hasConcurrentKernelQueues)
+    {
+        /* We cannot execute the event tests with OneApi on Intel GPU because the emulated kernel trigger via another
+         * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
+         * will not run out of order which is assumed for some of the tests.
+         */
+        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
+                  << " because the device does not support concurrent queues." << std::endl;
+        return;
+    }
+
+    onHost::Queue queue = device.makeQueue();
+    auto ev = TriggerKernel{device};
+    ev.submit(queue);
+    // we will deadlock here in case the GPU cannot see the state change
+    ev.trigger();
+    ev.wait();
+    CHECK(ev.isComplete() == true);
+}
+
+TEMPLATE_LIST_TEST_CASE("eventTestShouldBeFalseWhileInQueueAndTrueAfterBeingProcessed", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+
+    bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
+    if(!hasConcurrentKernelQueues)
+    {
+        /* We cannot execute the event tests with OneApi on Intel GPU because the emulated kernel trigger via another
+         * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
+         * will not run out of order which is assumed for some of the tests.
+         */
+        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
+                  << " because the device does not support concurrent queues." << std::endl;
+        return;
+    }
+
+    onHost::Queue q1 = device.makeQueue();
+    auto e1 = TriggerKernel{device};
+
+    e1.submit(q1);
+    REQUIRE(e1.isComplete() == false);
+
+    e1.trigger();
+    e1.wait();
+    REQUIRE(e1.isComplete() == true);
+}
+
+TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfNobodyWaitsFor", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+
+    bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
+    if(!hasConcurrentKernelQueues)
+    {
+        /* We cannot execute the event tests with OneApi on Intel GPU because the emulated kernel trigger via another
+         * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
+         * will not run out of order which is assumed for some of the tests.
+         */
+        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
+                  << " because the device does not support concurrent queues." << std::endl;
+        return;
+    }
+    if(std::is_same_v<ALPAKA_TYPEOF(deviceSpec.getApi()), api::OneApi>
+       && std::is_same_v<ALPAKA_TYPEOF(deviceSpec.getDeviceKind()), deviceKind::IntelGpu>)
+    {
+        std::cout << "Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking."
+                  << std::endl;
+        return;
+    }
+
+    onHost::Queue q1 = device.makeQueue();
+    auto k1 = TriggerKernel{device};
+    auto k2 = TriggerKernel{device};
+    auto e1 = device.makeEvent();
+    REQUIRE(k1.isComplete());
+
+    k1.submit(q1);
+    // wait to detect if the kernel ends before we trigger the end
+    std::this_thread::sleep_for(std::chrono::milliseconds(500u));
+    // q1 = [k1]
+    REQUIRE(!k1.isComplete());
+
+    q1.enqueue(e1);
+    // q1 = [k1, e1]
+    REQUIRE(!k1.isComplete());
+    REQUIRE(!e1.isComplete());
+
+    k2.submit(q1);
+    // q1 = [k1, e1, k2]
+    REQUIRE(!k1.isComplete());
+    REQUIRE(!e1.isComplete());
+    REQUIRE(!k2.isComplete());
+
+    // re-enqueue should be possible
+    q1.enqueue(e1);
+    // q1 = [k1, k2, e1]
+    REQUIRE(!k1.isComplete());
+    REQUIRE(!k2.isComplete());
+    REQUIRE(!e1.isComplete());
+
+    k1.trigger();
+    // q1 = [k2, e1]
+    REQUIRE(k1.isComplete());
+    REQUIRE(!k2.isComplete());
+    REQUIRE(!e1.isComplete());
+
+    k2.trigger();
+    // q1 = [e1]
+    REQUIRE(k2.isComplete());
+    onHost::wait(e1);
+    REQUIRE(e1.isComplete());
+}
+
+TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+
+    bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
+    if(!hasConcurrentKernelQueues)
+    {
+        /* We cannot execute the event tests with OneApi on Intel GPU because the emulated kernel trigger via another
+         * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
+         * will not run out of order which is assumed for some of the tests.
+         */
+        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
+                  << " because the device does not support concurrent queues." << std::endl;
+        return;
+    }
+    if(std::is_same_v<ALPAKA_TYPEOF(deviceSpec.getApi()), api::OneApi>
+       && std::is_same_v<ALPAKA_TYPEOF(deviceSpec.getDeviceKind()), deviceKind::IntelGpu>)
+    {
+        std::cout << "Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking."
+                  << std::endl;
+        return;
+    }
+
+    onHost::Queue q1 = device.makeQueue();
+    onHost::Queue q2 = device.makeQueue();
+    auto k1 = TriggerKernel{device};
+    auto k2 = TriggerKernel{device};
+    auto e1 = device.makeEvent();
+    auto e2 = device.makeEvent();
+
+    k1.submit(q1);
+    // q1 = [k1]
+    REQUIRE(!k1.isComplete());
+
+    q1.enqueue(e1);
+    // q1 = [k1, e1]
+    REQUIRE(!k1.isComplete());
+    REQUIRE(!e1.isComplete());
+
+    k2.submit(q1);
+    // q1 = [k1, e1, k2]
+    REQUIRE(!k1.isComplete());
+    REQUIRE(!e1.isComplete());
+    REQUIRE(!k2.isComplete());
+
+    // wait for e1
+    q2.waitFor(e1);
+    // q2 = [->e1]
+
+    q2.enqueue(e2);
+    // q2 = [->e1, e2]
+    REQUIRE(!e2.isComplete());
+
+    // re-enqueue should be possible
+    q1.enqueue(e1);
+    // q1 = [k1, e1, k2, e1_new]
+    // q2 = [->e1, e2]
+    REQUIRE(!k1.isComplete());
+    REQUIRE(!k2.isComplete());
+    REQUIRE(!e1.isComplete());
+    REQUIRE(!e2.isComplete());
+
+    k1.trigger();
+    // q1 = [k2, e1_new]
+    // q2 = []
+    REQUIRE(k1.isComplete());
+    REQUIRE(!k2.isComplete());
+    REQUIRE(!e1.isComplete());
+    REQUIRE(e2.isComplete());
+
+    k2.trigger();
+    // q1 = []
+    // q2 = []
+    REQUIRE(k2.isComplete());
+    onHost::wait(e1);
+    REQUIRE(e1.isComplete());
+    onHost::wait(e2);
+    REQUIRE(e2.isComplete());
+}
+
+TEMPLATE_LIST_TEST_CASE("waitForEventThatAlreadyFinishedShouldBeSkipped", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+
+    bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
+    if(!hasConcurrentKernelQueues)
+    {
+        /* We cannot execute the event tests with OneApi on Intel GPU because the emulated kernel trigger via another
+         * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
+         * will not run out of order which is assumed for some of the tests.
+         */
+        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
+                  << " because the device does not support concurrent queues." << std::endl;
+        return;
+    }
+    if(std::is_same_v<ALPAKA_TYPEOF(deviceSpec.getApi()), api::OneApi>
+       && std::is_same_v<ALPAKA_TYPEOF(deviceSpec.getDeviceKind()), deviceKind::IntelGpu>)
+    {
+        std::cout << "Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking."
+                  << std::endl;
+        return;
+    }
+
+    onHost::Queue q1 = device.makeQueue();
+    onHost::Queue q2 = device.makeQueue();
+    auto k1 = TriggerKernel{device};
+    auto k2 = TriggerKernel{device};
+    auto e1 = device.makeEvent();
+
+    // 1. kernel k1 is enqueued into queue q1
+    k1.submit(q1);
+    // q1 = [k1]
+
+    // 2. event e1 is enqueued into queue q1
+    q1.enqueue(e1);
+    // q1 = [k1, e1]
+
+    // 3. kernel k2 is enqueued into queue q2
+    k2.submit(q2);
+    // q2 = [k2]
+
+    // 4. q2 waits for e1
+    q2.waitFor(e1);
+    // q2 = [k2, ->e1]
+
+    // 5. kernel k1 finishes
+    k1.trigger();
+    // q1 = [e1]
+    // q2 = [k2, ->e1]
+
+    // 6. e1 is finished
+    onHost::wait(e1);
+    // q1 = []
+    // q2 = [k2, ->e1]
+    REQUIRE(!k2.isComplete());
+    REQUIRE(e1.isComplete());
+
+    // 7. e1 is re-enqueued again but this time into q2
+    q2.enqueue(e1);
+
+    // q2 = [k2, ->e1, e1]
+    REQUIRE(!k2.isComplete());
+    REQUIRE(!e1.isComplete());
+
+    // 8. k2 is triggered
+    k2.trigger();
+    // q2 = [e1]
+    REQUIRE(k2.isComplete());
+
+    // 9. e1 had already been signaled, so there should not be waited even though the event is now reused within
+    // q2 and its current state is 'unfinished' again. q2 = [e1]
+
+    // Both queues should successfully finish
+    onHost::wait(q1);
+    onHost::wait(q2);
+}
+
+TEMPLATE_LIST_TEST_CASE("evReEnqueueWithSomeoneWaitsForEventInOrderLifetimeRelease", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+
+    bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
+    if(!hasConcurrentKernelQueues)
+    {
+        /* We cannot execute the event tests with OneApi on Intel GPU because the emulated kernel trigger via another
+         * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
+         * will not run out of order which is assumed for some of the tests.
+         */
+        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
+                  << " because the device does not support concurrent queues." << std::endl;
+        return;
+    }
+    if(std::is_same_v<ALPAKA_TYPEOF(deviceSpec.getApi()), api::OneApi>
+       && std::is_same_v<ALPAKA_TYPEOF(deviceSpec.getDeviceKind()), deviceKind::IntelGpu>)
+    {
+        std::cout << "Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking."
+                  << std::endl;
+        return;
+    }
+
+    onHost::Queue q1 = device.makeQueue();
+    onHost::Queue q2 = device.makeQueue();
+    onHost::Queue q3 = device.makeQueue();
+    auto k1_0 = TriggerKernel{device};
+    auto k1_1 = TriggerKernel{device};
+    auto k2 = TriggerKernel{device};
+    auto k3 = TriggerKernel{device};
+    auto e1 = device.makeEvent();
+    auto e2 = device.makeEvent();
+    auto e3 = device.makeEvent();
+
+    k1_0.submit(q1);
+    // q1 = [k1_0]
+    q1.enqueue(e1);
+    // q1 = [k1_0, e1]
+    k2.submit(q2);
+    // q2 = [k2]
+    REQUIRE(!k1_0.isComplete());
+
+    q2.waitFor(e1);
+    // q2 = [k2,->e1]
+    q2.enqueue(e2);
+    // q2 = [k2,->e1, e2]
+    k1_1.submit(q1);
+    q1.enqueue(e1);
+    // q1 = [k1_0, e1, k1_1, e1_new]
+    k3.submit(q3);
+    q3.waitFor(e1);
+    // q3 = [k3, ->e1]
+    q3.enqueue(e3);
+    // q3 = [k3, ->e1, e3]
+
+    // q1 = [k1_0,e1,k1_1,e1_new]
+    // q2 = [k2,->e1,e2]
+    // q3 = [k3,->e1_new,e3]
+    REQUIRE(!k1_0.isComplete());
+    REQUIRE(!k1_1.isComplete());
+    REQUIRE(!k2.isComplete());
+    REQUIRE(!k3.isComplete());
+    REQUIRE(!e1.isComplete());
+    REQUIRE(!e2.isComplete());
+    REQUIRE(!e3.isComplete());
+
+    k3.trigger();
+    // q1 = [k1_0,e1,k1_1,e1_new]
+    // q2 = [k2,->e1,e2]
+    // q3 = [->e1_new,e3]
+    REQUIRE(!k1_0.isComplete());
+    REQUIRE(!k1_1.isComplete());
+    REQUIRE(!k2.isComplete());
+    REQUIRE(k3.isComplete());
+    REQUIRE(!e1.isComplete());
+    REQUIRE(!e2.isComplete());
+    REQUIRE(!e3.isComplete());
+
+    k2.trigger();
+    // q1 = [k1_0,e1,k1_1,e1_new]
+    // q2 = [->e1,e2]
+    // q3 = [->e1_new,e3]
+    REQUIRE(!k1_0.isComplete());
+    REQUIRE(!k1_1.isComplete());
+    REQUIRE(k2.isComplete());
+    REQUIRE(k3.isComplete());
+    REQUIRE(!e1.isComplete());
+    REQUIRE(!e2.isComplete());
+    REQUIRE(!e3.isComplete());
+
+    // After the kernel k1_0 is released e3 is not allowed to be ready because q3 depends on the oldest e1_new
+    // state.
+    k1_0.trigger();
+    // q1 = [k1_1,e1_new]
+    // q2 = []
+    // q3 = [->e1_new,e3]
+    REQUIRE(k1_0.isComplete());
+    REQUIRE(!k1_1.isComplete());
+    REQUIRE(k2.isComplete());
+    REQUIRE(k3.isComplete());
+    REQUIRE(!e1.isComplete());
+    REQUIRE(e2.isComplete());
+    REQUIRE(!e3.isComplete());
+
+    k1_1.trigger();
+    // q1 = []
+    // q2 = []
+    // q3 = []
+    REQUIRE(k1_0.isComplete());
+    REQUIRE(k1_1.isComplete());
+    REQUIRE(k2.isComplete());
+    REQUIRE(k3.isComplete());
+    REQUIRE(e1.isComplete());
+    REQUIRE(e2.isComplete());
+    REQUIRE(e3.isComplete());
+}
+
+TEMPLATE_LIST_TEST_CASE("EventOutOfOrderLifetimeRelease", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+
+    bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
+    if(!hasConcurrentKernelQueues)
+    {
+        /* We cannot execute the event tests with OneApi on Intel GPU because the emulated kernel trigger via another
+         * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
+         * will not run out of order which is assumed for some of the tests.
+         */
+        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
+                  << " because the device does not support concurrent queues." << std::endl;
+        return;
+    }
+    if(std::is_same_v<ALPAKA_TYPEOF(deviceSpec.getApi()), api::OneApi>
+       && std::is_same_v<ALPAKA_TYPEOF(deviceSpec.getDeviceKind()), deviceKind::IntelGpu>)
+    {
+        std::cout << "Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking."
+                  << std::endl;
+        return;
+    }
+
+    onHost::Queue q1 = device.makeQueue();
+    onHost::Queue q2 = device.makeQueue();
+    onHost::Queue q3 = device.makeQueue();
+    auto k1_0 = TriggerKernel{device};
+    auto k2 = TriggerKernel{device};
+    auto e1 = device.makeEvent();
+    auto e2 = device.makeEvent();
+    auto e3 = device.makeEvent();
+
+    k1_0.submit(q1);
+    // q1 = [k1_0]
+    q1.enqueue(e1);
+    // q1 = [k1_0, e1]
+    k2.submit(q2);
+    // q2 = [k2]
+    REQUIRE(!k1_0.isComplete());
+
+    q3.waitFor(e1);
+    // q3 = [->e1]
+    q3.enqueue(e3);
+    // q3 = [->e1, e3]
+
+    q2.enqueue(e1);
+    // q2 = [k2, e1_new]
+
+    q2.enqueue(e2);
+    // q1 = [k1_0,e1]
+    // q2 = [k2,e1_new,e2]
+    // q3 = [->e1,e3]
+
+    REQUIRE(!k1_0.isComplete());
+    REQUIRE(!k2.isComplete());
+    REQUIRE(!e1.isComplete());
+    REQUIRE(!e2.isComplete());
+    REQUIRE(!e3.isComplete());
+
+
+    // We release first the kernel which is blocking the most recent enqueue of event e1.
+    // q3 is not allowed to be freed because this queue depends on the oldest enqueue of e1.
+    k2.trigger();
+    // q1 = [k1_0,e1]
+    // q2 = []
+    // q3 = [->e1,e3]
+
+    REQUIRE(!k1_0.isComplete());
+    REQUIRE(k2.isComplete());
+    REQUIRE(e1.isComplete());
+    REQUIRE(e2.isComplete());
+    REQUIRE(!e3.isComplete());
+
+    k1_0.trigger();
+    // q1 = []
+    // q2 = []
+    // q3 = []
+
+    REQUIRE(k1_0.isComplete());
+    REQUIRE(k2.isComplete());
+    REQUIRE(e1.isComplete());
+    REQUIRE(e2.isComplete());
+    REQUIRE(e3.isComplete());
+
+    onHost::wait(q1);
+    onHost::wait(q2);
+    onHost::wait(q3);
+}

--- a/tests/unit/event/eventHelper.hpp
+++ b/tests/unit/event/eventHelper.hpp
@@ -1,0 +1,296 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <iostream>
+
+namespace alpaka::test::event
+{
+    using namespace alpaka;
+
+    namespace detail
+    {
+        // emulates sleeping even if there is no sleeep methods available
+        inline ALPAKA_FN_ACC void alpakaSleep(
+            [[maybe_unused]] int32_t* i,
+            [[maybe_unused]] int32_t rounds,
+            [[maybe_unused]] int32_t roundsGuard)
+        {
+#if ALPAKA_ARCH_PTX
+            __nanosleep(100000);
+#elif !ALPAKA_LANG_SYCL && !ALPAKA_LANG_HIP
+            std::this_thread::sleep_for(std::chrono::microseconds(100u));
+#else
+            (*i) = 0;
+            // Use a busy wait loop to avoid to fast polling
+            for(; *i < roundsGuard; ++(*i))
+            {
+                if((*i) >= rounds)
+                    break;
+            }
+#endif
+        }
+
+        /** Kernel waits for a signal to be finished.
+         *
+         * The kernel is stopping after a short time and report this not triggered exit.
+         * This avoids that we deadlock.
+         */
+        struct KernelTestBussyWait
+        {
+            /**
+             *
+             * @param acc
+             * @param triggerData
+             * @param i
+             * @param rounds
+             * @param roundsGuard
+             * @param status 1 if the kernel exists due to the host trigger else 0. Zero means the kernel stopped
+             * because does not see the trigger data has changed.
+             */
+            ALPAKA_FN_ACC void operator()(
+                onAcc::concepts::Acc auto const& acc,
+                int volatile* triggerData,
+                int* i,
+                int32_t rounds,
+                int32_t roundsGuard,
+                int* status) const
+            {
+                constexpr uint32_t maxNumTriggerReads = 50000;
+                uint32_t foo = 0;
+                /* In principle, we could use an atomic load here, but tests showed that if we trigger with a second
+                 * kernel with atomic operations, the second kernel is not running in parallel on the same backends.
+                 * Using a volatile pointer showed to work best with all backends.
+                 */
+                while(triggerData == 0)
+                {
+                    if(++foo >= maxNumTriggerReads)
+                    {
+                        *status = 0;
+                        return;
+                    }
+                    // Use a busy wait loop to avoid to fast polling
+                    alpakaSleep(i, rounds, roundsGuard);
+                }
+                *status = 1;
+            }
+        };
+
+        struct UpdateValue
+        {
+            ALPAKA_FN_ACC void operator()(
+                onAcc::concepts::Acc auto const& acc,
+                int volatile* triggerData,
+                int32_t value) const
+            {
+                *triggerData = value;
+            }
+        };
+
+        inline bool detectConcurrentQueueHelper(auto& device)
+        {
+            auto triggerQueue = device.makeQueue();
+            auto mainQueue = device.makeQueue();
+
+            auto devCounter = onHost::alloc<int32_t>(device, 1);
+            auto devTrigger = onHost::alloc<int32_t>(device, 1);
+            auto status = onHost::allocMapped<int32_t>(device, 1);
+
+
+            constexpr int waitLoopCount = 1000;
+            onHost::fill(mainQueue, devCounter, 0);
+            onHost::fill(mainQueue, devTrigger, 0);
+            onHost::fill(mainQueue, status, -1);
+            // wait that all data for the test is setup
+            onHost::wait(mainQueue);
+            mainQueue.enqueue(
+                onHost::FrameSpec{Vec{1}, Vec{1}},
+                KernelBundle{
+                    KernelTestBussyWait{},
+                    devTrigger.data(),
+                    devCounter.data(),
+                    waitLoopCount,
+                    waitLoopCount + 10,
+                    status.data()});
+
+            // Uses a second kernel in a different queue to trigger the first kernel via a signal on device memory.
+            triggerQueue.enqueue(
+                onHost::FrameSpec{Vec{1}, Vec{1}},
+                KernelBundle{UpdateValue{}, devTrigger.data(), 42});
+
+            onHost::wait(mainQueue);
+            onHost::wait(triggerQueue);
+            return status[0] == 1;
+        }
+
+        inline bool mappedMemTriggerDetectionHelper(auto& device)
+        {
+            auto mainQueue = device.makeQueue();
+
+            auto devCounter = onHost::alloc<int32_t>(device, 1);
+            auto trigger = onHost::allocMapped<int32_t>(device, 1);
+            auto status = onHost::allocMapped<int32_t>(device, 1);
+
+
+            constexpr int waitLoopCount = 1000;
+            onHost::fill(mainQueue, devCounter, 0);
+            trigger[0] = 0;
+            onHost::fill(mainQueue, status, -1);
+            // wait that all data for the test is set up
+            onHost::wait(mainQueue);
+            mainQueue.enqueue(
+                onHost::FrameSpec{Vec{1}, Vec{1}},
+                KernelBundle{
+                    KernelTestBussyWait{},
+                    trigger.data(),
+                    devCounter.data(),
+                    waitLoopCount,
+                    waitLoopCount + 10,
+                    status.data()});
+
+            // trigger via mapped memory
+            trigger[0] = 42;
+
+            onHost::wait(mainQueue);
+            return status[0] == 1;
+        }
+
+        struct KernelBlockUntilReady
+        {
+            ALPAKA_FN_ACC void operator()(
+                onAcc::concepts::Acc auto const& acc,
+                int volatile* triggerData,
+                int* i,
+                int rounds,
+                int roundsGuard) const
+            {
+                while(*triggerData == 0)
+                {
+                    alpakaSleep(i, rounds, roundsGuard);
+                }
+            }
+        };
+    } // namespace detail
+
+    /** Checks if device queue can execute concurrent work.
+     *
+     * Some native api's alpaka is using have only a single hardware/ord driver limited compute queue, in this case all
+     * tasks enqueued in user created independent queues will me in FIFO mode.
+     * The test checks only if two queues can run concurrent, it not necessary says more than two queues can run
+     * concurrent.
+     *
+     * @param device device which is tested
+     * @param maxRepetitions number of rounds the test is executed to avoid false positives
+     * @return true if the device support concurrent queues, else false. @attention: false is returned even if the
+     * device is supporting concurrent queues, the reason is that the detection works with hard coded number of
+     * retries. This is required to avoid triggering the watchdog terminating long running kernels on some systems. If
+     * one of the test repetitions reports that concurrent queues are not supported the result will be false.
+     */
+    inline bool detectConcurrentQueue(auto& device, int maxRepetitions = 3)
+    {
+        bool result = true;
+        for(int i = 0; i < maxRepetitions && result; ++i)
+            result = result && detail::detectConcurrentQueueHelper(device);
+        return result;
+    }
+
+    /** Checks if mapped memory can be used to trigger a kernel.
+     *
+     * The test checks if a kernel can be triggered by writing into mapped memory.
+     * The test is executed multiple times to avoid false positives.
+     *  @return true if the device support concurrent queues, else false
+     */
+    inline bool mappedMemTriggerDetection(auto& device, int maxRepetitions = 3)
+    {
+        bool result = true;
+        for(int i = 0; i < maxRepetitions && result; ++i)
+            result = result && detail::mappedMemTriggerDetectionHelper(device);
+        return result;
+    }
+
+    // Checks if the device supports cuncurrent queue execution and if we can send via mapped memory information to a
+    // running kernel.
+    inline bool checkIfDeviceCanExecuteEventTests(auto& device, int maxRepetitions = 3)
+    {
+        return mappedMemTriggerDetection(device, maxRepetitions) && detectConcurrentQueue(device, maxRepetitions);
+    }
+
+    /** Emulates an kernel which runs until on host side an event is triggerd to release the kernel.
+     *
+     * Use mapped memory to send signals to the blocking kernels to release them.
+     */
+    template<typename T_Device>
+    struct TriggerKernel
+    {
+        TriggerKernel() = default;
+
+        TriggerKernel(T_Device& device)
+            : m_CounterDev{onHost::alloc<int32_t>(device, 1)}
+            , m_triggerData{onHost::allocMapped<int32_t>(device, 1)}
+            , m_preEvent{device.makeEvent()}
+            , m_postEvent{device.makeEvent()}
+        {
+            auto initQueue = device.makeQueue();
+            onHost::fill(initQueue, m_CounterDev, 0);
+            onHost::fill(initQueue, m_triggerData, 0);
+            onHost::wait(initQueue);
+        }
+
+        // set event to ready state
+        constexpr void trigger()
+        {
+            for(int i = 0; i < 10; ++i)
+            {
+                m_triggerData[0] = 42;
+                // Give alpaka time to update into the new state, process all events and tasks.
+                std::this_thread::sleep_for(std::chrono::milliseconds(500u));
+                if(isRunning())
+                    break;
+                else
+                {
+                    std::cout << "warning: trigger had no effect, re-trigger " << i + 1 << " of " << 10 << std::endl;
+                }
+            }
+        }
+
+        void submit(auto& queue)
+        {
+            constexpr int waitLoopCount = 10000;
+
+            queue.enqueue(m_preEvent);
+            queue.enqueue(
+                onHost::FrameSpec{Vec{1}, Vec{1}},
+                KernelBundle{
+                    detail::KernelBlockUntilReady{},
+                    m_triggerData.data(),
+                    m_CounterDev.data(),
+                    waitLoopCount,
+                    waitLoopCount + 10});
+            queue.enqueue(m_postEvent);
+        }
+
+        bool isComplete() const
+        {
+            return m_postEvent.isComplete();
+        }
+
+        // inform if the emulated kernel is scheduled by the device and therefore can be triggered and tested for
+        // completeness
+        bool isRunning() const
+        {
+            return m_preEvent.isComplete();
+        }
+
+        void wait() const
+        {
+            return onHost::wait(m_postEvent);
+        }
+
+        ALPAKA_TYPEOF(onHost::alloc<int32_t>(std::declval<T_Device>(), 1)) m_CounterDev;
+        ALPAKA_TYPEOF(onHost::allocMapped<int32_t>(std::declval<T_Device>(), 1)) m_triggerData;
+        onHost::Event<T_Device> m_preEvent;
+        onHost::Event<T_Device> m_postEvent;
+    };
+} // namespace alpaka::test::event

--- a/tests/unit/event/eventHelper.hpp
+++ b/tests/unit/event/eventHelper.hpp
@@ -18,7 +18,7 @@ namespace alpaka::test::event
             [[maybe_unused]] int32_t rounds,
             [[maybe_unused]] int32_t roundsGuard)
         {
-#if ALPAKA_ARCH_PTX
+#if ALPAKA_ARCH_PTX && __CUDA_ARCH__ >= 700
             __nanosleep(100000);
 #elif !ALPAKA_LANG_SYCL && !ALPAKA_LANG_HIP
             std::this_thread::sleep_for(std::chrono::microseconds(100u));


### PR DESCRIPTION
- implement event support for all API's
-  test event's for all backends
  - take over most tests from older alpaka 2.0