### PR TITLE
cleanup and doxygen auto brief

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -179,7 +179,7 @@ void testKernels(auto const deviceSpec, auto const exec)
 
     std::cout << devAcc.getDeviceProperties() << std::endl;
 
-    std::cout << "used exec " << core::demangledName(exec) << std::endl;
+    std::cout << "used exec " << onHost::demangledName(exec) << std::endl;
 
     // A MetaData class instance to keep the benchmark info and results to print later. Does not include intermediate
     // runtime data.
@@ -485,7 +485,7 @@ void testKernels(auto const deviceSpec, auto const exec)
     metaData.setItem(BMInfoDataType::DataType, dataTypeStr);
     // Device and accelerator
     metaData.setItem(BMInfoDataType::DeviceName, onHost::getName(devAcc));
-    metaData.setItem(BMInfoDataType::AcceleratorType, core::demangledName(exec));
+    metaData.setItem(BMInfoDataType::AcceleratorType, onHost::demangledName(exec));
     // XML reporter of catch2 always converts to Nano Seconds
     metaData.setItem(BMInfoDataType::TimeUnit, "Nano Seconds");
 

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -195,7 +195,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the JAVADOC_BANNER tag is set to YES then doxygen will interpret a line
 # such as

--- a/docs/Doxyfile_dev
+++ b/docs/Doxyfile_dev
@@ -195,7 +195,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the JAVADOC_BANNER tag is set to YES then doxygen will interpret a line
 # such as

--- a/example/grayScale/src/grayScale.cpp
+++ b/example/grayScale/src/grayScale.cpp
@@ -137,7 +137,7 @@ auto example(T_Cfg const& cfg, size_t numElements, bool enableStdForEach) -> int
 
     std::cout << "Example GrayScale" << std::endl;
     std::cout << "    Number of elements [#]: " << numElements << std::endl;
-    std::cout << "    Element type [byte]: " << core::demangledName<Data>() << std::endl;
+    std::cout << "    Element type [byte]: " << onHost::demangledName<Data>() << std::endl;
     std::cout << "    Buffer size [Gbyte]: " << numElements * sizeof(Data) / 1.e9 << std::endl;
     std::cout << std::endl;
 
@@ -210,7 +210,7 @@ auto example(T_Cfg const& cfg, size_t numElements, bool enableStdForEach) -> int
 
     // Enqueue the kernel execution task
     {
-        std::cout << "Using alpaka accelerator: " << core::demangledName(exec) << " for "
+        std::cout << "Using alpaka accelerator: " << onHost::demangledName(exec) << " for "
                   << deviceSpec.getApi().getName() << std::endl;
         onHost::wait(queue);
         auto const beginT = std::chrono::high_resolution_clock::now();

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -46,7 +46,7 @@ int example(auto const deviceSpec, auto const computeExec)
 
     std::cout << deviceSpec.getApi().getName() << std::endl;
 
-    std::cout << "Using alpaka accelerator: " << core::demangledName(computeExec) << " for "
+    std::cout << "Using alpaka accelerator: " << onHost::demangledName(computeExec) << " for "
               << deviceSpec.getApi().getName() << std::endl;
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);

--- a/example/scan/src/scan_executors.hpp
+++ b/example/scan/src/scan_executors.hpp
@@ -88,7 +88,7 @@ namespace alpaka::example::scan
         bool const enableCheck)
     {
         std::cout << std::endl << std::endl;
-        std::cout << "===== EXECUTOR " << core::demangledName(exec) << " =====" << std::endl;
+        std::cout << "===== EXECUTOR " << onHost::demangledName(exec) << " =====" << std::endl;
 
         alpaka::onHost::wait(queue);
         auto const beginT = std::chrono::high_resolution_clock::now();

--- a/example/scan/src/scan_main.hpp
+++ b/example/scan/src/scan_main.hpp
@@ -37,7 +37,7 @@ namespace alpaka::example::scan
         else
             std::cout << "    Not running in-place (input buffer != output buffer)" << std::endl;
         std::cout << "    Number of elements [#]: " << numElements << std::endl;
-        std::cout << "    Element type [byte]: " << core::demangledName<Data>() << std::endl;
+        std::cout << "    Element type [byte]: " << onHost::demangledName<Data>() << std::endl;
         std::cout << "    Buffer size [Gbyte]: " << numElements * sizeof(Data) / 1.e9 << std::endl;
         std::cout << "================================" << std::endl;
         std::cout << std::endl;

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -65,10 +65,10 @@ auto example(auto const deviceSpec, auto const exec, size_t numElements) -> int
     using Data = uint32_t;
 
     std::cout << "Number of elements: " << numElements << std::endl;
-    std::cout << "Element type: " << core::demangledName<Data>() << std::endl;
+    std::cout << "Element type: " << onHost::demangledName<Data>() << std::endl;
 
-    std::cout << "Using alpaka accelerator: " << core::demangledName(exec) << " for " << deviceSpec.getApi().getName()
-              << " " << deviceSpec.getDeviceKind().getName() << std::endl;
+    std::cout << "Using alpaka accelerator: " << onHost::demangledName(exec) << " for "
+              << deviceSpec.getApi().getName() << " " << deviceSpec.getDeviceKind().getName() << std::endl;
 
     // Select a device
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -13,7 +13,6 @@
 #include "alpaka/api/oneApi.hpp"
 #include "alpaka/api/unifiedCudaHip.hpp"
 #include "alpaka/apply.hpp"
-#include "alpaka/core/DemangleTypeNames.hpp"
 #include "alpaka/core/Dict.hpp"
 #include "alpaka/core/Tag.hpp"
 #include "alpaka/core/common.hpp"
@@ -42,3 +41,16 @@
 #include "alpaka/onHost/mem/stdContainer.hpp"
 #include "alpaka/tag.hpp"
 #include "utility.hpp"
+
+#include <alpaka/onHost/demangledName.hpp>
+
+/** main alpaka namespace.
+ *
+ * namespace onHost::* contains all functionality which is usable on the host CPU controller thread.
+ * namespace onAcc::* contains all functionality which is usable on the accelerator compute device from within a
+ * kernel. namespace alpaka contains all functionality which is generic and can be used from within the host controller
+ * thread and within compute device kernels.
+ */
+namespace alpaka
+{
+}

--- a/include/alpaka/api/syclGeneric/Platform.hpp
+++ b/include/alpaka/api/syclGeneric/Platform.hpp
@@ -171,7 +171,7 @@ namespace alpaka
 
                 static constexpr auto getName()
                 {
-                    return core::demangledName<syclGeneric::Platform<T_ApiInterface, T_DeviceKind>>();
+                    return onHost::demangledName<syclGeneric::Platform<T_ApiInterface, T_DeviceKind>>();
                 }
 
                 friend struct internal::GetDeviceProperties::Op<syclGeneric::Platform<T_ApiInterface, T_DeviceKind>>;

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -182,7 +182,7 @@ namespace alpaka::onHost
                             static_cast<std::size_t>(extents.x()) * sizeof(T_Type),
                             static_cast<std::size_t>(extents.y())));
 
-                    pitches = alpaka::mem::calculatePitches<T_Type>(extents, static_cast<Idx>(rowPitchInBytes));
+                    pitches = alpaka::calculatePitches<T_Type>(extents, static_cast<Idx>(rowPitchInBytes));
                 }
                 else if constexpr(dim >= 3u)
                 {
@@ -197,7 +197,7 @@ namespace alpaka::onHost
 
                     ptr = reinterpret_cast<T_Type*>(pitchedPtrVal.ptr);
                     Idx rowPitchInBytes = pitchedPtrVal.pitch;
-                    pitches = alpaka::mem::calculatePitches<T_Type>(extents, static_cast<Idx>(pitchedPtrVal.pitch));
+                    pitches = alpaka::calculatePitches<T_Type>(extents, static_cast<Idx>(pitchedPtrVal.pitch));
                 }
 
                 auto deviceDependency = onHost::Device{device.getSharedPtr()};

--- a/include/alpaka/api/util.hpp
+++ b/include/alpaka/api/util.hpp
@@ -113,7 +113,7 @@ namespace alpaka::api::util
 
             IdxType rowExtentInBytes = extents.x() * static_cast<IdxType>(sizeof(T_ValueType));
             IdxType rowPitchInBytes = alpaka::divCeil(rowExtentInBytes, alignment) * alignment;
-            auto pitches = alpaka::mem::calculatePitches<T_ValueType>(extents, rowPitchInBytes);
+            auto pitches = alpaka::calculatePitches<T_ValueType>(extents, rowPitchInBytes);
 
             size_t memSizeInByte = static_cast<size_t>(pitches[0]) * static_cast<size_t>(extents[0]);
             return std::make_tuple(memSizeInByte, pitches);

--- a/include/alpaka/internal.hpp
+++ b/include/alpaka/internal.hpp
@@ -5,13 +5,19 @@
 #pragma once
 
 #include "alpaka/KernelBundle.hpp"
-#include "alpaka/core/DemangleTypeNames.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/mem/Alignment.hpp"
 #include "alpaka/onHost/Handle.hpp"
 
+#include <alpaka/onHost/demangledName.hpp>
+
 namespace alpaka
 {
+    /** alpaka internal implementations.
+     *
+     * @attention do not use any functions from this namespace in our user applications.
+     *          The interface can change at any time without further notice and is for internal use only.
+     */
     namespace internal
     {
         struct GetStaticName
@@ -24,7 +30,7 @@ namespace alpaka
                     if constexpr(requires { T_Any::getName(); })
                         return T_Any::getName();
                     else
-                        return core::demangledName(any);
+                        return onHost::demangledName(any);
                 }
             };
         };

--- a/include/alpaka/mem/DataPitches.hpp
+++ b/include/alpaka/mem/DataPitches.hpp
@@ -13,40 +13,37 @@
 
 namespace alpaka
 {
-    namespace mem
+    //! Calculate the pitches purely from the extents.
+    template<typename T_Elem, alpaka::concepts::Vector T_Vec>
+    constexpr auto calculatePitchesFromExtents(T_Vec const& extent)
     {
-        //! Calculate the pitches purely from the extents.
-        template<typename T_Elem, alpaka::concepts::Vector T_Vec>
-        constexpr auto calculatePitchesFromExtents(T_Vec const& extent)
-        {
-            constexpr auto dim = T_Vec::dim();
-            using type = typename T_Vec::type;
-            auto pitchBytes = typename T_Vec::UniVec{};
-            if constexpr(dim > 0)
-                pitchBytes.back() = static_cast<type>(sizeof(T_Elem));
-            if constexpr(dim > 1)
-                for(type i = dim - 1; i > 0; i--)
-                    pitchBytes[i - 1] = extent[i] * pitchBytes[i];
-            return pitchBytes;
-        }
-
-        //! Calculate the pitches purely from the extents.
-        template<typename T_Elem, alpaka::concepts::Vector T_Vec>
-        requires(T_Vec::dim() >= 2)
-        constexpr auto calculatePitches(T_Vec const& extent, typename T_Vec::type const& rowPitchBytes)
-        {
-            constexpr auto dim = T_Vec::dim();
-            using type = typename T_Vec::type;
-            auto pitchBytes = typename T_Vec::UniVec{};
+        constexpr auto dim = T_Vec::dim();
+        using type = typename T_Vec::type;
+        auto pitchBytes = typename T_Vec::UniVec{};
+        if constexpr(dim > 0)
             pitchBytes.back() = static_cast<type>(sizeof(T_Elem));
-            if constexpr(dim > 1)
-                pitchBytes[dim - 2u] = rowPitchBytes;
-            if constexpr(dim > 2)
-                for(type i = dim - 2; i > 0; i--)
-                    pitchBytes[i - 1] = extent[i] * pitchBytes[i];
-            return pitchBytes;
-        }
-    } // namespace mem
+        if constexpr(dim > 1)
+            for(type i = dim - 1; i > 0; i--)
+                pitchBytes[i - 1] = extent[i] * pitchBytes[i];
+        return pitchBytes;
+    }
+
+    //! Calculate the pitches purely from the extents.
+    template<typename T_Elem, alpaka::concepts::Vector T_Vec>
+    requires(T_Vec::dim() >= 2)
+    constexpr auto calculatePitches(T_Vec const& extent, typename T_Vec::type const& rowPitchBytes)
+    {
+        constexpr auto dim = T_Vec::dim();
+        using type = typename T_Vec::type;
+        auto pitchBytes = typename T_Vec::UniVec{};
+        pitchBytes.back() = static_cast<type>(sizeof(T_Elem));
+        if constexpr(dim > 1)
+            pitchBytes[dim - 2u] = rowPitchBytes;
+        if constexpr(dim > 2)
+            for(type i = dim - 2; i > 0; i--)
+                pitchBytes[i - 1] = extent[i] * pitchBytes[i];
+        return pitchBytes;
+    }
 
     template<typename T_Type, concepts::Vector T_Pitches>
     struct DataPitches

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -48,7 +48,7 @@ namespace alpaka
         concepts::Vector auto const& extents,
         T_MemAlignment const memAlignment = T_MemAlignment{})
     {
-        auto pitchMd = alpaka::mem::calculatePitchesFromExtents<T_ValueType>(extents);
+        auto pitchMd = alpaka::calculatePitchesFromExtents<T_ValueType>(extents);
         return MdSpan{pointer, extents, pitchMd, memAlignment};
     }
 

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -39,7 +39,7 @@ namespace alpaka
         concepts::Vector auto const& extents,
         T_MemAlignment const memAlignment = T_MemAlignment{})
     {
-        auto pitchMd = alpaka::mem::calculatePitchesFromExtents<T_ValueType>(extents);
+        auto pitchMd = alpaka::calculatePitchesFromExtents<T_ValueType>(extents);
         return View{getApi(ALPAKA_FORWARD(anyWithApi)), pointer, extents, pitchMd, memAlignment};
     }
 

--- a/include/alpaka/onAcc.hpp
+++ b/include/alpaka/onAcc.hpp
@@ -18,6 +18,7 @@
 #include "alpaka/onAcc/layout.hpp"
 #include "alpaka/onAcc/traverse.hpp"
 
+/** functionality which is usable on the accelerator compute device from within a kernel. */
 namespace alpaka::onAcc
 {
     /** Creates an index container that can be traversed with a range based for loop.

--- a/include/alpaka/onHost.hpp
+++ b/include/alpaka/onHost.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/tag.hpp"
 #include "alpaka/trait.hpp"
 
+/** functionality which is usable on the host CPU controller thread */
 namespace alpaka::onHost
 {
     /** Get extents of an object

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -42,7 +42,7 @@ namespace alpaka::onHost::internal
 
             // Shared memory for block-wide reduction
             T_DataType* dynS = onAcc::getDynSharedMem<T_DataType>(acc);
-            auto pitchMd = alpaka::mem::calculatePitchesFromExtents<T_DataType>(frameExtent);
+            auto pitchMd = alpaka::calculatePitchesFromExtents<T_DataType>(frameExtent);
             auto tbSum = MdSpan{dynS, frameExtent, pitchMd}; // makeMdSpan(dynS, frameExtent, pitchMd);
             //  auto tbSum = onAcc::declareSharedMdArray<T_DataType, uniqueId()>(acc, CVec<uint32_t, 2>{});
             // T_DataType* dynS = &tbSum[0];

--- a/include/alpaka/onHost/demangledName.hpp
+++ b/include/alpaka/onHost/demangledName.hpp
@@ -15,7 +15,7 @@ struct AlpakaDemangleReferenceType
 {
 };
 
-namespace alpaka::core
+namespace alpaka::onHost
 {
     /// \file
     /// use source_location to derive the demangled type name
@@ -56,4 +56,4 @@ namespace alpaka::core
     {
         return std::string(Demangled<T>::name());
     }
-} // namespace alpaka::core
+} // namespace alpaka::onHost

--- a/include/alpaka/onHost/mem/ManagedView.hpp
+++ b/include/alpaka/onHost/mem/ManagedView.hpp
@@ -43,7 +43,7 @@ namespace alpaka::onHost
             T_Type* data,
             T_Extents const& extents,
             T_Extents const& pitches,
-            std::shared_ptr<mem::ManagedDealloc> managedDeleter,
+            std::shared_ptr<internal::ManagedDealloc> managedDeleter,
             T_MemAlignment const memAlignment)
             : BaseView{api, data, extents, pitches, memAlignment}
             , m_deleter{std::move(managedDeleter)}
@@ -67,7 +67,7 @@ namespace alpaka::onHost
             std::invocable<> auto deleter,
             T_MemAlignment const memAlignment = Alignment{})
             : BaseView{any, data, extents, pitches, memAlignment}
-            , m_deleter{std::make_shared<mem::ManagedDealloc>(deleter)}
+            , m_deleter{std::make_shared<internal::ManagedDealloc>(deleter)}
         {
             static_assert(
                 isLosslessConvertible_v<typename T_UserPitches::type, typename T_UserExtents::type>,
@@ -146,7 +146,7 @@ namespace alpaka::onHost
         template<alpaka::concepts::IsPointer T>
         using ConstPtr_t = std::add_pointer_t<std::add_const_t<std::remove_pointer_t<T>>>;
 
-        std::shared_ptr<mem::ManagedDealloc> m_deleter;
+        std::shared_ptr<internal::ManagedDealloc> m_deleter;
     }; // namespace alpaka::onHost
 
     template<

--- a/include/alpaka/onHost/mem/MangedDealloc.hpp
+++ b/include/alpaka/onHost/mem/MangedDealloc.hpp
@@ -7,7 +7,7 @@
 #include <functional>
 #include <memory>
 
-namespace alpaka::onHost::mem
+namespace alpaka::onHost::internal
 {
     /** Manage the deallocation of memory
      *
@@ -60,4 +60,4 @@ namespace alpaka::onHost::mem
         std::mutex actionGuard;
         std::vector<std::function<void()>> actions;
     };
-} // namespace alpaka::onHost::mem
+} // namespace alpaka::onHost::internal

--- a/tests/unit/algorithm/concurrent.cpp
+++ b/tests/unit/algorithm/concurrent.cpp
@@ -60,7 +60,7 @@ void executeTest(
     auto const functorPair,
     concepts::Vector auto extentMd)
 {
-    std::cout << "run func : " << core::demangledName(functorPair.second) << std::endl;
+    std::cout << "run func : " << onHost::demangledName(functorPair.second) << std::endl;
 
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;

--- a/tests/unit/algorithm/reduce.cpp
+++ b/tests/unit/algorithm/reduce.cpp
@@ -56,7 +56,7 @@ void executeTest(
     auto const functorPair,
     concepts::Vector auto extentMd)
 {
-    std::cout << "run func : " << core::demangledName(std::get<2>(functorPair)) << std::endl;
+    std::cout << "run func : " << onHost::demangledName(std::get<2>(functorPair)) << std::endl;
 
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;

--- a/tests/unit/algorithm/transform.cpp
+++ b/tests/unit/algorithm/transform.cpp
@@ -71,7 +71,7 @@ void executeTest(
     auto const functorPair,
     concepts::Vector auto extentMd)
 {
-    std::cout << "run func : " << core::demangledName(functorPair.second) << std::endl;
+    std::cout << "run func : " << onHost::demangledName(functorPair.second) << std::endl;
 
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;

--- a/tests/unit/algorithm/transformReduce.cpp
+++ b/tests/unit/algorithm/transformReduce.cpp
@@ -86,8 +86,8 @@ void executeTest(
     auto const functorPair,
     concepts::Vector auto extentMd)
 {
-    std::cout << "run reduce(func) : " << core::demangledName(std::get<1>(functorPair).second) << "("
-              << core::demangledName(std::get<2>(functorPair).second) << ")" << std::endl;
+    std::cout << "run reduce(func) : " << onHost::demangledName(std::get<1>(functorPair).second) << "("
+              << onHost::demangledName(std::get<2>(functorPair).second) << ")" << std::endl;
 
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;

--- a/tests/unit/block/block.cpp
+++ b/tests/unit/block/block.cpp
@@ -67,7 +67,7 @@ TEMPLATE_LIST_TEST_CASE("block iota", "", TestApis)
     constexpr Vec numBlocks = Vec{9u};
     constexpr Vec blockExtent = Vec{4u};
     constexpr Vec dataExtent = numBlocks * blockExtent;
-    std::cout << "block iota exec=" << core::demangledName(exec) << std::endl;
+    std::cout << "block iota exec=" << onHost::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
 
     auto hBuff = onHost::allocHostLike(dBuff);

--- a/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -87,7 +87,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
     constexpr Vec numBlocks = Vec{1u};
     constexpr Vec blockExtent = Vec{4u};
     constexpr Vec dataExtent = numBlocks * blockExtent;
-    std::cout << "block shared iota exec=" << core::demangledName(exec) << std::endl;
+    std::cout << "block shared iota exec=" << onHost::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
 
     auto hBuff = onHost::allocHostLike(dBuff);

--- a/tests/unit/math/TestTemplate.hpp
+++ b/tests/unit/math/TestTemplate.hpp
@@ -9,7 +9,7 @@
 #include "Defines.hpp"
 #include "Functor.hpp"
 
-#include <alpaka/core/DemangleTypeNames.hpp>
+#include <alpaka/onHost/demangledName.hpp>
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_message.hpp>
@@ -147,10 +147,10 @@ namespace mathtest
             }
 #endif
             INFO(
-                "testing" << " data type:" << alpaka::core::demangledName<TData>()
-                          << " functor:" << alpaka::core::demangledName<TWrappedFunctor>() << " seed:" << seed);
+                "testing" << " data type:" << alpaka::onHost::demangledName<TData>()
+                          << " functor:" << alpaka::onHost::demangledName<TWrappedFunctor>() << " seed:" << seed);
             INFO(deviceSpec.getApi().getName());
-            INFO("exec:" << core::demangledName(exec));
+            INFO("exec:" << onHost::demangledName(exec));
             INFO("device:" << device.getName());
             onHost::Queue queue = device.makeQueue();
 
@@ -201,7 +201,7 @@ namespace mathtest
 
 
             INFO("Operator: " << functor);
-            INFO("Type: " << alpaka::core::demangledName<TData>()); // Compiler specific.
+            INFO("Type: " << alpaka::onHost::demangledName<TData>()); // Compiler specific.
 #if ALPAKA_DEBUG_FULL
             INFO(
                 "The args buffer: \n"

--- a/tests/unit/math/executeOnComputeDevice.hpp
+++ b/tests/unit/math/executeOnComputeDevice.hpp
@@ -38,7 +38,7 @@ namespace alpaka::test
             return false;
         }
 
-        INFO("testing" << " functor:" << alpaka::core::demangledName(kernelFnObj));
+        INFO("testing" << " functor:" << alpaka::onHost::demangledName(kernelFnObj));
         INFO("api:" << deviceSpec.getApi().getName());
         onHost::Device device = devSelector.makeDevice(0);
 
@@ -58,7 +58,7 @@ namespace alpaka::test
         }
 #endif
 
-        INFO("exec:" << core::demangledName(exec));
+        INFO("exec:" << onHost::demangledName(exec));
         INFO("device:" << device.getName());
         onHost::Queue queue = device.makeQueue();
         auto hViewResults = onHost::allocHost<bool>(1u);

--- a/tests/unit/precision/precision.cpp
+++ b/tests/unit/precision/precision.cpp
@@ -89,7 +89,7 @@ void callTests(auto cfg)
 
     Queue queue = device.makeQueue();
 
-    std::cout << "exec=" << core::demangledName(exec) << std::endl;
+    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
 
     {
         using MemIdxType = std::conditional_t<T_signedMemIdx, std::make_signed_t<uint32_t>, uint32_t>;

--- a/tests/unit/queue/kernelMD.cpp
+++ b/tests/unit/queue/kernelMD.cpp
@@ -49,7 +49,7 @@ struct Case
 void validate(auto& queue, auto& device, auto exec, auto testCase)
 {
     Vec extentMd = testCase.m_extents;
-    std::cout << " exec=" << core::demangledName(exec) << " extents=" << testCase.m_extents
+    std::cout << " exec=" << onHost::demangledName(exec) << " extents=" << testCase.m_extents
               << " frame size=" << testCase.m_frameSize << std::endl;
     auto dBuff = onHost::alloc<Vec<uint32_t, extentMd.dim()>>(device, extentMd);
 

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -50,7 +50,7 @@ TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec extent = Vec{12u};
-    std::cout << "exec=" << core::demangledName(exec) << std::endl;
+    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<uint32_t>(device, extent);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -99,7 +99,7 @@ TEMPLATE_LIST_TEST_CASE("iota2D", "", TestApis)
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec extent = Vec{8u, 16u};
-    std::cout << "exec=" << core::demangledName(exec) << std::endl;
+    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<Vec<uint32_t, 2u>>(device, extent);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -135,7 +135,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D", "", TestApis)
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec extent = Vec{4u, 8u, 16u};
-    std::cout << "exec=" << core::demangledName(exec) << std::endl;
+    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<Vec<uint32_t, 3u>>(device, extent);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -169,7 +169,7 @@ TEMPLATE_LIST_TEST_CASE("iota4D", "", TestApis)
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec extent = Vec{4u, 8u, 16, 32};
-    std::cout << "exec=" << core::demangledName(exec) << std::endl;
+    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<Vec<uint32_t, 4u>>(device, extent);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -235,7 +235,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
     numBlocksReduced.ref(CVec<uint32_t, 2u, 1u>{}) = 1u;
 
     std::cout << numBlocksReduced << std::endl;
-    std::cout << "exec=" << core::demangledName(exec) << std::endl;
+    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<Vec<uint32_t, 3u>>(device, numBlocks);
 
     auto hBuff = onHost::allocHostLike(dBuff);

--- a/tests/unit/sharedMem/sharedMem.cpp
+++ b/tests/unit/sharedMem/sharedMem.cpp
@@ -67,7 +67,7 @@ TEMPLATE_LIST_TEST_CASE("block shared iota", "", TestApis)
     constexpr Vec numBlocks = Vec{2u};
     constexpr Vec blockExtent = Vec{128u};
     constexpr Vec dataExtent = numBlocks * blockExtent;
-    std::cout << "block shared iota exec=" << core::demangledName(exec) << std::endl;
+    std::cout << "block shared iota exec=" << onHost::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
 
     auto hBuff = onHost::allocHostLike(dBuff);


### PR DESCRIPTION
- enable auto brief in doxygen to interpret the first line as @brief
- move `core::demangledName()` to `onHost::demangledName()` to allow the usaer to use the method
- remove namespace `alpaak::mem` to reduce the number of namespaces
- annotate few namespaces with documentation