### PR TITLE
View/MdSpan preserve constness

### DIFF
--- a/example/scan/src/scan_executors.hpp
+++ b/example/scan/src/scan_executors.hpp
@@ -31,7 +31,7 @@ namespace alpaka::example::scan
         int falseResults = 0;
         static constexpr int MAX_PRINT_FALSE_RESULTS = 20;
 
-        auto const& groundtruth = alpaka::onHost::allocHost<Data>(numElements);
+        auto groundtruth = alpaka::onHost::allocHost<Data>(numElements);
         switch(scanType)
         {
         case EXCLUSIVE_SCAN:
@@ -160,6 +160,7 @@ namespace alpaka::example::scan
             alpaka::onHost::wait(queue);
             auto const beginT = std::chrono::high_resolution_clock::now();
 
+            static_assert(!std::is_const_v<typename ALPAKA_TYPEOF(bufY)::value_type>);
             switch(scanType)
             {
             case EXCLUSIVE_SCAN:

--- a/include/alpaka/KernelBundle.hpp
+++ b/include/alpaka/KernelBundle.hpp
@@ -109,6 +109,11 @@ namespace alpaka
         constexpr auto operator()(TAcc const& acc) const
         {
             alpaka::apply(
+                /* It is required to take the arguments as const reference.
+                 * The reason is that these arguments are shared between threads in a block. If the user like to mutate
+                 * these he should use a non const copy in the kernel function signature. This is the reason why we can
+                 * not keep const correctness for buffers and view within the copy-constructor of these.
+                 */
                 [&](alpaka::concepts::KernelArg auto const&... args) constexpr { m_kernelFn(acc, args...); },
                 m_args);
         }

--- a/include/alpaka/SimdPtr.hpp
+++ b/include/alpaka/SimdPtr.hpp
@@ -152,6 +152,13 @@ namespace alpaka
         }
 
         template<typename T_Storage>
+        constexpr void storeTo(Simd<value_type, SimdPtr::width(), T_Storage> const& rhs)
+        {
+            auto* ptr = &T_MdSpan::operator[](m_idx);
+            rhs.copyTo(ptr, getAlignment());
+        }
+
+        template<typename T_Storage>
         constexpr SimdPtr const& operator=(Simd<value_type, SimdPtr::width(), T_Storage> const& rhs) const
         {
             storeTo(rhs);

--- a/include/alpaka/api/generic.hpp
+++ b/include/alpaka/api/generic.hpp
@@ -21,8 +21,7 @@ namespace alpaka::internal::generic
      */
     struct SimdFillKernel
     {
-        ALPAKA_FN_ACC void operator()(auto const& acc, alpaka::concepts::MdSpan auto const& dest, auto const value)
-            const
+        ALPAKA_FN_ACC void operator()(auto const& acc, alpaka::concepts::MdSpan auto dest, auto const value) const
         {
             auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
             simdGrid.concurrent(

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -245,7 +245,7 @@ namespace alpaka::onHost
                 /* Get all required properties outside the lambda function to not extend the life-time of the data.
                  * The life-time is not extended to have some life-time behaviours with all backends.
                  */
-                void* destPtr = static_cast<void*>(alpaka::onHost::data(dest));
+                void* destPtr = static_cast<void*>(alpaka::onHost::data(ALPAKA_FORWARD(dest)));
                 auto const* srcPtr = alpaka::onHost::data(source);
 
                 if constexpr(dim == 1u)

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     /** Lightweight view to data in a n-dimensional array
      *
-     * Const-ness of the MdSpan is NOT propagated to the data region.
+     * Const-ness of the MdSpan instance is propagated to the data region.
      * A constant MdSpan can be used to access non-const data.
      *
      * @tparam T_Type if the type is const the data is only readable
@@ -66,7 +66,9 @@ namespace alpaka
     {
         using value_type = T_Type;
         using reference = value_type&;
+        using const_reference = value_type const&;
         using pointer = value_type*;
+        using const_pointer = value_type const*;
         using index_type = typename T_Pitches::type;
 
         using ConstThis = MdSpan<std::add_const_t<value_type>, T_Extents, T_Pitches, T_MemAlignment>;
@@ -82,6 +84,11 @@ namespace alpaka
          *
          * @return value at the current location
          */
+        constexpr const_reference operator*() const
+        {
+            return *this->m_ptr;
+        }
+
         constexpr reference operator*()
         {
             return *this->m_ptr;
@@ -91,7 +98,12 @@ namespace alpaka
          *
          * If the pointer is const and therefore read only depends on T_Type and not the const-ness of MdSPan.
          */
-        constexpr pointer data() const
+        constexpr const_pointer data() const
+        {
+            return this->m_ptr;
+        }
+
+        constexpr pointer data()
         {
             return this->m_ptr;
         }
@@ -152,12 +164,22 @@ namespace alpaka
          * @param idx n-dimensional offset, relative to the origin pointer
          * @return reference to the value
          */
-        constexpr reference operator[](concepts::Vector auto const& idx) const
+        constexpr const_reference operator[](concepts::Vector auto const& idx) const
         {
             return *ptr(idx);
         }
 
-        constexpr reference operator[](std::integral auto const& idx) const requires(dim() == 1u)
+        constexpr reference operator[](concepts::Vector auto const& idx)
+        {
+            return *ptr(idx);
+        }
+
+        constexpr const_reference operator[](std::integral auto const& idx) const requires(dim() == 1u)
+        {
+            return *ptr(Vec{idx});
+        }
+
+        constexpr reference operator[](std::integral auto const& idx) requires(dim() == 1u)
         {
             return *ptr(Vec{idx});
         }
@@ -263,7 +285,9 @@ namespace alpaka
         using extentType = std::extent<T_ArrayType, std::rank_v<T_ArrayType>>;
         using value_type = std::remove_all_extents_t<T_ArrayType>;
         using reference = value_type&;
+        using const_reference = value_type const&;
         using pointer = value_type*;
+        using const_pointer = value_type const*;
         using index_type = typename extentType::value_type;
 
         static consteval uint32_t dim()
@@ -275,13 +299,23 @@ namespace alpaka
          *
          * @return value at the current location
          */
-        constexpr reference operator*() const
+        constexpr const_reference operator*() const
+        {
+            return *this->m_ptr;
+        }
+
+        constexpr reference operator*()
         {
             return *this->m_ptr;
         }
 
         /** get origin pointer */
-        constexpr pointer data() const
+        constexpr const_pointer data() const
+        {
+            return this->m_ptr;
+        }
+
+        constexpr pointer data()
         {
             return this->m_ptr;
         }
@@ -337,12 +371,22 @@ namespace alpaka
          * @return reference to the value
          * @{
          */
-        constexpr reference operator[](concepts::Vector auto const& idx) const
+        constexpr const_reference operator[](concepts::Vector auto const& idx) const
         {
             return ResolveArrayAccess<dim()>{}(*m_ptr, idx);
         }
 
-        constexpr reference operator[](index_type const& idx) const
+        constexpr reference operator[](concepts::Vector auto const& idx)
+        {
+            return ResolveArrayAccess<dim()>{}(*m_ptr, idx);
+        }
+
+        constexpr const_reference operator[](index_type const& idx) const
+        {
+            return (*m_ptr)[idx];
+        }
+
+        constexpr reference operator[](index_type const& idx)
         {
             return (*m_ptr)[idx];
         }

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -66,9 +66,9 @@ namespace alpaka
     {
         using value_type = T_Type;
         using reference = value_type&;
-        using const_reference = value_type const&;
+        using const_reference = std::add_const_t<value_type>&;
         using pointer = value_type*;
-        using const_pointer = value_type const*;
+        using const_pointer = std::add_const_t<value_type>*;
         using index_type = typename T_Pitches::type;
 
         using ConstThis = MdSpan<std::add_const_t<value_type>, T_Extents, T_Pitches, T_MemAlignment>;
@@ -210,7 +210,7 @@ namespace alpaka
          * @param idx n-dimensional offset
          * @return pointer to value
          */
-        constexpr pointer ptr(concepts::Vector auto const& idx) const requires(dim() >= 2u)
+        constexpr auto ptr(concepts::Vector auto const& idx) const requires(dim() >= 2u)
         {
             /** offset in bytes
              *
@@ -223,10 +223,16 @@ namespace alpaka
                 offset += m_pitch[d] * idx[d];
             }
             using CharPtrType = std::conditional_t<std::is_const_v<value_type>, char const*, char*>;
-            return reinterpret_cast<pointer>(reinterpret_cast<CharPtrType>(this->m_ptr) + offset);
+            using ResultPtrType = std::conditional_t<std::is_const_v<value_type>, const_pointer, pointer>;
+            return reinterpret_cast<ResultPtrType>(reinterpret_cast<CharPtrType>(this->m_ptr) + offset);
         }
 
-        constexpr pointer ptr(concepts::Vector auto const& idx) const requires(dim() == 1u)
+        constexpr const_pointer ptr(concepts::Vector auto const& idx) const requires(dim() == 1u)
+        {
+            return this->m_ptr + idx.x();
+        }
+
+        constexpr pointer ptr(concepts::Vector auto const& idx) requires(dim() == 1u)
         {
             return this->m_ptr + idx.x();
         }

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -23,7 +23,7 @@ namespace alpaka
     /** Non owning view to data
      *
      * This view is only holding a points to real data, copying the view is cheap.
-     * Const-ness of the view is NOT propagated to the data region.
+     * Const-ness of the view instance is propagated to the data region.
      */
     template<
         typename T_Api,
@@ -43,14 +43,26 @@ namespace alpaka
         return View{getApi(ALPAKA_FORWARD(anyWithApi)), pointer, extents, pitchMd, memAlignment};
     }
 
+    template<typename T_ValueType, concepts::Alignment T_MemAlignment = Alignment<>>
+    inline constexpr auto makeView(
+        auto&& anyWithApi,
+        T_ValueType* pointer,
+        concepts::Vector auto const& extents,
+        concepts::Vector auto const& pitches,
+        T_MemAlignment const memAlignment = T_MemAlignment{})
+    {
+        static_assert(std::is_same_v<ALPAKA_TYPEOF(extents), ALPAKA_TYPEOF(pitches)>);
+        return View{getApi(ALPAKA_FORWARD(anyWithApi)), pointer, extents, pitches, memAlignment};
+    }
+
     inline constexpr auto makeView(auto&& any)
     {
         return View{
-            getApi(any),
-            onHost::data(any),
-            onHost::getExtents(any),
-            onHost::getPitches(any),
-            alpaka::getAlignment(any)};
+            getApi(ALPAKA_FORWARD(any)),
+            onHost::data(ALPAKA_FORWARD(any)),
+            onHost::getExtents(ALPAKA_FORWARD(any)),
+            onHost::getPitches(ALPAKA_FORWARD(any)),
+            alpaka::getAlignment(ALPAKA_FORWARD(any))};
     }
 
     template<
@@ -103,6 +115,11 @@ namespace alpaka
 
         constexpr alpaka::concepts::MdSpan auto getMdSpan() const
         {
+            return BaseMdSpan::getConstMdSpan();
+        }
+
+        constexpr alpaka::concepts::MdSpan auto getMdSpan()
+        {
             return BaseMdSpan{*this};
         }
 
@@ -126,7 +143,13 @@ namespace alpaka
         constexpr auto getSubView(alpaka::concepts::Vector auto const& extents) const
         {
             assert((extents <= this->getExtents()).reduce(std::logical_and{}));
-            return View{T_Api{}, this->data(), extents, this->getPitches(), T_MemAlignment{}};
+            return makeView(T_Api{}, this->data(), extents, this->getPitches(), T_MemAlignment{});
+        }
+
+        constexpr auto getSubView(alpaka::concepts::Vector auto const& extents)
+        {
+            assert((extents <= this->getExtents()).reduce(std::logical_and{}));
+            return makeView(T_Api{}, this->data(), extents, this->getPitches(), T_MemAlignment{});
         }
 
         /** Creates a sub view to a part of the memory.
@@ -141,8 +164,17 @@ namespace alpaka
             alpaka::concepts::Vector auto const& extents) const
         {
             assert((extents <= this->getExtents()).reduce(std::logical_and{}));
-            auto shiftedPtr = &getMdSpan()[offset];
-            return View{T_Api{}, shiftedPtr, extents, this->getPitches(), Alignment<>{}};
+            auto shiftedPtr = &(*this)[offset];
+            return makeView(T_Api{}, shiftedPtr, extents, this->getPitches(), Alignment<>{});
+        }
+
+        constexpr auto getSubView(
+            alpaka::concepts::Vector auto const& offset,
+            alpaka::concepts::Vector auto const& extents)
+        {
+            assert((extents <= this->getExtents()).reduce(std::logical_and{}));
+            auto shiftedPtr = &(*this)[offset];
+            return makeView(T_Api{}, shiftedPtr, extents, this->getPitches(), Alignment<>{});
         }
     };
 

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -140,16 +140,18 @@ namespace alpaka
          * @param extents number of elements for each dimension
          * @return View which is pointing only to a part of the original view.
          */
-        constexpr auto getSubView(alpaka::concepts::Vector auto const& extents) const
+        constexpr auto getSubView(alpaka::concepts::VectorOrScalar auto const& extents) const
         {
-            assert((extents <= this->getExtents()).reduce(std::logical_and{}));
-            return makeView(T_Api{}, this->data(), extents, this->getPitches(), T_MemAlignment{});
+            Vec extentMd = extents;
+            assert((extentMd <= this->getExtents()).reduce(std::logical_and{}));
+            return makeView(T_Api{}, this->data(), extentMd, this->getPitches(), T_MemAlignment{});
         }
 
-        constexpr auto getSubView(alpaka::concepts::Vector auto const& extents)
+        constexpr auto getSubView(alpaka::concepts::VectorOrScalar auto const& extents)
         {
-            assert((extents <= this->getExtents()).reduce(std::logical_and{}));
-            return makeView(T_Api{}, this->data(), extents, this->getPitches(), T_MemAlignment{});
+            Vec extentMd = extents;
+            assert((extentMd <= this->getExtents()).reduce(std::logical_and{}));
+            return makeView(T_Api{}, this->data(), extentMd, this->getPitches(), T_MemAlignment{});
         }
 
         /** Creates a sub view to a part of the memory.
@@ -160,21 +162,25 @@ namespace alpaka
          *         View which pointThe alignment of the sub view is reduced to the element alignment.
          */
         constexpr auto getSubView(
-            alpaka::concepts::Vector auto const& offset,
-            alpaka::concepts::Vector auto const& extents) const
+            alpaka::concepts::VectorOrScalar auto const& offset,
+            alpaka::concepts::VectorOrScalar auto const& extents) const
         {
-            assert((extents <= this->getExtents()).reduce(std::logical_and{}));
-            auto shiftedPtr = &(*this)[offset];
-            return makeView(T_Api{}, shiftedPtr, extents, this->getPitches(), Alignment<>{});
+            Vec offsetMd = offset;
+            Vec extentMd = extents;
+            assert((offsetMd + extentMd <= this->getExtents()).reduce(std::logical_and{}));
+            auto shiftedPtr = &(*this)[offsetMd];
+            return makeView(T_Api{}, shiftedPtr, extentMd, this->getPitches(), Alignment<>{});
         }
 
         constexpr auto getSubView(
-            alpaka::concepts::Vector auto const& offset,
-            alpaka::concepts::Vector auto const& extents)
+            alpaka::concepts::VectorOrScalar auto const& offset,
+            alpaka::concepts::VectorOrScalar auto const& extents)
         {
-            assert((extents <= this->getExtents()).reduce(std::logical_and{}));
-            auto shiftedPtr = &(*this)[offset];
-            return makeView(T_Api{}, shiftedPtr, extents, this->getPitches(), Alignment<>{});
+            Vec offsetMd = offset;
+            Vec extentMd = extents;
+            assert((offsetMd + extentMd <= this->getExtents()).reduce(std::logical_and{}));
+            auto shiftedPtr = &(*this)[offsetMd];
+            return makeView(T_Api{}, shiftedPtr, extentMd, this->getPitches(), Alignment<>{});
         }
     };
 

--- a/include/alpaka/onHost/mem/ManagedView.hpp
+++ b/include/alpaka/onHost/mem/ManagedView.hpp
@@ -50,9 +50,13 @@ namespace alpaka::onHost
         {
         }
 
-        // friend declaration is required that a non const managed view can access the private constructor
-        friend struct ManagedView<T_Api, std::remove_const_t<T_Type>, T_Extents, T_MemAlignment>;
-
+        // friend declaration is required that any type of ManagedView can access the private constructor
+        template<
+            alpaka::concepts::Api T_OtherApi,
+            typename T_OtherType,
+            alpaka::concepts::Vector T_OtherExtents,
+            alpaka::concepts::Alignment T_OtherMemAlignment2>
+        friend struct ManagedView;
 
     public:
         template<
@@ -72,6 +76,12 @@ namespace alpaka::onHost
             static_assert(
                 isLosslessConvertible_v<typename T_UserPitches::type, typename T_UserExtents::type>,
                 "extent type and pitch type must be lossless convertible");
+        }
+
+        auto& operator=(auto const& otherManagedView) const
+        {
+            *this = otherManagedView.getConstManagedView();
+            return *this;
         }
 
         auto getView() const
@@ -102,25 +112,27 @@ namespace alpaka::onHost
          * @param extents number of elements for each dimension
          * @return View which is pointing only to a part of the original managed view.
          */
-        auto getManagedSubView(alpaka::concepts::Vector auto const& extents) const
+        auto getManagedSubView(alpaka::concepts::VectorOrScalar auto const& extents) const
         {
-            assert(extents <= this->getExtents());
+            Vec extentMd = extents;
+            assert((extentMd <= this->getExtents()).reduce(std::logical_and{}));
             return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(this->data())>, T_Extents, T_MemAlignment>{
                 T_Api{},
                 this->data(),
-                extents,
+                extentMd,
                 this->getPitches(),
                 m_deleter,
                 T_MemAlignment{}};
         }
 
-        auto getManagedSubView(alpaka::concepts::Vector auto const& extents)
+        auto getManagedSubView(alpaka::concepts::VectorOrScalar auto const& extents)
         {
-            assert(extents <= this->getExtents());
+            Vec extentMd = extents;
+            assert((extentMd <= this->getExtents()).reduce(std::logical_and{}));
             return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(this->data())>, T_Extents, T_MemAlignment>{
                 T_Api{},
                 this->data(),
-                extents,
+                extentMd,
                 this->getPitches(),
                 m_deleter,
                 T_MemAlignment{}};
@@ -128,36 +140,40 @@ namespace alpaka::onHost
 
         /** Creates a sub managed view to a part of the memory.
          *
-         * @param offset offset in elements to the original managed view
+         * @param offsets offset in elements to the original managed view
          * @param extents number of elements for each dimension
          * @return View which is pointing only to a part of the original managed view with a shifted origin pointer.
          *         View which pointThe alignment of the sub view is reduced to the element alignment.
          */
         auto getManagedSubView(
-            alpaka::concepts::Vector auto const& offset,
-            alpaka::concepts::Vector auto const& extents) const
+            alpaka::concepts::VectorOrScalar auto const& offsets,
+            alpaka::concepts::VectorOrScalar auto const& extents) const
         {
-            assert(offset + extents <= this->getExtents());
-            auto shiftedPtr = &this->getMdSpan()[offset];
+            Vec offsetMd = offsets;
+            Vec extentMd = extents;
+            assert((offsetMd + extentMd <= this->getExtents()).reduce(std::logical_and{}));
+            auto shiftedPtr = &(*this)[offsetMd];
             return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(shiftedPtr)>, T_Extents, Alignment<>>{
                 T_Api{},
                 shiftedPtr,
-                extents,
+                extentMd,
                 this->getPitches(),
                 m_deleter,
                 Alignment<>{}};
         }
 
         auto getManagedSubView(
-            alpaka::concepts::Vector auto const& offset,
-            alpaka::concepts::Vector auto const& extents)
+            alpaka::concepts::VectorOrScalar auto const& offsets,
+            alpaka::concepts::VectorOrScalar auto const& extents)
         {
-            assert(offset + extents <= this->getExtents());
-            auto shiftedPtr = &this->getMdSpan()[offset];
+            Vec offsetMd = offsets;
+            Vec extentMd = extents;
+            assert((offsetMd + extentMd <= this->getExtents()).reduce(std::logical_and{}));
+            auto shiftedPtr = &(*this)[offsetMd];
             return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(shiftedPtr)>, T_Extents, Alignment<>>{
                 T_Api{},
                 shiftedPtr,
-                extents,
+                extentMd,
                 this->getPitches(),
                 m_deleter,
                 Alignment<>{}};

--- a/include/alpaka/onHost/mem/ManagedView.hpp
+++ b/include/alpaka/onHost/mem/ManagedView.hpp
@@ -25,7 +25,7 @@ namespace alpaka::onHost
     /** Life time managed view with contiguous data
      *
      * This managed view owns the data and will deallocate it when the view is destroyed.
-     * Const-ness of the managed view is NOT propagated to the data region.
+     * Const-ness of the managed view instance is propagated to the data region.
      */
     template<
         alpaka::concepts::Api T_Api,
@@ -76,6 +76,11 @@ namespace alpaka::onHost
 
         auto getView() const
         {
+            return BaseView::getConstView();
+        }
+
+        auto getView()
+        {
             return static_cast<BaseView>(*this);
         }
 
@@ -100,7 +105,25 @@ namespace alpaka::onHost
         auto getManagedSubView(alpaka::concepts::Vector auto const& extents) const
         {
             assert(extents <= this->getExtents());
-            return ManagedView{T_Api{}, this->data(), extents, this->getPitches(), m_deleter, T_MemAlignment{}};
+            return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(this->data())>, T_Extents, T_MemAlignment>{
+                T_Api{},
+                this->data(),
+                extents,
+                this->getPitches(),
+                m_deleter,
+                T_MemAlignment{}};
+        }
+
+        auto getManagedSubView(alpaka::concepts::Vector auto const& extents)
+        {
+            assert(extents <= this->getExtents());
+            return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(this->data())>, T_Extents, T_MemAlignment>{
+                T_Api{},
+                this->data(),
+                extents,
+                this->getPitches(),
+                m_deleter,
+                T_MemAlignment{}};
         }
 
         /** Creates a sub managed view to a part of the memory.
@@ -116,7 +139,28 @@ namespace alpaka::onHost
         {
             assert(offset + extents <= this->getExtents());
             auto shiftedPtr = &this->getMdSpan()[offset];
-            return ManagedView{T_Api{}, shiftedPtr, extents, this->getPitches(), Alignment<>{}};
+            return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(shiftedPtr)>, T_Extents, Alignment<>>{
+                T_Api{},
+                shiftedPtr,
+                extents,
+                this->getPitches(),
+                m_deleter,
+                Alignment<>{}};
+        }
+
+        auto getManagedSubView(
+            alpaka::concepts::Vector auto const& offset,
+            alpaka::concepts::Vector auto const& extents)
+        {
+            assert(offset + extents <= this->getExtents());
+            auto shiftedPtr = &this->getMdSpan()[offset];
+            return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(shiftedPtr)>, T_Extents, Alignment<>>{
+                T_Api{},
+                shiftedPtr,
+                extents,
+                this->getPitches(),
+                m_deleter,
+                Alignment<>{}};
         }
 
         /** Adds a destructor action to the managed view

--- a/tests/unit/algorithm/concurrent.cpp
+++ b/tests/unit/algorithm/concurrent.cpp
@@ -30,7 +30,7 @@ struct StencilAddWithAcc
 {
     constexpr void operator()(
         onAcc::concepts::Acc auto const&,
-        concepts::SimdPtr auto const& a,
+        concepts::SimdPtr auto a,
         concepts::SimdPtr auto const& b) const
     {
         a = a.load() + b.load();

--- a/tests/unit/cvecKernelCall/cvecKernelCall.cpp
+++ b/tests/unit/cvecKernelCall/cvecKernelCall.cpp
@@ -65,7 +65,10 @@ TEMPLATE_LIST_TEST_CASE("CVec frame extent kernel call", "", TestApis)
     auto hBuff = onHost::allocHostLike(dBuff);
     onHost::wait(queue);
     {
-        queue.enqueue(exec, FrameSpec{Vec{1u}, CVec<uint32_t, 43u>{}}, KernelBundle{KernelCVecFrameExtents{}, dBuff});
+        queue.enqueue(
+            exec,
+            FrameSpec{Vec{1u}, CVec<uint32_t, 43u>{}},
+            KernelBundle{KernelCVecFrameExtents{}, dBuff.getView()});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
         CHECK(hBuff[0] == true);

--- a/tests/unit/math/Buffer.hpp
+++ b/tests/unit/math/Buffer.hpp
@@ -55,7 +55,12 @@ namespace mathtest
             alpaka::onHost::memcpy(queue, m_hostView, m_deviceView);
         }
 
-        ALPAKA_FN_HOST auto operator()(size_t idx) const -> value_type&
+        ALPAKA_FN_HOST decltype(auto) operator()(size_t idx) const
+        {
+            return m_hostView[idx];
+        }
+
+        ALPAKA_FN_HOST decltype(auto) operator()(size_t idx)
         {
             return m_hostView[idx];
         }

--- a/tests/unit/mem/constCorrectness.cpp
+++ b/tests/unit/mem/constCorrectness.cpp
@@ -1,0 +1,208 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/onHost/example/executors.hpp>
+#include <alpaka/onHost/executeForEach.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <iostream>
+
+using namespace alpaka;
+
+/** @file test the behaviour for constness of buffers/views/MdSpan
+ *
+ * We run two different test, one for access with 1D memory and the usage of scalars to access the memory and one for
+ * multidimensional memory, because there are specializations for 1D in our implementations.
+ */
+
+/** validate that the buffer is mutable
+ *
+ * If we use non-outer const buffers/views in the function signature it should be possible to call the function even if
+ * the buffer/view had an outer const before. The reason why we can not transform the outer const into an inner const
+ * is that we requires this within @c KernelBundle to forward the kernel user arguments in a tuple to the user kernel.
+ */
+void requiresMutableBufferMd(concepts::MdSpan auto buffer)
+{
+    static_assert(!std::is_const_v<std::remove_pointer_t<decltype(buffer.data())>>);
+    static_assert(!std::is_const_v<std::remove_reference_t<decltype(buffer[Vec{0, 0}])>>);
+}
+
+TEST_CASE("buffer const correctness 1D", "")
+{
+    auto buffer0 = onHost::allocHost<int>(10);
+    static_assert(!std::is_const_v<std::remove_pointer_t<decltype(buffer0.data())>>);
+    // mutable views
+    {
+        [[maybe_unused]] auto subBuffer0 = buffer0.getManagedSubView(2);
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subBuffer0[0])>>);
+
+        [[maybe_unused]] auto subOffsetBuffer0 = buffer0.getManagedSubView(1, 2);
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[0])>>);
+
+        [[maybe_unused]] auto subView0 = buffer0.getSubView(2);
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subView0.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subView0[0])>>);
+
+        [[maybe_unused]] auto subOffsetView0 = buffer0.getSubView(1, 2);
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subOffsetView0.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subOffsetView0[0])>>);
+
+        [[maybe_unused]] View view = buffer0.getView();
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(view.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(view[0])>>);
+
+        [[maybe_unused]] MdSpan mdSpan = buffer0.getMdSpan();
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(mdSpan.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(mdSpan[0])>>);
+    }
+    // non-mutable views
+    {
+        onHost::ManagedView innerConstBuffer0 = buffer0.getConstManagedView();
+        [[maybe_unused]] auto subBuffer0 = innerConstBuffer0.getManagedSubView(2);
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subBuffer0[0])>>);
+
+        [[maybe_unused]] auto subOffsetBuffer0 = innerConstBuffer0.getManagedSubView(1, 2);
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[0])>>);
+
+        [[maybe_unused]] auto subView0 = innerConstBuffer0.getSubView(2);
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subView0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subView0[0])>>);
+
+        [[maybe_unused]] auto subOffsetView0 = innerConstBuffer0.getSubView(1, 2);
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetView0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetView0[0])>>);
+
+        [[maybe_unused]] View view = innerConstBuffer0.getView();
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(view.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(view[0])>>);
+
+        [[maybe_unused]] MdSpan mdSpan = innerConstBuffer0.getMdSpan();
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(mdSpan.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(mdSpan[0])>>);
+    }
+    // non-mutable views (outer const)
+    {
+        onHost::ManagedView const outerConstBuffer0 = buffer0;
+        [[maybe_unused]] auto subBuffer0 = outerConstBuffer0.getManagedSubView(2);
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subBuffer0[0])>>);
+
+        [[maybe_unused]] auto subOffsetBuffer0 = outerConstBuffer0.getManagedSubView(1, 2);
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[0])>>);
+
+        [[maybe_unused]] auto subView0 = outerConstBuffer0.getSubView(2);
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subView0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subView0[0])>>);
+
+        [[maybe_unused]] auto subOffsetView0 = outerConstBuffer0.getSubView(1, 2);
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetView0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetView0[0])>>);
+
+        [[maybe_unused]] View view = outerConstBuffer0.getView();
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(view.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(view[0])>>);
+
+        [[maybe_unused]] MdSpan mdSpan = outerConstBuffer0.getMdSpan();
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(mdSpan.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(mdSpan[0])>>);
+    }
+}
+
+TEST_CASE("buffer const correctness MD", "")
+{
+    auto buffer0 = onHost::allocHost<int>(Vec{10, 10});
+    requiresMutableBufferMd(buffer0);
+    static_assert(!std::is_const_v<std::remove_pointer_t<decltype(buffer0.data())>>);
+    // mutable views
+    {
+        [[maybe_unused]] auto subBuffer0 = buffer0.getManagedSubView(Vec{2, 2});
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subBuffer0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] auto subOffsetBuffer0 = buffer0.getManagedSubView(Vec{1, 1}, Vec{2, 2});
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] auto subView0 = buffer0.getSubView(Vec{2, 2});
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subView0.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subView0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] auto subOffsetView0 = buffer0.getSubView(Vec{1, 1}, Vec{2, 2});
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subOffsetView0.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subOffsetView0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] View view = buffer0.getView();
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(view.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(view[Vec{0, 0}])>>);
+
+        [[maybe_unused]] MdSpan mdSpan = buffer0.getMdSpan();
+        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(mdSpan.data())>>);
+        static_assert(!std::is_const_v<std::remove_reference_t<decltype(mdSpan[Vec{0, 0}])>>);
+    }
+    // non-mutable views
+    {
+        onHost::ManagedView innerConstBuffer0 = buffer0.getConstManagedView();
+
+        [[maybe_unused]] auto subBuffer0 = innerConstBuffer0.getManagedSubView(Vec{2, 2});
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subBuffer0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] auto subOffsetBuffer0 = innerConstBuffer0.getManagedSubView(Vec{1, 1}, Vec{2, 2});
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] auto subView0 = innerConstBuffer0.getSubView(Vec{2, 2});
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subView0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subView0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] auto subOffsetView0 = innerConstBuffer0.getSubView(Vec{1, 1}, Vec{2, 2});
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetView0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetView0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] View view = innerConstBuffer0.getView();
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(view.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(view[Vec{0, 0}])>>);
+
+        [[maybe_unused]] MdSpan mdSpan = innerConstBuffer0.getMdSpan();
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(mdSpan.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(mdSpan[Vec{0, 0}])>>);
+    }
+    // non-mutable views (outer const)
+    {
+        onHost::ManagedView const outerConstBuffer0 = buffer0;
+        requiresMutableBufferMd(outerConstBuffer0);
+
+        [[maybe_unused]] auto subBuffer0 = outerConstBuffer0.getManagedSubView(Vec{2, 2});
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subBuffer0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] auto subOffsetBuffer0 = outerConstBuffer0.getManagedSubView(Vec{1, 1}, Vec{2, 2});
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] auto subView0 = outerConstBuffer0.getSubView(Vec{2, 2});
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subView0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subView0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] auto subOffsetView0 = outerConstBuffer0.getSubView(Vec{1, 1}, Vec{2, 2});
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetView0.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetView0[Vec{0, 0}])>>);
+
+        [[maybe_unused]] View view = outerConstBuffer0.getView();
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(view.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(view[Vec{0, 0}])>>);
+
+        [[maybe_unused]] MdSpan mdSpan = outerConstBuffer0.getMdSpan();
+        static_assert(std::is_const_v<std::remove_pointer_t<decltype(mdSpan.data())>>);
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(mdSpan[Vec{0, 0}])>>);
+    }
+}

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -279,6 +279,11 @@ struct TestMdSpan
         return m_span.data();
     }
 
+    constexpr auto* data()
+    {
+        return m_span.data();
+    }
+
     constexpr auto getExtents() const
     {
         return m_span.getExtents();


### PR DESCRIPTION
This PR changes the behaviour of MdPSpan and View. The constness of the view/span is forwarded to the data too.

- [x] add tests to ensure correct behaviour

```C++
auto foo = onHost::allocHost<int>(10);
// mutable view
auto fooSub = foo.getSubView(2); 
static_assert(!std::is_constant_v<std::remove_pointer_t<ALPAKA_TYPEOF(fooSub.data())>>);

auto const fooOuterConst = foo;
// outer const of fooOuterConst is propagated into inner const of the subview
auto fooSubInnerConst = fooOuterConst.getSubView(2); 
static_assert(std::is_constant_v<std::remove_pointer_t<ALPAKA_TYPEOF(fooOuterConst.data())>>);
```