### PR TITLE
handle ALPAKA_ARCH_PTX and ALPAKA_ARCH_HSA

### DIFF
--- a/include/alpaka/core/PP.hpp
+++ b/include/alpaka/core/PP.hpp
@@ -19,3 +19,27 @@
 /** @} */
 
 #define ALPAKA_PP_REMOVE_BRACKETS(x) ALPAKA_PP_REMOVE_BRACKETS_DO(x)
+
+/* version number encoding
+ * 4 digits for major version (max 9999)
+ * 3 digits for minor version (max 999)
+ * 5 digits for patch version (max 99999)
+ * example: version 1.2.3 -> 0001 002 00003
+ */
+#define ALPAKA_VERSION_NUMBER(major, minor, patch)                                                                    \
+    ((((major) % 10000llu) * 100'000'000llu) + (((minor) % 1000llu) * 100000llu) + ((patch) % 100000llu))
+
+#define ALPAKA_VERSION_NUMBER_NOT_AVAILABLE ALPAKA_VERSION_NUMBER(0llu, 0llu, 0llu)
+#define ALPAKA_VERSION_NUMBER_UNKNOWN ALPAKA_VERSION_NUMBER(9999llu, 999llu, 99999llu)
+
+// version number conversion from vendor format to ALPAKA_VERSION_NUMBER
+#define ALPAKA_YYYYMMDD_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 10000llu), ((V) / 100llu) % 100llu, (V) % 100llu)
+
+#define ALPAKA_YYYYMM_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 100llu) % 10000llu, (V) % 100llu, 0llu)
+
+#define ALPAKA_VVRRP_TO_VERSION(V)                                                                                    \
+    ALPAKA_VERSION_NUMBER(((V) / 1000llu) % 10000llu, ((V) / 10llu) % 100llu, (V) % 10llu)
+
+#define ALPAKA_VRP_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 100llu) % 10000llu, ((V) / 10llu) % 10llu, (V) % 10llu)
+
+#define ALPAKA_VRRR_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 1000llu) % 10000llu, (V) % 1000llu, 0)

--- a/include/alpaka/core/config.hpp
+++ b/include/alpaka/core/config.hpp
@@ -5,22 +5,12 @@
 
 #pragma once
 
+#include "alpaka/core/PP.hpp"
+
 #ifdef __INTEL_COMPILER
 #    warning                                                                                                          \
         "The Intel Classic compiler (icpc) is no longer supported. Please upgrade to the Intel LLVM compiler (ipcx)."
 #endif
-
-#define ALPAKA_VERSION_NUMBER(major, minor, patch)                                                                    \
-    ((((major) % 10000llu) * 100'000'000llu) + (((minor) % 1000llu) * 100000llu) + ((patch) % 100000llu))
-
-#define ALPAKA_VERSION_NUMBER_NOT_AVAILABLE ALPAKA_VERSION_NUMBER(0llu, 0llu, 0llu)
-
-#define ALPAKA_YYYYMMDD_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 10000llu), ((V) / 100llu) % 100llu, (V) % 100llu)
-
-#define ALPAKA_YYYYMM_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 100llu) % 10000llu, (V) % 100llu, 0llu)
-
-#define ALPAKA_VVRRP_10_TO_VERSION(V)                                                                                 \
-    ALPAKA_VERSION_NUMBER(((V) / 1000llu) % 100llu, ((V) / 10llu) % 100llu, (V) % 10llu)
 
 // ######## detect operating systems ########
 
@@ -90,21 +80,38 @@
 #    endif
 #endif
 
-// NVIDIA device compile
+/** NVIDIA device compile
+ *
+ * * The version on the host side will always be ALPAKA_VERSION_NUMBER_NOT_AVAILABLE.
+ *
+ *   Rules:
+ *   - sm75 -> ALPAKA_VERSION_NUMBER(7,5,0)
+ *   - sm91 -> ALPAKA_VERSION_NUMBER(9,1,0)
+ */
 #if !defined(ALPAKA_ARCH_PTX)
 #    if defined(__CUDA_ARCH__)
-#        define ALPAKA_ARCH_PTX 1
+#        define ALPAKA_ARCH_PTX ALPAKA_VRP_TO_VERSION(__CUDA_ARCH__)
 #    else
-#        define ALPAKA_ARCH_PTX 0
+#        define ALPAKA_ARCH_PTX ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif
 #endif
 
-// HIP device compile
+/** HIP device compile
+ *
+ * The version on the host side will always be ALPAKA_VERSION_NUMBER_NOT_AVAILABLE.
+ * On the device side unknown version will be set to ALPAKA_VERSION_NUMBER_UNKNOWN.
+ *
+ *  Rules:
+ *   - gfx9xx (numeric): 9xy -> ALPAKA_VERSION_NUMBER(9,xy,0)
+ *   - gfx10xx / gfx11xx: stxy -> ALPAKA_VERSION_NUMBER(st,xy,0)
+ *   - Suffix: a->+100 (90a->9100), b->+200, c->+300
+ *      - gfx90a -> ALPAKA_VERSION_NUMBER(9,100,0)
+ */
 #if !defined(ALPAKA_ARCH_HSA)
 #    if defined(__HIP__) && defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__ == 1
-#        define ALPAKA_ARCH_HSA 1
+#        define ALPAKA_ARCH_HSA ALPAKA_AMDGPU_ARCH
 #    else
-#        define ALPAKA_ARCH_HSA 0
+#        define ALPAKA_ARCH_HSA ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif
 #endif
 
@@ -207,7 +214,7 @@
 #    if defined(__CUDACC__) || defined(__CUDA__)
 #        include <cuda.h>
 // CUDA doesn't give us a patch level for the last entry, just zero.
-#        define ALPAKA_LANG_CUDA ALPAKA_VVRRP_10_TO_VERSION(CUDART_VERSION)
+#        define ALPAKA_LANG_CUDA ALPAKA_VVRRP_TO_VERSION(CUDART_VERSION)
 #    else
 #        define ALPAKA_LANG_CUDA ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif

--- a/include/alpaka/core/hipConfig.hpp
+++ b/include/alpaka/core/hipConfig.hpp
@@ -1,0 +1,118 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/PP.hpp"
+
+#if ALPAKA_LANG_HIP
+
+#    include <hip/hip_version.h>
+
+// version numbers are only defined on the device side
+#    if !defined(ALPAKA_AMDGPU_ARCH) && defined(__HIP__) && defined(__HIP_DEVICE_COMPILE__)                           \
+        && __HIP_DEVICE_COMPILE__ == 1
+
+/* Map AMDGPU arch macro -> ALPAKA_VRRR_TO_VERSION(wrapped code)
+ *  Rules:
+ *   - gfx9xx (numeric): 9xy -> 90xy  (e.g., 908->9008, 906->9006, 942->9042)
+ *   - gfx10xx / gfx11xx: stxy -> st0xy (e.g., 1036->10036, 1103->11003)
+ *   - Suffix: a->+100 (90a->9100), b->+200, c->+300
+ */
+
+#        if defined(__gfx1153__)
+/* RDNA 3.5 iGPU (Medusa Point / Strix Halo successor) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11053)
+#        elif defined(__gfx1152__)
+/* RDNA 3.5 iGPU (Krackan Point) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11052)
+#        elif defined(__gfx1151__)
+/* RDNA 3.5 iGPU (Strix Halo) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11051)
+#        elif defined(__gfx1150__)
+/* RDNA 3.5 iGPU (Radeon 890M on Strix Point) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11050)
+
+#        elif defined(__gfx1103__)
+/* RDNA 3 APU (Radeon 780M, 760M, ROG Ally Extreme) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11003)
+#        elif defined(__gfx1102__)
+/* RDNA 3 Desktop (RX 7600 / 7600 XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11002)
+#        elif defined(__gfx1101__)
+/* RDNA 3 Desktop (RX 7700 / 7700 XT, Pro W7700 / V710) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11001)
+#        elif defined(__gfx1100__)
+/* RDNA 3 Desktop (RX 7900 XT, XTX, Pro W7900) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11000)
+
+#        elif defined(__gfx1036__)
+/* RDNA 2 APU (Radeon Graphics 128-SP iGPU) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10036)
+#        elif defined(__gfx1035__)
+/* RDNA 2 APU (Radeon 660M, 680M) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10035)
+#        elif defined(__gfx1034__)
+/* RDNA 2 Mobile (Pro W6300/W6400, RX 6400-6500) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10034)
+#        elif defined(__gfx1033__)
+/* RDNA 2 APU (Steam Deck) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10033)
+#        elif defined(__gfx1032__)
+/* RDNA 2 Desktop (RX 6600 XT, 6650 XT/S, 6700S) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10032)
+#        elif defined(__gfx1031__)
+/* RDNA 2 Desktop (RX 6700 series, 6750/6850M XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10031)
+#        elif defined(__gfx1030__)
+/* RDNA 2 Desktop (RX 6800 / 6900 XT, Pro W6800) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10030)
+
+#        elif defined(__gfx1013__)
+/* RDNA 1 Mobile (RX 5300M / 5500M) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10013)
+#        elif defined(__gfx1012__)
+/* RDNA 1 Desktop (RX 5500 / 5500 XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10012)
+#        elif defined(__gfx1011__)
+/* RDNA 1 Desktop (Pro V520) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10011)
+#        elif defined(__gfx1010__)
+/* RDNA 1 Desktop (RX 5700 / 5700 XT, Pro 5600 XT/M) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10010)
+
+#        elif defined(__gfx942__)
+/* CDNA 3 (Instinct MI300 series: MI300/MI300A/MI300X) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9042)
+#        elif defined(__gfx941__)
+/* CDNA 2/3 (Instinct MI210) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9041)
+#        elif defined(__gfx940__)
+/* CDNA 2 (Instinct MI200) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9040)
+
+#        elif defined(__gfx90c__)
+/* CDNA 1 (Renoir APUs), c -> +300 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9300)
+#        elif defined(__gfx90b__)
+/* (If present) b -> +200 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9200)
+#        elif defined(__gfx90a__)
+/* CDNA 2 (Instinct MI250 / MI250X), a -> +100 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9100)
+#        elif defined(__gfx908__)
+/* CDNA 1 (Instinct MI100) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9008)
+#        elif defined(__gfx906__)
+/* Vega 20 (Radeon VII, Instinct MI50/60) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9006)
+
+#        else
+#            warning                                                                                                  \
+                "Unknown AMDGPU architecture, please define __gfxXXX__ macro for your target. Until alpaka is updated you can define the macro ALPAKA_AMDGPU_ARCH to avoid this warning."
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VERSION_NUMBER_UNKNOWN
+#        endif
+
+#    endif
+#endif

--- a/tests/unit/core/config.cpp
+++ b/tests/unit/core/config.cpp
@@ -9,16 +9,35 @@
 TEST_CASE("config macros", "")
 {
     static_assert(ALPAKA_VERSION_NUMBER(2025, 2, 1) == 202'500'200'001);
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VERSION_NUMBER(12025, 2, 1) == 202'500'200'001);
+    static_assert(ALPAKA_VERSION_NUMBER(12025, 2, 1) == ALPAKA_VERSION_NUMBER(2025, 2, 1));
 
     static_assert(ALPAKA_VERSION_NUMBER_NOT_AVAILABLE == 0000000000000);
     static_assert(ALPAKA_VERSION_NUMBER_NOT_AVAILABLE == ALPAKA_VERSION_NUMBER(0, 0, 0));
 
     static_assert(ALPAKA_YYYYMMDD_TO_VERSION(20'250'201) == 202'500'200'001);
     static_assert(ALPAKA_YYYYMMDD_TO_VERSION(20'250'201) == ALPAKA_VERSION_NUMBER(2025, 2, 1));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_YYYYMMDD_TO_VERSION(120'250'201) == ALPAKA_VERSION_NUMBER(2025, 2, 1));
 
     static_assert(ALPAKA_YYYYMM_TO_VERSION(202502) == 202'500'200'000);
     static_assert(ALPAKA_YYYYMM_TO_VERSION(202502) == ALPAKA_VERSION_NUMBER(2025, 2, 0));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_YYYYMM_TO_VERSION(1'202'502) == ALPAKA_VERSION_NUMBER(2025, 2, 0));
 
-    static_assert(ALPAKA_VVRRP_10_TO_VERSION(12081) == 1'200'800'001);
-    static_assert(ALPAKA_VVRRP_10_TO_VERSION(12081) == ALPAKA_VERSION_NUMBER(12, 8, 1));
+    static_assert(ALPAKA_VVRRP_TO_VERSION(12081) == 1'200'800'001);
+    static_assert(ALPAKA_VVRRP_TO_VERSION(12081) == ALPAKA_VERSION_NUMBER(12, 8, 1));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VVRRP_TO_VERSION(12'345'081) == ALPAKA_VERSION_NUMBER(2345, 8, 1));
+
+    static_assert(ALPAKA_VRP_TO_VERSION(751) == 700'500'001);
+    static_assert(ALPAKA_VRP_TO_VERSION(751) == ALPAKA_VERSION_NUMBER(7, 5, 1));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VRP_TO_VERSION(1'234'567) == ALPAKA_VERSION_NUMBER(2345, 6, 7));
+
+    static_assert(ALPAKA_VRRR_TO_VERSION(12053) == 1'205'300'000);
+    static_assert(ALPAKA_VRRR_TO_VERSION(12053) == ALPAKA_VERSION_NUMBER(12, 53, 0));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VRRR_TO_VERSION(12'345'053) == ALPAKA_VERSION_NUMBER(2345, 53, 0));
 }


### PR DESCRIPTION
Provide a useful version number for both architecture macros.

`ALPAKA_ARCH_HSA` can now be used to detect the warp size at compile time on the device side during compilation.

```C++
if constexpr (ALPAKA_ARCH_HSA >= ALPAKA_VERSION_NUMBER(10,0,0))
  // ALPAKA_VERSION_NUMBER_UNKNOWN will return 32 too
  return 32;
else
  return 64;
```