### PR TITLE
rename `ManagedView` to `SharedBuffer`

### DIFF
--- a/docs/snippets/10_memory.cpp
+++ b/docs/snippets/10_memory.cpp
@@ -35,25 +35,25 @@ TEST_CASE("memory", "[docs]")
 
     // Allocate a memory view on the compute device.
     // The memory will be freed automatically when the view goes out of scope.
-    onHost::SharedBuffer computeView = onHost::alloc<int>(computeDev, 10);
+    onHost::SharedBuffer computeBuffer = onHost::alloc<int>(computeDev, 10);
     // Derive the properties except the location.
-    onHost::SharedBuffer hostView = onHost::allocHostLike(computeView);
+    onHost::SharedBuffer hostBuffer = onHost::allocHostLike(computeBuffer);
 
     // To operate on host memory views, we need a host queue. Sett all bytes to zero.
-    onHost::memset(hostQueue, hostView, 0);
+    onHost::memset(hostQueue, hostBuffer, 0);
     onHost::wait(hostQueue);
 
     // Both memory views are not filled with valid data yet, so let us assign a value to each element and copy it to
     // the host. note: currently you cannot use a compute queue of a GPU device to fill a host memory view. @todo add
     // host task execution to any compute queue
-    onHost::fill(computeQueue, computeView, 42);
+    onHost::fill(computeQueue, computeBuffer, 42);
     // copy the data to the host
-    onHost::memcpy(computeQueue, hostView, computeView);
+    onHost::memcpy(computeQueue, hostBuffer, computeBuffer);
     // wait because all previous operations are asynchronous
     onHost::wait(computeQueue);
 
     // check that the data is valid
-    for(auto const& v : hostView)
+    for(auto const& v : hostBuffer)
         CHECK(v == 42);
 }
 
@@ -75,13 +75,13 @@ TEST_CASE("memory using std::vector", "[docs]")
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
     onHost::Queue computeQueue = computeDev.makeQueue();
 
-    onHost::SharedBuffer computeView = onHost::alloc<int>(computeDev, 10);
+    onHost::SharedBuffer computeBuffer = onHost::alloc<int>(computeDev, 10);
 
     // use std::vector instead of an alpaka view
     std::vector stdVec = std::vector<int>(10, 0);
 
-    onHost::fill(computeQueue, computeView, 42);
-    onHost::memcpy(computeQueue, stdVec, computeView);
+    onHost::fill(computeQueue, computeBuffer, 42);
+    onHost::memcpy(computeQueue, stdVec, computeBuffer);
     onHost::wait(computeQueue);
 
     // check that the data is valid

--- a/docs/snippets/10_memory.cpp
+++ b/docs/snippets/10_memory.cpp
@@ -35,9 +35,9 @@ TEST_CASE("memory", "[docs]")
 
     // Allocate a memory view on the compute device.
     // The memory will be freed automatically when the view goes out of scope.
-    onHost::ManagedView computeView = onHost::alloc<int>(computeDev, 10);
+    onHost::SharedBuffer computeView = onHost::alloc<int>(computeDev, 10);
     // Derive the properties except the location.
-    onHost::ManagedView hostView = onHost::allocHostLike(computeView);
+    onHost::SharedBuffer hostView = onHost::allocHostLike(computeView);
 
     // To operate on host memory views, we need a host queue. Sett all bytes to zero.
     onHost::memset(hostQueue, hostView, 0);
@@ -75,7 +75,7 @@ TEST_CASE("memory using std::vector", "[docs]")
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
     onHost::Queue computeQueue = computeDev.makeQueue();
 
-    onHost::ManagedView computeView = onHost::alloc<int>(computeDev, 10);
+    onHost::SharedBuffer computeView = onHost::alloc<int>(computeDev, 10);
 
     // use std::vector instead of an alpaka view
     std::vector stdVec = std::vector<int>(10, 0);

--- a/docs/snippets/15_kernel.cpp
+++ b/docs/snippets/15_kernel.cpp
@@ -42,23 +42,23 @@ TEST_CASE("first kernel", "[docs]")
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
     onHost::Queue computeQueue = computeDev.makeQueue();
 
-    onHost::SharedBuffer computeView = onHost::alloc<int>(computeDev, 111);
+    onHost::SharedBuffer computeBuffer = onHost::alloc<int>(computeDev, 111);
 
     // use std::vector instead of an alpaka view
-    std::vector stdVec = std::vector<int>(computeView.getExtents().x(), 0);
+    std::vector stdVec = std::vector<int>(computeBuffer.getExtents().x(), 0);
     std::iota(stdVec.begin(), stdVec.end(), 0);
 
-    onHost::fill(computeQueue, computeView, 42);
-    onHost::memcpy(computeQueue, computeView, stdVec);
+    onHost::fill(computeQueue, computeBuffer, 42);
+    onHost::memcpy(computeQueue, computeBuffer, stdVec);
 
     // The frame extent is randomly chosen
     constexpr auto frameExtents = Vec{256};
-    auto frameSpec = onHost::FrameSpec{divExZero(computeView.getExtents(), frameExtents), frameExtents};
+    auto frameSpec = onHost::FrameSpec{divExZero(computeBuffer.getExtents(), frameExtents), frameExtents};
     // If no executor is given as first argument to enqueue than the default executor is used.
     // The default is the fastest for the corresponding device.
     // For deviceKind::cpu the default is exec::cpuOmpBlocks if omp is enabled, otherwise exec::cpuSerial
-    computeQueue.enqueue(frameSpec, KernelBundle{AddOne{}, computeView});
-    onHost::memcpy(computeQueue, stdVec, computeView);
+    computeQueue.enqueue(frameSpec, KernelBundle{AddOne{}, computeBuffer});
+    onHost::memcpy(computeQueue, stdVec, computeBuffer);
     onHost::wait(computeQueue);
 
     // check that the data is valid
@@ -102,27 +102,27 @@ TEST_CASE("MD vector add kernel", "[docs]")
     onHost::Queue computeQueue = computeDev.makeQueue();
 
     auto extentMd = Vec{5, 7, 4097};
-    onHost::SharedBuffer computeViewOut = onHost::alloc<int>(computeDev, extentMd);
-    onHost::SharedBuffer computeViewIn0 = onHost::allocLike(computeDev, computeViewOut);
-    onHost::SharedBuffer computeViewIn1 = onHost::allocLike(computeDev, computeViewOut);
+    onHost::SharedBuffer computeBufferOut = onHost::alloc<int>(computeDev, extentMd);
+    onHost::SharedBuffer computeBufferIn0 = onHost::allocLike(computeDev, computeBufferOut);
+    onHost::SharedBuffer computeBufferIn1 = onHost::allocLike(computeDev, computeBufferOut);
 
-    onHost::SharedBuffer hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewOut);
+    onHost::SharedBuffer hostBufferIota = onHost::allocLike(onHost::makeHostDevice(), computeBufferOut);
 
     // initialize with the linearized index
     int iotaCounter = 0;
-    for(auto& value : hostViewIota)
+    for(auto& value : hostBufferIota)
     {
         value = iotaCounter;
         ++iotaCounter;
     }
 
-    onHost::fill(computeQueue, computeViewOut, 42);
-    onHost::memcpy(computeQueue, computeViewIn0, hostViewIota);
-    onHost::memcpy(computeQueue, computeViewIn1, hostViewIota);
+    onHost::fill(computeQueue, computeBufferOut, 42);
+    onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+    onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
 
     // The frame extent is randomly chosen, the dimensionality of the kernel is defined by the FrameSpec dimsions.
     constexpr auto frameExtents = Vec{8, 8, 8};
-    concepts::Vector auto numFrames = divExZero(computeViewOut.getExtents(), frameExtents);
+    concepts::Vector auto numFrames = divExZero(computeBufferOut.getExtents(), frameExtents);
     auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
 
     onHost::wait(computeQueue);
@@ -131,14 +131,14 @@ TEST_CASE("MD vector add kernel", "[docs]")
     computeQueue.enqueue(
         exec::cpuSerial,
         frameSpec,
-        KernelBundle{MDVectorAdd{}, computeViewOut, computeViewIn0, computeViewIn1});
+        KernelBundle{MDVectorAdd{}, computeBufferOut, computeBufferIn0, computeBufferIn1});
     onHost::wait(computeQueue);
     auto const endT = std::chrono::high_resolution_clock::now();
     std::cout << "Time for kernel: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-              << " data size: " << computeViewOut.getExtents() << std::endl;
+              << " data size: " << computeBufferOut.getExtents() << std::endl;
 
     // we overwrite the iota data because we are to lazy to allocate additional memory^^
-    onHost::memcpy(computeQueue, hostViewIota, computeViewOut);
+    onHost::memcpy(computeQueue, hostBufferIota, computeBufferOut);
     onHost::wait(computeQueue);
 
     // validate that all data
@@ -147,7 +147,7 @@ TEST_CASE("MD vector add kernel", "[docs]")
         extentMd,
         [&](auto idx)
         {
-            CHECK(hostViewIota[idx] == (resultCounter + resultCounter));
+            CHECK(hostBufferIota[idx] == (resultCounter + resultCounter));
             ++resultCounter;
         });
 }

--- a/docs/snippets/15_kernel.cpp
+++ b/docs/snippets/15_kernel.cpp
@@ -42,7 +42,7 @@ TEST_CASE("first kernel", "[docs]")
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
     onHost::Queue computeQueue = computeDev.makeQueue();
 
-    onHost::ManagedView computeView = onHost::alloc<int>(computeDev, 111);
+    onHost::SharedBuffer computeView = onHost::alloc<int>(computeDev, 111);
 
     // use std::vector instead of an alpaka view
     std::vector stdVec = std::vector<int>(computeView.getExtents().x(), 0);
@@ -102,11 +102,11 @@ TEST_CASE("MD vector add kernel", "[docs]")
     onHost::Queue computeQueue = computeDev.makeQueue();
 
     auto extentMd = Vec{5, 7, 4097};
-    onHost::ManagedView computeViewOut = onHost::alloc<int>(computeDev, extentMd);
-    onHost::ManagedView computeViewIn0 = onHost::allocLike(computeDev, computeViewOut);
-    onHost::ManagedView computeViewIn1 = onHost::allocLike(computeDev, computeViewOut);
+    onHost::SharedBuffer computeViewOut = onHost::alloc<int>(computeDev, extentMd);
+    onHost::SharedBuffer computeViewIn0 = onHost::allocLike(computeDev, computeViewOut);
+    onHost::SharedBuffer computeViewIn1 = onHost::allocLike(computeDev, computeViewOut);
 
-    onHost::ManagedView hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewOut);
+    onHost::SharedBuffer hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewOut);
 
     // initialize with the linearized index
     int iotaCounter = 0;

--- a/docs/snippets/20_simdKernel.cpp
+++ b/docs/snippets/20_simdKernel.cpp
@@ -55,11 +55,11 @@ TEST_CASE("MD vector simd add kernel", "[docs]")
 
     using DataType = int;
     auto extentMd = Vec{5, 7, 4097};
-    onHost::ManagedView computeViewOut = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::ManagedView computeViewIn0 = onHost::allocLike(computeDev, computeViewOut);
-    onHost::ManagedView computeViewIn1 = onHost::allocLike(computeDev, computeViewOut);
+    onHost::SharedBuffer computeViewOut = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::SharedBuffer computeViewIn0 = onHost::allocLike(computeDev, computeViewOut);
+    onHost::SharedBuffer computeViewIn1 = onHost::allocLike(computeDev, computeViewOut);
 
-    onHost::ManagedView hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewOut);
+    onHost::SharedBuffer hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewOut);
 
     // initialize with the linearized index
     DataType iotaCounter = 0;

--- a/docs/snippets/20_simdKernel.cpp
+++ b/docs/snippets/20_simdKernel.cpp
@@ -55,23 +55,23 @@ TEST_CASE("MD vector simd add kernel", "[docs]")
 
     using DataType = int;
     auto extentMd = Vec{5, 7, 4097};
-    onHost::SharedBuffer computeViewOut = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::SharedBuffer computeViewIn0 = onHost::allocLike(computeDev, computeViewOut);
-    onHost::SharedBuffer computeViewIn1 = onHost::allocLike(computeDev, computeViewOut);
+    onHost::SharedBuffer computeBufferOut = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::SharedBuffer computeBufferIn0 = onHost::allocLike(computeDev, computeBufferOut);
+    onHost::SharedBuffer computeBufferIn1 = onHost::allocLike(computeDev, computeBufferOut);
 
-    onHost::SharedBuffer hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewOut);
+    onHost::SharedBuffer hostBufferIota = onHost::allocLike(onHost::makeHostDevice(), computeBufferOut);
 
     // initialize with the linearized index
     DataType iotaCounter = 0;
-    for(auto& value : hostViewIota)
+    for(auto& value : hostBufferIota)
     {
         value = iotaCounter;
         ++iotaCounter;
     }
 
-    onHost::fill(computeQueue, computeViewOut, DataType{42});
-    onHost::memcpy(computeQueue, computeViewIn0, hostViewIota);
-    onHost::memcpy(computeQueue, computeViewIn1, hostViewIota);
+    onHost::fill(computeQueue, computeBufferOut, DataType{42});
+    onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+    onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
 
     // The frame extent is randomly chosen, the dimensionality of the kernel is defined by the FrameSpec dimsions.
     constexpr auto frameExtents = Vec{8, 8, 8};
@@ -81,7 +81,7 @@ TEST_CASE("MD vector simd add kernel", "[docs]")
     // We only reduce the frame specification for the fast moving dimension.
     int elementsPerFrameItem = getNumElemPerThread<DataType>(computeQueue);
     concepts::Vector auto numFrames
-        = divExZero(computeViewOut.getExtents(), frameExtents * frameExtents.all(1).rAssign(elementsPerFrameItem));
+        = divExZero(computeBufferOut.getExtents(), frameExtents * frameExtents.all(1).rAssign(elementsPerFrameItem));
     // The frame specification is not required to be a multiple of the extent, it can be smaller.
     auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
     std::cout << frameSpec << std::endl;
@@ -91,14 +91,14 @@ TEST_CASE("MD vector simd add kernel", "[docs]")
     computeQueue.enqueue(
         exec::cpuSerial,
         frameSpec,
-        KernelBundle{MDVectorSimdAdd{}, computeViewOut, computeViewIn0, computeViewIn1});
+        KernelBundle{MDVectorSimdAdd{}, computeBufferOut, computeBufferIn0, computeBufferIn1});
     onHost::wait(computeQueue);
     auto const endT = std::chrono::high_resolution_clock::now();
     std::cout << "Time for simd kernel: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-              << " data size: " << computeViewOut.getExtents() << std::endl;
+              << " data size: " << computeBufferOut.getExtents() << std::endl;
 
     // we overwrite the iota data because we are to lazy to allocate additional memory^^
-    onHost::memcpy(computeQueue, hostViewIota, computeViewOut);
+    onHost::memcpy(computeQueue, hostBufferIota, computeBufferOut);
     onHost::wait(computeQueue);
 
     // validate that all data
@@ -107,7 +107,7 @@ TEST_CASE("MD vector simd add kernel", "[docs]")
         extentMd,
         [&](auto idx)
         {
-            CHECK(hostViewIota[idx] == (resultCounter + resultCounter));
+            CHECK(hostBufferIota[idx] == (resultCounter + resultCounter));
             ++resultCounter;
         });
 }

--- a/docs/snippets/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet.cpp
@@ -306,7 +306,7 @@ auto main() -> int
             // the real location depends on the native backend e.g. CUDA, OneApi, ...
             concepts::View auto devUnifiedBuffer = onHost::allocUnified<DataType>(device, extentMd);
             // allocate memory accessible from host
-            concepts::View auto hostView = onHost::allocHost<DataType>(extentMd);
+            concepts::View auto hostBuffer = onHost::allocHost<DataType>(extentMd);
             // Data will not be automatically freed, user must take care that
             // the original data life-time is longer than the non-owning view.
             concepts::View auto devNonOwningView = devBuffer.getView();

--- a/docs/snippets/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet.cpp
@@ -226,13 +226,13 @@ auto main() -> int
         // END-CHEATSHEET-waitEvent
 
         {
-            // BEGIN-CHEATSHEET-allocHostView
+            // BEGIN-CHEATSHEET-allocHostBuffer
             // Allocate memory for the alpaka buffer, which is a dynamic 3-dimensional array
             // Memory allocations support any dimensionality
-            concepts::View auto hostView = onHost::allocHost<DataType>(extent3D);
-            // END-CHEATSHEET-allocHostView
+            concepts::View auto hostBuffer = onHost::allocHost<DataType>(extent3D);
+            // END-CHEATSHEET-allocHostBuffer
 
-            unused(hostView);
+            unused(hostBuffer);
         }
 
         {
@@ -250,7 +250,7 @@ auto main() -> int
             // BEGIN-CHEATSHEET-makeViewFromStdVector
             std::vector vec = std::vector<DataType>(42u);
             // the api is not required, std::vector is assumed to be api::host
-            // a non managed view us usable within a kernel and on the host therefore no namespace 'onHost' is required
+            // a non owning view us usable within a kernel and on the host therefore no namespace 'onHost' is required
             auto hostView = makeView(vec);
             // END-CHEATSHEET-makeViewFromStdVector
 
@@ -270,57 +270,59 @@ auto main() -> int
         }
 
         {
-            concepts::View auto view = onHost::allocHost<DataType>(numElements);
+            concepts::View auto buffer = onHost::allocHost<DataType>(numElements);
             // BEGIN-CHEATSHEET-dataPtr
-            DataType* rawPtr = onHost::data(view);
+            DataType* rawPtr = onHost::data(buffer);
             // END-CHEATSHEET-dataPtr
 
             unused(rawPtr);
 
             // BEGIN-CHEATSHEET-getPitches
-            // memory in bytes to the next element in the view along the pitch dimension
-            concepts::Vector auto viewPitches = onHost::getPitches(view);
+            // memory in bytes to the next element in the buffer along the pitch dimension
+            concepts::Vector auto bufferPitches = onHost::getPitches(buffer);
             // END-CHEATSHEET-getPitches
 
-            unused(viewPitches);
+            unused(bufferPitches);
 
             // BEGIN-CHEATSHEET-initView
-            // the view can have any dimensionality
+            // The buffer can have any dimensionality.
+            // Memory manipulation functions supporting views too.
             // set all bytes to zero
-            onHost::memset(queue, view, uint8_t{0});
+            onHost::memset(queue, buffer, uint8_t{0});
             // element-wise fill with value
-            onHost::fill(queue, view, 42);
+            onHost::fill(queue, buffer, 42);
             // END-CHEATSHEET-initView
         }
 
         concepts::Vector auto extentMd = Vec{value};
         {
-            // BEGIN-CHEATSHEET-allocView
-            // the allocation is providing a managed view which will be
+            // BEGIN-CHEATSHEET-allocBuffer
+            // the allocation is providing a shared buffer which will be
             // automatically freed if the last handle runs out of a life-time
-            concepts::View auto devView = onHost::alloc<DataType>(device, extentMd);
+            concepts::View auto devBuffer = onHost::alloc<DataType>(device, extentMd);
             // allocate memory which lives on the host but is accessible from the device too
-            concepts::View auto devMappedView = onHost::allocMapped<DataType>(device, extentMd);
+            concepts::View auto devMappedBuffer = onHost::allocMapped<DataType>(device, extentMd);
             // allocate memory can be accessed from host and device (unified memory),
             // the real location depends on the native backend e.g. CUDA, OneApi, ...
-            concepts::View auto devUnifiedView = onHost::allocUnified<DataType>(device, extentMd);
+            concepts::View auto devUnifiedBuffer = onHost::allocUnified<DataType>(device, extentMd);
             // allocate memory accessible from host
             concepts::View auto hostView = onHost::allocHost<DataType>(extentMd);
-            // data will not be automatically freed, user must take care that
-            // the original data life-time is longer than the unmanaged view
-            concepts::View auto devViewUnmanaged = devView.getView();
-            // END-CHEATSHEET-allocView
+            // Data will not be automatically freed, user must take care that
+            // the original data life-time is longer than the non-owning view.
+            concepts::View auto devNonOwningView = devBuffer.getView();
+            // END-CHEATSHEET-allocBuffer
 
-            unused(devMappedView, devUnifiedView, devViewUnmanaged);
+            unused(devMappedBuffer, devUnifiedBuffer, devNonOwningView);
 
-            auto dstView = devView;
-            auto srcView = devMappedView;
+            auto dstBuffer = devBuffer;
+            auto srcBuffer = devMappedBuffer;
 
-            // BEGIN-CHEATSHEET-copyView
-            onHost::memcpy(queue, dstView, srcView);
-            // providing the extent is optional and allow partial copies
-            onHost::memcpy(queue, dstView, srcView, extentMd);
-            // END-CHEATSHEET-copyView
+            // BEGIN-CHEATSHEET-memcpy
+            // Memory manipulation functions supporting views too.
+            onHost::memcpy(queue, dstBuffer, srcBuffer);
+            // Providing the extent is optional and allow partial copies.
+            onHost::memcpy(queue, dstBuffer, srcBuffer, extentMd);
+            // END-CHEATSHEET-memcpy
         }
 
         concepts::Vector auto numFramesMd = Vec{valueY, valueX};

--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -163,11 +163,11 @@ Memory
 
 Memory allocation and transfers are symmetric for host and devices, both done via alpaka API
 
-Allocate a managed view in host memory
+Allocate a shared buffer in host memory
   .. literalinclude:: ../../snippets/cheatsheet.cpp
     :language: cpp
-    :start-after: BEGIN-CHEATSHEET-allocHostView
-    :end-before: END-CHEATSHEET-allocHostView
+    :start-after: BEGIN-CHEATSHEET-allocHostBuffer
+    :end-before: END-CHEATSHEET-allocHostBuffer
     :dedent:
 
 Create a view to host memory represented by a pointer
@@ -212,18 +212,18 @@ View initialization, etc.
     :end-before: END-CHEATSHEET-initView
     :dedent:
 
-Allocate a view
+Allocate a buffer
   .. literalinclude:: ../../snippets/cheatsheet.cpp
     :language: cpp
-    :start-after: BEGIN-CHEATSHEET-allocView
-    :end-before: END-CHEATSHEET-allocView
+    :start-after: BEGIN-CHEATSHEET-allocBuffer
+    :end-before: END-CHEATSHEET-allocBuffer
     :dedent:
 
-Copy view data
+Copy multidimensiona buffer/view or span data
   .. literalinclude:: ../../snippets/cheatsheet.cpp
     :language: cpp
-    :start-after: BEGIN-CHEATSHEET-copyView
-    :end-before: END-CHEATSHEET-copyView
+    :start-after: BEGIN-CHEATSHEET-memcpy
+    :end-before: END-CHEATSHEET-memcpy
     :dedent:
 
 Kernel Execution

--- a/docs/source/basic/library.rst
+++ b/docs/source/basic/library.rst
@@ -40,9 +40,9 @@ The interaction of the main user facing concepts can be seen in the following fi
 
 
 For each type of ``Device`` there is a ``DeviceSelector`` for enumerating the available ``Device``s.
-A ``Device`` is the requirement for creating ``Queues`` and ``Events`` as it is for allocating ``ManagedViews`` on the respective ``Device``.
-``ManagedViews`` can be copied, their memory be byte-wise set or filled with element-wise.
-The location of the ``ManagedView`` data can be on the host, on the host but mapped into the device address space, directly on the device or even in a unified memory space shared between host and device.
+A ``Device`` is the requirement for creating ``Queues`` and ``Events`` as it is for allocating ``SharedBuffers`` on the respective ``Device``.
+``SharedBuffers`` can be copied, their memory be byte-wise set or filled with element-wise.
+The location of the ``SharedBuffer`` data can be on the host, on the host but mapped into the device address space, directly on the device or even in a unified memory space shared between host and device.
 Copying, setting or filling a view requires the corresponding ``Copy``, ``Set`` or ``Fill` tasks to be enqueued into the ``Queue``.
 An ``Event`` can be enqueued into a ``Queue`` and its completion state can be queried by the user.
 It is possible to wait for (synchronize with) a single ``Event``, a ``Queue`` or a whole ``Device``.

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -13,7 +13,7 @@
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/onHost/DeviceProperties.hpp"
 #include "alpaka/onHost/Handle.hpp"
-#include "alpaka/onHost/mem/ManagedView.hpp"
+#include "alpaka/onHost/mem/SharedBuffer.hpp"
 #include "alpaka/onHost/trait.hpp"
 #include "alpaka/utility.hpp"
 
@@ -159,14 +159,14 @@ namespace alpaka::onHost
                 // deviceDependency is captured to keep the device alive until the memory is deleted
                 auto deleter = [ptr, deviceDependency]() { alpaka::core::alignedFree(alignment, ptr); };
 
-                auto managedView = onHost::ManagedView{
+                auto sharedBuffer = onHost::SharedBuffer{
                     deviceDependency,
                     ptr,
                     extents,
                     pitches,
                     std::move(deleter),
                     Alignment<alignment>{}};
-                return managedView;
+                return sharedBuffer;
             }
         };
 

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -19,7 +19,7 @@
 #include "alpaka/onHost/Handle.hpp"
 #include "alpaka/onHost/interface.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
-#include "alpaka/onHost/mem/ManagedView.hpp"
+#include "alpaka/onHost/mem/SharedBuffer.hpp"
 
 #include <cstdint>
 #include <cstring>
@@ -348,7 +348,7 @@ namespace alpaka::onHost
                                && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
             {
                 auto executors = supportedMappings(getDevice(queue), exec::allExecutors);
-                // avoid that we pass a ManagedView and convert non alpaka data views
+                // avoid that we pass a SharedBuffer and convert non alpaka data views
                 alpaka::concepts::MdSpan<T_Value> auto dataView = makeView(dest);
 
                 alpaka::internal::generic::fill(
@@ -394,14 +394,14 @@ namespace alpaka::onHost
                 auto deleter = [ptr, queueDep = std::move(queueDependency)]()
                 { internal::enqueue(*queueDep.get(), [ptr]() { alpaka::core::alignedFree(alignment, ptr); }); };
 
-                auto managedView = onHost::ManagedView{
+                auto sharedBuffer = onHost::SharedBuffer{
                     deviceDependency,
                     ptr,
                     extents,
                     pitches,
                     std::move(deleter),
                     Alignment<alignment>{}};
-                return managedView;
+                return sharedBuffer;
             }
         };
     } // namespace internal

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -119,7 +119,7 @@ namespace alpaka::onHost::internal
                      && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
         {
             auto executors = supportedMappings(getDevice(queue), exec::allExecutors);
-            // avoid that we pass a ManagedView and convert non alpaka data views
+            // avoid that we pass a SharedBuffer and convert non alpaka data views
             auto dataView = makeView(dest);
 
             alpaka::internal::generic::fill(queue, std::get<0>(executors), dataView.getSubView(extents), elementValue);

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -13,7 +13,7 @@
 #    include "alpaka/api/syclGeneric/Event.hpp"
 #    include "alpaka/api/syclGeneric/Queue.hpp"
 #    include "alpaka/api/util.hpp"
-#    include "alpaka/onHost/mem/ManagedView.hpp"
+#    include "alpaka/onHost/mem/SharedBuffer.hpp"
 
 #    include <sycl/sycl.hpp>
 
@@ -127,14 +127,14 @@ namespace alpaka::onHost
                     sycl::aligned_alloc_device(alignment, memSizeInByte, sycl_device, sycl_context));
                 auto deleter = [ctx = sycl_context, ptr]() { sycl::free(toVoidPtr(ptr), ctx); };
 
-                auto managedView = onHost::ManagedView{
+                auto sharedBuffer = onHost::SharedBuffer{
                     deviceDependency,
                     ptr,
                     extents,
                     pitches,
                     std::move(deleter),
                     Alignment<alignment>{}};
-                return managedView;
+                return sharedBuffer;
             }
         };
 
@@ -161,14 +161,14 @@ namespace alpaka::onHost
                     sycl::aligned_alloc_shared(alignment, memSizeInByte, sycl_device, sycl_context));
                 auto deleter = [ctx = sycl_context, ptr]() { sycl::free(toVoidPtr(ptr), ctx); };
 
-                auto managedView = onHost::ManagedView{
+                auto sharedBuffer = onHost::SharedBuffer{
                     deviceDependency,
                     ptr,
                     extents,
                     pitches,
                     std::move(deleter),
                     Alignment<alignment>{}};
-                return managedView;
+                return sharedBuffer;
             }
         };
 
@@ -189,14 +189,14 @@ namespace alpaka::onHost
                     = reinterpret_cast<T_Type*>(sycl::aligned_alloc_host(alignment, memSizeInByte, sycl_context));
                 auto deleter = [ctx = sycl_context, ptr]() { sycl::free(toVoidPtr(ptr), ctx); };
 
-                auto managedView = onHost::ManagedView{
+                auto sharedBuffer = onHost::SharedBuffer{
                     deviceDependency,
                     ptr,
                     extents,
                     pitches,
                     std::move(deleter),
                     Alignment<alignment>{}};
-                return managedView;
+                return sharedBuffer;
             }
         };
 

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -18,7 +18,7 @@
 #    include "alpaka/onHost/concepts.hpp"
 #    include "alpaka/onHost/interface.hpp"
 #    include "alpaka/onHost/internal/interface.hpp"
-#    include "alpaka/onHost/mem/ManagedView.hpp"
+#    include "alpaka/onHost/mem/SharedBuffer.hpp"
 #    include "alpaka/onHost/trait.hpp"
 
 #    include <sycl/sycl.hpp>
@@ -255,14 +255,14 @@ namespace alpaka::onHost
                 sycl::free(toVoidPtr(ptr), queueDep->getNativeHandle());
             };
 
-            auto managedView = onHost::ManagedView{
+            auto sharedBuffer = onHost::SharedBuffer{
                 deviceDependency,
                 ptr,
                 extents,
                 pitches,
                 std::move(deleter),
                 Alignment<alignment>{}};
-            return managedView;
+            return sharedBuffer;
         }
     };
 } // namespace alpaka::onHost

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -11,7 +11,7 @@
 #    include "alpaka/api/unifiedCudaHip/Queue.hpp"
 #    include "alpaka/api/util.hpp"
 #    include "alpaka/core/UniformCudaHip.hpp"
-#    include "alpaka/onHost/mem/ManagedView.hpp"
+#    include "alpaka/onHost/mem/SharedBuffer.hpp"
 
 #    include <cstdint>
 #    include <memory>
@@ -212,7 +212,7 @@ namespace alpaka::onHost
                  */
                 constexpr uint32_t alignment = 128u;
 
-                auto buffer = onHost::ManagedView{
+                auto buffer = onHost::SharedBuffer{
                     deviceDependency,
                     ptr,
                     extents,
@@ -254,14 +254,14 @@ namespace alpaka::onHost
                 auto deleter = [ptr, deviceDependency]()
                 { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::free(toVoidPtr(ptr))); };
 
-                auto managedView = onHost::ManagedView{
+                auto sharedBuffer = onHost::SharedBuffer{
                     deviceDependency,
                     ptr,
                     extents,
                     pitches,
                     std::move(deleter),
                     Alignment<alignment>{}};
-                return managedView;
+                return sharedBuffer;
             }
         };
 
@@ -293,14 +293,14 @@ namespace alpaka::onHost
                 auto deleter = [ptr, deviceDependency]()
                 { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::hostFree(toVoidPtr(ptr))); };
 
-                auto managedView = onHost::ManagedView{
+                auto sharedBuffer = onHost::SharedBuffer{
                     deviceDependency,
                     ptr,
                     extents,
                     pitches,
                     std::move(deleter),
                     Alignment<alignment>{}};
-                return managedView;
+                return sharedBuffer;
             }
         };
 

--- a/include/alpaka/api/unifiedCudaHip/Event.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Event.hpp
@@ -26,7 +26,7 @@
 #    include "alpaka/onHost/Handle.hpp"
 #    include "alpaka/onHost/interface.hpp"
 #    include "alpaka/onHost/internal/interface.hpp"
-#    include "alpaka/onHost/mem/ManagedView.hpp"
+#    include "alpaka/onHost/mem/SharedBuffer.hpp"
 
 #    include <cstdint>
 #    include <sstream>

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -27,7 +27,7 @@
 #    include "alpaka/onHost/Handle.hpp"
 #    include "alpaka/onHost/interface.hpp"
 #    include "alpaka/onHost/internal/interface.hpp"
-#    include "alpaka/onHost/mem/ManagedView.hpp"
+#    include "alpaka/onHost/mem/SharedBuffer.hpp"
 
 #    include <cstdint>
 #    include <sstream>
@@ -574,7 +574,7 @@ namespace alpaka::onHost
                          && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
             {
                 auto executors = supportedMappings(getDevice(queue), exec::allExecutors);
-                // avoid that we pass a ManagedView and convert non alpaka data views
+                // avoid that we pass a SharedBuffer and convert non alpaka data views
                 auto dataView = makeView(dest);
 
                 alpaka::internal::generic::fill(
@@ -621,14 +621,14 @@ namespace alpaka::onHost
                         ApiInterface::freeAsync(toVoidPtr(ptr), queueDependency.getNativeHandle()));
                 };
 
-                auto managedView = onHost::ManagedView{
+                auto sharedBuffer = onHost::SharedBuffer{
                     deviceDependency,
                     ptr,
                     extents,
                     pitches,
                     std::move(deleter),
                     Alignment<alignment>{}};
-                return managedView;
+                return sharedBuffer;
             }
         };
     } // namespace internal

--- a/include/alpaka/onHost/interface.hpp
+++ b/include/alpaka/onHost/interface.hpp
@@ -189,7 +189,7 @@ namespace alpaka::onHost
     /** Allocate host memory with the same value type and extents as an existing view.
      *
      * The content of the source view is **not** copied. The function deduces the
-     * element type and extents from `view` and creates a new managed view on the
+     * element type and extents from `view` and creates a new shared buffer on the
      * host controller device.
      *
      * @param view a view (e.g. `std::vector`, `std::array`, or any compatible type)

--- a/include/alpaka/onHost/mem/SharedBuffer.hpp
+++ b/include/alpaka/onHost/mem/SharedBuffer.hpp
@@ -22,23 +22,25 @@
 
 namespace alpaka::onHost
 {
-    /** Life time managed view with contiguous data
+    /** Life time managed buffer with contiguous data
      *
-     * This managed view owns the data and will deallocate it when the view is destroyed.
-     * Const-ness of the managed view instance is propagated to the data region.
+     * This buffer owns the data and will deallocate it when last copy is destroyed.
+     * Const-ness of the buffer instance is propagated to the data region.
+     * A copy of this instance will only perform a shallow copy, to perform a deep copy to duplicate the data you
+     * should use @c onHost::memcpy.
      */
     template<
         alpaka::concepts::Api T_Api,
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment = Alignment<>>
-    struct ManagedView : View<T_Api, T_Type, T_Extents, T_MemAlignment>
+    struct SharedBuffer : View<T_Api, T_Type, T_Extents, T_MemAlignment>
     {
     private:
         using BaseView = View<T_Api, T_Type, T_Extents, T_MemAlignment>;
 
         /** Constructor with existing managed deleter */
-        ManagedView(
+        SharedBuffer(
             T_Api const api,
             T_Type* data,
             T_Extents const& extents,
@@ -50,20 +52,20 @@ namespace alpaka::onHost
         {
         }
 
-        // friend declaration is required that any type of ManagedView can access the private constructor
+        // friend declaration is required that any type of SharedBuffer can access the private constructor
         template<
             alpaka::concepts::Api T_OtherApi,
             typename T_OtherType,
             alpaka::concepts::Vector T_OtherExtents,
             alpaka::concepts::Alignment T_OtherMemAlignment2>
-        friend struct ManagedView;
+        friend struct SharedBuffer;
 
     public:
         template<
             alpaka::concepts::HasApi T_Any,
             alpaka::concepts::Vector T_UserExtents,
             alpaka::concepts::Vector T_UserPitches>
-        ManagedView(
+        SharedBuffer(
             T_Any const& any,
             T_Type* data,
             T_UserExtents const& extents,
@@ -78,9 +80,9 @@ namespace alpaka::onHost
                 "extent type and pitch type must be lossless convertible");
         }
 
-        auto& operator=(auto const& otherManagedView) const
+        auto& operator=(auto const& otherSharedBuffer) const
         {
-            *this = otherManagedView.getConstManagedView();
+            *this = otherSharedBuffer.getConstSharedBuffer();
             return *this;
         }
 
@@ -94,11 +96,11 @@ namespace alpaka::onHost
             return static_cast<BaseView>(*this);
         }
 
-        /** create a read only managed view */
-        auto getConstManagedView() const
+        /** create a read shared buffer view */
+        auto getConstSharedBuffer() const
         {
             using ConstValueType = std::add_const_t<typename BaseView::value_type>;
-            return ManagedView<T_Api, ConstValueType, T_Extents, T_MemAlignment>(
+            return SharedBuffer<T_Api, ConstValueType, T_Extents, T_MemAlignment>(
                 T_Api{},
                 static_cast<ConstValueType*>(this->data()),
                 this->getExtents(),
@@ -107,16 +109,16 @@ namespace alpaka::onHost
                 T_MemAlignment{});
         }
 
-        /** Creates a sub managed view to a part of the memory.
+        /** Creates a buffer pointing to a part of the memory.
          *
          * @param extents number of elements for each dimension
-         * @return View which is pointing only to a part of the original managed view.
+         * @return shared buffer which is pointing only to a part of the original buffer.
          */
-        auto getManagedSubView(alpaka::concepts::VectorOrScalar auto const& extents) const
+        auto getSubSharedBuffer(alpaka::concepts::VectorOrScalar auto const& extents) const
         {
             Vec extentMd = extents;
             assert((extentMd <= this->getExtents()).reduce(std::logical_and{}));
-            return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(this->data())>, T_Extents, T_MemAlignment>{
+            return SharedBuffer<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(this->data())>, T_Extents, T_MemAlignment>{
                 T_Api{},
                 this->data(),
                 extentMd,
@@ -125,11 +127,11 @@ namespace alpaka::onHost
                 T_MemAlignment{}};
         }
 
-        auto getManagedSubView(alpaka::concepts::VectorOrScalar auto const& extents)
+        auto getSubSharedBuffer(alpaka::concepts::VectorOrScalar auto const& extents)
         {
             Vec extentMd = extents;
             assert((extentMd <= this->getExtents()).reduce(std::logical_and{}));
-            return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(this->data())>, T_Extents, T_MemAlignment>{
+            return SharedBuffer<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(this->data())>, T_Extents, T_MemAlignment>{
                 T_Api{},
                 this->data(),
                 extentMd,
@@ -138,14 +140,14 @@ namespace alpaka::onHost
                 T_MemAlignment{}};
         }
 
-        /** Creates a sub managed view to a part of the memory.
+        /** Creates a shared sub-buffer view to a part of the memory.
          *
-         * @param offsets offset in elements to the original managed view
+         * @param offsets offset in elements to the original buffer
          * @param extents number of elements for each dimension
-         * @return View which is pointing only to a part of the original managed view with a shifted origin pointer.
-         *         View which pointThe alignment of the sub view is reduced to the element alignment.
+         * @return Buffer which is pointing only to a part of the original buffer with a shifted origin pointer.
+         *         Buffer which pointThe alignment of the sub view is reduced to the element alignment.
          */
-        auto getManagedSubView(
+        auto getSubSharedBuffer(
             alpaka::concepts::VectorOrScalar auto const& offsets,
             alpaka::concepts::VectorOrScalar auto const& extents) const
         {
@@ -153,7 +155,7 @@ namespace alpaka::onHost
             Vec extentMd = extents;
             assert((offsetMd + extentMd <= this->getExtents()).reduce(std::logical_and{}));
             auto shiftedPtr = &(*this)[offsetMd];
-            return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(shiftedPtr)>, T_Extents, Alignment<>>{
+            return SharedBuffer<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(shiftedPtr)>, T_Extents, Alignment<>>{
                 T_Api{},
                 shiftedPtr,
                 extentMd,
@@ -162,7 +164,7 @@ namespace alpaka::onHost
                 Alignment<>{}};
         }
 
-        auto getManagedSubView(
+        auto getSubSharedBuffer(
             alpaka::concepts::VectorOrScalar auto const& offsets,
             alpaka::concepts::VectorOrScalar auto const& extents)
         {
@@ -170,7 +172,7 @@ namespace alpaka::onHost
             Vec extentMd = extents;
             assert((offsetMd + extentMd <= this->getExtents()).reduce(std::logical_and{}));
             auto shiftedPtr = &(*this)[offsetMd];
-            return ManagedView<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(shiftedPtr)>, T_Extents, Alignment<>>{
+            return SharedBuffer<T_Api, std::remove_pointer_t<ALPAKA_TYPEOF(shiftedPtr)>, T_Extents, Alignment<>>{
                 T_Api{},
                 shiftedPtr,
                 extentMd,
@@ -179,9 +181,9 @@ namespace alpaka::onHost
                 Alignment<>{}};
         }
 
-        /** Adds a destructor action to the managed view
+        /** Adds a destructor action to the shared buffer
          *
-         * The action will be executed when the managed view is destroyed.
+         * The action will be executed when the buffer is destroyed.
          * This can be used to add additional cleanup actions e.g. waiting on a specific queue.
          * Actions are executed in FIFO order.
          *
@@ -215,14 +217,14 @@ namespace alpaka::onHost
         alpaka::concepts::Vector T_UserExtents,
         alpaka::concepts::Vector T_UserPitches,
         alpaka::concepts::Alignment T_MemAlignment>
-    ManagedView(
+    SharedBuffer(
         T_Any const&,
         T_Type*,
         T_UserExtents const&,
         T_UserPitches const&,
         std::invocable<> auto,
         T_MemAlignment const)
-        -> ManagedView<
+        -> SharedBuffer<
             ALPAKA_TYPEOF(getApi(std::declval<T_Any>())),
             T_Type,
             typename T_UserPitches::UniVec,
@@ -233,8 +235,8 @@ namespace alpaka::onHost
         typename T_Type,
         alpaka::concepts::Vector T_UserExtents,
         alpaka::concepts::Vector T_UserPitches>
-    ManagedView(T_Any const&, T_Type*, T_UserExtents const&, T_UserPitches const&, std::invocable<> auto)
-        -> ManagedView<
+    SharedBuffer(T_Any const&, T_Type*, T_UserExtents const&, T_UserPitches const&, std::invocable<> auto)
+        -> SharedBuffer<
             ALPAKA_TYPEOF(getApi(std::declval<T_Any>())),
             T_Type,
             typename T_UserPitches::UniVec,
@@ -245,7 +247,7 @@ namespace alpaka::onHost
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment>
-    struct MakeAccessibleOnAcc::Op<ManagedView<T_Api, T_Type, T_Extents, T_MemAlignment>>
+    struct MakeAccessibleOnAcc::Op<SharedBuffer<T_Api, T_Type, T_Extents, T_MemAlignment>>
     {
         auto operator()(auto&& any) const
         {
@@ -263,7 +265,7 @@ namespace alpaka::internal
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment>
-    struct GetApi::Op<onHost::ManagedView<T_Api, T_Type, T_Extents, T_MemAlignment>>
+    struct GetApi::Op<onHost::SharedBuffer<T_Api, T_Type, T_Extents, T_MemAlignment>>
     {
         inline constexpr auto operator()(auto&& data) const
         {
@@ -275,7 +277,7 @@ namespace alpaka::internal
 namespace alpaka::trait
 {
     template<typename T>
-    requires(isSpecializationOf_v<std::remove_cvref_t<T>, alpaka::onHost::ManagedView>)
+    requires(isSpecializationOf_v<std::remove_cvref_t<T>, alpaka::onHost::SharedBuffer>)
     struct IsMdSpan<T> : std::true_type
     {
     };

--- a/tests/unit/algorithm/concurrent.cpp
+++ b/tests/unit/algorithm/concurrent.cpp
@@ -65,33 +65,33 @@ void executeTest(
 
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
-    onHost::SharedBuffer computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::SharedBuffer computeViewIn1 = onHost::allocLike(computeDev, computeViewIn0);
-    onHost::SharedBuffer hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
-    onHost::SharedBuffer hostViewOut = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
+    onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::SharedBuffer computeBufferIn1 = onHost::allocLike(computeDev, computeBufferIn0);
+    onHost::SharedBuffer hostBufferIota = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
+    onHost::SharedBuffer hostBufferOut = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
 
     // initialize with the linearized index
     DataType iotaCounter = 0;
-    for(auto& value : hostViewIota)
+    for(auto& value : hostBufferIota)
     {
         value = iotaCounter;
         ++iotaCounter;
     }
 
-    onHost::memcpy(computeQueue, computeViewIn0, hostViewIota);
-    onHost::memcpy(computeQueue, computeViewIn1, hostViewIota);
+    onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+    onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
 
     onHost::wait(computeQueue);
     auto const beginT = std::chrono::high_resolution_clock::now();
 
-    onHost::concurrent<DataType>(computeQueue, exec, extentMd, functorPair.first, computeViewIn0, computeViewIn1);
+    onHost::concurrent<DataType>(computeQueue, exec, extentMd, functorPair.first, computeBufferIn0, computeBufferIn1);
 
     onHost::wait(computeQueue);
     auto const endT = std::chrono::high_resolution_clock::now();
     std::cout << "Time for concurrent: " << std::chrono::duration<double>(endT - beginT).count() << 's'
               << " data size: " << extentMd << std::endl;
 
-    onHost::memcpy(computeQueue, hostViewOut, computeViewIn0);
+    onHost::memcpy(computeQueue, hostBufferOut, computeBufferIn0);
     onHost::wait(computeQueue);
 
     // validate without using the forward iterator
@@ -100,7 +100,7 @@ void executeTest(
         extentMd,
         [&](auto idx)
         {
-            CHECK(hostViewOut[idx] == functorPair.second(refIotaCounter, refIotaCounter));
+            CHECK(hostBufferOut[idx] == functorPair.second(refIotaCounter, refIotaCounter));
             ++refIotaCounter;
         });
 };

--- a/tests/unit/algorithm/concurrent.cpp
+++ b/tests/unit/algorithm/concurrent.cpp
@@ -65,10 +65,10 @@ void executeTest(
 
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
-    onHost::ManagedView computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::ManagedView computeViewIn1 = onHost::allocLike(computeDev, computeViewIn0);
-    onHost::ManagedView hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
-    onHost::ManagedView hostViewOut = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
+    onHost::SharedBuffer computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::SharedBuffer computeViewIn1 = onHost::allocLike(computeDev, computeViewIn0);
+    onHost::SharedBuffer hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
+    onHost::SharedBuffer hostViewOut = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
 
     // initialize with the linearized index
     DataType iotaCounter = 0;

--- a/tests/unit/algorithm/iota.cpp
+++ b/tests/unit/algorithm/iota.cpp
@@ -25,24 +25,24 @@ void executeTest(concepts::Executor auto exec, auto const& computeQueue, concept
 {
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
-    onHost::SharedBuffer computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::SharedBuffer hostViewOut0 = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
+    onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::SharedBuffer hostBufferOut0 = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
 
     auto initValue = DataType{42};
     {
-        onHost::memset(computeQueue, computeViewIn0, 0u);
+        onHost::memset(computeQueue, computeBufferIn0, 0u);
 
         onHost::wait(computeQueue);
         auto const beginT = std::chrono::high_resolution_clock::now();
         {
-            onHost::iota<DataType>(computeQueue, exec, initValue, computeViewIn0);
+            onHost::iota<DataType>(computeQueue, exec, initValue, computeBufferIn0);
             onHost::wait(computeQueue);
         }
         auto const endT = std::chrono::high_resolution_clock::now();
         std::cout << "Time for iota: " << std::chrono::duration<double>(endT - beginT).count() << 's'
                   << " data size: " << extentMd << std::endl;
 
-        onHost::memcpy(computeQueue, hostViewOut0, computeViewIn0);
+        onHost::memcpy(computeQueue, hostBufferOut0, computeBufferIn0);
         onHost::wait(computeQueue);
 
         // validate without using the forward iterator
@@ -51,31 +51,31 @@ void executeTest(concepts::Executor auto exec, auto const& computeQueue, concept
             extentMd,
             [&](auto idx)
             {
-                CHECK(hostViewOut0[idx] == refIotaCounter);
+                CHECK(hostBufferOut0[idx] == refIotaCounter);
                 ++refIotaCounter;
             });
     }
 
     // check if iota can be called with multiple inputs
-    onHost::SharedBuffer computeViewIn1 = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::SharedBuffer hostViewOut1 = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
-    onHost::memset(computeQueue, computeViewIn0, 0u);
-    onHost::memset(computeQueue, computeViewIn1, 0u);
+    onHost::SharedBuffer computeBufferIn1 = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::SharedBuffer hostBufferOut1 = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
+    onHost::memset(computeQueue, computeBufferIn0, 0u);
+    onHost::memset(computeQueue, computeBufferIn1, 0u);
     // set new initial value
     ++initValue;
     {
         onHost::wait(computeQueue);
         auto const beginT = std::chrono::high_resolution_clock::now();
         {
-            onHost::iota<DataType>(computeQueue, exec, initValue, computeViewIn0, computeViewIn1);
+            onHost::iota<DataType>(computeQueue, exec, initValue, computeBufferIn0, computeBufferIn1);
             onHost::wait(computeQueue);
         }
         auto const endT = std::chrono::high_resolution_clock::now();
         std::cout << "Time for iota two inputs: " << std::chrono::duration<double>(endT - beginT).count() << 's'
                   << " data size: " << extentMd << std::endl;
 
-        onHost::memcpy(computeQueue, hostViewOut0, computeViewIn0);
-        onHost::memcpy(computeQueue, hostViewOut1, computeViewIn1);
+        onHost::memcpy(computeQueue, hostBufferOut0, computeBufferIn0);
+        onHost::memcpy(computeQueue, hostBufferOut1, computeBufferIn1);
         onHost::wait(computeQueue);
 
         // validate without using the forward iterator
@@ -84,8 +84,8 @@ void executeTest(concepts::Executor auto exec, auto const& computeQueue, concept
             extentMd,
             [&](auto idx)
             {
-                CHECK(hostViewOut0[idx] == refIotaCounter);
-                CHECK(hostViewOut1[idx] == refIotaCounter);
+                CHECK(hostBufferOut0[idx] == refIotaCounter);
+                CHECK(hostBufferOut1[idx] == refIotaCounter);
                 ++refIotaCounter;
             });
     }

--- a/tests/unit/algorithm/iota.cpp
+++ b/tests/unit/algorithm/iota.cpp
@@ -25,8 +25,8 @@ void executeTest(concepts::Executor auto exec, auto const& computeQueue, concept
 {
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
-    onHost::ManagedView computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::ManagedView hostViewOut0 = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
+    onHost::SharedBuffer computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::SharedBuffer hostViewOut0 = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
 
     auto initValue = DataType{42};
     {
@@ -57,8 +57,8 @@ void executeTest(concepts::Executor auto exec, auto const& computeQueue, concept
     }
 
     // check if iota can be called with multiple inputs
-    onHost::ManagedView computeViewIn1 = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::ManagedView hostViewOut1 = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
+    onHost::SharedBuffer computeViewIn1 = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::SharedBuffer hostViewOut1 = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
     onHost::memset(computeQueue, computeViewIn0, 0u);
     onHost::memset(computeQueue, computeViewIn1, 0u);
     // set new initial value

--- a/tests/unit/algorithm/reduce.cpp
+++ b/tests/unit/algorithm/reduce.cpp
@@ -62,20 +62,20 @@ void executeTest(
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
     using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
-    onHost::SharedBuffer computeViewOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd.all(1));
-    onHost::SharedBuffer computeViewIn = onHost::allocAsync<DataType>(computeQueue, extentMd);
-    onHost::SharedBuffer hostViewIota = onHost::allocHostLike(computeViewIn);
-    onHost::SharedBuffer hostViewOut = onHost::allocHostLike(computeViewOut);
+    onHost::SharedBuffer computeBufferOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd.all(1));
+    onHost::SharedBuffer computeBufferIn = onHost::allocAsync<DataType>(computeQueue, extentMd);
+    onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn);
+    onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);
 
     // initialize with the linearized index
     DataType iotaCounter = 0;
-    for(auto& value : hostViewIota)
+    for(auto& value : hostBufferIota)
     {
         value = iotaCounter;
         ++iotaCounter;
     }
 
-    onHost::memcpy(computeQueue, computeViewIn, hostViewIota);
+    onHost::memcpy(computeQueue, computeBufferIn, hostBufferIota);
 
     onHost::wait(computeQueue);
     auto const beginT = std::chrono::high_resolution_clock::now();
@@ -84,16 +84,16 @@ void executeTest(
         computeQueue,
         exec,
         std::get<0>(functorPair),
-        computeViewOut,
+        computeBufferOut,
         std::get<1>(functorPair),
-        computeViewIn);
+        computeBufferIn);
 
     onHost::wait(computeQueue);
     auto const endT = std::chrono::high_resolution_clock::now();
     std::cout << "Time for reduction: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-              << " data size: " << hostViewIota.getExtents() << std::endl;
+              << " data size: " << hostBufferIota.getExtents() << std::endl;
 
-    onHost::memcpy(computeQueue, hostViewOut, computeViewOut);
+    onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
     onHost::wait(computeQueue);
 
     // validate without using the forward iterator
@@ -107,7 +107,7 @@ void executeTest(
             ++refIotaCounter;
         });
 
-    CHECK(*hostViewOut.data() == result);
+    CHECK(*hostBufferOut.data() == result);
 };
 
 template<typename T_DataType>

--- a/tests/unit/algorithm/reduce.cpp
+++ b/tests/unit/algorithm/reduce.cpp
@@ -62,10 +62,10 @@ void executeTest(
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
     using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
-    onHost::ManagedView computeViewOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd.all(1));
-    onHost::ManagedView computeViewIn = onHost::allocAsync<DataType>(computeQueue, extentMd);
-    onHost::ManagedView hostViewIota = onHost::allocHostLike(computeViewIn);
-    onHost::ManagedView hostViewOut = onHost::allocHostLike(computeViewOut);
+    onHost::SharedBuffer computeViewOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd.all(1));
+    onHost::SharedBuffer computeViewIn = onHost::allocAsync<DataType>(computeQueue, extentMd);
+    onHost::SharedBuffer hostViewIota = onHost::allocHostLike(computeViewIn);
+    onHost::SharedBuffer hostViewOut = onHost::allocHostLike(computeViewOut);
 
     // initialize with the linearized index
     DataType iotaCounter = 0;

--- a/tests/unit/algorithm/transform.cpp
+++ b/tests/unit/algorithm/transform.cpp
@@ -77,11 +77,11 @@ void executeTest(
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
     using OutDataType = decltype(functorPair.second(std::declval<DataType>(), std::declval<DataType>()));
-    onHost::ManagedView computeViewOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd);
-    onHost::ManagedView computeViewIn0 = onHost::allocAsync<DataType>(computeQueue, extentMd);
-    onHost::ManagedView computeViewIn1 = onHost::allocLikeAsync(computeQueue, computeViewIn0);
-    onHost::ManagedView hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
-    onHost::ManagedView hostViewOut = onHost::allocLike(onHost::makeHostDevice(), computeViewOut);
+    onHost::SharedBuffer computeViewOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd);
+    onHost::SharedBuffer computeViewIn0 = onHost::allocAsync<DataType>(computeQueue, extentMd);
+    onHost::SharedBuffer computeViewIn1 = onHost::allocLikeAsync(computeQueue, computeViewIn0);
+    onHost::SharedBuffer hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
+    onHost::SharedBuffer hostViewOut = onHost::allocLike(onHost::makeHostDevice(), computeViewOut);
 
     // initialize with the linearized index
     DataType iotaCounter = 0;

--- a/tests/unit/algorithm/transform.cpp
+++ b/tests/unit/algorithm/transform.cpp
@@ -77,34 +77,34 @@ void executeTest(
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
     using OutDataType = decltype(functorPair.second(std::declval<DataType>(), std::declval<DataType>()));
-    onHost::SharedBuffer computeViewOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd);
-    onHost::SharedBuffer computeViewIn0 = onHost::allocAsync<DataType>(computeQueue, extentMd);
-    onHost::SharedBuffer computeViewIn1 = onHost::allocLikeAsync(computeQueue, computeViewIn0);
-    onHost::SharedBuffer hostViewIota = onHost::allocLike(onHost::makeHostDevice(), computeViewIn0);
-    onHost::SharedBuffer hostViewOut = onHost::allocLike(onHost::makeHostDevice(), computeViewOut);
+    onHost::SharedBuffer computeBufferOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd);
+    onHost::SharedBuffer computeBufferIn0 = onHost::allocAsync<DataType>(computeQueue, extentMd);
+    onHost::SharedBuffer computeBufferIn1 = onHost::allocLikeAsync(computeQueue, computeBufferIn0);
+    onHost::SharedBuffer hostBufferIota = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
+    onHost::SharedBuffer hostBufferOut = onHost::allocLike(onHost::makeHostDevice(), computeBufferOut);
 
     // initialize with the linearized index
     DataType iotaCounter = 0;
-    for(auto& value : hostViewIota)
+    for(auto& value : hostBufferIota)
     {
         value = iotaCounter;
         ++iotaCounter;
     }
 
-    onHost::memcpy(computeQueue, computeViewIn0, hostViewIota);
-    onHost::memcpy(computeQueue, computeViewIn1, hostViewIota);
+    onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+    onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
 
     onHost::wait(computeQueue);
     auto const beginT = std::chrono::high_resolution_clock::now();
 
-    onHost::transform(computeQueue, exec, computeViewOut, functorPair.first, computeViewIn0, computeViewIn1);
+    onHost::transform(computeQueue, exec, computeBufferOut, functorPair.first, computeBufferIn0, computeBufferIn1);
 
     onHost::wait(computeQueue);
     auto const endT = std::chrono::high_resolution_clock::now();
     std::cout << "Time for transform: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-              << " data size: " << computeViewOut.getExtents() << std::endl;
+              << " data size: " << computeBufferOut.getExtents() << std::endl;
 
-    onHost::memcpy(computeQueue, hostViewOut, computeViewOut);
+    onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
     onHost::wait(computeQueue);
 
     // validate without using the forward iterator
@@ -113,7 +113,7 @@ void executeTest(
         extentMd,
         [&](auto idx)
         {
-            CHECK(hostViewOut[idx] == functorPair.second(refIotaCounter, refIotaCounter));
+            CHECK(hostBufferOut[idx] == functorPair.second(refIotaCounter, refIotaCounter));
             ++refIotaCounter;
         });
 };

--- a/tests/unit/algorithm/transformReduce.cpp
+++ b/tests/unit/algorithm/transformReduce.cpp
@@ -93,11 +93,11 @@ void executeTest(
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
     using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
-    onHost::ManagedView computeViewOut = onHost::alloc<OutDataType>(computeDev, extentMd.all(1));
-    onHost::ManagedView computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::ManagedView computeViewIn1 = onHost::allocLike(computeDev, computeViewIn0);
-    onHost::ManagedView hostViewIota = onHost::allocHostLike(computeViewIn0);
-    onHost::ManagedView hostViewOut = onHost::allocHostLike(computeViewOut);
+    onHost::SharedBuffer computeViewOut = onHost::alloc<OutDataType>(computeDev, extentMd.all(1));
+    onHost::SharedBuffer computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::SharedBuffer computeViewIn1 = onHost::allocLike(computeDev, computeViewIn0);
+    onHost::SharedBuffer hostViewIota = onHost::allocHostLike(computeViewIn0);
+    onHost::SharedBuffer hostViewOut = onHost::allocHostLike(computeViewOut);
 
     // initialize with the linearized index
     DataType iotaCounter = 0;

--- a/tests/unit/algorithm/transformReduce.cpp
+++ b/tests/unit/algorithm/transformReduce.cpp
@@ -93,22 +93,22 @@ void executeTest(
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
     using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
-    onHost::SharedBuffer computeViewOut = onHost::alloc<OutDataType>(computeDev, extentMd.all(1));
-    onHost::SharedBuffer computeViewIn0 = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::SharedBuffer computeViewIn1 = onHost::allocLike(computeDev, computeViewIn0);
-    onHost::SharedBuffer hostViewIota = onHost::allocHostLike(computeViewIn0);
-    onHost::SharedBuffer hostViewOut = onHost::allocHostLike(computeViewOut);
+    onHost::SharedBuffer computeBufferOut = onHost::alloc<OutDataType>(computeDev, extentMd.all(1));
+    onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+    onHost::SharedBuffer computeBufferIn1 = onHost::allocLike(computeDev, computeBufferIn0);
+    onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn0);
+    onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);
 
     // initialize with the linearized index
     DataType iotaCounter = 0;
-    for(auto& value : hostViewIota)
+    for(auto& value : hostBufferIota)
     {
         value = iotaCounter;
         ++iotaCounter;
     }
 
-    onHost::memcpy(computeQueue, computeViewIn0, hostViewIota);
-    onHost::memcpy(computeQueue, computeViewIn1, hostViewIota);
+    onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+    onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
 
     onHost::wait(computeQueue);
     auto const beginT = std::chrono::high_resolution_clock::now();
@@ -117,18 +117,18 @@ void executeTest(
         computeQueue,
         exec,
         std::get<0>(functorPair),
-        computeViewOut,
+        computeBufferOut,
         std::get<1>(functorPair).first,
         std::get<2>(functorPair).first,
-        computeViewIn0,
-        computeViewIn1);
+        computeBufferIn0,
+        computeBufferIn1);
 
     onHost::wait(computeQueue);
     auto const endT = std::chrono::high_resolution_clock::now();
     std::cout << "Time for transform reduce: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-              << " data size: " << hostViewIota.getExtents() << std::endl;
+              << " data size: " << hostBufferIota.getExtents() << std::endl;
 
-    onHost::memcpy(computeQueue, hostViewOut, computeViewOut);
+    onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
     onHost::wait(computeQueue);
 
     // validate without using the forward iterator
@@ -142,7 +142,7 @@ void executeTest(
                          .second(result, std::get<2>(functorPair).second(refIotaCounter, refIotaCounter));
             ++refIotaCounter;
         });
-    CHECK(*hostViewOut.data() == result);
+    CHECK(*hostBufferOut.data() == result);
 };
 
 template<typename T_DataType>

--- a/tests/unit/math/Buffer.hpp
+++ b/tests/unit/math/Buffer.hpp
@@ -19,25 +19,25 @@ namespace mathtest
     //! @tparam TAcc Used accelerator, not interchangeable
     //! @tparam TData The Data-type, only restricted by the alpaka-interface.
     //! @tparam Tcapacity The size of the buffer.
-    template<typename T_Queue, typename T_HostView, typename T_DeviceView>
+    template<typename T_Queue, typename T_HostBuffer, typename T_DeviceBuffer>
     struct Buffer
     {
-        using value_type = typename T_HostView::value_type;
-        static_assert(std::is_same_v<typename T_HostView::value_type, typename T_DeviceView::value_type>);
+        using value_type = typename T_HostBuffer::value_type;
+        static_assert(std::is_same_v<typename T_HostBuffer::value_type, typename T_DeviceBuffer::value_type>);
 
         T_Queue m_queue;
-        T_HostView m_hostView;
-        T_DeviceView m_deviceView;
+        T_HostBuffer m_hostBuffer;
+        T_DeviceBuffer m_deviceBuffer;
 
         // This constructor cant be used,
         // because BufHost and BufAcc need to be initialised.
         Buffer() = delete;
 
         // Constructor needs to initialize all Buffer.
-        Buffer(T_Queue const& queue, T_HostView const& hostView, T_DeviceView const& deviceView)
+        Buffer(T_Queue const& queue, T_HostBuffer const& hostBuffer, T_DeviceBuffer const& deviceBuffer)
             : m_queue{queue}
-            , m_hostView{hostView}
-            , m_deviceView{deviceView}
+            , m_hostBuffer{hostBuffer}
+            , m_deviceBuffer{deviceBuffer}
         {
         }
 
@@ -45,29 +45,29 @@ namespace mathtest
         template<typename Queue>
         auto copyToDevice(Queue queue) -> void
         {
-            alpaka::onHost::memcpy(queue, m_deviceView, m_hostView);
+            alpaka::onHost::memcpy(queue, m_deviceBuffer, m_hostBuffer);
         }
 
         // Copy Acc -> Host.
         template<typename Queue>
         auto copyFromDevice(Queue queue) -> void
         {
-            alpaka::onHost::memcpy(queue, m_hostView, m_deviceView);
+            alpaka::onHost::memcpy(queue, m_hostBuffer, m_deviceBuffer);
         }
 
         ALPAKA_FN_HOST decltype(auto) operator()(size_t idx) const
         {
-            return m_hostView[idx];
+            return m_hostBuffer[idx];
         }
 
         ALPAKA_FN_HOST decltype(auto) operator()(size_t idx)
         {
-            return m_hostView[idx];
+            return m_hostBuffer[idx];
         }
 
         auto getCapacity() const
         {
-            return m_hostView.getExtents().x();
+            return m_hostBuffer.getExtents().x();
         }
 
         ALPAKA_FN_HOST friend auto operator<<(std::ostream& os, Buffer const& buffer) -> std::ostream&

--- a/tests/unit/math/TestTemplate.hpp
+++ b/tests/unit/math/TestTemplate.hpp
@@ -167,9 +167,9 @@ namespace mathtest
             TFunctor functor;
             auto args = Buffer{queue, hViewArgs, dViewArgs};
 
-            auto hViewResults = onHost::allocHost<TData>(capacity);
-            auto dViewResults = onHost::allocLike(device, hViewResults);
-            auto results = Buffer{queue, hViewResults, dViewResults};
+            auto hBufferResults = onHost::allocHost<TData>(capacity);
+            auto dBufferResults = onHost::allocLike(device, hBufferResults);
+            auto results = Buffer{queue, hBufferResults, dBufferResults};
 
             // Let alpaka calculate good block and grid sizes given our full problem extent
             constexpr uint32_t frameExtents = 256;

--- a/tests/unit/math/TestTemplate.hpp
+++ b/tests/unit/math/TestTemplate.hpp
@@ -177,9 +177,9 @@ namespace mathtest
                 = onHost::FrameSpec{divExZero(capacity, frameExtents), frameExtents};
             auto kernel = KernelBundle{
                 TestKernel<capacity>{},
-                results.m_deviceView.getMdSpan(),
+                results.m_deviceBuffer.getMdSpan(),
                 wrappedFunctor,
-                args.m_deviceView.getMdSpan()};
+                args.m_deviceBuffer.getMdSpan()};
 
             // Fill the buffer with random test-numbers.
             fillWithRndArgs<TData>(args, functor, seed);

--- a/tests/unit/math/executeOnComputeDevice.hpp
+++ b/tests/unit/math/executeOnComputeDevice.hpp
@@ -61,15 +61,15 @@ namespace alpaka::test
         INFO("exec:" << onHost::demangledName(exec));
         INFO("device:" << device.getName());
         onHost::Queue queue = device.makeQueue();
-        auto hViewResults = onHost::allocHost<bool>(1u);
-        auto dViewResults = onHost::allocLike(device, hViewResults);
-        onHost::memset(queue, dViewResults, static_cast<std::uint8_t>(true));
+        auto hBufferResults = onHost::allocHost<bool>(1u);
+        auto dBufferResults = onHost::allocLike(device, hBufferResults);
+        onHost::memset(queue, dBufferResults, static_cast<std::uint8_t>(true));
         // Let alpaka calculate good block and grid sizes given our full problem extent
         onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{1u, 1u};
-        auto kernel = KernelBundle{kernelFnObj, dViewResults, ALPAKA_FORWARD(args)...};
+        auto kernel = KernelBundle{kernelFnObj, dBufferResults, ALPAKA_FORWARD(args)...};
         queue.enqueue(exec, frameSpec, kernel);
-        onHost::memcpy(queue, hViewResults, dViewResults);
+        onHost::memcpy(queue, hBufferResults, dBufferResults);
         alpaka::onHost::wait(queue);
-        return hViewResults[0];
+        return hBufferResults[0];
     }
 } // namespace alpaka::test

--- a/tests/unit/mem/alloc.cpp
+++ b/tests/unit/mem/alloc.cpp
@@ -56,21 +56,21 @@ void allocAsyncImplicitWait(auto device, alpaka::concepts::Executor auto exec)
 
     int dataSize = 42;
 
-    auto hostView = onHost::allocHost<int>(dataSize);
-    auto hostViewMapped = onHost::allocMapped<int>(device, dataSize);
+    auto hostBuffer = onHost::allocHost<int>(dataSize);
+    auto hostBufferMapped = onHost::allocMapped<int>(device, dataSize);
     auto deviceView = onHost::alloc<int>(device, dataSize);
     auto unifiedView = onHost::allocUnified<int>(device, dataSize);
 
-    REQUIRE(onHost::isDataAccessible(hostDevice, hostView) == true);
+    REQUIRE(onHost::isDataAccessible(hostDevice, hostBuffer) == true);
     REQUIRE(onHost::isDataAccessible(hostDevice, unifiedView) == true);
-    REQUIRE(onHost::isDataAccessible(hostDevice, hostViewMapped) == true);
-    for(int i = 0; i < hostView.getExtents().x(); ++i)
+    REQUIRE(onHost::isDataAccessible(hostDevice, hostBufferMapped) == true);
+    for(int i = 0; i < hostBuffer.getExtents().x(); ++i)
     {
-        hostView[i] = i;
+        hostBuffer[i] = i;
         // unified memory must be accessible on the host
         unifiedView[i] = i;
         // is located on the host, so it must be accessible
-        hostViewMapped[i] = i;
+        hostBufferMapped[i] = i;
     }
 
     auto deviceQueue = device.makeQueue();
@@ -80,15 +80,15 @@ void allocAsyncImplicitWait(auto device, alpaka::concepts::Executor auto exec)
 
     if(getDeviceKind(device) == deviceKind::cpu)
     {
-        REQUIRE(onHost::isDataAccessible(device, hostView) == true);
-        validateAccess(device, exec, hostView);
+        REQUIRE(onHost::isDataAccessible(device, hostBuffer) == true);
+        validateAccess(device, exec, hostBuffer);
     }
     else
-        REQUIRE(onHost::isDataAccessible(device, hostView) == false);
+        REQUIRE(onHost::isDataAccessible(device, hostBuffer) == false);
 
     // mapped memory is defined to be accessible on the device
-    REQUIRE(onHost::isDataAccessible(device, hostViewMapped) == true);
-    validateAccess(device, exec, hostViewMapped);
+    REQUIRE(onHost::isDataAccessible(device, hostBufferMapped) == true);
+    validateAccess(device, exec, hostBufferMapped);
 
     REQUIRE(onHost::isDataAccessible(device, unifiedView) == true);
     validateAccess(device, exec, unifiedView);
@@ -100,8 +100,8 @@ void allocAsyncImplicitWait(auto device, alpaka::concepts::Executor auto exec)
     validateAccess(hostDevice, exec::cpuSerial, unifiedView);
 
     // is located on the host, so it must be accessible
-    REQUIRE(onHost::isDataAccessible(device, hostViewMapped) == true);
-    validateAccess(hostDevice, exec::cpuSerial, hostViewMapped);
+    REQUIRE(onHost::isDataAccessible(device, hostBufferMapped) == true);
+    validateAccess(hostDevice, exec::cpuSerial, hostBufferMapped);
 }
 
 TEMPLATE_LIST_TEST_CASE("alloc", "", TestBackends)
@@ -146,9 +146,9 @@ TEMPLATE_LIST_TEST_CASE("alloc zero bytes", "", TestDeviceSpecs)
     // test to allocate zero byte memory to validate of the allocation and free works as expected
     int dataSize = 0;
 
-    [[maybe_unused]] auto hostView = onHost::allocHost<int>(dataSize);
-    [[maybe_unused]] auto hostViewAsync = onHost::allocAsync<int>(onHost::makeHostDevice().makeQueue(), dataSize);
-    [[maybe_unused]] auto hostViewMapped = onHost::allocMapped<int>(device, dataSize);
+    [[maybe_unused]] auto hostBuffer = onHost::allocHost<int>(dataSize);
+    [[maybe_unused]] auto hostBufferAsync = onHost::allocAsync<int>(onHost::makeHostDevice().makeQueue(), dataSize);
+    [[maybe_unused]] auto hostBufferMapped = onHost::allocMapped<int>(device, dataSize);
     [[maybe_unused]] auto deviceView = onHost::alloc<int>(device, dataSize);
     [[maybe_unused]] auto deviceViewAsync = onHost::allocAsync<int>(device.makeQueue(), dataSize);
     [[maybe_unused]] auto unifiedView = onHost::allocUnified<int>(device, dataSize);
@@ -182,12 +182,12 @@ void validateAlignment(alpaka::concepts::MdSpan auto data)
 template<typename T_DataType>
 void prepareAlignmentValidation(auto& device, alpaka::concepts::Vector auto extents)
 {
-    auto hostView = onHost::allocHost<T_DataType>(extents);
-    validateAlignment(hostView);
-    auto hostViewAsync = onHost::allocAsync<T_DataType>(onHost::makeHostDevice().makeQueue(), extents);
-    validateAlignment(hostViewAsync);
-    auto hostViewMapped = onHost::allocMapped<T_DataType>(device, extents);
-    validateAlignment(hostViewMapped);
+    auto hostBuffer = onHost::allocHost<T_DataType>(extents);
+    validateAlignment(hostBuffer);
+    auto hostBufferAsync = onHost::allocAsync<T_DataType>(onHost::makeHostDevice().makeQueue(), extents);
+    validateAlignment(hostBufferAsync);
+    auto hostBufferMapped = onHost::allocMapped<T_DataType>(device, extents);
+    validateAlignment(hostBufferMapped);
     auto deviceView = onHost::alloc<T_DataType>(device, extents);
     validateAlignment(deviceView);
     auto deviceViewAsync = onHost::allocAsync<T_DataType>(device.makeQueue(), extents);
@@ -223,9 +223,9 @@ template<typename T_DataType>
 void volatileBuffers(auto& device, alpaka::concepts::Vector auto extents)
 {
     // just test if they can be allocated and destructed again
-    auto hostView = onHost::allocHost<T_DataType volatile>(extents);
-    auto hostViewAsync = onHost::allocAsync<T_DataType volatile>(onHost::makeHostDevice().makeQueue(), extents);
-    auto hostViewMapped = onHost::allocMapped<T_DataType volatile>(device, extents);
+    auto hostBuffer = onHost::allocHost<T_DataType volatile>(extents);
+    auto hostBufferAsync = onHost::allocAsync<T_DataType volatile>(onHost::makeHostDevice().makeQueue(), extents);
+    auto hostBufferMapped = onHost::allocMapped<T_DataType volatile>(device, extents);
     auto deviceView = onHost::alloc<T_DataType volatile>(device, extents);
     auto deviceViewAsync = onHost::allocAsync<T_DataType volatile>(device.makeQueue(), extents);
     auto unifiedView = onHost::allocUnified<T_DataType volatile>(device, extents);

--- a/tests/unit/mem/allocAsync.cpp
+++ b/tests/unit/mem/allocAsync.cpp
@@ -32,33 +32,33 @@ void allocAsyncImplicitWait(auto device, auto exec)
 {
     onHost::Queue queue0 = device.makeQueue();
 
-    auto hViewResults = onHost::allocHost<int>(1u);
-    auto dViewResults = onHost::allocLike(device, hViewResults);
+    auto hBufferResults = onHost::allocHost<int>(1u);
+    auto dBufferResults = onHost::allocLike(device, hBufferResults);
 
-    onHost::fill(queue0, dViewResults, 1);
+    onHost::fill(queue0, dBufferResults, 1);
     onHost::wait(queue0);
     {
         // Asynchronous allocation memory is in the destructor waiting for all work enqueued in the creator queue.
-        auto managedView = onHost::allocAsync<float>(queue0, 10ul);
-        onHost::fill(queue0, managedView, 3.14159265f);
+        auto sharedBuffer = onHost::allocAsync<float>(queue0, 10ul);
+        onHost::fill(queue0, sharedBuffer, 3.14159265f);
         queue0.enqueue(
             exec,
-            getFrameSpec<float>(queue0.getDevice(), managedView.getExtents()),
-            KernelBundle{RaceCheckKernel{}, dViewResults, managedView});
-        /* managedView is detroyed here before the kernel is finshed.
+            getFrameSpec<float>(queue0.getDevice(), sharedBuffer.getExtents()),
+            KernelBundle{RaceCheckKernel{}, dBufferResults, sharedBuffer});
+        /* sharedBuffer is detroyed here before the kernel is finshed.
          * If the view is not waiting for all work in the queue enqueued before the destructor of the view is called,
          * the application should crash with invalid memory access or the validation in the kernel should fail.
          * Typically, the kernel is reading zero's if the synchronization is missing.
          */
     }
     {
-        auto managedView = onHost::allocAsync<float>(queue0, 10ul);
-        onHost::fill(queue0, managedView, 42.0f);
+        auto sharedBuffer = onHost::allocAsync<float>(queue0, 10ul);
+        onHost::fill(queue0, sharedBuffer, 42.0f);
     }
 
-    onHost::memcpy(queue0, hViewResults, dViewResults);
+    onHost::memcpy(queue0, hBufferResults, dBufferResults);
     onHost::wait(queue0);
-    REQUIRE(hViewResults[0] == 1);
+    REQUIRE(hBufferResults[0] == 1);
 }
 
 void allocAsyncExplicitWait(auto device, auto exec)
@@ -66,33 +66,33 @@ void allocAsyncExplicitWait(auto device, auto exec)
     onHost::Queue queue0 = device.makeQueue();
     onHost::Queue queue1 = device.makeQueue();
 
-    auto hViewResults = onHost::allocHost<int>(1u);
-    auto dViewResults = onHost::allocLike(device, hViewResults);
+    auto hBufferResults = onHost::allocHost<int>(1u);
+    auto dBufferResults = onHost::allocLike(device, hBufferResults);
 
-    onHost::fill(queue0, dViewResults, 1);
+    onHost::fill(queue0, dBufferResults, 1);
     onHost::wait(queue0);
     {
-        auto managedView = onHost::allocAsync<float>(queue1, 10ul);
+        auto sharedBuffer = onHost::allocAsync<float>(queue1, 10ul);
         // set an action that the destructor is waiting for all work enqueued in queue0
-        managedView.destructorWaitFor(queue0);
+        sharedBuffer.destructorWaitFor(queue0);
         // wait for the allocation
         onHost::wait(queue1);
 
-        onHost::fill(queue0, managedView, 3.14159265f);
+        onHost::fill(queue0, sharedBuffer, 3.14159265f);
         queue0.enqueue(
             exec,
-            getFrameSpec<float>(queue0.getDevice(), managedView.getExtents()),
-            KernelBundle{RaceCheckKernel{}, dViewResults, managedView});
-        /* managedView is detroyed here before the kernel is finshed.
+            getFrameSpec<float>(queue0.getDevice(), sharedBuffer.getExtents()),
+            KernelBundle{RaceCheckKernel{}, dBufferResults, sharedBuffer});
+        /* sharedBuffer is detroyed here before the kernel is finshed.
          * If the view is not waiting for all work in the queue enqueued before the destructor of the view is called,
          * the application should crash with invalid memory access or the validation in the kernel should fail.
          * Typically, the kernel is reading zero's if the synchronization is missing.
          */
     }
 
-    onHost::memcpy(queue0, hViewResults, dViewResults);
+    onHost::memcpy(queue0, hBufferResults, dBufferResults);
     onHost::wait(queue0);
-    REQUIRE(hViewResults[0] == 1);
+    REQUIRE(hBufferResults[0] == 1);
 }
 
 TEMPLATE_LIST_TEST_CASE("allocAsync", "", TestApis)

--- a/tests/unit/mem/constCorrectness.cpp
+++ b/tests/unit/mem/constCorrectness.cpp
@@ -37,11 +37,11 @@ TEST_CASE("buffer const correctness 1D", "")
     static_assert(!std::is_const_v<std::remove_pointer_t<decltype(buffer0.data())>>);
     // mutable views
     {
-        [[maybe_unused]] auto subBuffer0 = buffer0.getManagedSubView(2);
+        [[maybe_unused]] auto subBuffer0 = buffer0.getSubSharedBuffer(2);
         static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
         static_assert(!std::is_const_v<std::remove_reference_t<decltype(subBuffer0[0])>>);
 
-        [[maybe_unused]] auto subOffsetBuffer0 = buffer0.getManagedSubView(1, 2);
+        [[maybe_unused]] auto subOffsetBuffer0 = buffer0.getSubSharedBuffer(1, 2);
         static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
         static_assert(!std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[0])>>);
 
@@ -63,12 +63,12 @@ TEST_CASE("buffer const correctness 1D", "")
     }
     // non-mutable views
     {
-        onHost::ManagedView innerConstBuffer0 = buffer0.getConstManagedView();
-        [[maybe_unused]] auto subBuffer0 = innerConstBuffer0.getManagedSubView(2);
+        onHost::SharedBuffer innerConstBuffer0 = buffer0.getConstSharedBuffer();
+        [[maybe_unused]] auto subBuffer0 = innerConstBuffer0.getSubSharedBuffer(2);
         static_assert(std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
         static_assert(std::is_const_v<std::remove_reference_t<decltype(subBuffer0[0])>>);
 
-        [[maybe_unused]] auto subOffsetBuffer0 = innerConstBuffer0.getManagedSubView(1, 2);
+        [[maybe_unused]] auto subOffsetBuffer0 = innerConstBuffer0.getSubSharedBuffer(1, 2);
         static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
         static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[0])>>);
 
@@ -90,12 +90,12 @@ TEST_CASE("buffer const correctness 1D", "")
     }
     // non-mutable views (outer const)
     {
-        onHost::ManagedView const outerConstBuffer0 = buffer0;
-        [[maybe_unused]] auto subBuffer0 = outerConstBuffer0.getManagedSubView(2);
+        onHost::SharedBuffer const outerConstBuffer0 = buffer0;
+        [[maybe_unused]] auto subBuffer0 = outerConstBuffer0.getSubSharedBuffer(2);
         static_assert(std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
         static_assert(std::is_const_v<std::remove_reference_t<decltype(subBuffer0[0])>>);
 
-        [[maybe_unused]] auto subOffsetBuffer0 = outerConstBuffer0.getManagedSubView(1, 2);
+        [[maybe_unused]] auto subOffsetBuffer0 = outerConstBuffer0.getSubSharedBuffer(1, 2);
         static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
         static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[0])>>);
 
@@ -124,11 +124,11 @@ TEST_CASE("buffer const correctness MD", "")
     static_assert(!std::is_const_v<std::remove_pointer_t<decltype(buffer0.data())>>);
     // mutable views
     {
-        [[maybe_unused]] auto subBuffer0 = buffer0.getManagedSubView(Vec{2, 2});
+        [[maybe_unused]] auto subBuffer0 = buffer0.getSubSharedBuffer(Vec{2, 2});
         static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
         static_assert(!std::is_const_v<std::remove_reference_t<decltype(subBuffer0[Vec{0, 0}])>>);
 
-        [[maybe_unused]] auto subOffsetBuffer0 = buffer0.getManagedSubView(Vec{1, 1}, Vec{2, 2});
+        [[maybe_unused]] auto subOffsetBuffer0 = buffer0.getSubSharedBuffer(Vec{1, 1}, Vec{2, 2});
         static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
         static_assert(!std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[Vec{0, 0}])>>);
 
@@ -150,13 +150,13 @@ TEST_CASE("buffer const correctness MD", "")
     }
     // non-mutable views
     {
-        onHost::ManagedView innerConstBuffer0 = buffer0.getConstManagedView();
+        onHost::SharedBuffer innerConstBuffer0 = buffer0.getConstSharedBuffer();
 
-        [[maybe_unused]] auto subBuffer0 = innerConstBuffer0.getManagedSubView(Vec{2, 2});
+        [[maybe_unused]] auto subBuffer0 = innerConstBuffer0.getSubSharedBuffer(Vec{2, 2});
         static_assert(std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
         static_assert(std::is_const_v<std::remove_reference_t<decltype(subBuffer0[Vec{0, 0}])>>);
 
-        [[maybe_unused]] auto subOffsetBuffer0 = innerConstBuffer0.getManagedSubView(Vec{1, 1}, Vec{2, 2});
+        [[maybe_unused]] auto subOffsetBuffer0 = innerConstBuffer0.getSubSharedBuffer(Vec{1, 1}, Vec{2, 2});
         static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
         static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[Vec{0, 0}])>>);
 
@@ -178,14 +178,14 @@ TEST_CASE("buffer const correctness MD", "")
     }
     // non-mutable views (outer const)
     {
-        onHost::ManagedView const outerConstBuffer0 = buffer0;
+        onHost::SharedBuffer const outerConstBuffer0 = buffer0;
         requiresMutableBufferMd(outerConstBuffer0);
 
-        [[maybe_unused]] auto subBuffer0 = outerConstBuffer0.getManagedSubView(Vec{2, 2});
+        [[maybe_unused]] auto subBuffer0 = outerConstBuffer0.getSubSharedBuffer(Vec{2, 2});
         static_assert(std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
         static_assert(std::is_const_v<std::remove_reference_t<decltype(subBuffer0[Vec{0, 0}])>>);
 
-        [[maybe_unused]] auto subOffsetBuffer0 = outerConstBuffer0.getManagedSubView(Vec{1, 1}, Vec{2, 2});
+        [[maybe_unused]] auto subOffsetBuffer0 = outerConstBuffer0.getSubSharedBuffer(Vec{1, 1}, Vec{2, 2});
         static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
         static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[Vec{0, 0}])>>);
 


### PR DESCRIPTION
We decided in the developer meeting to rename the managed view to `SharedBuffer`