### PR TITLE
refactor ALPAKA_ARCH_HSA and ALPAKA_AMDGPU_ARCH

### DIFF
--- a/include/alpaka/core/PP.hpp
+++ b/include/alpaka/core/PP.hpp
@@ -42,4 +42,5 @@
 
 #define ALPAKA_VRP_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 100llu) % 10000llu, ((V) / 10llu) % 10llu, (V) % 10llu)
 
-#define ALPAKA_VRRR_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 1000llu) % 10000llu, (V) % 1000llu, 0)
+#define ALPAKA_VRRPP_TO_VERSION(V)                                                                                    \
+    ALPAKA_VERSION_NUMBER(((V) / 10000llu) % 10000llu, ((V) / 100llu) % 100llu, (V) % 100llu)

--- a/include/alpaka/core/config.hpp
+++ b/include/alpaka/core/config.hpp
@@ -102,16 +102,18 @@
  * On the device side unknown version will be set to ALPAKA_VERSION_NUMBER_UNKNOWN.
  *
  *  Rules:
- *   - gfx9xx (numeric): 9xy -> ALPAKA_VERSION_NUMBER(9,xy,0)
- *   - gfx10xx / gfx11xx: stxy -> ALPAKA_VERSION_NUMBER(st,xy,0)
- *   - Suffix: a->+100 (90a->9100), b->+200, c->+300
- *      - gfx90a -> ALPAKA_VERSION_NUMBER(9,100,0)
+ *   - the last two digits will be handled as HEX values and support 0-9 and a-f
+ *   - gfx9xy (numeric): 9xy -> ALPAKA_VERSION_NUMBER(9,x,y)
+ *   - gfx10xy / gfx11xy: stxy -> ALPAKA_VERSION_NUMBER(st,x,y)
+ *   - Suffix: a == 10, b == 11, c == 12
+ *      - gfx90a -> ALPAKA_VERSION_NUMBER(9,0,10)
+ *      - gfx90c -> ALPAKA_VERSION_NUMBER(9,0,12)
  */
-#if !defined(ALPAKA_ARCH_HSA)
+#if !defined(ALPAKA_ARCH_AMD)
 #    if defined(__HIP__) && defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__ == 1
-#        define ALPAKA_ARCH_HSA ALPAKA_AMDGPU_ARCH
+#        define ALPAKA_ARCH_AMD ALPAKA_AMDGPU_ARCH
 #    else
-#        define ALPAKA_ARCH_HSA ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
+#        define ALPAKA_ARCH_AMD ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif
 #endif
 

--- a/include/alpaka/core/hipConfig.hpp
+++ b/include/alpaka/core/hipConfig.hpp
@@ -14,11 +14,11 @@
 #    if !defined(ALPAKA_AMDGPU_ARCH) && defined(__HIP__) && defined(__HIP_DEVICE_COMPILE__)                           \
         && __HIP_DEVICE_COMPILE__ == 1
 
-/* Map AMDGPU arch macro -> ALPAKA_VRRR_TO_VERSION(wrapped code)
+/* Map AMDGPU arch macro -> ALPAKA_VRRPP_TO_VERSION(wrapped code)
  *  Rules:
- *   - gfx9xx (numeric): 9xy -> 90xy  (e.g., 908->9008, 906->9006, 942->9042)
- *   - gfx10xx / gfx11xx: stxy -> st0xy (e.g., 1036->10036, 1103->11003)
- *   - Suffix: a->+100 (90a->9100), b->+200, c->+300
+ *   - gfx9xy (numeric): 9xy -> 90x0y  (e.g., 908->90008, 906->90006, 942->90402)
+ *   - gfx10xy / gfx11xy: stxy -> st0x0y (e.g., 1036->100306, 1103->110003)
+ *   - Suffix: a == 10 (90a->90010), b == 11, c == 11
  *
  * An overview of AMD GPU architectures can be found here:
  * https://llvm.org/docs/AMDGPUUsage.html#processors
@@ -26,90 +26,90 @@
 
 #        if defined(__gfx1153__)
 /* RDNA 3.5 iGPU (Medusa Point / Strix Halo successor) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11053)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110503)
 #        elif defined(__gfx1152__)
 /* RDNA 3.5 iGPU (Krackan Point) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11052)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110502)
 #        elif defined(__gfx1151__)
 /* RDNA 3.5 iGPU (Strix Halo) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11051)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110501)
 #        elif defined(__gfx1150__)
 /* RDNA 3.5 iGPU (Radeon 890M on Strix Point) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11050)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110500)
 
 #        elif defined(__gfx1103__)
 /* RDNA 3 APU (Radeon 780M, 760M, ROG Ally Extreme) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11003)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110003)
 #        elif defined(__gfx1102__)
 /* RDNA 3 Desktop (RX 7600 / 7600 XT) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11002)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110002)
 #        elif defined(__gfx1101__)
 /* RDNA 3 Desktop (RX 7700 / 7700 XT, Pro W7700 / V710) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11001)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110001)
 #        elif defined(__gfx1100__)
 /* RDNA 3 Desktop (RX 7900 XT, XTX, Pro W7900) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(11000)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110000)
 
 #        elif defined(__gfx1036__)
 /* RDNA 2 APU (Radeon Graphics 128-SP iGPU) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10036)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100306)
 #        elif defined(__gfx1035__)
 /* RDNA 2 APU (Radeon 660M, 680M) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10035)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100305)
 #        elif defined(__gfx1034__)
 /* RDNA 2 Mobile (Pro W6300/W6400, RX 6400-6500) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10034)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100304)
 #        elif defined(__gfx1033__)
 /* RDNA 2 APU (Steam Deck) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10033)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100303)
 #        elif defined(__gfx1032__)
 /* RDNA 2 Desktop (RX 6600 XT, 6650 XT/S, 6700S) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10032)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100302)
 #        elif defined(__gfx1031__)
 /* RDNA 2 Desktop (RX 6700 series, 6750/6850M XT) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10031)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100301)
 #        elif defined(__gfx1030__)
 /* RDNA 2 Desktop (RX 6800 / 6900 XT, Pro W6800) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10030)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100300)
 
 #        elif defined(__gfx1013__)
 /* RDNA 1 Mobile (RX 5300M / 5500M) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10013)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100103)
 #        elif defined(__gfx1012__)
 /* RDNA 1 Desktop (RX 5500 / 5500 XT) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10012)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100102)
 #        elif defined(__gfx1011__)
 /* RDNA 1 Desktop (Pro V520) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10011)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100101)
 #        elif defined(__gfx1010__)
 /* RDNA 1 Desktop (RX 5700 / 5700 XT, Pro 5600 XT/M) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(10010)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100100)
 
 #        elif defined(__gfx942__)
 /* CDNA 3 (Instinct MI300 series: MI300/MI300A/MI300X) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9042)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90402)
 #        elif defined(__gfx941__)
 /* CDNA 2/3 (Instinct MI210) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9041)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90401)
 #        elif defined(__gfx940__)
 /* CDNA 2 (Instinct MI200) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9040)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90400)
 
 #        elif defined(__gfx90c__)
-/* CDNA 1 (Renoir APUs), c -> +300 */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9300)
+/* CDNA 1 (Renoir APUs), c -> 12 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90012)
 #        elif defined(__gfx90b__)
-/* (If present) b -> +200 */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9200)
+/* (If present) b -> 11 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90011)
 #        elif defined(__gfx90a__)
-/* CDNA 2 (Instinct MI250 / MI250X), a -> +100 */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9100)
+/* CDNA 2 (Instinct MI250 / MI250X), a -> 10 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90010)
 #        elif defined(__gfx908__)
 /* CDNA 1 (Instinct MI100) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9008)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90008)
 #        elif defined(__gfx906__)
 /* Vega 20 (Radeon VII, Instinct MI50/60) */
-#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRR_TO_VERSION(9006)
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90006)
 
 #        else
 #            warning                                                                                                  \

--- a/tests/unit/core/config.cpp
+++ b/tests/unit/core/config.cpp
@@ -36,8 +36,8 @@ TEST_CASE("config macros", "")
     // to long major version should be cut to 4 digits
     static_assert(ALPAKA_VRP_TO_VERSION(1'234'567) == ALPAKA_VERSION_NUMBER(2345, 6, 7));
 
-    static_assert(ALPAKA_VRRR_TO_VERSION(12053) == 1'205'300'000);
-    static_assert(ALPAKA_VRRR_TO_VERSION(12053) == ALPAKA_VERSION_NUMBER(12, 53, 0));
+    static_assert(ALPAKA_VRRPP_TO_VERSION(120503) == 1'200'500'003);
+    static_assert(ALPAKA_VRRPP_TO_VERSION(120503) == ALPAKA_VERSION_NUMBER(12, 5, 3));
     // to long major version should be cut to 4 digits
-    static_assert(ALPAKA_VRRR_TO_VERSION(12'345'053) == ALPAKA_VERSION_NUMBER(2345, 53, 0));
+    static_assert(ALPAKA_VRRPP_TO_VERSION(123'451'513) == ALPAKA_VERSION_NUMBER(2345, 15, 13));
 }


### PR DESCRIPTION
Change versioning schema: `906 -> ALPAKA_VERSION_NUMBER(9,0,6)`

The last two digits will be handled as hex values which adds support for a,b,c used by AMD.

- rename ` ALPAKA_ARCH_HSA` to `ALPAKA_ARCH_AMD`

This changes the code snippet for the warp size within a kernel from #226 to

```C++
if constexpr (ALPAKA_ARCH_AMD >= ALPAKA_VERSION_NUMBER(10,0,0))
  // ALPAKA_VERSION_NUMBER_UNKNOWN will return 32 too
  return 32;
else
  return 64;
```