### PR TITLE
Boundary Iteration

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -15,6 +15,7 @@ project("alpakaExamples" LANGUAGES CXX)
 # Add subdirectories.
 ################################################################################
 
+add_subdirectory("boundaryIter/")
 add_subdirectory("grayScale/")
 add_subdirectory("heatEquation2D/")
 add_subdirectory("scan/")

--- a/example/boundaryIter/CMakeLists.txt
+++ b/example/boundaryIter/CMakeLists.txt
@@ -1,0 +1,47 @@
+#
+# Copyright 2025 Anton Reinhard
+# SPDX-License-Identifier: ISC
+#
+
+# ###############################################################################
+# Required CMake version.
+
+cmake_minimum_required(VERSION 3.25)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+# ###############################################################################
+# Project.
+set(_TARGET_NAME boundaryIter)
+
+project(tutorial LANGUAGES CXX)
+
+# -------------------------------------------------------------------------------
+# Find alpaka.
+if(NOT TARGET alpaka::alpaka)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+
+    if(alpaka_USE_SOURCE_TREE)
+        # Don't build the examples recursively
+        set(alpaka_BUILD_EXAMPLES OFF)
+        add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")
+    else()
+        find_package(alpaka REQUIRED)
+    endif()
+endif()
+
+# -------------------------------------------------------------------------------
+# Add executable.
+file(GLOB_RECURSE boundaryIterSource "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+
+foreach(boundaryIterFile ${boundaryIterSource})
+    get_filename_component(boundaryIterFileName ${boundaryIterFile} NAME)
+    string(REPLACE ".cpp" "" boundaryIterName ${boundaryIterFileName})
+    add_executable(${boundaryIterName} ${boundaryIterFile})
+    target_link_libraries(${boundaryIterName} PUBLIC alpaka::alpaka)
+    set_target_properties(${boundaryIterName} PROPERTIES FOLDER tutorial)
+    target_compile_features(${boundaryIterName} PRIVATE cxx_std_20)
+    alpaka_finalize(${boundaryIterName})
+
+    add_test(NAME ${boundaryIterName} COMMAND ${boundaryIterName})
+endforeach()

--- a/example/boundaryIter/src/boundaryIter.cpp
+++ b/example/boundaryIter/src/boundaryIter.cpp
@@ -36,7 +36,7 @@ int example(auto const devSpec)
     auto devSelector = onHost::makeDeviceSelector(devSpec);
 
     // require at least one device
-    std::size_t n = devSelector.getDeviceCount();
+    [[maybe_unused]] std::size_t n = devSelector.getDeviceCount();
     assert(n > 0);
     auto device = devSelector.makeDevice(0);
 
@@ -91,7 +91,7 @@ int example(auto const devSpec)
         printBoundaryContainer(view, bd_container_halo_heterogeneous);
     }
 
-    return 0;
+    return EXIT_SUCCESS;
 }
 
 auto main() -> int

--- a/example/boundaryIter/src/boundaryIter.cpp
+++ b/example/boundaryIter/src/boundaryIter.cpp
@@ -1,0 +1,103 @@
+/* Copyright 2025 Anton Reinhard
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/onHost/executeForEach.hpp>
+
+#include <iostream>
+
+using IdxType = uint32_t;
+
+using namespace alpaka;
+
+auto printBoundaryContainer(auto view, auto bd_container)
+{
+    std::cout << "Number of unique boundaries: " << bd_container.length() << std::endl;
+    for(auto bd : bd_container)
+    {
+        // create the sub view for this boundary direction
+        auto subView = view.getSubView(bd);
+        std::cout << bd << ":";
+        std::cout << " extent: " << subView.getExtents() << " elements: ";
+
+        // show sub view's values
+        for(auto const& el : subView)
+            std::cout << el << " ";
+        std::cout << std::endl;
+    }
+
+    std::cout << "End of Boundaries\n\n" << std::endl;
+}
+
+int example(auto const devSpec)
+{
+    // initialise the accelerator platform
+    auto devSelector = onHost::makeDeviceSelector(devSpec);
+
+    // require at least one device
+    std::size_t n = devSelector.getDeviceCount();
+    assert(n > 0);
+    auto device = devSelector.makeDevice(0);
+
+    // set example buffer size
+    constexpr IdxType Dimensions = 4;
+    constexpr auto size = alpaka::fillCVec<IdxType, Dimensions, 4>();
+
+    // allocate a buffer of floats in host memory
+    auto buffer = onHost::alloc<float>(device, size);
+    auto const view = buffer.getView();
+
+    auto hostDev = onHost::makeHostDevice();
+    auto deviceQueue = hostDev.makeQueue();
+    onHost::iota(deviceQueue, 1.f, buffer);
+    onHost::wait(deviceQueue);
+
+    std::cout << Dimensions << "D volume" << std::endl;
+    std::cout << "Volume Extents: " << view.getExtents() << std::endl;
+
+    // show all values once
+    for(auto& el : view)
+        std::cout << el << " ";
+    std::cout << std::endl;
+
+    {
+        std::cout << "Halo size 1 (default) for " << Dimensions << "D" << std::endl;
+
+        constexpr auto bd_container = makeBoundaryDirIterator<Dimensions>();
+        printBoundaryContainer(view, bd_container);
+    }
+
+    {
+        std::cout << "Halo size 1 (default), constructed directly from the view" << std::endl;
+
+        constexpr auto bd_container = makeBoundaryDirIterator(view);
+        printBoundaryContainer(view, bd_container);
+    }
+
+    {
+        std::cout << "Halo size 2" << std::endl;
+
+        constexpr auto bd_container_halo = makeBoundaryDirIterator(alpaka::fillCVec<IdxType, Dimensions, 2>());
+        printBoundaryContainer(view, bd_container_halo);
+    }
+
+    {
+        std::cout << "Lower halo sizes = 1, upper halo sizes = 2" << std::endl;
+
+        constexpr auto bd_container_halo_heterogeneous = makeBoundaryDirIterator(
+            alpaka::fillCVec<IdxType, Dimensions, 1>(),
+            alpaka::fillCVec<IdxType, Dimensions, 2>());
+        printBoundaryContainer(view, bd_container_halo_heterogeneous);
+    }
+
+    return 0;
+}
+
+auto main() -> int
+{
+    // Execute the example once for each enabled API and executor.
+    return executeForEachIfHasDevice(
+        [=](auto const& devSpec) { return example(devSpec); },
+        onHost::getDeviceSpecsFor(onHost::enabledApis));
+}

--- a/example/boundaryIter/src/common.hpp
+++ b/example/boundaryIter/src/common.hpp
@@ -1,0 +1,18 @@
+/* Copyright 2025 Anton Reinhard
+ * SPDX-License-Identifier: ISC
+ */
+
+#pragma once
+
+#include <alpaka/alpaka.hpp>
+
+#include <cstddef>
+
+using IdxType = std::size_t;
+using Data = std::int32_t;
+using Vec1D = alpaka::Vec<IdxType, 1u>;
+
+constexpr IdxType operator""_idx(unsigned long long n)
+{
+    return IdxType{n};
+}

--- a/include/alpaka/CVec.hpp
+++ b/include/alpaka/CVec.hpp
@@ -98,16 +98,17 @@ namespace alpaka
         return detail::integerSequenceToCVec(IotaSeq{});
     }
 
-    template<typename T, uint32_t T_dim, T Val>
+    template<typename T, uint32_t T_dim, T T_val>
     consteval auto fillCVec()
     {
-        auto concatCVec = []<T... Values>(CVec<T, Values...> cvec) -> auto { return CVec<T, Values..., Val>{}; };
+        auto concatCVec
+            = []<T... T_values>(CVec<T, T_values...> cvec) -> auto { return CVec<T, T_values..., T_val>{}; };
 
         static_assert(T_dim > 0);
         if constexpr(T_dim == 1)
-            return CVec<T, Val>{};
+            return CVec<T, T_val>{};
         else
-            return concatCVec(fillCVec<T, T_dim - 1, Val>());
+            return concatCVec(fillCVec<T, T_dim - 1, T_val>());
     }
 
     /** Find all values only exists in the left vector

--- a/include/alpaka/CVec.hpp
+++ b/include/alpaka/CVec.hpp
@@ -92,10 +92,22 @@ namespace alpaka
     } // namespace detail
 
     template<typename T, uint32_t T_dim>
-    constexpr auto iotaCVec()
+    consteval auto iotaCVec()
     {
         using IotaSeq = std::make_integer_sequence<T, T_dim>;
         return detail::integerSequenceToCVec(IotaSeq{});
+    }
+
+    template<typename T, uint32_t T_dim, T Val>
+    consteval auto fillCVec()
+    {
+        auto concatCVec = []<T... Values>(CVec<T, Values...> cvec) -> auto { return CVec<T, Values..., Val>{}; };
+
+        static_assert(T_dim > 0);
+        if constexpr(T_dim == 1)
+            return CVec<T, Val>{};
+        else
+            return concatCVec(fillCVec<T, T_dim - 1, Val>());
     }
 
     /** Find all values only exists in the left vector

--- a/include/alpaka/KernelBundle.hpp
+++ b/include/alpaka/KernelBundle.hpp
@@ -79,7 +79,7 @@ namespace alpaka
                      remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>>
                  && ...),
                 "All kernel arguments must be trivially copyable or specialize "
-                "trai::IsKernelArgumentTriviallyCopyable<>!");
+                "trait::IsKernelArgumentTriviallyCopyable<>!");
         }
 
         constexpr KernelBundle(KernelBundle const& b) = default;

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -151,12 +151,12 @@ namespace alpaka
             }
 
         private:
-            template<T... T_indecies>
+            template<T... T_indices>
             static constexpr auto integerSequenceToCVec(
-                std::integer_sequence<T, T_indecies...>,
+                std::integer_sequence<T, T_indices...>,
                 auto const op = std::identity{})
             {
-                return CVec<T, op(T_indecies)...>{};
+                return CVec<T, op(T_indices)...>{};
             };
         };
 
@@ -987,7 +987,7 @@ namespace alpaka
         };
     } // namespace internal
 
-    /** @todo the function for intergral values is defined in Utils.hpp
+    /** @todo the function for integral values is defined in Utils.hpp
      * move this to a better place, e.g. math and expose this for the user too
      */
     template<concepts::Vector T_Vector0, concepts::Vector T_Vector1>

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -23,6 +23,7 @@
 #include "alpaka/math.hpp"
 #include "alpaka/math/constants.hpp"
 #include "alpaka/math/internal/Complex.hpp"
+#include "alpaka/mem/BoundaryIter.hpp"
 #include "alpaka/mem/Iter.hpp"
 #include "alpaka/onAcc/Acc.hpp"
 #include "alpaka/onAcc/GlobalMem.hpp"

--- a/include/alpaka/mem/BoundaryIter.hpp
+++ b/include/alpaka/mem/BoundaryIter.hpp
@@ -1,0 +1,398 @@
+/* Copyright 2025 Anton Reinhard
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/CVec.hpp"
+#include "alpaka/Vec.hpp"
+#include "alpaka/api/api.hpp"
+#include "alpaka/api/host/Api.hpp"
+#include "alpaka/concepts.hpp"
+#include "alpaka/core/Assert.hpp"
+#include "alpaka/utility.hpp"
+
+#include <ostream>
+
+namespace alpaka
+{
+
+    /**
+     * @brief An enum representing the different types of boundary, with LOWER, MIDDLE, and UPPER being valid states,
+     * and OOB being invalid (out-of-bounds).
+     */
+    enum class BoundaryType : uint32_t
+    {
+        LOWER,
+        MIDDLE,
+        UPPER,
+        OOB
+    };
+
+    /**
+     * @brief An n-dimensional boundary direction. Encodes a single unique boundary of an nD volume, e.g., a specific
+     * corner of a 2D plane or a side of a 3D cube.
+     *
+     * @tparam Dim The dimensionality of the volume that this is a boundary direction for.
+     * @tparam LowHaloVecType The vector type used for the lower halo sizes.
+     * @tparam UpHaloVecType The vector type used for the upper halo sizes.
+     */
+    template<uint32_t Dim, alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+    struct BoundaryDirection
+    {
+        using BoundaryVecType = alpaka::Vec<BoundaryType, Dim>;
+
+        BoundaryVecType data;
+        LowHaloVecType lowerHaloSize;
+        UpHaloVecType upperHaloSize;
+
+        constexpr BoundaryDirection(
+            alpaka::concepts::Vector auto const& boundaries,
+            LowHaloVecType const& lower_halo_sizes,
+            UpHaloVecType const& upper_halo_sizes)
+            : data(boundaries)
+            , lowerHaloSize(lower_halo_sizes)
+            , upperHaloSize(upper_halo_sizes)
+        {
+        }
+
+        [[nodiscard]] static constexpr uint32_t dim()
+        {
+            return Dim;
+        }
+
+        [[nodiscard]] constexpr uint32_t boundaryDimensionality() const
+        {
+            uint32_t c = 0;
+            for(auto i = 0; i < Dim; ++i)
+            {
+                if(data[i] == BoundaryType::MIDDLE)
+                    ++c;
+            }
+            return c;
+        }
+
+        [[nodiscard]] constexpr bool isPoint() const
+        {
+            return boundaryDimensionality() == 0;
+        }
+
+        [[nodiscard]] constexpr bool isLine() const
+        {
+            return boundaryDimensionality() == 1;
+        }
+
+        [[nodiscard]] constexpr bool isPlane() const
+        {
+            return boundaryDimensionality() == 2;
+        }
+
+        [[nodiscard]] constexpr bool isVolume() const
+        {
+            return boundaryDimensionality() == 3;
+        }
+
+        [[nodiscard]] constexpr auto operator<=>(BoundaryDirection const&) const = default;
+    };
+
+    /**
+     * @brief The iterator type for [`BoundaryDirectionsContainer`](@ref)
+     *
+     * @tparam Dim The dimensionality of the volume that this is a boundary direction iterator for.
+     * @tparam LowHaloVecType The vector type used for the lower halo sizes.
+     * @tparam UpHaloVecType The vector type used for the upper halo sizes.
+     */
+    template<uint32_t Dim, alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+    struct BoundaryDirectionIter
+    {
+        using BoundaryVecType = alpaka::Vec<BoundaryType, Dim>;
+
+        using difference_type = std::ptrdiff_t;
+        using value_type = BoundaryDirection<Dim, LowHaloVecType, UpHaloVecType>;
+        using reference = value_type&;
+        using const_reference = value_type const&;
+        using pointer = value_type*;
+        using const_pointer = value_type const*;
+
+        constexpr BoundaryDirectionIter(
+            BoundaryVecType const& boundaries,
+            LowHaloVecType const& lower_halo_sizes,
+            UpHaloVecType const& upper_halo_sizes)
+            : boundaries(boundaries, lower_halo_sizes, upper_halo_sizes)
+            , lowerHaloSizes(lower_halo_sizes)
+            , upperHaloSizes(upper_halo_sizes)
+        {
+        }
+
+        [[nodiscard]] constexpr const_reference& operator*() const
+        {
+            return boundaries;
+        }
+
+        [[nodiscard]] constexpr reference& operator*()
+        {
+            return boundaries;
+        }
+
+        constexpr auto& operator++()
+        {
+            uint32_t i = Dim - 1;
+            bool oob = true;
+            while(i != static_cast<uint32_t>(-1))
+            {
+                switch(boundaries.data[i])
+                {
+                case BoundaryType::LOWER:
+                    boundaries.data[i] = BoundaryType::MIDDLE;
+                    i = static_cast<uint32_t>(-1);
+                    oob = false;
+                    break;
+                case BoundaryType::MIDDLE:
+                    boundaries.data[i] = BoundaryType::UPPER;
+                    i = static_cast<uint32_t>(-1);
+                    oob = false;
+                    break;
+                case BoundaryType::UPPER:
+                    boundaries.data[i] = BoundaryType::LOWER;
+                    --i;
+                    break;
+                case BoundaryType::OOB:
+                    [[fallthrough]];
+                default:
+                    constexpr bool onHost = std::is_same_v<api::Host, ALPAKA_TYPEOF(thisApi())>;
+                    if constexpr(onHost)
+                        assert(false);
+                    else
+                        ALPAKA_ASSERT_ACC(false);
+                }
+            }
+            if(oob)
+            {
+                boundaries
+                    = {Vec<BoundaryType, Dim>([](int) { return BoundaryType::OOB; }), lowerHaloSizes, upperHaloSizes};
+            }
+            return *this;
+        }
+
+        [[nodiscard]] static constexpr auto dim()
+        {
+            return Dim;
+        }
+
+        [[nodiscard]] constexpr auto operator<=>(BoundaryDirectionIter const&) const = default;
+
+    private:
+        BoundaryDirection<Dim, LowHaloVecType, UpHaloVecType> boundaries;
+
+        LowHaloVecType lowerHaloSizes;
+        UpHaloVecType upperHaloSizes;
+    };
+
+    /**
+     * @brief A container for boundary directions of an n-dimensional volume.
+     * For example, a 1-dimensional (1D) volume has two 0D ends and a 1D center. A 2D volume has 4 0D corners, 4 1D
+     * edges, and one 2D center. In general, there are 3^n boundaries for an nD volume. This class implements begin(),
+     * end(), and length(), and can be iterated over.
+     *
+     * @tparam Dim The dimensionality of the volume that this contains boundaries for.
+     * @tparam LowHaloVecType The vector type used for the lower halo sizes.
+     * @tparam UpHaloVecType The vector type used for the upper halo sizes.
+     */
+    template<uint32_t Dim, alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+    struct BoundaryDirectionsContainer
+    {
+        static_assert(Dim > 0, "0 Dimension Boundary Direction Container is not defined");
+
+        constexpr BoundaryDirectionsContainer(
+            LowHaloVecType const& lowerHaloSizes,
+            UpHaloVecType const& upperHaloSizes)
+            : lowerHaloSizes(lowerHaloSizes)
+            , upperHaloSizes(upperHaloSizes)
+        {
+        }
+
+        [[nodiscard]] constexpr BoundaryDirectionIter<Dim, LowHaloVecType, UpHaloVecType> begin() const
+        {
+            return BoundaryDirectionIter<Dim, LowHaloVecType, UpHaloVecType>{
+                Vec<BoundaryType, Dim>([](int) { return BoundaryType::LOWER; }),
+                lowerHaloSizes,
+                upperHaloSizes};
+        }
+
+        [[nodiscard]] constexpr BoundaryDirectionIter<Dim, LowHaloVecType, UpHaloVecType> end() const
+        {
+            return BoundaryDirectionIter<Dim, LowHaloVecType, UpHaloVecType>{
+                Vec<BoundaryType, Dim>([](int) { return BoundaryType::OOB; }),
+                lowerHaloSizes,
+                upperHaloSizes};
+        }
+
+        [[nodiscard]] static consteval uint32_t length()
+        {
+            return ipow(3u, Dim);
+        }
+
+        [[nodiscard]] static constexpr auto dim()
+        {
+            return Dim;
+        }
+
+    private:
+        LowHaloVecType const lowerHaloSizes;
+        UpHaloVecType const upperHaloSizes;
+    };
+
+    template<alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+    BoundaryDirectionsContainer(LowHaloVecType const& lowerHalos, UpHaloVecType const& upperHalos)
+        -> BoundaryDirectionsContainer<LowHaloVecType::dim(), LowHaloVecType, UpHaloVecType>;
+
+    /** @brief Construct and return a single boundary direction specifying the middle of a volume.
+     */
+    template<uint32_t Dims>
+    [[nodiscard]] constexpr auto makeCoreBoundaryDirection(
+        alpaka::concepts::Vector auto const& lowerHalos,
+        alpaka::concepts::Vector auto const& upperHalos)
+    {
+        return BoundaryDirection<Dims, ALPAKA_TYPEOF(lowerHalos), ALPAKA_TYPEOF(upperHalos)>{
+            fillCVec<BoundaryType, Dims, BoundaryType::MIDDLE>(),
+            lowerHalos,
+            upperHalos};
+    }
+
+    /** @brief Construct and return a single boundary direction specifying the middle of a volume with symmetric halos.
+     */
+    template<uint32_t Dims>
+    [[nodiscard]] constexpr auto makeCoreBoundaryDirection(alpaka::concepts::Vector auto const& halos)
+    {
+        return BoundaryDirection<Dims, ALPAKA_TYPEOF(halos), ALPAKA_TYPEOF(halos)>{
+            fillCVec<BoundaryType, Dims, BoundaryType::MIDDLE>(),
+            halos,
+            halos};
+    }
+
+    /**
+     * @brief Construct and return a single boundary direction specifying the middle of a volume with all halo sizes
+     * set to 1.
+     */
+    template<uint32_t Dims>
+    consteval auto makeCoreBoundaryDirection()
+    {
+        return makeCoreBoundaryDirection<Dims>(fillCVec<uint32_t, Dims, 1u>());
+    }
+
+    /** @brief Construct and return a boundary direction container. This container can be iterated over. See
+     * BoundaryDirectionsContainer.
+     * This constructor uses a default halo size of 1 everywhere.
+     *
+     * @tparam Dims The dimensionality of the container.
+     */
+    template<uint32_t Dims>
+    [[nodiscard]] constexpr auto makeBoundaryDirIterator()
+    {
+        auto lowerHalos = alpaka::fillCVec<uint32_t, Dims, static_cast<uint32_t>(1)>();
+        auto upperHalos = alpaka::fillCVec<uint32_t, Dims, static_cast<uint32_t>(1)>();
+        return BoundaryDirectionsContainer{lowerHalos, upperHalos};
+    }
+
+    /** @brief Construct and return a boundary direction container with the given halo sizes.
+     * This container can be iterated over. See BoundaryDirectionsContainer.
+     * The dimensionality is inferred from the given haloSizes.
+     *
+     * @param haloSizes The halo sizes per dimension. The halos are used for both "ends" of each dimension
+     * symmetrically.
+     */
+    [[nodiscard]] constexpr auto makeBoundaryDirIterator(alpaka::concepts::Vector auto const& haloSizes)
+    {
+        return BoundaryDirectionsContainer{haloSizes, haloSizes};
+    }
+
+    /** @brief Construct and return a boundary direction container with the given halo sizes.
+     * This container can be iterated over. See BoundaryDirectionsContainer.
+     * The dimensionality is inferred from the given halo sizes, which are asserted to be identical.
+     *
+     * @param lowerHaloSizes The lower end halo sizes per dimension. These are the halos from 0 in each dimension.
+     * @param upperHaloSizes The upper end halo sizes per dimension. These are the halos to `size()` in each dimension.
+     */
+    [[nodiscard]] constexpr auto makeBoundaryDirIterator(
+        alpaka::concepts::Vector auto const& lowerHaloSizes,
+        alpaka::concepts::Vector auto const& upperHaloSizes)
+    {
+        static_assert(
+            ALPAKA_TYPEOF(lowerHaloSizes)::dim() == ALPAKA_TYPEOF(upperHaloSizes)::dim(),
+            "Dimension mismatch");
+        return BoundaryDirectionsContainer{lowerHaloSizes, upperHaloSizes};
+    }
+
+    /** @brief Construct and return a boundary direction container for the given view with default (size 1) halo
+     * sizes. This container can be iterated over. See BoundaryDirectionsContainer.
+     * For custom halo sizes, use one of the other overloads.
+     *
+     * @param view The given view; only the dimension of the view matters.
+     */
+    [[nodiscard]] constexpr auto makeBoundaryDirIterator(alpaka::concepts::View auto const& view)
+    {
+        return makeBoundaryDirIterator<static_cast<uint32_t>(ALPAKA_TYPEOF(view)::dim())>();
+    }
+
+    namespace trait
+    {
+        template<typename T>
+        struct IsBoundaryDirection : std::false_type
+        {
+        };
+
+        template<uint32_t Dim, alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+        requires(Dim == LowHaloVecType::dim() && Dim == UpHaloVecType::dim())
+        struct IsBoundaryDirection<BoundaryDirection<Dim, LowHaloVecType, UpHaloVecType>> : std::true_type
+        {
+        };
+    } // namespace trait
+
+    template<typename T>
+    constexpr bool isBoundaryDirection_v = trait::IsBoundaryDirection<T>::value;
+
+    namespace concepts
+    {
+        /** @brief Concept checking whether T is a boundary direction.
+         */
+        template<typename T>
+        concept BoundaryDirection = isBoundaryDirection_v<T>;
+    } // namespace concepts
+
+    std::ostream& operator<<(std::ostream& os, concepts::BoundaryDirection auto const& bd)
+    {
+        for(auto i = 0; i < bd.dim(); ++i)
+        {
+            switch(bd.data[i])
+            {
+            case BoundaryType::LOWER:
+                os << 'v';
+                break;
+            case BoundaryType::MIDDLE:
+                os << '-';
+                break;
+            case BoundaryType::UPPER:
+                os << '^';
+                break;
+            case BoundaryType::OOB:
+                [[fallthrough]];
+            default:
+                os << 'x';
+                break;
+            }
+        }
+
+        if(bd.isPoint())
+            os << " (point) ";
+        if(bd.isLine())
+            os << " (line)  ";
+        if(bd.isPlane())
+            os << " (plane) ";
+        if(bd.isVolume())
+            os << " (volume)";
+        if(bd.boundaryDimensionality() >= 4)
+            os << " (" << bd.boundaryDimensionality() << "D volume)";
+
+        return os;
+    }
+} // namespace alpaka

--- a/include/alpaka/mem/BoundaryIter.hpp
+++ b/include/alpaka/mem/BoundaryIter.hpp
@@ -70,7 +70,7 @@ namespace alpaka
         [[nodiscard]] constexpr uint32_t boundaryDimensionality() const
         {
             uint32_t c = 0;
-            for(auto i = 0; i < T_dim; ++i)
+            for(uint32_t i = 0; i < T_dim; ++i)
             {
                 if(data[i] == BoundaryType::MIDDLE)
                     ++c;
@@ -384,7 +384,7 @@ namespace alpaka
 
     std::ostream& operator<<(std::ostream& os, concepts::BoundaryDirection auto const& bd)
     {
-        for(auto i = 0; i < bd.dim(); ++i)
+        for(uint32_t i = 0; i < bd.dim(); ++i)
         {
             switch(bd.data[i])
             {

--- a/include/alpaka/mem/BoundaryIter.hpp
+++ b/include/alpaka/mem/BoundaryIter.hpp
@@ -33,23 +33,23 @@ namespace alpaka
      * @brief An n-dimensional boundary direction. Encodes a single unique boundary of an nD volume, e.g., a specific
      * corner of a 2D plane or a side of a 3D cube.
      *
-     * @tparam Dim The dimensionality of the volume that this is a boundary direction for.
-     * @tparam LowHaloVecType The vector type used for the lower halo sizes.
-     * @tparam UpHaloVecType The vector type used for the upper halo sizes.
+     * @tparam T_dim The dimensionality of the volume that this is a boundary direction for.
+     * @tparam T_LowHaloVec The vector type used for the lower halo sizes.
+     * @tparam T_UpHaloVec The vector type used for the upper halo sizes.
      */
-    template<uint32_t Dim, alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+    template<uint32_t T_dim, concepts::Vector T_LowHaloVec, concepts::Vector T_UpHaloVec>
     struct BoundaryDirection
     {
-        using BoundaryVecType = alpaka::Vec<BoundaryType, Dim>;
+        using T_BoundaryVec = Vec<BoundaryType, T_dim>;
 
-        BoundaryVecType data;
-        LowHaloVecType lowerHaloSize;
-        UpHaloVecType upperHaloSize;
+        T_BoundaryVec data;
+        T_LowHaloVec lowerHaloSize;
+        T_UpHaloVec upperHaloSize;
 
         constexpr BoundaryDirection(
-            alpaka::concepts::Vector auto const& boundaries,
-            LowHaloVecType const& lower_halo_sizes,
-            UpHaloVecType const& upper_halo_sizes)
+            concepts::Vector auto const& boundaries,
+            T_LowHaloVec const& lower_halo_sizes,
+            T_UpHaloVec const& upper_halo_sizes)
             : data(boundaries)
             , lowerHaloSize(lower_halo_sizes)
             , upperHaloSize(upper_halo_sizes)
@@ -58,13 +58,13 @@ namespace alpaka
 
         [[nodiscard]] static constexpr uint32_t dim()
         {
-            return Dim;
+            return T_dim;
         }
 
         [[nodiscard]] constexpr uint32_t boundaryDimensionality() const
         {
             uint32_t c = 0;
-            for(auto i = 0; i < Dim; ++i)
+            for(auto i = 0; i < T_dim; ++i)
             {
                 if(data[i] == BoundaryType::MIDDLE)
                     ++c;
@@ -98,26 +98,26 @@ namespace alpaka
     /**
      * @brief The iterator type for [`BoundaryDirectionsContainer`](@ref)
      *
-     * @tparam Dim The dimensionality of the volume that this is a boundary direction iterator for.
-     * @tparam LowHaloVecType The vector type used for the lower halo sizes.
-     * @tparam UpHaloVecType The vector type used for the upper halo sizes.
+     * @tparam T_dim The dimensionality of the volume that this is a boundary direction iterator for.
+     * @tparam T_LowHaloVec The vector type used for the lower halo sizes.
+     * @tparam T_UpHaloVec The vector type used for the upper halo sizes.
      */
-    template<uint32_t Dim, alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+    template<uint32_t T_dim, concepts::Vector T_LowHaloVec, concepts::Vector T_UpHaloVec>
     struct BoundaryDirectionIter
     {
-        using BoundaryVecType = alpaka::Vec<BoundaryType, Dim>;
+        using T_BoundaryVec = Vec<BoundaryType, T_dim>;
 
         using difference_type = std::ptrdiff_t;
-        using value_type = BoundaryDirection<Dim, LowHaloVecType, UpHaloVecType>;
+        using value_type = BoundaryDirection<T_dim, T_LowHaloVec, T_UpHaloVec>;
         using reference = value_type&;
         using const_reference = value_type const&;
         using pointer = value_type*;
         using const_pointer = value_type const*;
 
         constexpr BoundaryDirectionIter(
-            BoundaryVecType const& boundaries,
-            LowHaloVecType const& lower_halo_sizes,
-            UpHaloVecType const& upper_halo_sizes)
+            T_BoundaryVec const& boundaries,
+            T_LowHaloVec const& lower_halo_sizes,
+            T_UpHaloVec const& upper_halo_sizes)
             : boundaries(boundaries, lower_halo_sizes, upper_halo_sizes)
             , lowerHaloSizes(lower_halo_sizes)
             , upperHaloSizes(upper_halo_sizes)
@@ -136,7 +136,7 @@ namespace alpaka
 
         constexpr auto& operator++()
         {
-            uint32_t i = Dim - 1;
+            uint32_t i = T_dim - 1;
             bool oob = true;
             while(i != static_cast<uint32_t>(-1))
             {
@@ -169,23 +169,25 @@ namespace alpaka
             if(oob)
             {
                 boundaries
-                    = {Vec<BoundaryType, Dim>([](int) { return BoundaryType::OOB; }), lowerHaloSizes, upperHaloSizes};
+                    = {Vec<BoundaryType, T_dim>([](int) { return BoundaryType::OOB; }),
+                       lowerHaloSizes,
+                       upperHaloSizes};
             }
             return *this;
         }
 
-        [[nodiscard]] static constexpr auto dim()
+        [[nodiscard]] static consteval auto dim()
         {
-            return Dim;
+            return T_dim;
         }
 
         [[nodiscard]] constexpr auto operator<=>(BoundaryDirectionIter const&) const = default;
 
     private:
-        BoundaryDirection<Dim, LowHaloVecType, UpHaloVecType> boundaries;
+        BoundaryDirection<T_dim, T_LowHaloVec, T_UpHaloVec> boundaries;
 
-        LowHaloVecType lowerHaloSizes;
-        UpHaloVecType upperHaloSizes;
+        T_LowHaloVec lowerHaloSizes;
+        T_UpHaloVec upperHaloSizes;
     };
 
     /**
@@ -194,78 +196,76 @@ namespace alpaka
      * edges, and one 2D center. In general, there are 3^n boundaries for an nD volume. This class implements begin(),
      * end(), and length(), and can be iterated over.
      *
-     * @tparam Dim The dimensionality of the volume that this contains boundaries for.
-     * @tparam LowHaloVecType The vector type used for the lower halo sizes.
-     * @tparam UpHaloVecType The vector type used for the upper halo sizes.
+     * @tparam T_dim The dimensionality of the volume that this contains boundaries for.
+     * @tparam T_LowHaloVec The vector type used for the lower halo sizes.
+     * @tparam T_UpHaloVec The vector type used for the upper halo sizes.
      */
-    template<uint32_t Dim, alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+    template<uint32_t T_dim, concepts::Vector T_LowHaloVec, concepts::Vector T_UpHaloVec>
     struct BoundaryDirectionsContainer
     {
-        static_assert(Dim > 0, "0 Dimension Boundary Direction Container is not defined");
+        static_assert(T_dim > 0, "0 Dimension Boundary Direction Container is not defined");
 
-        constexpr BoundaryDirectionsContainer(
-            LowHaloVecType const& lowerHaloSizes,
-            UpHaloVecType const& upperHaloSizes)
+        constexpr BoundaryDirectionsContainer(T_LowHaloVec const& lowerHaloSizes, T_UpHaloVec const& upperHaloSizes)
             : lowerHaloSizes(lowerHaloSizes)
             , upperHaloSizes(upperHaloSizes)
         {
         }
 
-        [[nodiscard]] constexpr BoundaryDirectionIter<Dim, LowHaloVecType, UpHaloVecType> begin() const
+        [[nodiscard]] constexpr BoundaryDirectionIter<T_dim, T_LowHaloVec, T_UpHaloVec> begin() const
         {
-            return BoundaryDirectionIter<Dim, LowHaloVecType, UpHaloVecType>{
-                Vec<BoundaryType, Dim>([](int) { return BoundaryType::LOWER; }),
+            return BoundaryDirectionIter<T_dim, T_LowHaloVec, T_UpHaloVec>{
+                Vec<BoundaryType, T_dim>([](int) { return BoundaryType::LOWER; }),
                 lowerHaloSizes,
                 upperHaloSizes};
         }
 
-        [[nodiscard]] constexpr BoundaryDirectionIter<Dim, LowHaloVecType, UpHaloVecType> end() const
+        [[nodiscard]] constexpr BoundaryDirectionIter<T_dim, T_LowHaloVec, T_UpHaloVec> end() const
         {
-            return BoundaryDirectionIter<Dim, LowHaloVecType, UpHaloVecType>{
-                Vec<BoundaryType, Dim>([](int) { return BoundaryType::OOB; }),
+            return BoundaryDirectionIter<T_dim, T_LowHaloVec, T_UpHaloVec>{
+                Vec<BoundaryType, T_dim>([](int) { return BoundaryType::OOB; }),
                 lowerHaloSizes,
                 upperHaloSizes};
         }
 
         [[nodiscard]] static consteval uint32_t length()
         {
-            return ipow(3u, Dim);
+            return ipow(3u, T_dim);
         }
 
-        [[nodiscard]] static constexpr auto dim()
+        [[nodiscard]] static consteval auto dim()
         {
-            return Dim;
+            return T_dim;
         }
 
     private:
-        LowHaloVecType const lowerHaloSizes;
-        UpHaloVecType const upperHaloSizes;
+        T_LowHaloVec const lowerHaloSizes;
+        T_UpHaloVec const upperHaloSizes;
     };
 
-    template<alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+    template<concepts::Vector LowHaloVecType, concepts::Vector UpHaloVecType>
     BoundaryDirectionsContainer(LowHaloVecType const& lowerHalos, UpHaloVecType const& upperHalos)
         -> BoundaryDirectionsContainer<LowHaloVecType::dim(), LowHaloVecType, UpHaloVecType>;
 
     /** @brief Construct and return a single boundary direction specifying the middle of a volume.
      */
-    template<uint32_t Dims>
+    template<uint32_t T_dim>
     [[nodiscard]] constexpr auto makeCoreBoundaryDirection(
-        alpaka::concepts::Vector auto const& lowerHalos,
-        alpaka::concepts::Vector auto const& upperHalos)
+        concepts::Vector auto const& lowerHalos,
+        concepts::Vector auto const& upperHalos)
     {
-        return BoundaryDirection<Dims, ALPAKA_TYPEOF(lowerHalos), ALPAKA_TYPEOF(upperHalos)>{
-            fillCVec<BoundaryType, Dims, BoundaryType::MIDDLE>(),
+        return BoundaryDirection<T_dim, ALPAKA_TYPEOF(lowerHalos), ALPAKA_TYPEOF(upperHalos)>{
+            fillCVec<BoundaryType, T_dim, BoundaryType::MIDDLE>(),
             lowerHalos,
             upperHalos};
     }
 
     /** @brief Construct and return a single boundary direction specifying the middle of a volume with symmetric halos.
      */
-    template<uint32_t Dims>
-    [[nodiscard]] constexpr auto makeCoreBoundaryDirection(alpaka::concepts::Vector auto const& halos)
+    template<uint32_t T_dim>
+    [[nodiscard]] constexpr auto makeCoreBoundaryDirection(concepts::Vector auto const& halos)
     {
-        return BoundaryDirection<Dims, ALPAKA_TYPEOF(halos), ALPAKA_TYPEOF(halos)>{
-            fillCVec<BoundaryType, Dims, BoundaryType::MIDDLE>(),
+        return BoundaryDirection<T_dim, ALPAKA_TYPEOF(halos), ALPAKA_TYPEOF(halos)>{
+            fillCVec<BoundaryType, T_dim, BoundaryType::MIDDLE>(),
             halos,
             halos};
     }
@@ -274,23 +274,23 @@ namespace alpaka
      * @brief Construct and return a single boundary direction specifying the middle of a volume with all halo sizes
      * set to 1.
      */
-    template<uint32_t Dims>
+    template<uint32_t T_dim>
     consteval auto makeCoreBoundaryDirection()
     {
-        return makeCoreBoundaryDirection<Dims>(fillCVec<uint32_t, Dims, 1u>());
+        return makeCoreBoundaryDirection<T_dim>(fillCVec<uint32_t, T_dim, 1u>());
     }
 
     /** @brief Construct and return a boundary direction container. This container can be iterated over. See
      * BoundaryDirectionsContainer.
      * This constructor uses a default halo size of 1 everywhere.
      *
-     * @tparam Dims The dimensionality of the container.
+     * @tparam T_dim The dimensionality of the container.
      */
-    template<uint32_t Dims>
+    template<uint32_t T_dim>
     [[nodiscard]] constexpr auto makeBoundaryDirIterator()
     {
-        auto lowerHalos = alpaka::fillCVec<uint32_t, Dims, static_cast<uint32_t>(1)>();
-        auto upperHalos = alpaka::fillCVec<uint32_t, Dims, static_cast<uint32_t>(1)>();
+        auto lowerHalos = fillCVec<uint32_t, T_dim, static_cast<uint32_t>(1)>();
+        auto upperHalos = fillCVec<uint32_t, T_dim, static_cast<uint32_t>(1)>();
         return BoundaryDirectionsContainer{lowerHalos, upperHalos};
     }
 
@@ -301,7 +301,7 @@ namespace alpaka
      * @param haloSizes The halo sizes per dimension. The halos are used for both "ends" of each dimension
      * symmetrically.
      */
-    [[nodiscard]] constexpr auto makeBoundaryDirIterator(alpaka::concepts::Vector auto const& haloSizes)
+    [[nodiscard]] constexpr auto makeBoundaryDirIterator(concepts::Vector auto const& haloSizes)
     {
         return BoundaryDirectionsContainer{haloSizes, haloSizes};
     }
@@ -314,12 +314,12 @@ namespace alpaka
      * @param upperHaloSizes The upper end halo sizes per dimension. These are the halos to `size()` in each dimension.
      */
     [[nodiscard]] constexpr auto makeBoundaryDirIterator(
-        alpaka::concepts::Vector auto const& lowerHaloSizes,
-        alpaka::concepts::Vector auto const& upperHaloSizes)
+        concepts::Vector auto const& lowerHaloSizes,
+        concepts::Vector auto const& upperHaloSizes)
     {
         static_assert(
             ALPAKA_TYPEOF(lowerHaloSizes)::dim() == ALPAKA_TYPEOF(upperHaloSizes)::dim(),
-            "Dimension mismatch");
+            "dimension mismatch");
         return BoundaryDirectionsContainer{lowerHaloSizes, upperHaloSizes};
     }
 
@@ -329,7 +329,7 @@ namespace alpaka
      *
      * @param view The given view; only the dimension of the view matters.
      */
-    [[nodiscard]] constexpr auto makeBoundaryDirIterator(alpaka::concepts::View auto const& view)
+    [[nodiscard]] constexpr auto makeBoundaryDirIterator(concepts::View auto const& view)
     {
         return makeBoundaryDirIterator<static_cast<uint32_t>(ALPAKA_TYPEOF(view)::dim())>();
     }
@@ -341,9 +341,9 @@ namespace alpaka
         {
         };
 
-        template<uint32_t Dim, alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
-        requires(Dim == LowHaloVecType::dim() && Dim == UpHaloVecType::dim())
-        struct IsBoundaryDirection<BoundaryDirection<Dim, LowHaloVecType, UpHaloVecType>> : std::true_type
+        template<uint32_t T_dim, concepts::Vector T_LowHaloVec, concepts::Vector T_UpHaloVec>
+        requires(T_dim == T_LowHaloVec::dim() && T_dim == T_UpHaloVec::dim())
+        struct IsBoundaryDirection<BoundaryDirection<T_dim, T_LowHaloVec, T_UpHaloVec>> : std::true_type
         {
         };
     } // namespace trait

--- a/include/alpaka/mem/BoundaryIter.hpp
+++ b/include/alpaka/mem/BoundaryIter.hpp
@@ -56,11 +56,17 @@ namespace alpaka
         {
         }
 
+        /** @brief The dimensionality of the whole volume that this is a boundary direction for. Not to be confused
+         * with boundaryDimensionality().
+         */
         [[nodiscard]] static constexpr uint32_t dim()
         {
             return T_dim;
         }
 
+        /** @brief The dimensionality of the boundary direction. For example, a vertex (corner) of a 3D-volume (cube)
+         * is 0-dimensional. See also the functions isVertex(), isEdge(), etc.
+         */
         [[nodiscard]] constexpr uint32_t boundaryDimensionality() const
         {
             uint32_t c = 0;
@@ -72,24 +78,41 @@ namespace alpaka
             return c;
         }
 
-        [[nodiscard]] constexpr bool isPoint() const
+        /** @brief Return true if this boundary direction describes a vertex, for example the corner of a plane.
+         */
+        [[nodiscard]] constexpr bool isVertex() const
         {
             return boundaryDimensionality() == 0;
         }
 
-        [[nodiscard]] constexpr bool isLine() const
+        /** @brief Return true if this boundary direction describes an edge, for example any of the 12 edges of a cube.
+         */
+        [[nodiscard]] constexpr bool isEdge() const
         {
             return boundaryDimensionality() == 1;
         }
 
-        [[nodiscard]] constexpr bool isPlane() const
+        /** @brief Return true if this boundary direction describes a face, for example any of the 6 sides of a cube.
+         */
+        [[nodiscard]] constexpr bool isFace() const
         {
             return boundaryDimensionality() == 2;
         }
 
-        [[nodiscard]] constexpr bool isVolume() const
+        /** @brief Return true if this boundary direction describes a cell, for example the interior of a cube or one
+         * of the 8 cells in a tesseract.
+         */
+        [[nodiscard]] constexpr bool isCell() const
         {
             return boundaryDimensionality() == 3;
+        }
+
+        /** @brief Return true if this boundary direction describes the interior of a volume, like the 2D interior of a
+         * plane or the 3D interior of a cube.
+         */
+        [[nodiscard]] constexpr bool isInterior() const
+        {
+            return boundaryDimensionality() == dim();
         }
 
         [[nodiscard]] constexpr auto operator<=>(BoundaryDirection const&) const = default;
@@ -382,14 +405,14 @@ namespace alpaka
             }
         }
 
-        if(bd.isPoint())
-            os << " (point) ";
-        if(bd.isLine())
-            os << " (line)  ";
-        if(bd.isPlane())
-            os << " (plane) ";
-        if(bd.isVolume())
-            os << " (volume)";
+        if(bd.isVertex())
+            os << " (vertex) ";
+        if(bd.isEdge())
+            os << " (edge)   ";
+        if(bd.isFace())
+            os << " (face)   ";
+        if(bd.isCell())
+            os << " (cell)   ";
         if(bd.boundaryDimensionality() >= 4)
             os << " (" << bd.boundaryDimensionality() << "D volume)";
 

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/Vec.hpp"
 #include "alpaka/core/PP.hpp"
 #include "alpaka/core/common.hpp"
+#include "alpaka/mem/BoundaryIter.hpp"
 
 #include <cstdint>
 
@@ -101,6 +102,38 @@ namespace alpaka
         using type = typename T_Begin::type;
     };
 
+    template<uint32_t Dim, alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+    constexpr auto makeDirectionSubRange(
+        auto const range,
+        alpaka::BoundaryDirection<Dim, LowHaloVecType, UpHaloVecType> const& boundaryDir)
+    {
+        auto m_begin = Vec<uint32_t, Dim>::all(0u);
+        auto m_end = Vec<uint32_t, Dim>::all(0u);
+        for(uint32_t i = 0; i < Dim; ++i)
+        {
+            switch(boundaryDir.data[i])
+            {
+            case BoundaryType::LOWER:
+                m_begin[i] = range.m_begin[i];
+                m_end[i] = range.m_begin[i] + boundaryDir.lowerHaloSize[i];
+                break;
+            case BoundaryType::UPPER:
+                m_begin[i] = range.m_end[i] - boundaryDir.upperHaloSize[i];
+                m_end[i] = range.m_end[i];
+                break;
+            case BoundaryType::MIDDLE:
+                m_begin[i] = range.m_begin[i] + boundaryDir.lowerHaloSize[i];
+                m_end[i] = range.m_end[i] - boundaryDir.upperHaloSize[i];
+                break;
+            case BoundaryType::OOB:
+                [[fallthrough]];
+            default:
+                assert(false);
+            }
+        }
+        return IdxRange{m_begin, m_end, range.m_stride};
+    }
+
     namespace internal
     {
         template<typename T_To, concepts::Vector T_End, concepts::Vector T_Begin, concepts::Vector T_Stride>
@@ -163,7 +196,7 @@ namespace alpaka
 
     namespace concepts
     {
-        /** Concept to check if a type is a index range
+        /** Concept to check if a type is an index range
          *
          * @tparam T Type to check
          * @tparam T_ValueType enforce a value type of the index range, if not provided the type is not checked
@@ -175,7 +208,7 @@ namespace alpaka
               && (std::same_as<T_ValueType, typename T::IdxType> || std::same_as<T_ValueType, alpaka::NotRequired>)
               && ((T_dim == alpaka::notRequiredDim) || (T::dim() == T_dim));
 
-        /** Concept to check if a type is a lazy evaluated index range
+        /** Concept to check if a type is a lazy-evaluated index range
          *
          * @attention the value type and dimension can not be evaluated for lazy index ranges.
          *

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -102,14 +102,14 @@ namespace alpaka
         using type = typename T_Begin::type;
     };
 
-    template<uint32_t Dim, alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+    template<uint32_t T_dim, alpaka::concepts::Vector T_LowHaloVec, alpaka::concepts::Vector T_UpHaloVec>
     constexpr auto makeDirectionSubRange(
         auto const range,
-        alpaka::BoundaryDirection<Dim, LowHaloVecType, UpHaloVecType> const& boundaryDir)
+        alpaka::BoundaryDirection<T_dim, T_LowHaloVec, T_UpHaloVec> const& boundaryDir)
     {
-        auto m_begin = Vec<uint32_t, Dim>::all(0u);
-        auto m_end = Vec<uint32_t, Dim>::all(0u);
-        for(uint32_t i = 0; i < Dim; ++i)
+        auto m_begin = Vec<uint32_t, T_dim>::all(0u);
+        auto m_end = Vec<uint32_t, T_dim>::all(0u);
+        for(uint32_t i = 0; i < T_dim; ++i)
         {
             switch(boundaryDir.data[i])
             {
@@ -128,7 +128,7 @@ namespace alpaka
             case BoundaryType::OOB:
                 [[fallthrough]];
             default:
-                assert(false);
+                ALPAKA_ASSERT_ACC(false);
             }
         }
         return IdxRange{m_begin, m_end, range.m_stride};

--- a/include/alpaka/mem/ThreadSpace.hpp
+++ b/include/alpaka/mem/ThreadSpace.hpp
@@ -52,8 +52,9 @@ namespace alpaka
         }
 
         template<concepts::CVector T_CSelect>
-        constexpr ThreadSpace mapTo(T_CSelect selection) const requires(T_ThreadIdx::dim() == T_CSelect::dim())
+        constexpr ThreadSpace mapTo(T_CSelect selection) const requires(T_ThreadIdx::dim() <= T_CSelect::dim())
         {
+            static_assert(T_ThreadIdx::dim() == T_CSelect::dim(), "can not map to a larger dimension");
             return *this;
         }
 

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -4,22 +4,18 @@
 
 #pragma once
 
-#include "alpaka/core/config.hpp"
 #include "alpaka/interface.hpp"
 #include "alpaka/internal/interface.hpp"
+#include "alpaka/mem/BoundaryIter.hpp"
 #include "alpaka/mem/MdSpan.hpp"
 #include "alpaka/mem/concepts.hpp"
-#include "alpaka/onHost/Handle.hpp"
 #include "alpaka/onHost/interface.hpp"
 
 #include <cstdint>
 #include <functional>
-#include <memory>
-#include <sstream>
 
 namespace alpaka
 {
-
     /** Non owning view to data
      *
      * This view is only holding a points to real data, copying the view is cheap.
@@ -181,6 +177,37 @@ namespace alpaka
             assert((offsetMd + extentMd <= this->getExtents()).reduce(std::logical_and{}));
             auto shiftedPtr = &(*this)[offsetMd];
             return makeView(T_Api{}, shiftedPtr, extentMd, this->getPitches(), Alignment<>{});
+        }
+        
+         template<alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+        constexpr auto getSubView(
+            alpaka::BoundaryDirection<View::dim(), LowHaloVecType, UpHaloVecType> boundaryDir) const
+        {
+            constexpr uint32_t dim = View::dim();
+            auto offset = alpaka::Vec<uint32_t, dim>{};
+            auto extents = alpaka::Vec<uint32_t, dim>{};
+
+            for(uint32_t i = 0; i < dim; ++i)
+            {
+                switch(boundaryDir.data[i])
+                {
+                case BoundaryType::LOWER:
+                    offset[i] = 0;
+                    extents[i] = boundaryDir.lowerHaloSize[i];
+                    break;
+                case BoundaryType::UPPER:
+                    offset[i] = this->getExtents()[i] - boundaryDir.upperHaloSize[i];
+                    extents[i] = boundaryDir.upperHaloSize[i];
+                    break;
+                case BoundaryType::MIDDLE:
+                    offset[i] = boundaryDir.lowerHaloSize[i];
+                    extents[i] = this->getExtents()[i] - boundaryDir.lowerHaloSize[i] - boundaryDir.upperHaloSize[i];
+                    break;
+                default:
+                    throw std::invalid_argument("invalid direction");
+                }
+            }
+            return getSubView(offset, extents);
         }
     };
 

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -178,7 +178,7 @@ namespace alpaka
             auto shiftedPtr = &(*this)[offsetMd];
             return makeView(T_Api{}, shiftedPtr, extentMd, this->getPitches(), Alignment<>{});
         }
-        
+
         template<alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
         constexpr auto getSubView(
             alpaka::BoundaryDirection<View::dim(), LowHaloVecType, UpHaloVecType> boundaryDir) const

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -179,7 +179,7 @@ namespace alpaka
             return makeView(T_Api{}, shiftedPtr, extentMd, this->getPitches(), Alignment<>{});
         }
         
-         template<alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
+        template<alpaka::concepts::Vector LowHaloVecType, alpaka::concepts::Vector UpHaloVecType>
         constexpr auto getSubView(
             alpaka::BoundaryDirection<View::dim(), LowHaloVecType, UpHaloVecType> boundaryDir) const
         {

--- a/include/alpaka/onAcc/interface.hpp
+++ b/include/alpaka/onAcc/interface.hpp
@@ -13,6 +13,7 @@
 
 #include "alpaka/Vec.hpp"
 #include "alpaka/concepts.hpp"
+#include "alpaka/mem/BoundaryIter.hpp"
 #include "alpaka/mem/Iter.hpp"
 #include "alpaka/mem/MdSpan.hpp"
 #include "alpaka/onAcc/internal/interface.hpp"
@@ -54,6 +55,27 @@ namespace alpaka::onAcc
             Op<void, ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(DomainSpec{workGroup, range}), T_Traverse, T_IdxLayout>{}(
                 acc,
                 DomainSpec{workGroup, range},
+                traverse,
+                idxLayout);
+    }
+
+    /** Specialization for an index container with a given boundary direction of the volume described by the range.
+     */
+    template<concepts::IdxTraversing T_Traverse = traverse::Flat, concepts::IdxMapping T_IdxLayout = layout::Optimized>
+    ALPAKA_FN_HOST_ACC constexpr auto makeIdxMap(
+        auto const& acc,
+        auto const workGroup,
+        auto const range,
+        alpaka::concepts::BoundaryDirection auto const& bd,
+        T_Traverse traverse = T_Traverse{},
+        T_IdxLayout idxLayout = T_IdxLayout{})
+    {
+        static_assert(ALPAKA_TYPEOF(bd)::dim() == ALPAKA_TYPEOF(range)::dim());
+        auto const subRange = makeDirectionSubRange(range, bd);
+        return internal::MakeIter::
+            Op<void, ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(DomainSpec{workGroup, subRange}), T_Traverse, T_IdxLayout>{}(
+                acc,
+                DomainSpec{workGroup, subRange},
                 traverse,
                 idxLayout);
     }

--- a/include/alpaka/onHost/algo/iota.hpp
+++ b/include/alpaka/onHost/algo/iota.hpp
@@ -49,7 +49,7 @@ namespace alpaka::onHost
     }
 
     /**
-     * A available default executor will be selected automaticlally. The default executor is a executor with most
+     * An available default executor will be selected automatically. The default executor is the executor with the most
      * parallelism/performance.
      */
     template<typename T_DataType, typename T_Device>
@@ -61,7 +61,13 @@ namespace alpaka::onHost
                 std::is_convertible<T_DataType, typename alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(outOther)>>...>)
     {
         auto executor = supportedMappings(queue.getDevice(), exec::allExecutors);
-        internal::iota<T_DataType>(queue, std::get<0>(executor), ALPAKA_FORWARD(out0), ALPAKA_FORWARD(outOther)...);
+        internal::iota<T_DataType>(
+            queue,
+            std::get<0>(executor),
+            onHost::getExtents(out0),
+            initValue,
+            ALPAKA_FORWARD(out0),
+            ALPAKA_FORWARD(outOther)...);
     }
 
     /** @} */

--- a/include/alpaka/utility.hpp
+++ b/include/alpaka/utility.hpp
@@ -106,17 +106,21 @@ namespace alpaka
 
     /** @} */
 
+    /**
+     * @brief Helper function calculating the integer power for the given base and exponent.
+     */
     constexpr auto ipow(std::integral auto const base, std::integral auto const exponent)
         requires std::same_as<ALPAKA_TYPEOF(base), ALPAKA_TYPEOF(exponent)>
     {
-        ALPAKA_TYPEOF(base) result = 1;
-        if(exponent == 0)
+        using T_Res = ALPAKA_TYPEOF(base);
+        T_Res result = T_Res{1};
+        if(exponent == T_Res{0})
             return result;
 
-        result = ipow(base, exponent / 2);
+        result = ipow(base, exponent / T_Res{2});
         result *= result;
 
-        if(exponent & 1)
+        if(exponent % T_Res{2})
             result *= base;
 
         return result;

--- a/include/alpaka/utility.hpp
+++ b/include/alpaka/utility.hpp
@@ -106,4 +106,19 @@ namespace alpaka
 
     /** @} */
 
+    constexpr auto ipow(std::integral auto const base, std::integral auto const exponent)
+        requires std::same_as<ALPAKA_TYPEOF(base), ALPAKA_TYPEOF(exponent)>
+    {
+        ALPAKA_TYPEOF(base) result = 1;
+        if(exponent == 0)
+            return result;
+
+        result = ipow(base, exponent / 2);
+        result *= result;
+
+        if(exponent & 1)
+            result *= base;
+
+        return result;
+    }
 } // namespace alpaka


### PR DESCRIPTION
This adds boundary iteration.

- New functionality for iterating over volume (n-dimensional) boundaries using `BoundaryDirectionsContainer` and others.
- Example for the usage of the boundary iteration
- ~~Adaptation of the heatEquation2D to use boundary iteration~~ [update by @psychocoderHPC ]

There are still some improvements to be made. 
- make an n-dimensional stencil example
- use larger halos/stencils in an example
- make it easier to copy chunks with halos to shared memory (see heat equation stencil kernel)
- make it easier to start parallel kernels for boundary iteration