### PR TITLE
rename `allocManaged()` to `allocUnified()`

### DIFF
--- a/docs/snippets/10_memory.cpp
+++ b/docs/snippets/10_memory.cpp
@@ -33,7 +33,7 @@ TEST_CASE("memory", "[docs]")
 
     onHost::Queue hostQueue = onHost::makeHostDevice().makeQueue();
 
-    // Allocate a managed memory view on the compute device.
+    // Allocate a memory view on the compute device.
     // The memory will be freed automatically when the view goes out of scope.
     onHost::ManagedView computeView = onHost::alloc<int>(computeDev, 10);
     // Derive the properties except the location.

--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -184,7 +184,7 @@ Allocate a view
      // allocate memory which lives on the host but is accessible from the device too
      auto devMappedView = onHost::allocMapped<DataType>(device, extent);
      // allocate memory can be accessed from host and device (unified memory), the real location depends on the native backend e.g. CUDA, OneApi, ...
-     auto devUnifiedView = onHost::allocManaged<DataType>(device, extent);
+     auto devUnifiedView = onHost::allocUnified<DataType>(device, extent);
      // allocate memory accessible from host
      auto hostView = onHost::allocHost<DataType>(extent);
      // the data will not be automatically freed, user must take care that the original data life-time is longer than the view

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -121,7 +121,7 @@ namespace alpaka::onHost
             friend struct internal::GetDeviceProperties;
             friend struct internal::AdjustThreadSpec;
             friend struct internal::AllocAsync;
-            friend struct internal::AllocManaged;
+            friend struct internal::AllocUnified;
             friend struct internal::AllocMapped;
         };
     } // namespace cpu
@@ -171,7 +171,7 @@ namespace alpaka::onHost
         };
 
         template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct AllocManaged::Op<T_Type, cpu::Device<T_Platform>, T_Extents>
+        struct AllocUnified::Op<T_Type, cpu::Device<T_Platform>, T_Extents>
         {
             auto operator()(cpu::Device<T_Platform>& device, T_Extents const& extents) const
             {

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -101,7 +101,7 @@ namespace alpaka::onHost
             friend struct internal::GetDeviceProperties;
             friend struct internal::AdjustThreadSpec;
             friend struct onHost::internal::AllocAsync;
-            friend struct onHost::internal::AllocManaged;
+            friend struct onHost::internal::AllocUnified;
             friend struct onHost::internal::AllocMapped;
             friend struct onHost::internal::IsDataAccessible;
         };
@@ -139,7 +139,7 @@ namespace alpaka::onHost
         };
 
         template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct AllocManaged::Op<T_Type, syclGeneric::Device<T_Platform>, T_Extents>
+        struct AllocUnified::Op<T_Type, syclGeneric::Device<T_Platform>, T_Extents>
         {
             auto operator()(syclGeneric::Device<T_Platform>& device, T_Extents const& extents) const
             {
@@ -154,7 +154,7 @@ namespace alpaka::onHost
                 bool isManagedMemorySupported = sycl_device.has(sycl::aspect::usm_shared_allocations);
                 if(!isManagedMemorySupported)
                 {
-                    throw std::runtime_error("Sycl device does not support managed memory allocations.");
+                    throw std::runtime_error("Sycl device does not support unified memory allocations.");
                 }
 
                 T_Type* ptr = reinterpret_cast<T_Type*>(

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -126,7 +126,7 @@ namespace alpaka::onHost
 
             friend struct onHost::internal::Alloc;
             friend struct onHost::internal::AllocAsync;
-            friend struct onHost::internal::AllocManaged;
+            friend struct onHost::internal::AllocUnified;
             friend struct onHost::internal::AllocMapped;
             friend struct alpaka::internal::GetApi;
             friend struct internal::GetDeviceProperties;
@@ -224,7 +224,7 @@ namespace alpaka::onHost
         };
 
         template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct AllocManaged::Op<T_Type, unifiedCudaHip::Device<T_Platform>, T_Extents>
+        struct AllocUnified::Op<T_Type, unifiedCudaHip::Device<T_Platform>, T_Extents>
         {
             auto operator()(unifiedCudaHip::Device<T_Platform>& device, T_Extents const& extents) const
             {
@@ -241,7 +241,7 @@ namespace alpaka::onHost
                 auto deviceDependency = onHost::Device{device.getSharedPtr()};
 
                 T_Type* ptr = nullptr;
-                // HIP is failing if zero byte managed memory is allocated, therefore we do not call the allocation
+                // HIP is failing if zero byte unified memory is allocated, therefore we do not call the allocation
                 // method for HIP
                 bool isHipZeroByteAllocation = memSizeInByte == 0 && getApi(device) == api::hip;
                 if(!isHipZeroByteAllocation)

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -173,23 +173,23 @@ namespace alpaka::onHost
      * @param device device handle
      */
     template<typename T_Type>
-    inline auto allocManaged(concepts::Device auto const& device, alpaka::concepts::VectorOrScalar auto const& extents)
+    inline auto allocUnified(concepts::Device auto const& device, alpaka::concepts::VectorOrScalar auto const& extents)
     {
         Vec const extentsVec = extents;
-        return internal::AllocManaged::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
+        return internal::AllocUnified::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
             *device.get(),
             extentsVec);
     }
 
-    /** Allocates managed memory on the device associated with the given queue.
+    /** Allocates unified memory on the device associated with the given queue.
      *
      * @param queue queue handle
      */
     template<typename T_Type, typename T_Device>
-    inline auto allocManaged(Queue<T_Device> const& queue, alpaka::concepts::VectorOrScalar auto const& extents)
+    inline auto allocUnified(Queue<T_Device> const& queue, alpaka::concepts::VectorOrScalar auto const& extents)
     {
         Vec const extentsVec = extents;
-        return internal::AllocManaged::
+        return internal::AllocUnified::
             Op<T_Type, std::decay_t<decltype(*queue.getDevice().get())>, ALPAKA_TYPEOF(extentsVec)>{}(
                 *queue.getDevice().get(),
                 extentsVec);

--- a/include/alpaka/onHost/internal.hpp
+++ b/include/alpaka/onHost/internal.hpp
@@ -295,7 +295,7 @@ namespace alpaka::onHost
             };
         };
 
-        struct AllocManaged
+        struct AllocUnified
         {
             template<typename T_Type, typename T_Any, typename T_Extents>
             struct Op

--- a/tests/unit/mem/alloc.cpp
+++ b/tests/unit/mem/alloc.cpp
@@ -58,23 +58,23 @@ void allocAsyncImplicitWait(auto device, alpaka::concepts::Executor auto exec)
     auto hostView = onHost::allocHost<int>(dataSize);
     auto hostViewMapped = onHost::allocMapped<int>(device, dataSize);
     auto deviceView = onHost::alloc<int>(device, dataSize);
-    auto managedView = onHost::allocManaged<int>(device, dataSize);
+    auto unifiedView = onHost::allocUnified<int>(device, dataSize);
 
     REQUIRE(onHost::isDataAccessible(hostDevice, hostView) == true);
-    REQUIRE(onHost::isDataAccessible(hostDevice, managedView) == true);
+    REQUIRE(onHost::isDataAccessible(hostDevice, unifiedView) == true);
     REQUIRE(onHost::isDataAccessible(hostDevice, hostViewMapped) == true);
     for(int i = 0; i < hostView.getExtents().x(); ++i)
     {
         hostView[i] = i;
-        // managed memory must be accessible on the host
-        managedView[i] = i;
+        // unified memory must be accessible on the host
+        unifiedView[i] = i;
         // is located on the host, so it must be accessible
         hostViewMapped[i] = i;
     }
 
     auto deviceQueue = device.makeQueue();
-    // check that we can copy from managed memory to device memory
-    onHost::memcpy(deviceQueue, deviceView, managedView);
+    // check that we can copy from unified memory to device memory
+    onHost::memcpy(deviceQueue, deviceView, unifiedView);
     onHost::wait(deviceQueue);
 
     if(getDeviceKind(device) == deviceKind::cpu)
@@ -89,14 +89,14 @@ void allocAsyncImplicitWait(auto device, alpaka::concepts::Executor auto exec)
     REQUIRE(onHost::isDataAccessible(device, hostViewMapped) == true);
     validateAccess(device, exec, hostViewMapped);
 
-    REQUIRE(onHost::isDataAccessible(device, managedView) == true);
-    validateAccess(device, exec, managedView);
+    REQUIRE(onHost::isDataAccessible(device, unifiedView) == true);
+    validateAccess(device, exec, unifiedView);
 
     REQUIRE(onHost::isDataAccessible(device, deviceView) == true);
     validateAccess(device, exec, deviceView);
 
-    REQUIRE(onHost::isDataAccessible(hostDevice, managedView) == true);
-    validateAccess(hostDevice, exec::cpuSerial, managedView);
+    REQUIRE(onHost::isDataAccessible(hostDevice, unifiedView) == true);
+    validateAccess(hostDevice, exec::cpuSerial, unifiedView);
 
     // is located on the host, so it must be accessible
     REQUIRE(onHost::isDataAccessible(device, hostViewMapped) == true);
@@ -150,7 +150,7 @@ TEMPLATE_LIST_TEST_CASE("alloc zero bytes", "", TestDeviceSpecs)
     [[maybe_unused]] auto hostViewMapped = onHost::allocMapped<int>(device, dataSize);
     [[maybe_unused]] auto deviceView = onHost::alloc<int>(device, dataSize);
     [[maybe_unused]] auto deviceViewAsync = onHost::allocAsync<int>(device.makeQueue(), dataSize);
-    [[maybe_unused]] auto managedView = onHost::allocManaged<int>(device, dataSize);
+    [[maybe_unused]] auto unifiedView = onHost::allocUnified<int>(device, dataSize);
 }
 
 /** Evaluates on the host side that all rows start with an address which is a multiple of the alignment of the MdSpan
@@ -191,8 +191,8 @@ void prepareAlignmentValidation(auto& device, alpaka::concepts::Vector auto exte
     validateAlignment(deviceView);
     auto deviceViewAsync = onHost::allocAsync<T_DataType>(device.makeQueue(), extents);
     validateAlignment(deviceViewAsync);
-    auto managedView = onHost::allocManaged<T_DataType>(device, extents);
-    validateAlignment(managedView);
+    auto unifiedView = onHost::allocUnified<T_DataType>(device, extents);
+    validateAlignment(unifiedView);
 }
 
 TEMPLATE_LIST_TEST_CASE("alloc alignment", "", TestDeviceSpecs)
@@ -227,7 +227,7 @@ void volatileBuffers(auto& device, alpaka::concepts::Vector auto extents)
     auto hostViewMapped = onHost::allocMapped<T_DataType volatile>(device, extents);
     auto deviceView = onHost::alloc<T_DataType volatile>(device, extents);
     auto deviceViewAsync = onHost::allocAsync<T_DataType volatile>(device.makeQueue(), extents);
-    auto managedView = onHost::allocManaged<T_DataType volatile>(device, extents);
+    auto unifiedView = onHost::allocUnified<T_DataType volatile>(device, extents);
 }
 
 TEMPLATE_LIST_TEST_CASE("alloc volatile memory", "", TestDeviceSpecs)


### PR DESCRIPTION
The name managed memory is conflicting with the data structure `ManagedView()`, this can introduce a confusion.
By renaming it the naming is much more clear.