### PR TITLE
update documentation

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -392,7 +392,7 @@ IDL_PROPERTY_SUPPORT   = YES
 # all members of a group must be documented explicitly.
 # The default value is: NO.
 
-DISTRIBUTE_GROUP_DOC   = NO
+DISTRIBUTE_GROUP_DOC   = YES
 
 # If one adds a struct or class to a group and this option is enabled, then also
 # any nested class or struct is added to the same group. By default this option
@@ -944,7 +944,11 @@ EXCLUDE_PATTERNS       =
 EXCLUDE_SYMBOLS        = *internal* \
                          detail* \
                          CallbackThread \
-                         std::*
+                         std::* \
+                         unifiedCudaHip \
+                         syclGeneric \
+                         ::detail* \
+                         NO_HTML \
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/docs/Doxyfile_dev
+++ b/docs/Doxyfile_dev
@@ -392,7 +392,7 @@ IDL_PROPERTY_SUPPORT   = YES
 # all members of a group must be documented explicitly.
 # The default value is: NO.
 
-DISTRIBUTE_GROUP_DOC   = NO
+DISTRIBUTE_GROUP_DOC   = YES
 
 # If one adds a struct or class to a group and this option is enabled, then also
 # any nested class or struct is added to the same group. By default this option
@@ -473,7 +473,7 @@ EXTRACT_ALL            = YES
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 
 # If the EXTRACT_PRIV_VIRTUAL tag is set to YES, documented private virtual
 # methods of a class will be included in the documentation.
@@ -941,7 +941,7 @@ EXCLUDE_PATTERNS       =
 # exclude all test directories use the pattern */test/*
 
 # do not include specialization of standard library traits/methods
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = NO_HTML
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/include/alpaka/onAcc/interface.hpp
+++ b/include/alpaka/onAcc/interface.hpp
@@ -6,8 +6,9 @@
 
 /** @file
  *
- * On some constexpr function signatures ALPAKA_FN_HOST_ACC is required for cuda else __host__ function called from
- * __host__ __device__ warning is popping up and generated code is wrong.
+ * On some constexpr function signatures `ALPAKA_FN_HOST_ACC` is required for CUDA;
+ * otherwise a `__host__` function called from a `__host__ __device__` context
+ * triggers a warning and the generated code is wrong.
  */
 
 #include "alpaka/Vec.hpp"
@@ -21,17 +22,25 @@
 /** functionality which is usable on the accelerator compute device from within a kernel. */
 namespace alpaka::onAcc
 {
-    /** Creates an index container that can be traversed with a range based for loop.
+    /**@{
+     * @name range‑based loop indexable index container
+     */
+
+    /** Creates an index container
      *
-     * @param workGroup participating thread description. More than one thread can have the same index within the
-     * group. All worker with the same id will get the same index as result.
-     * @param range Index range description.
-     * @param traverse Policy to configure the method used to find the next valid index for a worker. @see namespace
-     * traverse
-     * @param idxLayout Policy to define how indecision will be mapped to worker threads. @see namsepsace layout
-     * @return
+     * The index data type is deduced from the supplied range.
+     * The traversal policy (`T_Traverse`) defines how the next valid index is found for a worker and
+     * defaults to @c traverse::Flat.
+     * The mapping policy (`T_IdxLayout`) defines how the index is mapped to worker threads and defaults to
+     * @c layout::Optimized.
      *
-     * @{
+     * @param workGroup Description of the participating thread group.  More than one
+     *                  thread can have the same index within the group; all workers
+     *                  with the same id obtain the same index as result.
+     * @param range     Index range description.
+     * @param traverse  Policy describing how the next value can be found.
+     * @param idxLayout Policy describing how real worker threads will be mapped to the range.
+     * @return A index container that can be used in a range‑based for loop.
      */
     template<concepts::IdxTraversing T_Traverse = traverse::Flat, concepts::IdxMapping T_IdxLayout = layout::Optimized>
     ALPAKA_FN_HOST_ACC constexpr auto makeIdxMap(
@@ -49,6 +58,22 @@ namespace alpaka::onAcc
                 idxLayout);
     }
 
+    /** Creates an index container
+     *
+     * The traversal policy (`T_Traverse`) defines how the next valid index is found for a worker and
+     * defaults to @c traverse::Flat.
+     * The mapping policy (`T_IdxLayout`) defines how the index is mapped to worker threads and defaults to
+     * @c layout::Optimized.
+     *
+     * @tparam T_ScalarIdxType scalar index type sed for the indices inside the iterator
+     * @param workGroup Description of the participating thread group.  More than one
+     *                  thread can have the same index within the group; all workers
+     *                  with the same id obtain the same index as result.
+     * @param range     Index range description.
+     * @param traverse  Policy describing how the next value can be found.
+     * @param idxLayout Policy describing how real worker threads will be mapped to the range.
+     * @return A index container that can be used in a range‑based for loop.
+     */
     template<
         typename T_ScalarIdxType,
         concepts::IdxTraversing T_Traverse = traverse::Flat,
@@ -68,11 +93,8 @@ namespace alpaka::onAcc
             T_IdxLayout>{}(acc, DomainSpec{workGroup, range}, traverse, idxLayout);
     }
 
-    /** specialization for 1-dimensional ranges
-     *
-     * It is using tiled iteration because there are no multiplications or divisions involved what is reducing the
-     * register footprint and number of calculation required.
-     */
+    ///@cond NO_HTML
+    /** Specialisation for one‑dimensional ranges. */
     template<
         concepts::IdxTraversing T_Traverse = traverse::Tiled,
         concepts::IdxMapping T_IdxLayout = layout::Optimized>
@@ -91,10 +113,7 @@ namespace alpaka::onAcc
                 idxLayout);
     }
 
-    /**
-     * @tparam T_ScalarIdxType The type of the indices used within the index container. If `void` the index type will
-     * be derived from the range
-     */
+    /** Specialisation for one‑dimensional ranges. */
     template<
         typename T_ScalarIdxType,
         concepts::IdxTraversing T_Traverse = traverse::Tiled,
@@ -114,8 +133,6 @@ namespace alpaka::onAcc
             T_IdxLayout>{}(acc, DomainSpec{workGroup, range}, traverse, idxLayout);
     }
 
-    /**
-     * @}
-     */
-
+    ///@endcond NO_HTML
+    /** @} */
 } // namespace alpaka::onAcc

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -139,7 +139,10 @@ namespace alpaka::onHost
         ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Device>())),
         ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Device>()))>;
 
-    /** allocate memory on the given device
+    /** @{
+     * @name Device allocations
+     */
+    /** Allocate memory on the given device
      *
      * @tparam T_Type type of the data elements
      * @param device device handle
@@ -155,22 +158,17 @@ namespace alpaka::onHost
             extentsVec);
     }
 
-    /** allocate memory on the given device with unified virtual memory
+    /** Allocate memory on the given device with unified virtual memory
      *
      * This memory can be accessed from all devices with the same Api and device kind. Depending of the backend e.g.
      * OneApi memory can be accessed by other device kind devices if they are using the same native context. It is not
      * allowed to access the data on two devices at the same time, this must be avoided by explicit synchronizations.
-     * Managed memory follows the rules of UVM memory of the device backend e.g. CUDA, HIP, ...
+     * Unified memory follows the rules of UVM memory of the device backend e.g. CUDA, HIP, ...
      *
      * @tparam T_Type type of the data elements
+     * @param device device handle
      * @param extents number of elements for each dimension
      * @return Managed view to the allocated memory
-     *
-     * @{
-     */
-
-    /**
-     * @param device device handle
      */
     template<typename T_Type>
     inline auto allocUnified(concepts::Device auto const& device, alpaka::concepts::VectorOrScalar auto const& extents)
@@ -183,7 +181,16 @@ namespace alpaka::onHost
 
     /** Allocates unified memory on the device associated with the given queue.
      *
+     * This memory can be accessed from all devices with the same Api and device kind. Depending of the backend e.g.
+     * OneApi memory can be accessed by other device kind devices if they are using the same native context. It is not
+     * allowed to access the data on two devices at the same time, this must be avoided by explicit synchronizations.
+     * Unified memory follows the rules of UVM memory of the device backend e.g. CUDA, HIP, ...
+     *
+     * @ingroup foo
+     *
+     * @tparam T_Type type of the data elements
      * @param queue queue handle
+     * @param extents number of elements for each dimension
      */
     template<typename T_Type, typename T_Device>
     inline auto allocUnified(Queue<T_Device> const& queue, alpaka::concepts::VectorOrScalar auto const& extents)
@@ -195,28 +202,15 @@ namespace alpaka::onHost
                 extentsVec);
     }
 
-    /** @} */
-
-    /** allocate pinned memory on the host which is mapped into the adress space of the device
-     *
-     * This memory can be accessed from all devices with the same Api and device kind. Depending of the backend e.g.
-     * OneApi memory can be accessed by other device kind devices if they are using the same native context. It is not
-     * allowed to access the data on two devices at the same time, this must be avoided by explicit synchronizations.
-     * Managed memory follows the rules of UVM memory of the device backend e.g. CUDA, HIP, ...
+    /** Allocate pinned memory on the host which is mapped into the adress space of the device
      *
      * Mapped memory is located on the host and is transferred for each access via the PCIe/Nvlink bus. The performance
      * on the device is mostly pure. Mapped memory should be used for host memory if you transfer memory between host
      * and device via `onHost::memcpy()` because the transfer will be optimized for latency and performance.
      *
      * @tparam T_Type type of the data elements
-     * @param extents number of elements for each dimension
-     * @return Managed view to the allocated memory
-     *
-     * @{
-     */
-
-    /**
      * @param device device handle
+     * @param extents number of elements for each dimension
      */
     template<typename T_Type>
     inline auto allocMapped(concepts::Device auto const& device, alpaka::concepts::VectorOrScalar auto const& extents)
@@ -227,9 +221,15 @@ namespace alpaka::onHost
             extentsVec);
     }
 
-    /** Allocates pinned mapped memory on the device associated with the given queue.
+    /** Allocate pinned memory on the host which is mapped into the adress space of the device
      *
+     * Mapped memory is located on the host and is transferred for each access via the PCIe/Nvlink bus. The performance
+     * on the device is mostly pure. Mapped memory should be used for host memory if you transfer memory between host
+     * and device via `onHost::memcpy()` because the transfer will be optimized for latency and performance.
+     *
+     * @tparam T_Type type of the data elements
      * @param queue queue handle
+     * @param extents number of elements for each dimension
      */
     template<typename T_Type, typename T_Device>
     inline auto allocMapped(Queue<T_Device> const& queue, alpaka::concepts::VectorOrScalar auto const& extents)
@@ -237,7 +237,22 @@ namespace alpaka::onHost
         return allocMapped<T_Type>(queue.getDevice(), extents);
     }
 
-    /** @} */
+    /** allocate memory on the given device based on a view
+     *
+     * Derives type and extents of the memory from the view.
+     * The content of the memory is NOT copied to the created allocated memory.
+     *
+     * @param device device handle
+     * @param[in] view memory where properties will be derived from
+     *
+     * @return memory owning view to the allocated memory
+     */
+    inline auto allocLike(concepts::Device auto const& device, auto const& view)
+    {
+        return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, getExtents(view));
+    }
+
+    ///@}
 
     /** check if the given view is accessible on the given device
      *
@@ -247,7 +262,6 @@ namespace alpaka::onHost
      * alpaka can not detect all memory access types therefore the result can be false even if the memory is accessible
      * because the view was allocated with a UVM allocator.
      *
-     * @{
      */
     inline bool isDataAccessible(concepts::Device auto const& device, alpaka::concepts::View auto const& view)
     {
@@ -274,23 +288,6 @@ namespace alpaka::onHost
                    ALPAKA_TYPEOF(getApi(view)),
                    ALPAKA_TYPEOF(getDeviceKind(queue.getDevice())),
                    ALPAKA_TYPEOF(view)>{}(getApi(view), getDeviceKind(queue.getDevice()), view);
-    }
-
-    /** @} */
-
-    /** allocate memory on the given device based on a view
-     *
-     * Derives type and extents of the memory from the view.
-     * The content of the memory is NOT copied to the created allocated memory.
-     *
-     * @param device device handle
-     * @param view memory where properties will be derived from
-     *
-     * @return memory owning view to the allocated memory
-     */
-    inline auto allocLike(concepts::Device auto const& device, auto const& view)
-    {
-        return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, getExtents(view));
     }
 
     /** provides a frame specification to operator on a given index range

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -108,8 +108,6 @@ namespace alpaka::onHost
          * @param specification thread or frame specification which provides a chunked description of the thread or
          * frame index domain
          * @param kernelBundle the compute kernel and there arguments
-         *
-         * @{
          */
 
         /**
@@ -136,8 +134,6 @@ namespace alpaka::onHost
         {
             internal::enqueue(*m_queue.get(), executor, specification, kernelBundle);
         }
-
-        /** @} */
 
         /** Enqueue a operation which is executed on the host side
          *
@@ -167,92 +163,23 @@ namespace alpaka::onHost
         }
     };
 
-    /** fill memory byte wise
+    template<typename T_Queue>
+    Queue(Handle<T_Queue>&&) -> Queue<Device<
+        ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Queue>())),
+        ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Queue>()))>>;
+
+    /** @{
+     * @name Memory modifiers
      *
-     * @param dest can be a container/view where the data should be written to
-     *             The caller should ensure that the memory is valid until the operation is completed not until the
-     *             execution handle is given back because alpaka is not extending the life-time until the operation
-     * is finished.
-     * @param byteValue value to be written to each byte
-     *
-     * @{
-     */
-    template<typename T_Device>
-    inline void memset(Queue<T_Device> const& queue, auto&& dest, uint8_t byteValue)
-    {
-        return memset(queue, ALPAKA_FORWARD(dest), byteValue, internal::getExtents(dest));
-    }
-
-    /** @param extents M-dimensional data extents in elements, can be smaller than the container capacity */
-    template<typename T_Device>
-    inline void memset(
-        Queue<T_Device> const& queue,
-        auto&& dest,
-        uint8_t byteValue,
-        alpaka::concepts::VectorOrScalar auto const& extents)
-    {
-        Vec const extentsVec = extents;
-        return internal::Memset::Op<
-            std::decay_t<decltype(*queue.get())>,
-            std::decay_t<decltype(dest)>,
-            std::decay_t<decltype(extentsVec)>>{}(*queue.get(), ALPAKA_FORWARD(dest), byteValue, extentsVec);
-    }
-
-    /** @} */
-
-    /** fill memory element wise
-     *
-     * @param dest can be a container/view where the data should be written to
-     *             The caller should ensure that the memory is valid until the operation is completed not until the
-     *             execution handle is given back because alpaka is not extending the life-time until the operation
-     *             is finished.
-     * @param elementValue value to be written to each element
-     *
-     * @{
-     */
-    template<typename T_Device, typename T_Value>
-    inline void fill(Queue<T_Device> const& queue, auto&& dest, T_Value elementValue)
-        requires std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
-                 && std::same_as<
-                     ALPAKA_TYPEOF(alpaka::internal::getApi(queue)),
-                     ALPAKA_TYPEOF(alpaka::internal::getApi(dest))>
-    {
-        return fill(queue, ALPAKA_FORWARD(dest), elementValue, internal::getExtents(dest));
-    }
-
-    /** @param extents M-dimensional data extents in elements, can be smaller than the container capacity */
-    template<typename T_Device, typename T_Value>
-    inline void fill(
-        Queue<T_Device> const& queue,
-        auto&& dest,
-        T_Value elementValue,
-        alpaka::concepts::VectorOrScalar auto const& extents)
-        requires std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
-                 && std::same_as<
-                     ALPAKA_TYPEOF(alpaka::internal::getApi(queue)),
-                     ALPAKA_TYPEOF(alpaka::internal::getApi(dest))>
-    {
-        Vec const extentsVec = extents;
-        return internal::Fill::Op<
-            ALPAKA_TYPEOF(*queue.get()),
-            ALPAKA_TYPEOF(dest),
-            ALPAKA_TYPEOF(elementValue),
-            ALPAKA_TYPEOF(extentsVec)>{}(*queue.get(), ALPAKA_FORWARD(dest), elementValue, extentsVec);
-    }
-
-    /** @} */
-
-    /** copy data byte wise from one to another container
-     *
-     * @attention For dest and source the caller should ensure that the memory is valid until the operation is
+     * @attention For input/output memory the caller should ensure that the memory is valid until the operation is
      * completed not until the execution handle is given back because alpaka is not extending the life-time until
      * the operation is finished.
+     */
+    /** copy data byte wise from one to another container
      *
      * @param queue the copy will be executed after all previous work in this queue is finished
-     * @param dest can be a container/view where the data should be written to
-     * @param source can be a container/view from which the data will be copied
-     *
-     * @{
+     * @param[in,out] dest can be a container/view where the data should be written to
+     * @param[in] source can be a container/view from which the data will be copied
      */
     template<typename T_Device>
     inline void memcpy(Queue<T_Device> const& queue, auto&& dest, auto const& source)
@@ -260,7 +187,13 @@ namespace alpaka::onHost
         return memcpy(queue, ALPAKA_FORWARD(dest), source, internal::getExtents(dest));
     }
 
-    /** @param extents M-dimensional data extents in elements, can be smaller than the container capacity */
+    /** copy data byte wise from one to another container
+     *
+     * @param queue the copy will be executed after all previous work in this queue is finished
+     * @param[in,out] dest can be a container/view where the data should be written to
+     * @param[in] source can be a container/view from which the data will be copied
+     * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
+     */
     template<typename T_Device>
     inline void memcpy(
         Queue<T_Device> const& queue,
@@ -276,12 +209,116 @@ namespace alpaka::onHost
             std::decay_t<decltype(extentsVec)>>{}(*queue.get(), ALPAKA_FORWARD(dest), source, extentsVec);
     }
 
+    /** fill memory byte wise
+     *
+     * @param[in,out] dest can be a container/view where the data should be written to
+     * The caller should ensure that the memory is valid until the operation is completed not until the
+     * execution handle is given back because alpaka is not extending the life-time until the operation
+     * is finished.
+     * @param byteValue value to be written to each byte
+     */
+    template<typename T_Device>
+    inline void memset(Queue<T_Device> const& queue, auto&& dest, uint8_t byteValue)
+    {
+        return memset(queue, ALPAKA_FORWARD(dest), byteValue, internal::getExtents(dest));
+    }
+
+    /** fill memory byte wise
+     *
+     * @param[in,out] dest can be a container/view where the data should be written to
+     * The caller should ensure that the memory is valid until the operation is completed not until the
+     * execution handle is given back because alpaka is not extending the life-time until the operation
+     * is finished.
+     * @param byteValue value to be written to each byte
+     * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
+     */
+    template<typename T_Device>
+    inline void memset(
+        Queue<T_Device> const& queue,
+        auto&& dest,
+        uint8_t byteValue,
+        alpaka::concepts::VectorOrScalar auto const& extents)
+    {
+        Vec const extentsVec = extents;
+        return internal::Memset::Op<
+            std::decay_t<decltype(*queue.get())>,
+            std::decay_t<decltype(dest)>,
+            std::decay_t<decltype(extentsVec)>>{}(*queue.get(), ALPAKA_FORWARD(dest), byteValue, extentsVec);
+    }
+
+    /** fill memory element wise
+     *
+     * @param[in,out] dest can be a container/view where the data should be written to
+     * The caller should ensure that the memory is valid until the operation is completed not until the
+     * execution handle is given back because alpaka is not extending the life-time until the operation
+     * is finished.
+     * @param elementValue value to be written to each element
+     */
+    template<typename T_Device, typename T_Value>
+    inline void fill(Queue<T_Device> const& queue, auto&& dest, T_Value elementValue) requires(
+        std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
+        && std::same_as<ALPAKA_TYPEOF(alpaka::internal::getApi(queue)), ALPAKA_TYPEOF(alpaka::internal::getApi(dest))>)
+    {
+        return fill(queue, ALPAKA_FORWARD(dest), elementValue, internal::getExtents(dest));
+    }
+
+    /** fill memory element wise
+     *
+     * @param[in,out] dest can be a container/view where the data should be written to
+     * The caller should ensure that the memory is valid until the operation is completed not until the
+     * execution handle is given back because alpaka is not extending the life-time until the operation
+     * is finished.
+     * @param elementValue value to be written to each element
+     * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
+     */
+    template<typename T_Device, typename T_Value>
+    inline void fill(
+        Queue<T_Device> const& queue,
+        auto&& dest,
+        T_Value elementValue,
+        alpaka::concepts::VectorOrScalar auto const& extents)
+        requires(
+            std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
+            && std::
+                same_as<ALPAKA_TYPEOF(alpaka::internal::getApi(queue)), ALPAKA_TYPEOF(alpaka::internal::getApi(dest))>)
+    {
+        Vec const extentsVec = extents;
+        return internal::Fill::Op<
+            ALPAKA_TYPEOF(*queue.get()),
+            ALPAKA_TYPEOF(dest),
+            ALPAKA_TYPEOF(elementValue),
+            ALPAKA_TYPEOF(extentsVec)>{}(*queue.get(), ALPAKA_FORWARD(dest), elementValue, extentsVec);
+    }
+
     /** @} */
 
-    template<typename T_Queue>
-    Queue(Handle<T_Queue>&&) -> Queue<Device<
-        ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Queue>())),
-        ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Queue>()))>>;
+    /** @{
+     * @name Async Device allocations
+     */
+    /** allocate memory asynchronously in the given queue
+     *
+     * @attention It is allowed that the function is blocking the caller until the memory is created.
+     *
+     * The memory is allowed to be used in other queues too.
+     * To avoid that a view to the memory is still in use during the deallocation you can use @see
+     * addDestructorAction() and wait for a queue if it differs to the queue used for the allocation.
+     *
+     * @tparam T_Type type of the data elements
+     * @param queue queue handle
+     * @return Memory owning view to the allocated memory. You are not allowed to derefence the view to access the
+     * memory before the allocation within the queue is finished. The view will be freed after the last instance to the
+     * memory is destroyed. The deallocation is asynchronous performed in the the queue which is used for the
+     * allocation.
+     * @param extents number of elements for each dimension
+     */
+    template<typename T_Type, typename T_Device>
+    inline auto allocAsync(Queue<T_Device> const& queue, alpaka::concepts::VectorOrScalar auto const& extents)
+    {
+        Vec const extentsVec = extents;
+        return internal::AllocAsync::Op<T_Type, std::decay_t<decltype(*queue.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
+            *queue.get(),
+            extentsVec);
+    }
 
     /** allocate memory asynchronously in the given queue
      *
@@ -297,24 +334,7 @@ namespace alpaka::onHost
      * memory before the allocation within the queue is finished. The view will be freed after the last instance to the
      * memory is destroyed. The deallocation is asynchronous performed in the the queue which is used for the
      * allocation.
-     *
-     * @{
-     */
-
-    /**
-     * @param extents number of elements for each dimension
-     */
-    template<typename T_Type, typename T_Device>
-    inline auto allocAsync(Queue<T_Device> const& queue, alpaka::concepts::VectorOrScalar auto const& extents)
-    {
-        Vec const extentsVec = extents;
-        return internal::AllocAsync::Op<T_Type, std::decay_t<decltype(*queue.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
-            *queue.get(),
-            extentsVec);
-    }
-
-    /**
-     * @param view other memory where the extents will be derived from
+     * @param[in] view other memory where the extents will be derived from
      */
     template<typename T_Device>
     inline auto allocLikeAsync(Queue<T_Device> const& queue, auto const& view)

--- a/include/alpaka/onHost/interface.hpp
+++ b/include/alpaka/onHost/interface.hpp
@@ -11,136 +11,189 @@
 #include "alpaka/tag.hpp"
 #include "alpaka/trait.hpp"
 
-/** functionality which is usable on the host CPU controller thread */
+/** Functionality which is usable on the host CPU controller thread. */
 namespace alpaka::onHost
 {
-    /** Get extents of an object
+    /** @{
+     * @name Query extents
+     */
+    /** Object extents
      *
-     * @param any can be a view, a data
+     * @param any can be a std::vector, std::array, ...
      * @return the extents of the object
-     *
-     * @{
      */
     inline decltype(auto) getExtents(auto&& any)
     {
         return internal::getExtents(ALPAKA_FORWARD(any));
     }
 
-    inline decltype(auto) getExtents(alpaka::concepts::HasGet auto&& any)
+    /** Handle extents
+     *
+     * @param handle can be a view, a data
+     * @return the extents of the object
+     */
+    inline decltype(auto) getExtents(alpaka::concepts::HasGet auto&& handle)
     {
-        return internal::getExtents(*any.get());
+        return internal::getExtents(*handle.get());
     }
 
     /** @} */
 
-    /** Get the number of elements of an object
+    /** @{
+     * @name Query multi-dimensional pitches
+     */
+    /** Object pitches
      *
-     * @param any can be a view, a data
+     * @param any can be a std::vector, std::array, ...
      * @return the number of elements of the object
-     *
-     * @{
      */
     inline decltype(auto) getPitches(auto&& any)
     {
         return internal::getPitches(ALPAKA_FORWARD(any));
     }
 
-    inline decltype(auto) getPitches(alpaka::concepts::HasGet auto&& any)
+    /** Handle pitches
+     *
+     * @param handle can be a view, a data
+     * @return the number of elements of the object
+     */
+    inline decltype(auto) getPitches(alpaka::concepts::HasGet auto&& handle)
     {
-        return internal::getPitches(*any.get());
+        return internal::getPitches(*handle.get());
     }
 
     /** @} */
 
+    /** @{
+     * @name Query the name
+     */
+
+    /** Compile‑time available name for a given object.
+     *
+     * @param any object whose name shall be queried
+     * @return a `std::string`‑compatible value holding the static name
+     */
     inline std::convertible_to<std::string> auto getStaticName(auto const& any)
     {
         return alpaka::internal::GetStaticName::Op<ALPAKA_TYPEOF(any)>{}(any);
     }
 
-    inline std::convertible_to<std::string> auto getStaticName(concepts::StaticNameHandle auto const& any)
+    /** Compile‑time available name of an handle
+     *
+     * @param handle object whose name shall be queried
+     * @return a `std::string`‑compatible value holding the static name
+     */
+    inline std::convertible_to<std::string> auto getStaticName(concepts::StaticNameHandle auto const& handle)
     {
-        return alpaka::internal::GetStaticName::Op<std::decay_t<decltype(*any.get())>>{}(*any.get());
+        return alpaka::internal::GetStaticName::Op<std::decay_t<decltype(*handle.get())>>{}(*handle.get());
     }
 
+    /** Runtime name for a given object.
+     *
+     * @param any object whose name shall be queried
+     * @return a `std::string`‑compatible value holding the name
+     */
     inline std::convertible_to<std::string> auto getName(auto&& any)
     {
         return alpaka::internal::GetName::Op<ALPAKA_TYPEOF(any)>{}(ALPAKA_FORWARD(any));
     }
 
-    inline std::convertible_to<std::string> auto getName(concepts::NameHandle auto const& any)
-    {
-        return alpaka::internal::GetName::Op<std::decay_t<decltype(*any.get())>>{}(*any.get());
-    }
-
-    /** Get the native handle type
+    /** Runtime name for a given handle.
      *
-     * The handle can be used with native API function from the underlying used parism library.
-     *
-     * @return the type depends on the used API
+     * @param handle object whose name shall be queried
+     * @return a `std::string`‑compatible value holding the name
      */
-    inline auto getNativeHandle(auto const& any)
+    inline std::convertible_to<std::string> auto getName(concepts::NameHandle auto const& handle)
     {
-        return internal::getNativeHandle(*any.get());
+        return alpaka::internal::GetName::Op<std::decay_t<decltype(*handle.get())>>{}(*handle.get());
     }
 
-    /** blocks the caller until the given handle executes all work
+    /** @} */
+
+    /** Get the native handle of an handle.
      *
-     * @param any currently only queue handles are supported
+     * The native handle can be passed to the underlying backend API
+     * (e.g. CUDA, HIP, OpenMP) for low‑level operations.
+     *
+     * @param handle object exposing a native handle
+     * @return the native handle returned by the backend‑specific implementation
      */
-    inline void wait(alpaka::concepts::HasGet auto& any)
+    inline auto getNativeHandle(auto const& handle)
     {
-        return internal::wait(*any.get());
+        return internal::getNativeHandle(*handle.get());
     }
 
-    /** pointer to data
+    /** wait for all work to be finished
      *
-     * For multi dimensional data the data is not required to be continues.
+     * Waits until all work submitted to any before this call has finished
      *
-     * @param any
-     * @return origin pointer to the data equal to std::data()
+     * @param handle queue/device/event
+     */
+    inline void wait(alpaka::concepts::HasGet auto& handle)
+    {
+        return internal::wait(*handle.get());
+    }
+
+    /** @{
+     * @name Query raw pointer
+     */
+    /** pointer to data of an object
      *
-     * @{
+     * For multi‑dimensional data the data is not required to be continuous.
+     *
+     * @param any object providing data access (e.g. std::vector)
+     * @return raw pointer to the underlying data (equivalent to `std::data`)
      */
     inline decltype(auto) data(auto&& any)
     {
         return internal::Data::data(ALPAKA_FORWARD(any));
     }
 
-    inline decltype(auto) data(alpaka::concepts::HasGet auto&& any)
+    /** pointer to data of an handle
+     *
+     * For multi‑dimensional data the data is not required to be continuous.
+     *
+     * @param handle handle providing data access (e.g. view)
+     * @return raw pointer to the underlying data
+     */
+    inline decltype(auto) data(alpaka::concepts::HasGet auto&& handle)
     {
-        return internal::Data::data(*any.get());
+        return internal::Data::data(*handle.get());
     }
 
     /** @} */
 
-    /** allocate memory on the given device
-     *
-     * @tparam T_Type type of the data elements
-     * @param extents number of elements for each dimension
-     * @return memory owning view to the allocated memory
-     *
-     * The host controller device is the deviceKind::Cpu from api::Host.
+    /** @{
+     * @name Host allocations
      */
-    template<typename T_Type>
+    /** Allocate host memory for a given element type and extents.
+     *
+     * The allocation is performed on the host controller device
+     * (`api::host` ans `deviceKind::cpu`).
+     * The returned view owns the allocated memory.
+     *
+     * @tparam T_ValueType type of the data elements
+     * @param extents number of elements per dimension (vector or scalar)
+     * @return a view owning the newly allocated memory
+     */
+    template<typename T_ValueType>
     inline auto allocHost(alpaka::concepts::VectorOrScalar auto const& extents)
     {
-        auto device = makeHostDevice<T_Type>();
+        auto device = makeHostDevice<T_ValueType>();
         Vec const extentsVec = extents;
-        return internal::Alloc::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
+        return internal::Alloc::Op<T_ValueType, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
             *device.get(),
             extentsVec);
     }
 
-    /** allocate memory on the given device based on a view
+    /** Allocate host memory with the same value type and extents as an existing view.
      *
-     * Derives type and extents of the memory from the view.
-     * The content of the memory is NOT copied to the created allocated memory.
+     * The content of the source view is **not** copied. The function deduces the
+     * element type and extents from `view` and creates a new managed view on the
+     * host controller device.
      *
-     * The host controller device is the deviceKind::Cpu from api::Host.
-     *
-     * @param view memory where properties will be derived from, std::vector, std::array, or any other
-     *
-     * @return memory owning view to the allocated memory
+     * @param view a view (e.g. `std::vector`, `std::array`, or any compatible type)
+     * @return a view owning the newly allocated memory
      */
     inline auto allocHostLike(auto const& view)
     {
@@ -148,6 +201,19 @@ namespace alpaka::onHost
         return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, internal::getExtents(view));
     }
 
+    /** @} */
+
+    /** @{
+     * @name Device selection utilities
+     */
+    /** Resolve the list of executors supported for a device specification.
+     *
+     * This helper is used internally to build backend dictionaries.
+     *
+     * @param deviceSpec      device specification to be used
+     * @param listOfExecutors tuple of executor types to be filtered
+     * @return a tuple containing the supported executor types
+     */
     constexpr auto getExecutorsList(auto const deviceSpec, auto const listOfExecutors)
     {
         using DevSelectorType = decltype(makeDeviceSelector(deviceSpec));
@@ -156,10 +222,13 @@ namespace alpaka::onHost
         return AutoDeviceMappings{};
     }
 
-    /** Get alist of supported device specifications
+    /** Create a tuple of device specifications for a single API.
      *
-     * @param api a single api
-     * @return tuple of device specifications
+     * Each device specifications combines the supplied API with one of the supported
+     * device types for that API.
+     *
+     * @param api a single alpaka API (e.g. `api::cuda`, `api::hip`)
+     * @return a tuple containing all device specifications for the given API
      */
     constexpr auto getDeviceSpecsFor(auto const api)
     {
@@ -168,10 +237,10 @@ namespace alpaka::onHost
             supportedDevices(api));
     }
 
-    /** Get alist of supported device specifications
+    /** Create a flattened tuple of device specification objects for a list of APIs.
      *
-     * @param apiList a tuple with APIs
-     * @return tuple of device specifications
+     * @param apiList a `std::tuple` containing the APIs
+     * @return a tuple containing all device specifications for the given API
      */
     template<alpaka::concepts::Api... T_Apis>
     constexpr auto getDeviceSpecsFor(std::tuple<T_Apis...> const apiList)
@@ -179,6 +248,16 @@ namespace alpaka::onHost
         return std::apply([](auto... api) constexpr { return std::tuple_cat(getDeviceSpecsFor(api)...); }, apiList);
     }
 
+    /** Build a tuple of backends for a single device specification.
+     *
+     * A backend is the combination of a device specification and an executor.
+     * Each dictionary stores a `deviceSpec`(query: foo[object::deviceSpec]) entry and an `exec`(query:
+     * foo[object::exec]) entry for the corresponding executor.
+     *
+     * @param deviceSpec the device specification to associate with the executors
+     * @param listOfExecutors tuple of executor types
+     * @return a tuple of backend objects, one per executor
+     */
     constexpr auto createBackendsFor(auto const deviceSpec, auto const listOfExecutors)
     {
         return std::apply(
@@ -190,6 +269,12 @@ namespace alpaka::onHost
             listOfExecutors);
     }
 
+    /** Create the complete backend list for all device specifications and executors.
+     *
+     * @param devSpecList tuple of device specifications
+     * @param listOfExecutors tuple of executor types
+     * @return a tuple of backend objects, for all executors
+     */
     constexpr auto createBackendList(auto const devSpecList, auto const listOfExecutors)
     {
         return std::apply(
@@ -198,6 +283,15 @@ namespace alpaka::onHost
             devSpecList);
     }
 
+    /** Generate the full set of backend dictionaries for a set of APIs.
+     *
+     * The result contains a backend entry for each combination of supported device
+     * specification for the APIs and executors.
+     *
+     * @param usedApis tuple of alpaka APIs to consider
+     * @param listOfExecutors tuple of executor types
+     * @return a tuple of backend dictionaries covering all APIs and executors
+     */
     consteval auto allBackends(auto const usedApis, auto const listOfExecutors)
     {
         return std::apply(
@@ -205,4 +299,6 @@ namespace alpaka::onHost
             { return std::tuple_cat(createBackendList(getDeviceSpecsFor(api), listOfExecutors)...); },
             usedApis);
     }
+
+    /** @} */
 } // namespace alpaka::onHost


### PR DESCRIPTION
- use doxygen groups correctly
- update Doxyfile for users:
  - remove detail namespace
  - remove unified cuda and sycl generic

Unfortunately, we need to repeat a lot of the documentation; otherwise, it is not readable in rendered Doxygen.
C++ `requires()` is producing doxygen parsing issues, adding `()`around `requires coneptFoo && conceptBar` helps sometimes.