### PR TITLE
fix missing `libdl`

### DIFF
--- a/example/alpaka-ls/CMakeLists.txt
+++ b/example/alpaka-ls/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 # Add executable.
 
 add_executable(${_TARGET_NAME} src/ls.cpp)
+target_link_libraries(${_TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS})
 target_link_libraries(${_TARGET_NAME} PUBLIC alpaka::headers)
 alpaka_finalize(${_TARGET_NAME})
 add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})


### PR DESCRIPTION
```
ls.cpp.o: undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
//usr/lib64/libdl.so.2: error adding symbols: DSO missing from command line
```