### PR TITLE
example: fix scan with CUDA

### DIFF
--- a/example/scan/CMakeLists.txt
+++ b/example/scan/CMakeLists.txt
@@ -51,29 +51,8 @@ if(alpaka_DEP_CUDA)
             "Found optional CUDAToolkit, version "
             ${CUDAToolkit_VERSION}
         )
-        if(
-            ${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR}
-                VERSION_EQUAL
-                "12.5"
-        )
-            message(
-                WARNING
-                "Found CUDA::cub version 12.5 which is not supported for this example. Native cub execution will be disabled."
-            )
-        elseif(
-            ${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR}
-                VERSION_EQUAL
-                "12.9"
-        )
-            # error: error: "cuda" is ambiguous in include/cub/util_type.cuh(237)
-            # using int_constant_t = cuda::std::integral_constant<int, Value>;
-            message(
-                WARNING
-                "Found CUDA::cub version 12.9 which is not supported for this example. Native cub execution will be disabled."
-            )
-        else()
-            set(HAS_CUDA_CUB 1)
-        endif()
+
+        set(HAS_CUDA_CUB 1)
     endif()
 endif()
 

--- a/example/scan/src/common.hpp
+++ b/example/scan/src/common.hpp
@@ -10,21 +10,24 @@
 
 #include <cstddef>
 
-enum ScanType
+namespace alpaka::example::scan
 {
-    EXCLUSIVE_SCAN,
-    INCLUSIVE_SCAN
-};
+    enum ScanType
+    {
+        EXCLUSIVE_SCAN,
+        INCLUSIVE_SCAN
+    };
 
-using IdxType = std::size_t;
-using Data = std::int32_t;
-using Vec1D = alpaka::Vec<IdxType, 1u>;
+    using IdxType = std::size_t;
+    using Data = std::int32_t;
+    using Vec1D = alpaka::Vec<IdxType, 1u>;
 
-constexpr IdxType numNvidiaBanks = 32u;
-constexpr IdxType numAmdBanks = 32u;
-constexpr IdxType numIntelBanks = 16u;
+    constexpr IdxType numNvidiaBanks = 32u;
+    constexpr IdxType numAmdBanks = 32u;
+    constexpr IdxType numIntelBanks = 16u;
 
-constexpr IdxType operator""_idx(unsigned long long n)
-{
-    return IdxType{n};
-}
+    constexpr IdxType operator""_idx(unsigned long long n)
+    {
+        return IdxType{n};
+    }
+} // namespace alpaka::example::scan

--- a/example/scan/src/scan.hpp
+++ b/example/scan/src/scan.hpp
@@ -17,198 +17,202 @@
 #include <type_traits> // is_same_v
 #include <typeinfo>
 
-using namespace alpaka;
-
-/* This function introduces padding to the shared memory accesses to reduce bank conflicts between threads. The
- * template parameter is the device kind, which dictates how many memory banks are assumed. For CPU or
- * unknown/unimplemented device kinds, infinite memory banks are assumed, i.e., no padding is used.
- */
-template<typename TDeviceKind>
-constexpr auto conflictFreeAccess(auto const& n)
+namespace alpaka::example::scan
 {
-    if constexpr(TDeviceKind{} == deviceKind::nvidiaGpu)
-        return n + n / numNvidiaBanks;
-    else if constexpr(TDeviceKind{} == deviceKind::amdGpu)
-        return n + n / numAmdBanks;
-    else if constexpr(TDeviceKind{} == deviceKind::intelGpu)
-        return n + n / numIntelBanks;
-    else // cpu or unknown backend
-        return n;
-}
 
-constexpr IdxType elsPerThread = 8u;
-
-/* This kernel calculates an exclusive scan for each block indvidually. The algorithm is based on Blelloch, written up
- * in the CUDA blog:
- * https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-39-parallel-prefix-sum-scan-cuda
- */
-template<ScanType SCAN_TYPE>
-class Scan_ScanBlocksKernel
-{
-public:
-    ALPAKA_FN_ACC void operator()(
-        auto const& acc,
-        concepts::MdSpan auto const& inputVec,
-        concepts::MdSpan auto outputVec,
-        auto... blockSums) const
+    /* This function introduces padding to the shared memory accesses to reduce bank conflicts between threads. The
+     * template parameter is the device kind, which dictates how many memory banks are assumed. For CPU or
+     * unknown/unimplemented device kinds, infinite memory banks are assumed, i.e., no padding is used.
+     */
+    template<typename TDeviceKind>
+    constexpr auto conflictFreeAccess(auto const& n)
     {
-        using DeviceType = ALPAKA_TYPEOF(acc.getDeviceKind());
-        concepts::Vector auto numFrames = acc[frame::count];
+        if constexpr(TDeviceKind{} == deviceKind::nvidiaGpu)
+            return n + n / numNvidiaBanks;
+        else if constexpr(TDeviceKind{} == deviceKind::amdGpu)
+            return n + n / numAmdBanks;
+        else if constexpr(TDeviceKind{} == deviceKind::intelGpu)
+            return n + n / numIntelBanks;
+        else // cpu or unknown backend
+            return n;
+    }
 
-        concepts::CVector auto _ = acc[frame::extent];
-        concepts::CVector auto frameExtent = CVec<IdxType, elsPerThread * _.x()>{};
-        concepts::Vector auto numElements = inputVec.getExtents();
+    constexpr IdxType elsPerThread = 8u;
 
-        /* This kernel is called with 1-dimensional frame extents.
-         *
-         * All thread blocks will be used to iterate over the frames. Each thread block will handle one or more frames.
-         */
-        for(auto frameIdx :
-            onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec<IdxType, 1u>{0}, numFrames}))
+    /* This kernel calculates an exclusive scan for each block indvidually. The algorithm is based on Blelloch, written
+     * up in the CUDA blog:
+     * https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-39-parallel-prefix-sum-scan-cuda
+     */
+    template<ScanType SCAN_TYPE>
+    class Scan_ScanBlocksKernel
+    {
+    public:
+        ALPAKA_FN_ACC void operator()(
+            auto const& acc,
+            concepts::MdSpan auto const& inputVec,
+            concepts::MdSpan auto outputVec,
+            auto... blockSums) const
         {
-            auto tmp = onAcc::declareSharedMdArray<Data, uniqueId()>(
+            using DeviceType = ALPAKA_TYPEOF(acc.getDeviceKind());
+            concepts::Vector auto numFrames = acc[frame::count];
+
+            concepts::CVector auto _ = acc[frame::extent];
+            concepts::CVector auto frameExtent = CVec<IdxType, elsPerThread * _.x()>{};
+            concepts::Vector auto numElements = inputVec.getExtents();
+
+            /* This kernel is called with 1-dimensional frame extents.
+             *
+             * All thread blocks will be used to iterate over the frames. Each thread block will handle one or more
+             * frames.
+             */
+            for(auto frameIdx :
+                onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec<IdxType, 1u>{0}, numFrames}))
+            {
+                auto tmp = onAcc::declareSharedMdArray<Data, uniqueId()>(
+                    acc,
+                    CVec<IdxType, conflictFreeAccess<DeviceType>(frameExtent.x())>{});
+                auto const frameOffset = frameExtent * frameIdx;
+
+                // -- COPY TO SHARED MEM --
+                for(auto frameElem : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{frameExtent}))
+                {
+                    if(frameOffset + frameElem < numElements)
+                        tmp[conflictFreeAccess<DeviceType>(frameElem)] = inputVec[frameOffset + frameElem];
+                    else
+                        tmp[conflictFreeAccess<DeviceType>(frameElem)] = 0;
+                }
+
+                // -- UP-SWEEP / REDUCE --
+                for(IdxType d = frameExtent.x() / 2_idx, offset = 1_idx; d > 0; d >>= 1, offset <<= 1)
+                {
+                    onAcc::syncBlockThreads(acc);
+                    for(auto frameElem : onAcc::makeIdxMap(
+                            acc,
+                            onAcc::worker::threadsInBlock,
+                            IdxRange{CVec<IdxType, 0>{}, Vec<IdxType, 1>{2_idx * d}, 2_idx}))
+                    {
+                        IdxType left = offset * (frameElem + 1_idx).x() - 1_idx;
+                        IdxType right = offset * (frameElem + 2_idx).x() - 1_idx;
+                        left = conflictFreeAccess<DeviceType>(left);
+                        right = conflictFreeAccess<DeviceType>(right);
+                        tmp[right] += tmp[left];
+                    }
+                }
+                onAcc::syncBlockThreads(acc);
+
+                for([[maybe_unused]] auto frameElem :
+                    onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{1}))
+                {
+                    // -- SAVE BLOCK SUMS --
+                    if constexpr(sizeof...(blockSums))
+                    {
+                        auto _blockSums = std::get<0>(std::make_tuple(blockSums...));
+                        _blockSums[frameIdx] = tmp[conflictFreeAccess<DeviceType>(frameExtent - 1_idx)];
+                    }
+
+                    // -- SET 0 --
+                    tmp[conflictFreeAccess<DeviceType>(frameExtent - 1_idx)] = 0;
+                }
+
+                // -- DOWN-SWEEP --
+                for(IdxType d = 1, offset = frameExtent.x() / 2_idx; d < frameExtent; d <<= 1, offset >>= 1)
+                {
+                    onAcc::syncBlockThreads(acc);
+                    for(auto frameElem : onAcc::makeIdxMap(
+                            acc,
+                            onAcc::worker::threadsInBlock,
+                            IdxRange{CVec<IdxType, 0>{}, Vec<IdxType, 1>{2_idx * d}, 2_idx}))
+                    {
+                        IdxType left = offset * (frameElem.x() + 1_idx) - 1_idx;
+                        IdxType right = offset * (frameElem.x() + 2_idx) - 1_idx;
+                        left = conflictFreeAccess<DeviceType>(left);
+                        right = conflictFreeAccess<DeviceType>(right);
+                        auto t = tmp[left];
+                        tmp[left] = tmp[right];
+                        tmp[right] += t;
+                    }
+                }
+                onAcc::syncBlockThreads(acc);
+
+                // -- WRITE BACK --
+                for(auto frameElem : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{frameExtent}))
+                {
+                    if(frameOffset + frameElem < numElements)
+                    {
+                        if constexpr(SCAN_TYPE == EXCLUSIVE_SCAN)
+                            outputVec[frameOffset + frameElem] = tmp[conflictFreeAccess<DeviceType>(frameElem)];
+                        else if constexpr(SCAN_TYPE == INCLUSIVE_SCAN)
+                            outputVec[frameOffset + frameElem]
+                                = inputVec[frameOffset + frameElem] + tmp[conflictFreeAccess<DeviceType>(frameElem)];
+                    }
+                }
+                onAcc::syncBlockThreads(acc);
+            }
+        }
+    };
+
+    /* Add prefix sum from previous blocks (blockSums) to all elements in each block.
+     */
+    class Scan_AddIncrementsKernel
+    {
+    public:
+        ALPAKA_FN_ACC void operator()(
+            auto const& acc,
+            concepts::MdSpan auto const& blockSums,
+            concepts::MdSpan auto outputVec) const
+        {
+            concepts::CVector auto frameExtent = acc[frame::extent];
+            concepts::Vector auto numElements = outputVec.getExtents();
+
+            auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
+            simdGrid.concurrent(
                 acc,
-                CVec<IdxType, conflictFreeAccess<DeviceType>(frameExtent.x())>{});
-            auto const frameOffset = frameExtent * frameIdx;
+                numElements,
+                [&](auto const&, auto&& simdOut) constexpr
+                { simdOut = simdOut.load() + blockSums[simdOut.getIdx() / frameExtent]; },
+                outputVec);
+        }
+    };
 
-            // -- COPY TO SHARED MEM --
-            for(auto frameElem : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{frameExtent}))
-            {
-                if(frameOffset + frameElem < numElements)
-                    tmp[conflictFreeAccess<DeviceType>(frameElem)] = inputVec[frameOffset + frameElem];
-                else
-                    tmp[conflictFreeAccess<DeviceType>(frameElem)] = 0;
-            }
+    template<ScanType SCAN_TYPE>
+    void scan(auto& exec, auto& devAcc, auto& queue, auto const& inputVec, auto outputVec)
+    {
+        // Instantiate the kernel function object
+        Scan_ScanBlocksKernel<SCAN_TYPE> scanBlocks;
 
-            // -- UP-SWEEP / REDUCE --
-            for(IdxType d = frameExtent.x() / 2_idx, offset = 1_idx; d > 0; d >>= 1, offset <<= 1)
-            {
-                onAcc::syncBlockThreads(acc);
-                for(auto frameElem : onAcc::makeIdxMap(
-                        acc,
-                        onAcc::worker::threadsInBlock,
-                        IdxRange{CVec<IdxType, 0>{}, Vec<IdxType, 1>{2_idx * d}, 2_idx}))
-                {
-                    IdxType left = offset * (frameElem + 1_idx).x() - 1_idx;
-                    IdxType right = offset * (frameElem + 2_idx).x() - 1_idx;
-                    left = conflictFreeAccess<DeviceType>(left);
-                    right = conflictFreeAccess<DeviceType>(right);
-                    tmp[right] += tmp[left];
-                }
-            }
-            onAcc::syncBlockThreads(acc);
+        // Define frameExtent
+        constexpr auto frameExtent = CVec<IdxType, 256u>{};
+        constexpr auto const adjustedFrameExtent = frameExtent * elsPerThread;
+        auto const frameSpec = onHost::FrameSpec{divCeil(inputVec.getExtents(), adjustedFrameExtent), frameExtent};
 
-            for([[maybe_unused]] auto frameElem : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{1}))
-            {
-                // -- SAVE BLOCK SUMS --
-                if constexpr(sizeof...(blockSums))
-                {
-                    auto _blockSums = std::get<0>(std::make_tuple(blockSums...));
-                    _blockSums[frameIdx] = tmp[conflictFreeAccess<DeviceType>(frameExtent - 1_idx)];
-                }
+        if(frameSpec.m_numFrames > 1_idx)
+        {
+            // problem does not fit in 1 frame, recurse
+            Scan_AddIncrementsKernel addIncrements;
 
-                // -- SET 0 --
-                tmp[conflictFreeAccess<DeviceType>(frameExtent - 1_idx)] = 0;
-            }
+            // allocate block increments, one element per frame
+            auto increments = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
+            auto blockSums = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
 
-            // -- DOWN-SWEEP --
-            for(IdxType d = 1, offset = frameExtent.x() / 2_idx; d < frameExtent; d <<= 1, offset >>= 1)
-            {
-                onAcc::syncBlockThreads(acc);
-                for(auto frameElem : onAcc::makeIdxMap(
-                        acc,
-                        onAcc::worker::threadsInBlock,
-                        IdxRange{CVec<IdxType, 0>{}, Vec<IdxType, 1>{2_idx * d}, 2_idx}))
-                {
-                    IdxType left = offset * (frameElem.x() + 1_idx) - 1_idx;
-                    IdxType right = offset * (frameElem.x() + 2_idx) - 1_idx;
-                    left = conflictFreeAccess<DeviceType>(left);
-                    right = conflictFreeAccess<DeviceType>(right);
-                    auto t = tmp[left];
-                    tmp[left] = tmp[right];
-                    tmp[right] += t;
-                }
-            }
-            onAcc::syncBlockThreads(acc);
+            IdxType elementsPerWorker = getNumElemPerThread<Data>(queue);
+            auto addIncrementsFrameSpec = onHost::FrameSpec{
+                divCeil(inputVec.getExtents(), adjustedFrameExtent * elementsPerWorker),
+                CVec<IdxType, adjustedFrameExtent.x()>{}};
 
-            // -- WRITE BACK --
-            for(auto frameElem : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{frameExtent}))
-            {
-                if(frameOffset + frameElem < numElements)
-                {
-                    if constexpr(SCAN_TYPE == EXCLUSIVE_SCAN)
-                        outputVec[frameOffset + frameElem] = tmp[conflictFreeAccess<DeviceType>(frameElem)];
-                    else if constexpr(SCAN_TYPE == INCLUSIVE_SCAN)
-                        outputVec[frameOffset + frameElem]
-                            = inputVec[frameOffset + frameElem] + tmp[conflictFreeAccess<DeviceType>(frameElem)];
-                }
-            }
-            onAcc::syncBlockThreads(acc);
+            // enqueue the kernel execution tasks
+            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
+            // always recurse into exclusive scan
+            scan<EXCLUSIVE_SCAN>(exec, devAcc, queue, increments, blockSums);
+            queue.enqueue(exec, addIncrementsFrameSpec, KernelBundle{addIncrements, blockSums, outputVec});
+
+            // need to wait here until the previous call is done before we can destruct the buffers for
+            // increments/blockSums when running out of scope
+            onHost::wait(queue);
+        }
+        else
+        {
+            // problem fits within 1 frame
+            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec});
         }
     }
-};
-
-/* Add prefix sum from previous blocks (blockSums) to all elements in each block.
- */
-class Scan_AddIncrementsKernel
-{
-public:
-    ALPAKA_FN_ACC void operator()(
-        auto const& acc,
-        concepts::MdSpan auto const& blockSums,
-        concepts::MdSpan auto outputVec) const
-    {
-        concepts::CVector auto frameExtent = acc[frame::extent];
-        concepts::Vector auto numElements = outputVec.getExtents();
-
-        auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
-        simdGrid.concurrent(
-            acc,
-            numElements,
-            [&](auto const&, auto&& simdOut) constexpr
-            { simdOut = simdOut.load() + blockSums[simdOut.getIdx() / frameExtent]; },
-            outputVec);
-    }
-};
-
-template<ScanType SCAN_TYPE>
-void scan(auto& exec, auto& devAcc, auto& queue, auto const& inputVec, auto outputVec)
-{
-    // Instantiate the kernel function object
-    Scan_ScanBlocksKernel<SCAN_TYPE> scanBlocks;
-
-    // Define frameExtent
-    constexpr auto frameExtent = CVec<IdxType, 256u>{};
-    constexpr auto const adjustedFrameExtent = frameExtent * elsPerThread;
-    auto const frameSpec = onHost::FrameSpec{divCeil(inputVec.getExtents(), adjustedFrameExtent), frameExtent};
-
-    if(frameSpec.m_numFrames > 1_idx)
-    {
-        // problem does not fit in 1 frame, recurse
-        Scan_AddIncrementsKernel addIncrements;
-
-        // allocate block increments, one element per frame
-        auto increments = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
-        auto blockSums = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
-
-        IdxType elementsPerWorker = getNumElemPerThread<Data>(queue);
-        auto addIncrementsFrameSpec = onHost::FrameSpec{
-            divCeil(inputVec.getExtents(), adjustedFrameExtent * elementsPerWorker),
-            CVec<IdxType, adjustedFrameExtent.x()>{}};
-
-        // enqueue the kernel execution tasks
-        queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
-        // always recurse into exclusive scan
-        scan<EXCLUSIVE_SCAN>(exec, devAcc, queue, increments, blockSums);
-        queue.enqueue(exec, addIncrementsFrameSpec, KernelBundle{addIncrements, blockSums, outputVec});
-
-        // need to wait here until the previous call is done before we can destruct the buffers for
-        // increments/blockSums when running out of scope
-        onHost::wait(queue);
-    }
-    else
-    {
-        // problem fits within 1 frame
-        queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec});
-    }
-}
+} // namespace alpaka::example::scan

--- a/example/scan/src/scan_executors.hpp
+++ b/example/scan/src/scan_executors.hpp
@@ -11,149 +11,84 @@
 
 #include <numeric> // std::exclusive_scan, std::inclusive_scan
 
-int validateResult(auto queue, auto const& inputData, auto const& bufY, IdxType numElements, ScanType scanType)
+namespace alpaka::example::scan
 {
-    // Copy back the result
-    auto bufHostY = alpaka::onHost::allocHost<Data>(numElements);
-
-    auto beginT = std::chrono::high_resolution_clock::now();
-    alpaka::onHost::memcpy(queue, bufHostY, bufY);
-    alpaka::onHost::wait(queue);
-    auto const endT = std::chrono::high_resolution_clock::now();
-    double copyRuntime = std::chrono::duration<double>(endT - beginT).count();
-    std::cout << "    Time for HtoD copy [s]: " << copyRuntime << std::endl;
-    std::cout << "    Copied [Gbyte/s]: " << (static_cast<double>(numElements * sizeof(Data)) / copyRuntime) / 1.e9
-              << std::endl;
-
-    // validate results
-    int falseResults = 0;
-    static constexpr int MAX_PRINT_FALSE_RESULTS = 20;
-
-    auto const& groundtruth = alpaka::onHost::allocHost<Data>(numElements);
-    switch(scanType)
+    int validateResult(auto queue, auto const& inputData, auto const& bufY, IdxType numElements, ScanType scanType)
     {
-    case EXCLUSIVE_SCAN:
-        std::exclusive_scan(inputData.data(), inputData.data() + numElements, groundtruth.data(), 0);
-        break;
-    case INCLUSIVE_SCAN:
-        std::inclusive_scan(inputData.data(), inputData.data() + numElements, groundtruth.data());
-        break;
-    }
+        // Copy back the result
+        auto bufHostY = alpaka::onHost::allocHost<Data>(numElements);
 
-    for(IdxType i = 0u; i < numElements; ++i)
-    {
-        Data const& computedY = bufHostY[i];
-        Data const& correctResult = groundtruth[i];
+        auto beginT = std::chrono::high_resolution_clock::now();
+        alpaka::onHost::memcpy(queue, bufHostY, bufY);
+        alpaka::onHost::wait(queue);
+        auto const endT = std::chrono::high_resolution_clock::now();
+        double copyRuntime = std::chrono::duration<double>(endT - beginT).count();
+        std::cout << "    Time for HtoD copy [s]: " << copyRuntime << std::endl;
+        std::cout << "    Copied [Gbyte/s]: " << (static_cast<double>(numElements * sizeof(Data)) / copyRuntime) / 1.e9
+                  << std::endl;
 
-        if(computedY != correctResult)
+        // validate results
+        int falseResults = 0;
+        static constexpr int MAX_PRINT_FALSE_RESULTS = 20;
+
+        auto const& groundtruth = alpaka::onHost::allocHost<Data>(numElements);
+        switch(scanType)
         {
-            if(falseResults < MAX_PRINT_FALSE_RESULTS)
-                std::cerr << "bufY[" << i << "] == " << computedY << " != " << correctResult << std::endl;
-            ++falseResults;
+        case EXCLUSIVE_SCAN:
+            std::exclusive_scan(inputData.data(), inputData.data() + numElements, groundtruth.data(), 0);
+            break;
+        case INCLUSIVE_SCAN:
+            std::inclusive_scan(inputData.data(), inputData.data() + numElements, groundtruth.data());
+            break;
+        }
+
+        for(IdxType i = 0u; i < numElements; ++i)
+        {
+            Data const& computedY = bufHostY[i];
+            Data const& correctResult = groundtruth[i];
+
+            if(computedY != correctResult)
+            {
+                if(falseResults < MAX_PRINT_FALSE_RESULTS)
+                    std::cerr << "bufY[" << i << "] == " << computedY << " != " << correctResult << std::endl;
+                ++falseResults;
+            }
+        }
+
+        if(falseResults == 0)
+        {
+            std::cout << "Execution results correct!" << std::endl;
+            return EXIT_SUCCESS;
+        }
+        else
+        {
+            std::cout << "Found " << falseResults << " false results, printed no more than " << MAX_PRINT_FALSE_RESULTS
+                      << "\n"
+                      << "Execution results incorrect!" << std::endl;
+            return EXIT_FAILURE;
         }
     }
 
-    if(falseResults == 0)
+    void printResults(double time, IdxType numElements)
     {
-        std::cout << "Execution results correct!" << std::endl;
-        return EXIT_SUCCESS;
-    }
-    else
-    {
-        std::cout << "Found " << falseResults << " false results, printed no more than " << MAX_PRINT_FALSE_RESULTS
-                  << "\n"
-                  << "Execution results incorrect!" << std::endl;
-        return EXIT_FAILURE;
-    }
-}
-
-void printResults(double time, IdxType numElements)
-{
-    std::cout << "    Time for kernel execution [s]: " << time << std::endl;
-    std::cout << "    Processed [Gbyte/s]: " << (static_cast<double>(numElements * sizeof(Data)) / time) / 1.e9
-              << std::endl;
-}
-
-int runExampleGeneric(
-    auto& exec,
-    auto const& dev,
-    auto const& queue,
-    auto const& inputData,
-    auto& bufX,
-    auto& bufY,
-    IdxType numElements,
-    ScanType scanType,
-    bool const enableCheck)
-{
-    std::cout << std::endl << std::endl;
-    std::cout << "===== EXECUTOR " << core::demangledName(exec) << " =====" << std::endl;
-
-    alpaka::onHost::wait(queue);
-    auto const beginT = std::chrono::high_resolution_clock::now();
-
-    switch(scanType)
-    {
-    case EXCLUSIVE_SCAN:
-        scan<EXCLUSIVE_SCAN>(exec, dev, queue, bufX, bufY);
-        break;
-    case INCLUSIVE_SCAN:
-        scan<INCLUSIVE_SCAN>(exec, dev, queue, bufX, bufY);
-        break;
+        std::cout << "    Time for kernel execution [s]: " << time << std::endl;
+        std::cout << "    Processed [Gbyte/s]: " << (static_cast<double>(numElements * sizeof(Data)) / time) / 1.e9
+                  << std::endl;
     }
 
-    alpaka::onHost::wait(queue); // for large n, scan is synchronous anyway
-
-    auto const endT = std::chrono::high_resolution_clock::now();
-    double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();
-
-    printResults(kernelRuntime, numElements);
-
-    return enableCheck ? validateResult(queue, inputData, bufY, numElements, scanType) : EXIT_SUCCESS;
-}
-
-// overload for generic executors with no special std implementation
-int runExample(
-    auto& exec,
-    auto const& dev,
-    auto const& queue,
-    auto const& inputData, // host buffer with input data
-    auto& bufX, // accelerator input buffer (uninitialized)
-    auto& bufY, // accelerator output buffer (may be same as bufX when running inplace)
-    IdxType numElements,
-    ScanType scanType,
-    bool const enableCheck,
-    bool const /*enableStd*/)
-{
-    // copy data to accelerator buffer
-    alpaka::onHost::memcpy(queue, bufX, inputData);
-    alpaka::onHost::wait(queue);
-
-    return runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
-}
-
-// overload for CpuSerial running std:: implementations if requested
-int runExample(
-    exec::CpuSerial exec,
-    auto const& dev,
-    auto const& queue,
-    auto const& inputData,
-    auto& bufX,
-    auto& bufY,
-    IdxType numElements,
-    ScanType scanType,
-    bool const enableCheck,
-    bool const enableStd)
-{
-    // copy data to accelerator buffer
-    alpaka::onHost::memcpy(queue, bufX, inputData);
-    alpaka::onHost::wait(queue);
-
-    int res = EXIT_SUCCESS;
-
-    if(enableStd)
+    int runExampleGeneric(
+        auto& exec,
+        auto const& dev,
+        auto const& queue,
+        auto const& inputData,
+        auto& bufX,
+        auto& bufY,
+        IdxType numElements,
+        ScanType scanType,
+        bool const enableCheck)
     {
         std::cout << std::endl << std::endl;
-        std::cout << "===== EXECUTOR CPU STDLIB =====" << std::endl;
+        std::cout << "===== EXECUTOR " << core::demangledName(exec) << " =====" << std::endl;
 
         alpaka::onHost::wait(queue);
         auto const beginT = std::chrono::high_resolution_clock::now();
@@ -161,37 +96,105 @@ int runExample(
         switch(scanType)
         {
         case EXCLUSIVE_SCAN:
-            std::exclusive_scan(bufX.data(), bufX.data() + bufX.getExtents().x(), bufY.data(), 0);
+            scan<EXCLUSIVE_SCAN>(exec, dev, queue, bufX, bufY);
             break;
         case INCLUSIVE_SCAN:
-            std::inclusive_scan(bufX.data(), bufX.data() + bufX.getExtents().x(), bufY.data());
+            scan<INCLUSIVE_SCAN>(exec, dev, queue, bufX, bufY);
             break;
         }
+
+        alpaka::onHost::wait(queue); // for large n, scan is synchronous anyway
 
         auto const endT = std::chrono::high_resolution_clock::now();
         double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();
 
         printResults(kernelRuntime, numElements);
 
-        if(enableCheck)
-        {
-            res = validateResult(queue, inputData, bufY, numElements, scanType);
-        }
+        return enableCheck ? validateResult(queue, inputData, bufY, numElements, scanType) : EXIT_SUCCESS;
+    }
 
-        // copy data to accelerator buffer for the next generic run
+    // overload for generic executors with no special std implementation
+    int runExample(
+        auto& exec,
+        auto const& dev,
+        auto const& queue,
+        auto const& inputData, // host buffer with input data
+        auto& bufX, // accelerator input buffer (uninitialized)
+        auto& bufY, // accelerator output buffer (may be same as bufX when running inplace)
+        IdxType numElements,
+        ScanType scanType,
+        bool const enableCheck,
+        bool const /*enableStd*/)
+    {
+        // copy data to accelerator buffer
         alpaka::onHost::memcpy(queue, bufX, inputData);
         alpaka::onHost::wait(queue);
+
+        return runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
     }
 
-    auto resGeneric = runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
-
-    if(resGeneric != EXIT_SUCCESS || res != EXIT_SUCCESS)
+    // overload for CpuSerial running std:: implementations if requested
+    int runExample(
+        exec::CpuSerial exec,
+        auto const& dev,
+        auto const& queue,
+        auto const& inputData,
+        auto& bufX,
+        auto& bufY,
+        IdxType numElements,
+        ScanType scanType,
+        bool const enableCheck,
+        bool const enableStd)
     {
-        return EXIT_FAILURE;
-    }
-    return EXIT_SUCCESS;
-}
+        // copy data to accelerator buffer
+        alpaka::onHost::memcpy(queue, bufX, inputData);
+        alpaka::onHost::wait(queue);
 
+        int res = EXIT_SUCCESS;
+
+        if(enableStd)
+        {
+            std::cout << std::endl << std::endl;
+            std::cout << "===== EXECUTOR CPU STDLIB =====" << std::endl;
+
+            alpaka::onHost::wait(queue);
+            auto const beginT = std::chrono::high_resolution_clock::now();
+
+            switch(scanType)
+            {
+            case EXCLUSIVE_SCAN:
+                std::exclusive_scan(bufX.data(), bufX.data() + bufX.getExtents().x(), bufY.data(), 0);
+                break;
+            case INCLUSIVE_SCAN:
+                std::inclusive_scan(bufX.data(), bufX.data() + bufX.getExtents().x(), bufY.data());
+                break;
+            }
+
+            auto const endT = std::chrono::high_resolution_clock::now();
+            double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();
+
+            printResults(kernelRuntime, numElements);
+
+            if(enableCheck)
+            {
+                res = validateResult(queue, inputData, bufY, numElements, scanType);
+            }
+
+            // copy data to accelerator buffer for the next generic run
+            alpaka::onHost::memcpy(queue, bufX, inputData);
+            alpaka::onHost::wait(queue);
+        }
+
+        auto resGeneric
+            = runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
+
+        if(resGeneric != EXIT_SUCCESS || res != EXIT_SUCCESS)
+        {
+            return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
+    }
+} // namespace alpaka::example::scan
 
 #if ALPAKA_HAS_CUB
 // only do this when CUB is found
@@ -209,126 +212,130 @@ int runExample(
             }                                                                                                         \
         } while(0);
 
-// overload for GpuCuda running cub implementations if requested
-int runExample(
-    exec::GpuCuda exec,
-    auto const& dev,
-    auto const& queue,
-    auto const& inputData,
-    auto& bufX,
-    auto& bufY,
-    IdxType numElements,
-    ScanType scanType,
-    bool const enableCheck,
-    bool const enableStd)
+namespace alpaka::example::scan
 {
-    // copy data to accelerator buffer
-    alpaka::onHost::memcpy(queue, bufX, inputData);
-    alpaka::onHost::wait(queue);
-
-    int res = EXIT_SUCCESS;
-
-    if(enableStd)
+    // overload for GpuCuda running cub implementations if requested
+    int runExample(
+        exec::GpuCuda exec,
+        auto const& dev,
+        auto const& queue,
+        auto const& inputData,
+        auto& bufX,
+        auto& bufY,
+        IdxType numElements,
+        ScanType scanType,
+        bool const enableCheck,
+        bool const enableStd)
     {
-        std::cout << std::endl << std::endl;
-        std::cout << "===== EXECUTOR CUDA CUB =====" << std::endl;
-
-        // implementation see:
-        // https://nvidia.github.io/cccl/cub/api/structcub_1_1DeviceScan.html#_CPPv4N3cub10DeviceScanE
-
-        auto d_in = bufX.data();
-        auto d_out = bufY.data();
-
-        alpaka::onHost::wait(queue);
-        auto const beginT = std::chrono::high_resolution_clock::now();
-
-        // in order to be fair to the alpaka implementation, which allocates its temporary memory inside the measured
-        // time too, we need to do the same for the cub implementation
-
-        void* d_temp_storage = nullptr;
-        size_t temp_storage_bytes = 0;
-
-        switch(scanType)
-        {
-        case EXCLUSIVE_SCAN:
-            // Determine temporary device storage requirements
-            CUDA_CHECK(
-                cub::DeviceScan::ExclusiveSum(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_in,
-                    d_out,
-                    numElements,
-                    queue.getNativeHandle()));
-
-            alpaka::onHost::wait(queue);
-
-            // Allocate temporary storage
-            CUDA_CHECK(cudaMalloc(&d_temp_storage, temp_storage_bytes));
-
-            CUDA_CHECK(
-                cub::DeviceScan::ExclusiveSum(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_in,
-                    d_out,
-                    numElements,
-                    queue.getNativeHandle()));
-            break;
-        case INCLUSIVE_SCAN:
-            // Determine temporary device storage requirements
-            CUDA_CHECK(
-                cub::DeviceScan::InclusiveSum(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_in,
-                    d_out,
-                    numElements,
-                    queue.getNativeHandle()));
-
-            alpaka::onHost::wait(queue);
-
-            // Allocate temporary storage
-            CUDA_CHECK(cudaMalloc(&d_temp_storage, temp_storage_bytes));
-
-            CUDA_CHECK(
-                cub::DeviceScan::InclusiveSum(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_in,
-                    d_out,
-                    numElements,
-                    queue.getNativeHandle()));
-            break;
-        }
-        alpaka::onHost::wait(queue);
-
-        if(d_temp_storage)
-            cudaFree(d_temp_storage);
-
-        auto const endT = std::chrono::high_resolution_clock::now();
-        double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();
-
-        printResults(kernelRuntime, numElements);
-
-        if(enableCheck)
-        {
-            res = validateResult(queue, inputData, bufY, numElements, scanType);
-        }
-
         // copy data to accelerator buffer
         alpaka::onHost::memcpy(queue, bufX, inputData);
         alpaka::onHost::wait(queue);
-    }
 
-    auto resGeneric = runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
+        int res = EXIT_SUCCESS;
 
-    if(resGeneric != EXIT_SUCCESS || res != EXIT_SUCCESS)
-    {
-        return EXIT_FAILURE;
+        if(enableStd)
+        {
+            std::cout << std::endl << std::endl;
+            std::cout << "===== EXECUTOR CUDA CUB =====" << std::endl;
+
+            // implementation see:
+            // https://nvidia.github.io/cccl/cub/api/structcub_1_1DeviceScan.html#_CPPv4N3cub10DeviceScanE
+
+            auto d_in = bufX.data();
+            auto d_out = bufY.data();
+
+            alpaka::onHost::wait(queue);
+            auto const beginT = std::chrono::high_resolution_clock::now();
+
+            // in order to be fair to the alpaka implementation, which allocates its temporary memory inside the
+            // measured time too, we need to do the same for the cub implementation
+
+            void* d_temp_storage = nullptr;
+            size_t temp_storage_bytes = 0;
+
+            switch(scanType)
+            {
+            case EXCLUSIVE_SCAN:
+                // Determine temporary device storage requirements
+                CUDA_CHECK(
+                    cub::DeviceScan::ExclusiveSum(
+                        d_temp_storage,
+                        temp_storage_bytes,
+                        d_in,
+                        d_out,
+                        numElements,
+                        queue.getNativeHandle()));
+
+                alpaka::onHost::wait(queue);
+
+                // Allocate temporary storage
+                CUDA_CHECK(cudaMalloc(&d_temp_storage, temp_storage_bytes));
+
+                CUDA_CHECK(
+                    cub::DeviceScan::ExclusiveSum(
+                        d_temp_storage,
+                        temp_storage_bytes,
+                        d_in,
+                        d_out,
+                        numElements,
+                        queue.getNativeHandle()));
+                break;
+            case INCLUSIVE_SCAN:
+                // Determine temporary device storage requirements
+                CUDA_CHECK(
+                    cub::DeviceScan::InclusiveSum(
+                        d_temp_storage,
+                        temp_storage_bytes,
+                        d_in,
+                        d_out,
+                        numElements,
+                        queue.getNativeHandle()));
+
+                alpaka::onHost::wait(queue);
+
+                // Allocate temporary storage
+                CUDA_CHECK(cudaMalloc(&d_temp_storage, temp_storage_bytes));
+
+                CUDA_CHECK(
+                    cub::DeviceScan::InclusiveSum(
+                        d_temp_storage,
+                        temp_storage_bytes,
+                        d_in,
+                        d_out,
+                        numElements,
+                        queue.getNativeHandle()));
+                break;
+            }
+            alpaka::onHost::wait(queue);
+
+            if(d_temp_storage)
+                cudaFree(d_temp_storage);
+
+            auto const endT = std::chrono::high_resolution_clock::now();
+            double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();
+
+            printResults(kernelRuntime, numElements);
+
+            if(enableCheck)
+            {
+                res = validateResult(queue, inputData, bufY, numElements, scanType);
+            }
+
+            // copy data to accelerator buffer
+            alpaka::onHost::memcpy(queue, bufX, inputData);
+            alpaka::onHost::wait(queue);
+        }
+
+        auto resGeneric
+            = runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
+
+        if(resGeneric != EXIT_SUCCESS || res != EXIT_SUCCESS)
+        {
+            return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
     }
-    return EXIT_SUCCESS;
-}
+} // namespace alpaka::example::scan
 
 #endif
 
@@ -337,8 +344,10 @@ int runExample(
 #    include <hipcub/device/device_scan.hpp>
 #    include <hipcub/util_allocator.hpp>
 
-using namespace hipcub;
-hipcub::CachingDeviceAllocator g_allocator; // Caching allocator for device memory
+namespace alpaka::example::scan
+{
+    using namespace hipcub;
+    hipcub::CachingDeviceAllocator g_allocator; // Caching allocator for device memory
 
 #    define HIP_CHECK(condition)                                                                                      \
         do                                                                                                            \
@@ -351,122 +360,123 @@ hipcub::CachingDeviceAllocator g_allocator; // Caching allocator for device memo
             }                                                                                                         \
         } while(0);
 
-// overload for GpuHip running hipcub implementations if requested
-int runExample(
-    exec::GpuHip exec,
-    auto const& dev,
-    auto const& queue,
-    auto const& inputData,
-    auto& bufX,
-    auto& bufY,
-    IdxType numElements,
-    ScanType scanType,
-    bool const enableCheck,
-    bool const enableStd)
-{
-    // copy data to accelerator buffer
-    alpaka::onHost::memcpy(queue, bufX, inputData);
-    alpaka::onHost::wait(queue);
-
-    int res = EXIT_SUCCESS;
-
-    if(enableStd)
+    // overload for GpuHip running hipcub implementations if requested
+    int runExample(
+        exec::GpuHip exec,
+        auto const& dev,
+        auto const& queue,
+        auto const& inputData,
+        auto& bufX,
+        auto& bufY,
+        IdxType numElements,
+        ScanType scanType,
+        bool const enableCheck,
+        bool const enableStd)
     {
-        std::cout << std::endl << std::endl;
-        std::cout << "===== EXECUTOR HIP CUB =====" << std::endl;
-
-        auto d_in = bufX.data();
-        auto d_out = bufY.data();
-
-        alpaka::onHost::wait(queue);
-        auto const beginT = std::chrono::high_resolution_clock::now();
-
-        // in order to be fair to the alpaka implementation, which allocates its temporary memory inside the measured
-        // time too, we need to do the same for the hip cub implementation
-
-        void* d_temp_storage = nullptr;
-        size_t temp_storage_bytes = 0;
-
-        switch(scanType)
-        {
-        case EXCLUSIVE_SCAN:
-            // Determine temporary device storage requirements
-            HIP_CHECK(
-                hipcub::DeviceScan::ExclusiveSum(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_in,
-                    d_out,
-                    numElements,
-                    queue.getNativeHandle()));
-
-            alpaka::onHost::wait(queue);
-
-            // Allocate temporary storage
-            HIP_CHECK(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
-
-            HIP_CHECK(
-                hipcub::DeviceScan::ExclusiveSum(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_in,
-                    d_out,
-                    numElements,
-                    queue.getNativeHandle()));
-            break;
-        case INCLUSIVE_SCAN:
-            // Determine temporary device storage requirements
-            HIP_CHECK(
-                hipcub::DeviceScan::InclusiveSum(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_in,
-                    d_out,
-                    numElements,
-                    queue.getNativeHandle()));
-
-            alpaka::onHost::wait(queue);
-
-            // Allocate temporary storage
-            HIP_CHECK(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
-
-            HIP_CHECK(
-                hipcub::DeviceScan::InclusiveSum(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_in,
-                    d_out,
-                    numElements,
-                    queue.getNativeHandle()));
-            break;
-        }
-        alpaka::onHost::wait(queue);
-
-        if(d_temp_storage)
-            HIP_CHECK(g_allocator.DeviceFree(d_temp_storage));
-
-        auto const endT = std::chrono::high_resolution_clock::now();
-        double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();
-
-        printResults(kernelRuntime, numElements);
-
-        if(enableCheck)
-        {
-            res = validateResult(queue, inputData, bufY, numElements, scanType);
-        }
-
         // copy data to accelerator buffer
         alpaka::onHost::memcpy(queue, bufX, inputData);
         alpaka::onHost::wait(queue);
+
+        int res = EXIT_SUCCESS;
+
+        if(enableStd)
+        {
+            std::cout << std::endl << std::endl;
+            std::cout << "===== EXECUTOR HIP CUB =====" << std::endl;
+
+            auto d_in = bufX.data();
+            auto d_out = bufY.data();
+
+            alpaka::onHost::wait(queue);
+            auto const beginT = std::chrono::high_resolution_clock::now();
+
+            // in order to be fair to the alpaka implementation, which allocates its temporary memory inside the
+            // measured time too, we need to do the same for the hip cub implementation
+
+            void* d_temp_storage = nullptr;
+            size_t temp_storage_bytes = 0;
+
+            switch(scanType)
+            {
+            case EXCLUSIVE_SCAN:
+                // Determine temporary device storage requirements
+                HIP_CHECK(
+                    hipcub::DeviceScan::ExclusiveSum(
+                        d_temp_storage,
+                        temp_storage_bytes,
+                        d_in,
+                        d_out,
+                        numElements,
+                        queue.getNativeHandle()));
+
+                alpaka::onHost::wait(queue);
+
+                // Allocate temporary storage
+                HIP_CHECK(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+
+                HIP_CHECK(
+                    hipcub::DeviceScan::ExclusiveSum(
+                        d_temp_storage,
+                        temp_storage_bytes,
+                        d_in,
+                        d_out,
+                        numElements,
+                        queue.getNativeHandle()));
+                break;
+            case INCLUSIVE_SCAN:
+                // Determine temporary device storage requirements
+                HIP_CHECK(
+                    hipcub::DeviceScan::InclusiveSum(
+                        d_temp_storage,
+                        temp_storage_bytes,
+                        d_in,
+                        d_out,
+                        numElements,
+                        queue.getNativeHandle()));
+
+                alpaka::onHost::wait(queue);
+
+                // Allocate temporary storage
+                HIP_CHECK(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+
+                HIP_CHECK(
+                    hipcub::DeviceScan::InclusiveSum(
+                        d_temp_storage,
+                        temp_storage_bytes,
+                        d_in,
+                        d_out,
+                        numElements,
+                        queue.getNativeHandle()));
+                break;
+            }
+            alpaka::onHost::wait(queue);
+
+            if(d_temp_storage)
+                HIP_CHECK(g_allocator.DeviceFree(d_temp_storage));
+
+            auto const endT = std::chrono::high_resolution_clock::now();
+            double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();
+
+            printResults(kernelRuntime, numElements);
+
+            if(enableCheck)
+            {
+                res = validateResult(queue, inputData, bufY, numElements, scanType);
+            }
+
+            // copy data to accelerator buffer
+            alpaka::onHost::memcpy(queue, bufX, inputData);
+            alpaka::onHost::wait(queue);
+        }
+
+        auto resGeneric
+            = runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
+
+        if(resGeneric != EXIT_SUCCESS || res != EXIT_SUCCESS)
+        {
+            return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
     }
-
-    auto resGeneric = runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
-
-    if(resGeneric != EXIT_SUCCESS || res != EXIT_SUCCESS)
-    {
-        return EXIT_FAILURE;
-    }
-    return EXIT_SUCCESS;
-}
-
+} // namespace alpaka::example::scan
 #endif

--- a/example/scan/src/scan_improved.hpp
+++ b/example/scan/src/scan_improved.hpp
@@ -16,121 +16,122 @@
 #include <type_traits> // is_same_v
 #include <typeinfo>
 
-using namespace alpaka;
-
-template<alpaka::deviceKind::concepts::DeviceKind TDeviceKind>
-consteval auto maximumMiniBlockSize()
+namespace alpaka::example::scan
 {
-    if constexpr(TDeviceKind{} == deviceKind::nvidiaGpu)
-        return 8_idx;
-    else if constexpr(TDeviceKind{} == deviceKind::amdGpu)
-        return 8_idx;
-    else if constexpr(TDeviceKind{} == deviceKind::intelGpu)
-        return 8_idx;
-    else
-        return 32768_idx / sizeof(Data);
-}
 
-/* This function introduces padding to the shared memory accesses to reduce bank conflicts between threads. The
- * template parameter is the device kind, which dictates how many memory banks are assumed. For CPU or
- * unknown/unimplemented device kinds, infinite memory banks are assumed, i.e., no padding is used.
- */
-template<typename TDeviceKind>
-constexpr auto conflictFreeAccess(auto const& n)
-{
-    if constexpr(TDeviceKind{} == deviceKind::nvidiaGpu)
-        return n + n / numNvidiaBanks;
-    else if constexpr(TDeviceKind{} == deviceKind::amdGpu)
-        return n + n / numAmdBanks;
-    else if constexpr(TDeviceKind{} == deviceKind::intelGpu)
-        return n + n / numIntelBanks;
-    else // cpu or unknown backend does nothing
-        return n;
-}
+    template<alpaka::deviceKind::concepts::DeviceKind TDeviceKind>
+    consteval auto maximumMiniBlockSize()
+    {
+        if constexpr(TDeviceKind{} == deviceKind::nvidiaGpu)
+            return 8_idx;
+        else if constexpr(TDeviceKind{} == deviceKind::amdGpu)
+            return 8_idx;
+        else if constexpr(TDeviceKind{} == deviceKind::intelGpu)
+            return 8_idx;
+        else
+            return 32768_idx / sizeof(Data);
+    }
 
-/* Do a muting exclusive scan on the given miniblock, and return the total sum.
- */
-ALPAKA_FN_ACC Data scanMiniBlock(Data* block, concepts::CVector auto const& extent)
-{
+    /* This function introduces padding to the shared memory accesses to reduce bank conflicts between threads. The
+     * template parameter is the device kind, which dictates how many memory banks are assumed. For CPU or
+     * unknown/unimplemented device kinds, infinite memory banks are assumed, i.e., no padding is used.
+     */
+    template<typename TDeviceKind>
+    constexpr auto conflictFreeAccess(auto const& n)
+    {
+        if constexpr(TDeviceKind{} == deviceKind::nvidiaGpu)
+            return n + n / numNvidiaBanks;
+        else if constexpr(TDeviceKind{} == deviceKind::amdGpu)
+            return n + n / numAmdBanks;
+        else if constexpr(TDeviceKind{} == deviceKind::intelGpu)
+            return n + n / numIntelBanks;
+        else // cpu or unknown backend does nothing
+            return n;
+    }
+
+    /* Do a muting exclusive scan on the given miniblock, and return the total sum.
+     */
+    ALPAKA_FN_ACC Data scanMiniBlock(Data* block, concepts::CVector auto const& extent)
+    {
 #if 0
     std::cout << "scanMiniBlock extent: " << extent << " block data: " << block[0] << ", " << block[1] << ", ..."
               << std::endl;
 #endif
-    // -- UP-SWEEP / REDUCE --
-    for(IdxType d = extent.x() / 2_idx, offset = 1_idx; d > 0; d >>= 1, offset <<= 1)
-    {
-        for(auto frameElem = 0_idx; frameElem < 2_idx * d; frameElem += 2_idx)
+        // -- UP-SWEEP / REDUCE --
+        for(IdxType d = extent.x() / 2_idx, offset = 1_idx; d > 0; d >>= 1, offset <<= 1)
         {
-            IdxType left = offset * (frameElem + 1_idx) - 1_idx;
-            IdxType right = offset * (frameElem + 2_idx) - 1_idx;
-            block[right] += block[left];
+            for(auto frameElem = 0_idx; frameElem < 2_idx * d; frameElem += 2_idx)
+            {
+                IdxType left = offset * (frameElem + 1_idx) - 1_idx;
+                IdxType right = offset * (frameElem + 2_idx) - 1_idx;
+                block[right] += block[left];
+            }
         }
-    }
 
-    // save total sum
-    Data blockSum = block[extent.x() - 1_idx];
+        // save total sum
+        Data blockSum = block[extent.x() - 1_idx];
 
-    // set 0
-    block[extent.x() - 1_idx] = Data{0};
+        // set 0
+        block[extent.x() - 1_idx] = Data{0};
 
-    // -- DOWN-SWEEP --
-    for(IdxType d = 1, offset = extent.x() / 2_idx; d < extent.x(); d <<= 1, offset >>= 1)
-    {
-        for(auto frameElem = 0_idx; frameElem < 2_idx * d; frameElem += 2_idx)
+        // -- DOWN-SWEEP --
+        for(IdxType d = 1, offset = extent.x() / 2_idx; d < extent.x(); d <<= 1, offset >>= 1)
         {
-            IdxType left = offset * (frameElem + 1_idx) - 1_idx;
-            IdxType right = offset * (frameElem + 2_idx) - 1_idx;
-            auto t = block[left];
-            block[left] = block[right];
-            block[right] += t;
+            for(auto frameElem = 0_idx; frameElem < 2_idx * d; frameElem += 2_idx)
+            {
+                IdxType left = offset * (frameElem + 1_idx) - 1_idx;
+                IdxType right = offset * (frameElem + 2_idx) - 1_idx;
+                auto t = block[left];
+                block[left] = block[right];
+                block[right] += t;
+            }
         }
-    }
 #if 0
     std::cout << "returning block sum: " << blockSum << std::endl;
 #endif
-    return blockSum;
-}
-
-/* Do an add increment on the given miniblock, adding the given blockSum to each element.
- */
-ALPAKA_FN_ACC void addIncrements(Data* block, Data const& blockSum, concepts::CVector auto const& extent)
-{
-    for(auto i = 0_idx; i < extent.x(); ++i)
-    {
-        block[i] += blockSum;
+        return blockSum;
     }
-    return;
-}
 
-/* This kernel calculates an exclusive scan for each block indvidually. The algorithm is based on Blelloch, with the
- * improvement from Lichterman, written up in the CUDA blog (see 39.2.5):
- * https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-39-parallel-prefix-sum-scan-cuda
- */
-template<ScanType SCAN_TYPE>
-class Scan_ScanBlocksKernel
-{
-public:
-    ALPAKA_FN_ACC void operator()(
-        auto const& acc,
-        concepts::MdSpan auto const& inputVec,
-        concepts::MdSpan auto outputVec,
-        auto... blockSums) const
+    /* Do an add increment on the given miniblock, adding the given blockSum to each element.
+     */
+    ALPAKA_FN_ACC void addIncrements(Data* block, Data const& blockSum, concepts::CVector auto const& extent)
     {
-        using DeviceType = ALPAKA_TYPEOF(acc.getDeviceKind());
-        concepts::Vector auto numFrames = acc[frame::count];
+        for(auto i = 0_idx; i < extent.x(); ++i)
+        {
+            block[i] += blockSum;
+        }
+        return;
+    }
 
-        concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
-        concepts::CVector auto frameExtent = acc[frame::extent];
-        constexpr auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
-        concepts::CVector auto chunkExtent = CVec<IdxType, elsPerThread * numThreadsPerBlock.x()>{};
-        concepts::Vector auto numElements = inputVec.getExtents();
+    /* This kernel calculates an exclusive scan for each block indvidually. The algorithm is based on Blelloch, with
+     * the improvement from Lichterman, written up in the CUDA blog (see 39.2.5):
+     * https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-39-parallel-prefix-sum-scan-cuda
+     */
+    template<ScanType SCAN_TYPE>
+    class Scan_ScanBlocksKernel
+    {
+    public:
+        ALPAKA_FN_ACC void operator()(
+            auto const& acc,
+            concepts::MdSpan auto const& inputVec,
+            concepts::MdSpan auto outputVec,
+            auto... blockSums) const
+        {
+            using DeviceType = ALPAKA_TYPEOF(acc.getDeviceKind());
+            concepts::Vector auto numFrames = acc[frame::count];
 
-        constexpr auto miniBlockSize = std::min(maximumMiniBlockSize<DeviceType>(), elsPerThread);
-        constexpr auto miniBlocksPerThread = elsPerThread / miniBlockSize;
-        constexpr auto miniBlocksPerChunk = chunkExtent.x() / miniBlockSize;
+            concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
+            concepts::CVector auto frameExtent = acc[frame::extent];
+            constexpr auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
+            concepts::CVector auto chunkExtent = CVec<IdxType, elsPerThread * numThreadsPerBlock.x()>{};
+            concepts::Vector auto numElements = inputVec.getExtents();
 
-        constexpr auto LocalArrayLength = miniBlocksPerThread * miniBlockSize;
-        using LocalArray = Data[LocalArrayLength];
+            constexpr auto miniBlockSize = std::min(maximumMiniBlockSize<DeviceType>(), elsPerThread);
+            constexpr auto miniBlocksPerThread = elsPerThread / miniBlockSize;
+            constexpr auto miniBlocksPerChunk = chunkExtent.x() / miniBlockSize;
+
+            constexpr auto LocalArrayLength = miniBlocksPerThread * miniBlockSize;
+            using LocalArray = Data[LocalArrayLength];
 
 #if 0
         std::cout << "frameExtent: " << frameExtent << std::endl;
@@ -141,247 +142,253 @@ public:
         std::cout << "miniBlocksPerThread: " << miniBlocksPerThread << std::endl;
 #endif
 
-        auto const validElementsInLastFrame = (numElements - 1_idx) % chunkExtent + 1_idx;
+            auto const validElementsInLastFrame = (numElements - 1_idx) % chunkExtent + 1_idx;
 
-        /* This kernel is called with 1-dimensional frame extents.
-         *
-         * All thread blocks will be used to iterate over the frames. Each thread block will handle one or more
-         * frames.
-         */
-        for(auto frameIdx :
-            onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec<IdxType, 1u>{0}, numFrames}))
-        {
-            bool const lastFrameFull = validElementsInLastFrame == chunkExtent;
-            bool const isLastFrame = frameIdx == numFrames - 1_idx;
+            /* This kernel is called with 1-dimensional frame extents.
+             *
+             * All thread blocks will be used to iterate over the frames. Each thread block will handle one or more
+             * frames.
+             */
+            for(auto frameIdx :
+                onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec<IdxType, 1u>{0}, numFrames}))
+            {
+                bool const lastFrameFull = validElementsInLastFrame == chunkExtent;
+                bool const isLastFrame = frameIdx == numFrames - 1_idx;
 
-            // allocate "per-thread" register memory to store all mini blocks of a thread persistently
-            LocalArray regMem;
+                // allocate "per-thread" register memory to store all mini blocks of a thread persistently
+                LocalArray regMem;
 
-            auto tmp = onAcc::declareSharedMdArray<Data, uniqueId()>(
-                acc,
-                CVec<IdxType, conflictFreeAccess<DeviceType>(miniBlocksPerChunk - 1_idx) + 1_idx>{});
-            auto const frameOffset = chunkExtent * frameIdx;
-
-            for(auto frameElem : onAcc::makeIdxMap(
+                auto tmp = onAcc::declareSharedMdArray<Data, uniqueId()>(
                     acc,
-                    onAcc::worker::threadsInBlock,
-                    IdxRange{CVec<IdxType, 0u>{}, chunkExtent, CVec<IdxType, elsPerThread>{}}))
-            {
-                // -- COPY TO SHARED MEM --
-                if((!lastFrameFull && isLastFrame) || elsPerThread % 4_idx != 0_idx)
-                {
-                    // load into miniblocks buffer, from frameElem to frameElem + elsPerThread
-                    for(auto i = 0_idx; i < elsPerThread; ++i)
-                    {
-                        if(frameOffset + frameElem + i < numElements)
-                            regMem[i] = inputVec[frameOffset + frameElem + i];
-                        else
-                            regMem[i] = 0;
-                    }
-                }
-                else
-                {
-                    MdSpanArray<LocalArray, alpaka::Alignment<16>> regMemMd{regMem};
+                    CVec<IdxType, conflictFreeAccess<DeviceType>(miniBlocksPerChunk - 1_idx) + 1_idx>{});
+                auto const frameOffset = chunkExtent * frameIdx;
 
-                    for(auto i = 0_idx; i < elsPerThread; i += 4_idx)
-                    {
-                        auto inputVecView
-                            = SimdPtr{inputVec, Vec{frameOffset + frameElem + i}, Alignment<16>{}, CVec<IdxType, 4>{}};
-                        auto regView = SimdPtr{regMemMd, Vec{i}, Alignment<16>{}, CVec<IdxType, 4>{}};
-
-                        regView = inputVecView.load();
-                    }
-                }
-
-                // -- HANDLE MINI BLOCKS OF THIS THREAD --
-                for(auto miniBlockOffset = 0_idx; miniBlockOffset < elsPerThread; miniBlockOffset += miniBlockSize)
-                {
-                    // scan miniblock
-                    auto miniBlockSum = scanMiniBlock(regMem + miniBlockOffset, CVec<IdxType, miniBlockSize>{});
-
-                    // write miniblock sum into shared memory
-                    tmp[conflictFreeAccess<DeviceType>((frameElem + miniBlockOffset) / miniBlockSize)] = miniBlockSum;
-                }
-            }
-
-            // -- UP-SWEEP / REDUCE --
-            for(IdxType d = miniBlocksPerChunk / 2_idx, offset = 1_idx; d > 0; d >>= 1, offset <<= 1)
-            {
-                onAcc::syncBlockThreads(acc);
                 for(auto frameElem : onAcc::makeIdxMap(
                         acc,
                         onAcc::worker::threadsInBlock,
-                        IdxRange{CVec<IdxType, 0>{}, Vec<IdxType, 1>{2_idx * d}, 2_idx}))
+                        IdxRange{CVec<IdxType, 0u>{}, chunkExtent, CVec<IdxType, elsPerThread>{}}))
                 {
-                    IdxType left = offset * (frameElem + 1_idx).x() - 1_idx;
-                    IdxType right = offset * (frameElem + 2_idx).x() - 1_idx;
-                    left = conflictFreeAccess<DeviceType>(left);
-                    right = conflictFreeAccess<DeviceType>(right);
-                    tmp[right] += tmp[left];
-                }
-            }
-            onAcc::syncBlockThreads(acc);
-
-            for([[maybe_unused]] auto frameElem : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{1}))
-            {
-                // -- SAVE BLOCK SUMS --
-                if constexpr(sizeof...(blockSums))
-                {
-                    auto _blockSums = std::get<0>(std::make_tuple(blockSums...));
-                    _blockSums[frameIdx] = tmp[conflictFreeAccess<DeviceType>(miniBlocksPerChunk - 1_idx)];
-                }
-
-                // -- SET 0 --
-                tmp[conflictFreeAccess<DeviceType>(miniBlocksPerChunk - 1_idx)] = 0;
-            }
-
-            // -- DOWN-SWEEP --
-            for(IdxType d = 1, offset = miniBlocksPerChunk / 2_idx; d < miniBlocksPerChunk; d <<= 1, offset >>= 1)
-            {
-                onAcc::syncBlockThreads(acc);
-                for(auto frameElem : onAcc::makeIdxMap(
-                        acc,
-                        onAcc::worker::threadsInBlock,
-                        IdxRange{CVec<IdxType, 0>{}, Vec<IdxType, 1>{2_idx * d}, 2_idx}))
-                {
-                    IdxType left = offset * (frameElem.x() + 1_idx) - 1_idx;
-                    IdxType right = offset * (frameElem.x() + 2_idx) - 1_idx;
-                    left = conflictFreeAccess<DeviceType>(left);
-                    right = conflictFreeAccess<DeviceType>(right);
-                    auto t = tmp[left];
-                    tmp[left] = tmp[right];
-                    tmp[right] += t;
-                }
-            }
-            onAcc::syncBlockThreads(acc);
-
-            // -- WRITE BACK --
-            for(auto frameElem : onAcc::makeIdxMap(
-                    acc,
-                    onAcc::worker::threadsInBlock,
-                    IdxRange{CVec<IdxType, 0u>{}, chunkExtent, CVec<IdxType, elsPerThread>{}}))
-            {
-                // -- HANDLE MINI BLOCKS OF THIS THREAD --
-                for(auto miniBlockOffset = 0_idx; miniBlockOffset < elsPerThread; miniBlockOffset += miniBlockSize)
-                {
-                    // load block sum from shared memory
-                    Data blockSum;
-                    if(frameOffset + frameElem + miniBlockOffset < numElements)
+                    // -- COPY TO SHARED MEM --
+                    if((!lastFrameFull && isLastFrame) || elsPerThread % 4_idx != 0_idx)
                     {
-                        blockSum
-                            = tmp[conflictFreeAccess<DeviceType>((frameElem.x() + miniBlockOffset) / miniBlockSize)];
-                    }
-
-                    // add block sum to mini block
-                    addIncrements(regMem + miniBlockOffset, blockSum, CVec<IdxType, miniBlockSize>{});
-                }
-
-                if((!lastFrameFull && isLastFrame) || elsPerThread % 4_idx != 0_idx)
-                {
-                    // write back to global mem, from frameElem to frameElem + elsPerThread
-                    for(auto i = 0_idx; i < elsPerThread; ++i)
-                    {
-                        if(frameOffset + frameElem + i < numElements)
+                        // load into miniblocks buffer, from frameElem to frameElem + elsPerThread
+                        for(auto i = 0_idx; i < elsPerThread; ++i)
                         {
-                            if constexpr(SCAN_TYPE == EXCLUSIVE_SCAN)
-                                outputVec[frameOffset + frameElem + i] = regMem[i];
-                            else if constexpr(SCAN_TYPE == INCLUSIVE_SCAN)
-                                outputVec[frameOffset + frameElem + i]
-                                    = inputVec[frameOffset + frameElem + i] + regMem[i];
+                            if(frameOffset + frameElem + i < numElements)
+                                regMem[i] = inputVec[frameOffset + frameElem + i];
+                            else
+                                regMem[i] = 0;
                         }
                     }
-                }
-                else
-                {
-                    MdSpanArray<LocalArray, alpaka::Alignment<16>> regMemMd{regMem};
-
-                    for(auto i = 0_idx; i < elsPerThread; i += 4_idx)
+                    else
                     {
-                        auto outputVecView = SimdPtr{
-                            outputVec,
-                            Vec{frameOffset + frameElem + i},
-                            Alignment<16>{},
-                            CVec<IdxType, 4>{}};
-                        auto regView = SimdPtr{regMemMd, Vec{i}, Alignment<16>{}, CVec<IdxType, 4>{}};
-                        if constexpr(SCAN_TYPE == EXCLUSIVE_SCAN)
-                            outputVecView = regView.load();
-                        else if constexpr(SCAN_TYPE == INCLUSIVE_SCAN)
+                        MdSpanArray<LocalArray, alpaka::Alignment<16>> regMemMd{regMem};
+
+                        for(auto i = 0_idx; i < elsPerThread; i += 4_idx)
                         {
                             auto inputVecView = SimdPtr{
                                 inputVec,
                                 Vec{frameOffset + frameElem + i},
                                 Alignment<16>{},
                                 CVec<IdxType, 4>{}};
-                            outputVecView = inputVecView.load() + regView.load();
+                            auto regView = SimdPtr{regMemMd, Vec{i}, Alignment<16>{}, CVec<IdxType, 4>{}};
+
+                            regView = inputVecView.load();
+                        }
+                    }
+
+                    // -- HANDLE MINI BLOCKS OF THIS THREAD --
+                    for(auto miniBlockOffset = 0_idx; miniBlockOffset < elsPerThread; miniBlockOffset += miniBlockSize)
+                    {
+                        // scan miniblock
+                        auto miniBlockSum = scanMiniBlock(regMem + miniBlockOffset, CVec<IdxType, miniBlockSize>{});
+
+                        // write miniblock sum into shared memory
+                        tmp[conflictFreeAccess<DeviceType>((frameElem + miniBlockOffset) / miniBlockSize)]
+                            = miniBlockSum;
+                    }
+                }
+
+                // -- UP-SWEEP / REDUCE --
+                for(IdxType d = miniBlocksPerChunk / 2_idx, offset = 1_idx; d > 0; d >>= 1, offset <<= 1)
+                {
+                    onAcc::syncBlockThreads(acc);
+                    for(auto frameElem : onAcc::makeIdxMap(
+                            acc,
+                            onAcc::worker::threadsInBlock,
+                            IdxRange{CVec<IdxType, 0>{}, Vec<IdxType, 1>{2_idx * d}, 2_idx}))
+                    {
+                        IdxType left = offset * (frameElem + 1_idx).x() - 1_idx;
+                        IdxType right = offset * (frameElem + 2_idx).x() - 1_idx;
+                        left = conflictFreeAccess<DeviceType>(left);
+                        right = conflictFreeAccess<DeviceType>(right);
+                        tmp[right] += tmp[left];
+                    }
+                }
+                onAcc::syncBlockThreads(acc);
+
+                for([[maybe_unused]] auto frameElem :
+                    onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{1}))
+                {
+                    // -- SAVE BLOCK SUMS --
+                    if constexpr(sizeof...(blockSums))
+                    {
+                        auto _blockSums = std::get<0>(std::make_tuple(blockSums...));
+                        _blockSums[frameIdx] = tmp[conflictFreeAccess<DeviceType>(miniBlocksPerChunk - 1_idx)];
+                    }
+
+                    // -- SET 0 --
+                    tmp[conflictFreeAccess<DeviceType>(miniBlocksPerChunk - 1_idx)] = 0;
+                }
+
+                // -- DOWN-SWEEP --
+                for(IdxType d = 1, offset = miniBlocksPerChunk / 2_idx; d < miniBlocksPerChunk; d <<= 1, offset >>= 1)
+                {
+                    onAcc::syncBlockThreads(acc);
+                    for(auto frameElem : onAcc::makeIdxMap(
+                            acc,
+                            onAcc::worker::threadsInBlock,
+                            IdxRange{CVec<IdxType, 0>{}, Vec<IdxType, 1>{2_idx * d}, 2_idx}))
+                    {
+                        IdxType left = offset * (frameElem.x() + 1_idx) - 1_idx;
+                        IdxType right = offset * (frameElem.x() + 2_idx) - 1_idx;
+                        left = conflictFreeAccess<DeviceType>(left);
+                        right = conflictFreeAccess<DeviceType>(right);
+                        auto t = tmp[left];
+                        tmp[left] = tmp[right];
+                        tmp[right] += t;
+                    }
+                }
+                onAcc::syncBlockThreads(acc);
+
+                // -- WRITE BACK --
+                for(auto frameElem : onAcc::makeIdxMap(
+                        acc,
+                        onAcc::worker::threadsInBlock,
+                        IdxRange{CVec<IdxType, 0u>{}, chunkExtent, CVec<IdxType, elsPerThread>{}}))
+                {
+                    // -- HANDLE MINI BLOCKS OF THIS THREAD --
+                    for(auto miniBlockOffset = 0_idx; miniBlockOffset < elsPerThread; miniBlockOffset += miniBlockSize)
+                    {
+                        // load block sum from shared memory
+                        Data blockSum;
+                        if(frameOffset + frameElem + miniBlockOffset < numElements)
+                        {
+                            blockSum = tmp[conflictFreeAccess<DeviceType>(
+                                (frameElem.x() + miniBlockOffset) / miniBlockSize)];
+                        }
+
+                        // add block sum to mini block
+                        addIncrements(regMem + miniBlockOffset, blockSum, CVec<IdxType, miniBlockSize>{});
+                    }
+
+                    if((!lastFrameFull && isLastFrame) || elsPerThread % 4_idx != 0_idx)
+                    {
+                        // write back to global mem, from frameElem to frameElem + elsPerThread
+                        for(auto i = 0_idx; i < elsPerThread; ++i)
+                        {
+                            if(frameOffset + frameElem + i < numElements)
+                            {
+                                if constexpr(SCAN_TYPE == EXCLUSIVE_SCAN)
+                                    outputVec[frameOffset + frameElem + i] = regMem[i];
+                                else if constexpr(SCAN_TYPE == INCLUSIVE_SCAN)
+                                    outputVec[frameOffset + frameElem + i]
+                                        = inputVec[frameOffset + frameElem + i] + regMem[i];
+                            }
+                        }
+                    }
+                    else
+                    {
+                        MdSpanArray<LocalArray, alpaka::Alignment<16>> regMemMd{regMem};
+
+                        for(auto i = 0_idx; i < elsPerThread; i += 4_idx)
+                        {
+                            auto outputVecView = SimdPtr{
+                                outputVec,
+                                Vec{frameOffset + frameElem + i},
+                                Alignment<16>{},
+                                CVec<IdxType, 4>{}};
+                            auto regView = SimdPtr{regMemMd, Vec{i}, Alignment<16>{}, CVec<IdxType, 4>{}};
+                            if constexpr(SCAN_TYPE == EXCLUSIVE_SCAN)
+                                outputVecView = regView.load();
+                            else if constexpr(SCAN_TYPE == INCLUSIVE_SCAN)
+                            {
+                                auto inputVecView = SimdPtr{
+                                    inputVec,
+                                    Vec{frameOffset + frameElem + i},
+                                    Alignment<16>{},
+                                    CVec<IdxType, 4>{}};
+                                outputVecView = inputVecView.load() + regView.load();
+                            }
                         }
                     }
                 }
+                onAcc::syncBlockThreads(acc);
             }
-            onAcc::syncBlockThreads(acc);
+        }
+    };
+
+    /* Add prefix sum from previous blocks (blockSums) to all elements in each block.
+     */
+    class Scan_AddIncrementsKernel
+    {
+    public:
+        ALPAKA_FN_ACC void operator()(
+            auto const& acc,
+            concepts::MdSpan auto const& blockSums,
+            concepts::MdSpan auto outputVec) const
+        {
+            concepts::Vector auto numElements = outputVec.getExtents();
+            concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
+            concepts::CVector auto frameExtent = acc[frame::extent];
+            constexpr auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
+            concepts::CVector auto chunkExtent = CVec<IdxType, elsPerThread * numThreadsPerBlock.x()>{};
+
+            auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
+            simdGrid.concurrent(
+                acc,
+                numElements,
+                [&](auto const&, auto&& simdOut) constexpr
+                { simdOut = simdOut.load() + blockSums[simdOut.getIdx() / chunkExtent]; },
+                outputVec);
+        }
+    };
+
+    template<ScanType SCAN_TYPE>
+    void scan(auto& exec, auto& devAcc, auto& queue, auto const& inputVec, auto outputVec)
+    {
+        // Instantiate the kernel function object with the given scan type
+        Scan_ScanBlocksKernel<SCAN_TYPE> scanBlocks;
+
+        // Define chunkExtent
+        constexpr auto chunkExtent = CVec<IdxType, 2048u>{};
+        auto numFrames = divCeil(inputVec.getExtents(), chunkExtent);
+        auto const frameSpec = onHost::FrameSpec{numFrames, chunkExtent, CVec<IdxType, 256u>{}};
+
+        if(frameSpec.m_numFrames > 1_idx)
+        {
+            // problem does not fit in 1 frame, recurse
+            Scan_AddIncrementsKernel addIncrements;
+
+            // allocate block increments, one element per frame
+            auto increments = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
+            auto blockSums = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
+
+            // enqueue the kernel execution tasks
+            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
+
+            // always recurse into exclusive scan
+            scan<EXCLUSIVE_SCAN>(exec, devAcc, queue, increments, blockSums);
+            queue.enqueue(exec, frameSpec, KernelBundle{addIncrements, blockSums, outputVec});
+
+            // need to wait here until the previous call is done before we can destruct the buffers for
+            // increments/blockSums when running out of scope
+            onHost::wait(queue);
+        }
+        else
+        {
+            // problem fits within 1 frame
+            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec});
         }
     }
-};
-
-/* Add prefix sum from previous blocks (blockSums) to all elements in each block.
- */
-class Scan_AddIncrementsKernel
-{
-public:
-    ALPAKA_FN_ACC void operator()(
-        auto const& acc,
-        concepts::MdSpan auto const& blockSums,
-        concepts::MdSpan auto outputVec) const
-    {
-        concepts::Vector auto numElements = outputVec.getExtents();
-        concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
-        concepts::CVector auto frameExtent = acc[frame::extent];
-        constexpr auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
-        concepts::CVector auto chunkExtent = CVec<IdxType, elsPerThread * numThreadsPerBlock.x()>{};
-
-        auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
-        simdGrid.concurrent(
-            acc,
-            numElements,
-            [&](auto const&, auto&& simdOut) constexpr
-            { simdOut = simdOut.load() + blockSums[simdOut.getIdx() / chunkExtent]; },
-            outputVec);
-    }
-};
-
-template<ScanType SCAN_TYPE>
-void scan(auto& exec, auto& devAcc, auto& queue, auto const& inputVec, auto outputVec)
-{
-    // Instantiate the kernel function object with the given scan type
-    Scan_ScanBlocksKernel<SCAN_TYPE> scanBlocks;
-
-    // Define chunkExtent
-    constexpr auto chunkExtent = CVec<IdxType, 2048u>{};
-    auto numFrames = divCeil(inputVec.getExtents(), chunkExtent);
-    auto const frameSpec = onHost::FrameSpec{numFrames, chunkExtent, CVec<IdxType, 256u>{}};
-
-    if(frameSpec.m_numFrames > 1_idx)
-    {
-        // problem does not fit in 1 frame, recurse
-        Scan_AddIncrementsKernel addIncrements;
-
-        // allocate block increments, one element per frame
-        auto increments = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
-        auto blockSums = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
-
-        // enqueue the kernel execution tasks
-        queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
-
-        // always recurse into exclusive scan
-        scan<EXCLUSIVE_SCAN>(exec, devAcc, queue, increments, blockSums);
-        queue.enqueue(exec, frameSpec, KernelBundle{addIncrements, blockSums, outputVec});
-
-        // need to wait here until the previous call is done before we can destruct the buffers for
-        // increments/blockSums when running out of scope
-        onHost::wait(queue);
-    }
-    else
-    {
-        // problem fits within 1 frame
-        queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec});
-    }
-}
+} // namespace alpaka::example::scan

--- a/example/scan/src/scan_main.hpp
+++ b/example/scan/src/scan_main.hpp
@@ -15,102 +15,109 @@
 #include <iostream> // std::cout
 #include <random> // std::random_eng
 
-// set to false to use all 1s as input, for example for debugging
-constexpr bool RANDOM_INPUT = true;
-
-void printExampleHeader(ScanType const scanType, IdxType const numElements, bool enableInPlace)
+namespace alpaka::example::scan
 {
-    std::cout << "================================" << std::endl;
-    switch(scanType)
+    // set to false to use all 1s as input, for example for debugging
+    constexpr bool RANDOM_INPUT = true;
+
+    void printExampleHeader(ScanType const scanType, IdxType const numElements, bool enableInPlace)
     {
-    case INCLUSIVE_SCAN:
-        std::cout << "Example Inclusive Scan" << std::endl;
-        break;
-    case EXCLUSIVE_SCAN:
-        std::cout << "Example Exclusive Scan" << std::endl;
-        break;
-    }
-    if(enableInPlace)
-        std::cout << "    Running in-place (input buffer = output buffer)" << std::endl;
-    else
-        std::cout << "    Not running in-place (input buffer != output buffer)" << std::endl;
-    std::cout << "    Number of elements [#]: " << numElements << std::endl;
-    std::cout << "    Element type [byte]: " << core::demangledName<Data>() << std::endl;
-    std::cout << "    Buffer size [Gbyte]: " << numElements * sizeof(Data) / 1.e9 << std::endl;
-    std::cout << "================================" << std::endl;
-    std::cout << std::endl;
-}
-
-auto example(
-    auto const deviceSpec,
-    auto const exec,
-    IdxType numElements,
-    bool enableStdScan,
-    bool enableCheck,
-    bool enableInPlace,
-    ScanType scanType) -> int
-{
-    // Number of elements to process
-    Vec1D const extent(numElements);
-
-    // Select a device
-    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
-    onHost::Device devAcc = devSelector.makeDevice(0);
-
-    // Create a queue on the device
-    onHost::Queue queue = devAcc.makeQueue();
-
-    auto inputData = onHost::allocHost<Data>(extent);
-
-    // Allocate host memory buffer for x (input) and y (output)
-    auto bufHostX = onHost::allocHost<Data>(extent);
-
-    // Fill input data with random values
-    std::random_device rd{};
-    std::default_random_engine eng{rd()};
-    std::uniform_int_distribution<std::int32_t> dist(0, 10);
-    for(IdxType i = 0u; i < extent; ++i)
-    {
-        if constexpr(RANDOM_INPUT)
-            inputData[i] = static_cast<Data>(dist(eng));
+        std::cout << "================================" << std::endl;
+        switch(scanType)
+        {
+        case INCLUSIVE_SCAN:
+            std::cout << "Example Inclusive Scan" << std::endl;
+            break;
+        case EXCLUSIVE_SCAN:
+            std::cout << "Example Exclusive Scan" << std::endl;
+            break;
+        }
+        if(enableInPlace)
+            std::cout << "    Running in-place (input buffer = output buffer)" << std::endl;
         else
-            inputData[i] = static_cast<Data>(1);
+            std::cout << "    Not running in-place (input buffer != output buffer)" << std::endl;
+        std::cout << "    Number of elements [#]: " << numElements << std::endl;
+        std::cout << "    Element type [byte]: " << core::demangledName<Data>() << std::endl;
+        std::cout << "    Buffer size [Gbyte]: " << numElements * sizeof(Data) / 1.e9 << std::endl;
+        std::cout << "================================" << std::endl;
+        std::cout << std::endl;
     }
 
-    // Allocate device memory buffers for x and y
-    auto bufAccX = onHost::allocLike(devAcc, bufHostX);
-    auto bufAccY = enableInPlace ? bufAccX : onHost::allocLike(devAcc, bufAccX);
+    auto example(
+        auto const deviceSpec,
+        auto const exec,
+        IdxType numElements,
+        bool enableStdScan,
+        bool enableCheck,
+        bool enableInPlace,
+        ScanType scanType) -> int
+    {
+        // Number of elements to process
+        Vec1D const extent(numElements);
 
-    return runExample(
-        exec,
-        devAcc,
-        queue,
-        inputData,
-        bufAccX,
-        bufAccY,
-        numElements,
-        scanType,
-        enableCheck,
-        enableStdScan);
-}
+        // Select a device
+        auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+        onHost::Device devAcc = devSelector.makeDevice(0);
 
-void help(char* argv[])
-{
-    std::cerr << argv[0] << " [OPTIONS]" << std::endl;
-    std::cerr << "  -n  numElements: Number of elements to process. Default: 2^24 = 16 Mi" << std::endl;
-    std::cerr << "  -e: disable execution of the native std::inclusive_scan or std::exclusive_scan implementation"
-              << std::endl;
-    std::cerr << "  -c: disable checking for correct results" << std::endl;
-    std::cerr << "  -i: enable in-place scan instead of creating an output buffer for the result" << std::endl;
-    std::cerr << "  -t: scanType: 0 for exclusive, 1 for inclusive scan. Default: 0 (exclusive)" << std::endl;
-    std::cerr << "  -h: Print this help message" << std::endl;
-    std::cerr << std::endl;
-    std::cerr << "Example call for an in-place inclusive scan with 256Ki elements:" << std::endl;
-    std::cerr << argv[0] << " -n 262144 -t 1 -i" << std::endl;
-}
+        // Create a queue on the device
+        onHost::Queue queue = devAcc.makeQueue();
+
+        auto inputData = onHost::allocHost<Data>(extent);
+
+        // Allocate host memory buffer for x (input) and y (output)
+        auto bufHostX = onHost::allocHost<Data>(extent);
+
+        // Fill input data with random values
+        std::random_device rd{};
+        std::default_random_engine eng{rd()};
+        std::uniform_int_distribution<std::int32_t> dist(0, 10);
+        for(IdxType i = 0u; i < extent; ++i)
+        {
+            if constexpr(RANDOM_INPUT)
+                inputData[i] = static_cast<Data>(dist(eng));
+            else
+                inputData[i] = static_cast<Data>(1);
+        }
+
+        // Allocate device memory buffers for x and y
+        auto bufAccX = onHost::allocLike(devAcc, bufHostX);
+        auto bufAccY = enableInPlace ? bufAccX : onHost::allocLike(devAcc, bufAccX);
+
+        return runExample(
+            exec,
+            devAcc,
+            queue,
+            inputData,
+            bufAccX,
+            bufAccY,
+            numElements,
+            scanType,
+            enableCheck,
+            enableStdScan);
+    }
+
+    void help(char* argv[])
+    {
+        std::cerr << argv[0] << " [OPTIONS]" << std::endl;
+        std::cerr << "  -n  numElements: Number of elements to process. Default: 2^24 = 16 Mi" << std::endl;
+        std::cerr << "  -e: disable execution of the native std::inclusive_scan or std::exclusive_scan implementation"
+                  << std::endl;
+        std::cerr << "  -c: disable checking for correct results" << std::endl;
+        std::cerr << "  -i: enable in-place scan instead of creating an output buffer for the result" << std::endl;
+        std::cerr << "  -t: scanType: 0 for exclusive, 1 for inclusive scan. Default: 0 (exclusive)" << std::endl;
+        std::cerr << "  -h: Print this help message" << std::endl;
+        std::cerr << std::endl;
+        std::cerr << "Example call for an in-place inclusive scan with 256Ki elements:" << std::endl;
+        std::cerr << argv[0] << " -n 262144 -t 1 -i" << std::endl;
+    }
+
+} // namespace alpaka::example::scan
 
 auto main(int argc, char* argv[]) -> int
 {
+    using namespace alpaka;
+    using namespace alpaka::example::scan;
+
     // Default value if no command line argument used
     IdxType numElements = 1 << 24;
 
@@ -194,7 +201,7 @@ auto main(int argc, char* argv[]) -> int
     auto result = executeForEachIfHasDevice(
         [=](auto const& backend)
         {
-            return example(
+            return alpaka::example::scan::example(
                 backend[alpaka::object::deviceSpec],
                 backend[alpaka::object::exec],
                 numElements,


### PR DESCRIPTION
fix comiler issue when using CUB

```
include/cuda/std/detail/libcxx/include/__functional/operations.h(367): error: name followed by "::" must be a class or namespace name
          noexcept(noexcept(::cuda::std::__4::forward<_T1>(__t) == ::cuda::std::__4::forward<_T2>(__u)))
```
and
```
include/cccl/cub/warp/warp_scan.cuh(176): error: "cuda" is ambiguous
2805
      IS_INTEGER = cuda::std::is_integral_v<T>
```

The error happen because we used `using namespace alpaka;` in the clobal cpp which collided with cub internal calls.