### PR TITLE
feat(benchmark/alloc): introduce minimal allocation benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -15,4 +15,4 @@ project("alpakaBenchmarks" LANGUAGES CXX)
 alpaka_install_catch2()
 
 add_subdirectory("babelstream/")
-add_subdirectory("alloc/") 
+add_subdirectory("alloc/")

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -15,3 +15,4 @@ project("alpakaBenchmarks" LANGUAGES CXX)
 alpaka_install_catch2()
 
 add_subdirectory("babelstream/")
+add_subdirectory("alloc/") 

--- a/benchmark/alloc/CMakeLists.txt
+++ b/benchmark/alloc/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright 2025 Andriievskyi Ivan
+# Copyright 2025 Ivan Andriievskyi
+# Work funded by US NAS and ONRG (IMPRESS-U).
 # SPDX-License-Identifier: ISC
 #
 cmake_minimum_required(VERSION 3.25)
@@ -31,13 +32,12 @@ set(_TARGET_NAME "alloc")
 # Collect all .cpp files (change the glob if you move sources)
 file(GLOB_RECURSE _FILES_SOURCE "./src/*.cpp")
 
-alpaka_add_executable(${_TARGET_NAME} ${_FILES_SOURCE})
+add_executable(${_TARGET_NAME} ${_FILES_SOURCE})
 
 target_include_directories(${_TARGET_NAME} PRIVATE "src")
 
-target_link_libraries(${_TARGET_NAME}
-    PRIVATE alpaka::alpaka
-            Catch2::Catch2WithMain)
+target_link_libraries(${_TARGET_NAME} PRIVATE alpaka::alpaka Catch2::Catch2WithMain)
+alpaka_finalize(${_TARGET_NAME})
 
 # Group inside IDE
 set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER benchmarks/alloc)

--- a/benchmark/alloc/CMakeLists.txt
+++ b/benchmark/alloc/CMakeLists.txt
@@ -1,0 +1,56 @@
+#
+# Copyright 2025 Andriievskyi Ivan
+# SPDX-License-Identifier: ISC
+#
+cmake_minimum_required(VERSION 3.25)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+project(alloc LANGUAGES CXX)
+
+# ---------------------------------------------------------------------------
+# Resolve Alpaka (either via install or in-tree checkout)
+# ---------------------------------------------------------------------------
+if(NOT TARGET alpaka::alpaka)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+
+    if(alpaka_USE_SOURCE_TREE)
+        # Prevent recursion when we add Alpaka itself
+        set(alpaka_BUILD_BENCHMARKS OFF)
+
+        # Path goes two levels up:  alloc/  ->  benchmark/  ->  <alpaka root>
+        add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")
+    else()
+        find_package(alpaka REQUIRED)
+    endif()
+endif()
+
+# ---------------------------------------------------------------------------
+# Target definition
+# ---------------------------------------------------------------------------
+set(_TARGET_NAME "alloc")
+
+# Collect all .cpp files (change the glob if you move sources)
+file(GLOB_RECURSE _FILES_SOURCE "./src/*.cpp")
+
+alpaka_add_executable(${_TARGET_NAME} ${_FILES_SOURCE})
+
+target_include_directories(${_TARGET_NAME} PRIVATE "src")
+
+target_link_libraries(${_TARGET_NAME}
+    PRIVATE alpaka::alpaka
+            Catch2::Catch2WithMain)
+
+# Group inside IDE
+set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER benchmarks/alloc)
+
+# ---------------------------------------------------------------------------
+# Optional: run via CTest (same logic as BabelStream)
+# ---------------------------------------------------------------------------
+if(alpaka_CI)
+    # In CI we usually only benchmark Release binaries
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})
+    endif()
+else()
+    # Local runs: always register the test
+    add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})
+endif()

--- a/benchmark/alloc/src/alloc_benchmark.cpp
+++ b/benchmark/alloc/src/alloc_benchmark.cpp
@@ -156,7 +156,6 @@ static double measureAlloc(TQueue &queue, std::size_t runs, AllocFn &&fn, uint8_
     using clock = std::chrono::high_resolution_clock;
     auto t0 = clock::now();
     uint8_t retval = uint8_t{1}; // to ensure buffer is used
-        uint8_t retval = uint8_t{1}; // init non-zero (sanity)
         for(std::size_t i = 0; i < runs; ++i)
         {
             auto buf = fn();                                // 1) allocate buffer

--- a/benchmark/alloc/src/alloc_benchmark.cpp
+++ b/benchmark/alloc/src/alloc_benchmark.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <utility>
 
 // =============================================================================
 // Minimal helpers copied from BabelStreamCommon for self‑contained
@@ -62,7 +63,8 @@ enum class BMInfoDataType
     KernelBandwidths,
     KernelMinTimes,
     KernelMaxTimes,
-    KernelAvgTimes
+    KernelAvgTimes,
+    KernelColdTimes
 };
 
 static std::string toStr(BMInfoDataType t)
@@ -89,6 +91,8 @@ static std::string toStr(BMInfoDataType t)
         return "Max(s)";
     case BMInfoDataType::KernelAvgTimes:
         return "Avg(s)";
+    case BMInfoDataType::KernelColdTimes:
+        return "Cold(s)";
     }
     return "";
 }
@@ -117,6 +121,9 @@ public:
              BMInfoDataType::NumRuns})
             if(auto it = m.find(k); it != m.end())
                 ss << toStr(k) << ":" << it->second << "\n";
+
+        if(auto cold = m.find(BMInfoDataType::KernelColdTimes); cold != m.end())
+            ss << toStr(BMInfoDataType::KernelColdTimes) << ":" << cold->second << "\n";
 
         // build table rows
         auto knames = m.at(BMInfoDataType::KernelNames);
@@ -182,25 +189,33 @@ static void handleAllocArgs(int& argc, char* argv[])
 
 // ---------------- helper: measure total time of N allocations ---------------
 // measureAlloc:
-//   allocate buffer -> memset -> read first byte -> wait
-//   ensures the buffer is actually touched (no lazy allocation, no dead-code removal)
-template<class TQueue, class AllocFn>
-static double measureAlloc(TQueue& queue, std::size_t runs, AllocFn&& fn, uint8_t& returnValue)
+//   allocate buffer -> memset -> wait
+//   ensures the buffer is touched via Alpaka and records per-run timings
+template<class TQueue, class AllocFn, class VerifyFn>
+static std::pair<std::vector<double>, bool>
+measureAlloc(TQueue& queue, std::size_t runs, AllocFn&& fn, VerifyFn&& verify)
 {
     using clock = std::chrono::high_resolution_clock;
-    auto t0 = clock::now();
-    uint8_t retval = uint8_t{1}; // to ensure buffer is used
+
+    std::vector<double> perRun;
+    perRun.reserve(runs);
+    bool allZero = true;
+
     for(std::size_t i = 0; i < runs; ++i)
     {
-        auto buf = fn(); // 1) allocate buffer
-        alpaka::onHost::memset(queue, buf, uint8_t{0}); // 2) touch buffer: zero-init
-        alpaka::onHost::wait(queue); // 3) sync memset + alloc
-        auto* raw = alpaka::onHost::data(buf);
-        retval = raw ? std::to_integer<uint8_t>(raw[0]) : uint8_t{0}; // 4) read first byte to enforce use
+        auto const loopStart = clock::now();
+        auto buf = fn();
+
+        alpaka::onHost::memset(queue, buf, uint8_t{0});
+        alpaka::onHost::wait(queue);
+
+        auto const loopEnd = clock::now();
+        perRun.push_back(std::chrono::duration<double>(loopEnd - loopStart).count());
+
+        allZero = allZero && verify(queue, buf);
     }
-    auto t1 = clock::now();
-    returnValue = retval; // return the last value read from the buffer
-    return std::chrono::duration<double>(t1 - t0).count(); // seconds total
+
+    return {std::move(perRun), allZero};
 }
 
 // ---------------- runtime container (2 "kernels": Host / Device) ----------
@@ -219,26 +234,43 @@ struct AllocResults
         data[name] = Entry{{}, bytes};
     }
 
-    void pushTime(std::string const& name, double t)
+    void setTimes(std::string const& name, std::vector<double> values)
     {
-        data[name].times.push_back(t);
+        data[name].times = std::move(values);
     }
 
     static double min(std::vector<double> const& v)
     {
-        return v.size() > 1 ? *std::min_element(v.begin() + 1, v.end()) : v.front();
+        if(v.empty())
+            return 0.0;
+        if(v.size() == 1)
+            return v.front();
+        return *std::min_element(v.begin() + 1, v.end());
     }
 
     static double max(std::vector<double> const& v)
     {
-        return v.size() > 1 ? *std::max_element(v.begin() + 1, v.end()) : v.front();
+        if(v.empty())
+            return 0.0;
+        if(v.size() == 1)
+            return v.front();
+        return *std::max_element(v.begin() + 1, v.end());
     }
 
     static double avg(std::vector<double> const& v)
     {
-        if(v.size() <= 1)
-            return v.front();
-        return std::accumulate(v.begin() + 1, v.end(), 0.0) / (v.size() - 1);
+        if(v.empty())
+            return 0.0;
+        auto const* beginHot = v.size() > 1 ? v.data() + 1 : v.data();
+        auto const count = static_cast<double>(v.size() > 1 ? v.size() - 1 : v.size());
+        return count > 0.0
+            ? std::accumulate(beginHot, v.data() + v.size(), 0.0) / count
+            : 0.0;
+    }
+
+    static double cold(std::vector<double> const& v)
+    {
+        return v.empty() ? 0.0 : v.front();
     }
 
     std::vector<double> bandwidths() const
@@ -270,6 +302,14 @@ struct AllocResults
         std::vector<double> r;
         for(auto const& p : data)
             r.push_back(avg(p.second.times));
+        return r;
+    }
+
+    std::vector<double> colds() const
+    {
+        std::vector<double> r;
+        for(auto const& p : data)
+            r.push_back(cold(p.second.times));
         return r;
     }
 
@@ -311,20 +351,29 @@ void testAlloc(DeviceSpec const& spec, Exec const& exec)
     results.addKernel("HostAlloc", allocBytesMain * 1.0e-6);
     results.addKernel("DeviceAlloc", allocBytesMain * 1.0e-6);
 
-    uint8_t resultByte = uint8_t{1}; // to ensure buffer is used
+    auto const hostVerifier = [](auto&, auto const& buf) {
+        auto* raw = alpaka::onHost::data(buf);
+        return raw && std::to_integer<uint8_t>(raw[0]) == 0;
+    };
 
-    double tHost
-        = measureAlloc(queue, numberOfRuns, [&] { return onHost::allocHost<std::byte>(allocBytesMain); }, resultByte);
-    results.pushTime("HostAlloc", tHost);
-
-    uint8_t resultByteDev = uint8_t{1}; // to ensure buffer is used
-
-    double tDev = measureAlloc(
+    auto [hostTimes, hostZeroed] = measureAlloc(
         queue,
         numberOfRuns,
-        [&] { return onHost::alloc<std::byte>(dev, allocBytesMain); },
-        resultByteDev);
-    results.pushTime("DeviceAlloc", tDev);
+        [&] { return onHost::allocHost<std::byte>(allocBytesMain); },
+        hostVerifier);
+    results.setTimes("HostAlloc", std::move(hostTimes));
+
+    auto deviceScratch = alpaka::onHost::allocHost<std::byte>(std::size_t{1});
+    auto deviceVerifier = [scratch = std::move(deviceScratch)](auto& q, auto const& buf) mutable {
+        alpaka::onHost::memcpy(q, scratch, buf, std::size_t{1});
+        alpaka::onHost::wait(q);
+        auto* raw = alpaka::onHost::data(scratch);
+        return raw && std::to_integer<uint8_t>(raw[0]) == 0;
+    };
+
+    auto [deviceTimes, deviceZeroed]
+        = measureAlloc(queue, numberOfRuns, [&] { return onHost::alloc<std::byte>(dev, allocBytesMain); }, deviceVerifier);
+    results.setTimes("DeviceAlloc", std::move(deviceTimes));
 
     // meta‑data summary
     BenchmarkMetaData meta;
@@ -338,11 +387,12 @@ void testAlloc(DeviceSpec const& spec, Exec const& exec)
     meta.setItem(BMInfoDataType::KernelMinTimes, joinElements(results.mins(), ", "));
     meta.setItem(BMInfoDataType::KernelMaxTimes, joinElements(results.maxs(), ", "));
     meta.setItem(BMInfoDataType::KernelAvgTimes, joinElements(results.avgs(), ", "));
+    meta.setItem(BMInfoDataType::KernelColdTimes, joinElements(results.colds(), ", "));
 
     std::cout << meta.serializeAsTable() << std::endl;
 
-    REQUIRE(resultByte == uint8_t{0}); // host buffer properly zero-initialized
-    REQUIRE(resultByteDev == uint8_t{0}); // device buffer properly zero-initialized
+    REQUIRE(hostZeroed); // host buffer properly zero-initialized
+    REQUIRE(deviceZeroed); // device buffer properly zero-initialized
 }
 
 // ---------------- Catch2 integration  ---------------------------------------

--- a/benchmark/alloc/src/alloc_benchmark.cpp
+++ b/benchmark/alloc/src/alloc_benchmark.cpp
@@ -1,0 +1,251 @@
+// Alpaka‑style micro‑benchmark for memory allocation
+// SPDX‑License‑Identifier: Apache‑2.0
+
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executors.hpp>   // provides onHost::allBackends
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// =============================================================================
+// Minimal helpers copied from BabelStreamCommon for self‑contained
+// =============================================================================
+
+// ---------- fuzzy float/int comparison -------------------------------------------------
+template<typename T>
+static bool FuzzyEqual(T a, T b)
+{
+    if constexpr(std::is_floating_point_v<T>)
+        return std::fabs(a - b) < (std::numeric_limits<T>::epsilon() * static_cast<T>(100.0));
+    else
+        return a == b;
+}
+
+// ---------- joinElements: convert vector -> "a, b, c" -----------------------------------
+template<typename T>
+static std::string joinElements(std::vector<T> const &vec, std::string const &delim)
+{
+    std::ostringstream oss;
+    for(std::size_t i = 0; i < vec.size(); ++i)
+    {
+        if(i) oss << delim;
+        oss << std::setprecision(5) << vec[i];
+    }
+    return oss.str();
+}
+
+// ---------- minimal metadata container --------------------------------------------------
+enum class BMInfoDataType
+{
+    AcceleratorType,
+    NumRuns,
+    DataSize,
+    DeviceName,
+    KernelNames,
+    KernelDataUsageValues,
+    KernelBandwidths,
+    KernelMinTimes,
+    KernelMaxTimes,
+    KernelAvgTimes
+};
+
+static std::string toStr(BMInfoDataType t)
+{
+    switch(t)
+    {
+    case BMInfoDataType::AcceleratorType:      return "Accelerator";
+    case BMInfoDataType::NumRuns:              return "Runs";
+    case BMInfoDataType::DataSize:             return "Bytes";
+    case BMInfoDataType::DeviceName:           return "Device";
+    case BMInfoDataType::KernelNames:          return "Kernels";
+    case BMInfoDataType::KernelDataUsageValues:return "Data(MB)";
+    case BMInfoDataType::KernelBandwidths:     return "BW(GB/s)";
+    case BMInfoDataType::KernelMinTimes:       return "Min(s)";
+    case BMInfoDataType::KernelMaxTimes:       return "Max(s)";
+    case BMInfoDataType::KernelAvgTimes:       return "Avg(s)";
+    }
+    return "";
+}
+
+class BenchmarkMetaData
+{
+    std::map<BMInfoDataType,std::string> m;
+public:
+    template<typename T>
+    void setItem(BMInfoDataType key, T const &val)
+    {
+        std::ostringstream oss; oss<<val; m[key]=oss.str();
+    }
+    std::string serializeAsTable() const
+    {
+        std::ostringstream ss;
+        // header fields (fixed order)
+        for(auto k: {BMInfoDataType::AcceleratorType,BMInfoDataType::DeviceName,BMInfoDataType::DataSize,BMInfoDataType::NumRuns})
+            if(auto it=m.find(k); it!=m.end()) ss<<toStr(k)<<":"<<it->second<<"\n";
+
+        // build table rows
+        auto knames = m.at(BMInfoDataType::KernelNames);
+        auto split   = [](std::string const &s){ std::vector<std::string> v; std::stringstream ss(s); std::string tok; while(std::getline(ss,tok,',')){ if(tok.size()&&tok[0]==' ') tok.erase(0,1); v.push_back(tok);} return v; };
+        auto names  = split(knames);
+        auto datMB  = split(m.at(BMInfoDataType::KernelDataUsageValues));
+        auto bw     = split(m.at(BMInfoDataType::KernelBandwidths));
+        auto tmin   = split(m.at(BMInfoDataType::KernelMinTimes));
+        auto tmax   = split(m.at(BMInfoDataType::KernelMaxTimes));
+        auto tavg   = split(m.at(BMInfoDataType::KernelAvgTimes));
+
+        ss<<std::left<<std::setw(12)<<"Kernel"<<" "<<std::setw(10)<<"BW"<<" "<<std::setw(8)<<"Min"<<" "<<std::setw(8)<<"Max"<<" "<<std::setw(8)<<"Avg"<<" "<<"Data"<<"\n";
+        for(std::size_t i=0;i<names.size();++i)
+        {
+            ss<<std::left<<std::setw(12)<<names[i]<<" "
+              <<std::setw(10)<<bw[i]<<" "
+              <<std::setw(8)<<tmin[i]<<" "
+              <<std::setw(8)<<tmax[i]<<" "
+              <<std::setw(8)<<tavg[i]<<" "
+              <<datMB[i]<<"\n";
+        }
+        return ss.str();
+    }
+};
+
+// =============================================================================
+// --------------- default parameters -----------------------------------------
+inline std::size_t allocBytesMain = 64ULL * 1024 * 1024; // 64 MiB
+inline std::size_t numberOfRuns   = 100;                 // iterations
+
+// ---------------- CLI parser -------------------------------------------------
+static void handleAllocArgs(int &argc, char *argv[])
+{
+    std::vector<char *> newArgv{argv[0]};
+    for(int i = 1; i < argc; ++i)
+    {
+        std::string arg{argv[i]};
+        if(arg.rfind("--bytes=", 0) == 0)
+            allocBytesMain = std::stoull(arg.substr(8));
+        else if(arg.rfind("--runs=", 0) == 0)
+            numberOfRuns = std::stoull(arg.substr(7));
+        else if(arg == "--help" || arg == "-?" || arg == "-h")
+        {
+            std::cout << "Usage: alloc_benchmark [--bytes=N] [--runs=N] [Catch2‑opts]\n";
+        }
+        else
+            newArgv.push_back(argv[i]); // pass through to Catch2
+    }
+    argc = static_cast<int>(newArgv.size());
+    for(int i = 0; i < argc; ++i) argv[i] = newArgv[i];
+}
+
+// ---------------- helper: measure total time of N allocations ---------------
+template<class TQueue, class AllocFn>
+static double measureAlloc(TQueue &queue, std::size_t runs, AllocFn &&fn)
+{
+    using clock = std::chrono::high_resolution_clock;
+    auto t0 = clock::now();
+    for(std::size_t i = 0; i < runs; ++i)
+    {
+        auto buf = fn();               // allocate buffer
+        alpaka::onHost::wait(queue);   // ensure operation finished
+    }
+    auto t1 = clock::now();
+    return std::chrono::duration<double>(t1 - t0).count(); // seconds total
+}
+
+// ---------------- runtime container (2 "kernels": Host / Device) ----------
+struct AllocResults
+{
+    struct Entry { std::vector<double> times; double bytesMB{0}; };
+    std::map<std::string, Entry> data;
+
+    void addKernel(std::string const &name, double bytes)
+    {
+        data[name] = Entry{{}, bytes};
+    }
+    void pushTime(std::string const &name, double t) { data[name].times.push_back(t); }
+
+    static double min(std::vector<double> const &v) { return v.size()>1? *std::min_element(v.begin()+1,v.end()):v.front(); }
+    static double max(std::vector<double> const &v) { return v.size()>1? *std::max_element(v.begin()+1,v.end()):v.front(); }
+    static double avg(std::vector<double> const &v) {
+        if(v.size()<=1) return v.front();
+        return std::accumulate(v.begin()+1,v.end(),0.0)/(v.size()-1);
+    }
+
+    std::vector<double> bandwidths() const
+    {
+        std::vector<double> bw;
+        for(auto const &p: data) bw.push_back(p.second.bytesMB/1.0e3 / min(p.second.times));
+        return bw;
+    }
+    std::vector<double> mins()  const { std::vector<double> r; for(auto const &p:data) r.push_back(min(p.second.times)); return r; }
+    std::vector<double> maxs()  const { std::vector<double> r; for(auto const &p:data) r.push_back(max(p.second.times)); return r; }
+    std::vector<double> avgs()  const { std::vector<double> r; for(auto const &p:data) r.push_back(avg(p.second.times)); return r; }
+    std::vector<double> bytes() const { std::vector<double> r; for(auto const &p:data) r.push_back(p.second.bytesMB); return r; }
+    std::string kernelNames() const  { std::string s; for(auto const &p:data){ if(!s.empty()) s += ", "; s += p.first;} return s; }
+};
+
+// ---------------- per‑backend test body -------------------------------------
+template<typename DeviceSpec, typename Exec>
+void testAlloc(DeviceSpec const &spec, Exec const &exec)
+{
+    using namespace alpaka;
+
+    auto selector = onHost::makeDeviceSelector(spec);
+    if(!selector.isAvailable())
+        return; // no device => skip
+
+    onHost::Device dev   = selector.makeDevice(0);
+    onHost::Queue  queue = dev.makeQueue();
+
+    AllocResults results;
+    results.addKernel("HostAlloc",   allocBytesMain * 1.0e-6);
+    results.addKernel("DeviceAlloc", allocBytesMain * 1.0e-6);
+
+    double tHost = measureAlloc(queue, numberOfRuns, [&]{ return onHost::allocHost<std::byte>(allocBytesMain); });
+    results.pushTime("HostAlloc", tHost);
+
+    double tDev  = measureAlloc(queue, numberOfRuns, [&]{ return onHost::alloc<std::byte>(dev, allocBytesMain); });
+    results.pushTime("DeviceAlloc", tDev);
+
+    // meta‑data summary
+    BenchmarkMetaData meta;
+    meta.setItem(BMInfoDataType::AcceleratorType, alpaka::core::demangledName(exec));
+    meta.setItem(BMInfoDataType::DeviceName,      alpaka::onHost::getName(dev));
+    meta.setItem(BMInfoDataType::DataSize,        std::to_string(allocBytesMain));
+    meta.setItem(BMInfoDataType::NumRuns,         std::to_string(numberOfRuns));
+    meta.setItem(BMInfoDataType::KernelNames,     results.kernelNames());
+    meta.setItem(BMInfoDataType::KernelDataUsageValues, joinElements(results.bytes(), ", "));
+    meta.setItem(BMInfoDataType::KernelBandwidths,       joinElements(results.bandwidths(), ", "));
+    meta.setItem(BMInfoDataType::KernelMinTimes,         joinElements(results.mins(), ", "));
+    meta.setItem(BMInfoDataType::KernelMaxTimes,         joinElements(results.maxs(), ", "));
+    meta.setItem(BMInfoDataType::KernelAvgTimes,         joinElements(results.avgs(), ", "));
+
+    std::cout << meta.serializeAsTable() << std::endl;
+
+    REQUIRE(FuzzyEqual(0,0)); // mark as passed
+}
+
+// ---------------- Catch2 integration  ---------------------------------------
+using Backends = std::decay_t<decltype(alpaka::onHost::allBackends(alpaka::onHost::enabledApis))>;
+
+TEMPLATE_LIST_TEST_CASE("Alloc benchmark", "[alloc]", Backends)
+{
+    auto be = TestType::makeDict();
+    testAlloc(be[alpaka::object::deviceSpec], be[alpaka::object::exec]);
+}
+
+// ---------------- main -------------------------------------------------------
+int main(int argc, char *argv[])
+{
+    handleAllocArgs(argc, argv);
+    return Catch::Session().run(argc, argv);
+}

--- a/benchmark/alloc/src/alloc_benchmark.cpp
+++ b/benchmark/alloc/src/alloc_benchmark.cpp
@@ -4,7 +4,8 @@
 // Work funded by US NAS and ONRG (IMPRESS-U).
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/example/executors.hpp> // provides onHost::allBackends
+#include <alpaka/onHost/demangledName.hpp>
+#include <alpaka/onHost/example/executors.hpp> // provides onHost::allBackends
 
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_template_test_macros.hpp>
@@ -193,8 +194,9 @@ static double measureAlloc(TQueue& queue, std::size_t runs, AllocFn&& fn, uint8_
     {
         auto buf = fn(); // 1) allocate buffer
         alpaka::onHost::memset(queue, buf, uint8_t{0}); // 2) touch buffer: zero-init
-        retval = static_cast<uint8_t>(buf[0]); // 3) read first byte to enforce use
-        alpaka::onHost::wait(queue); // 4) sync memset + alloc
+        alpaka::onHost::wait(queue); // 3) sync memset + alloc
+        auto* raw = alpaka::onHost::data(buf);
+        retval = raw ? std::to_integer<uint8_t>(raw[0]) : uint8_t{0}; // 4) read first byte to enforce use
     }
     auto t1 = clock::now();
     returnValue = retval; // return the last value read from the buffer
@@ -326,7 +328,7 @@ void testAlloc(DeviceSpec const& spec, Exec const& exec)
 
     // meta‑data summary
     BenchmarkMetaData meta;
-    meta.setItem(BMInfoDataType::AcceleratorType, alpaka::core::demangledName(exec));
+    meta.setItem(BMInfoDataType::AcceleratorType, alpaka::onHost::demangledName(exec));
     meta.setItem(BMInfoDataType::DeviceName, alpaka::onHost::getName(dev));
     meta.setItem(BMInfoDataType::DataSize, std::to_string(allocBytesMain));
     meta.setItem(BMInfoDataType::NumRuns, std::to_string(numberOfRuns));
@@ -344,7 +346,9 @@ void testAlloc(DeviceSpec const& spec, Exec const& exec)
 }
 
 // ---------------- Catch2 integration  ---------------------------------------
-using Backends = std::decay_t<decltype(alpaka::onHost::allBackends(alpaka::onHost::enabledApis))>;
+using Backends = std::decay_t<decltype(alpaka::onHost::allBackends(
+    alpaka::onHost::enabledApis,
+    alpaka::onHost::example::enabledExecutors))>;
 
 TEMPLATE_LIST_TEST_CASE("Alloc benchmark", "[alloc]", Backends)
 {

--- a/benchmark/alloc/src/alloc_benchmark.cpp
+++ b/benchmark/alloc/src/alloc_benchmark.cpp
@@ -1,5 +1,7 @@
 // Alpaka‑style micro‑benchmark for memory allocation
-// SPDX‑License‑Identifier: Apache‑2.0
+// SPDX‑License‑Identifier: MPL‑2.0
+// Authors: Ivan Andriievskyi, Jiří Vyskočil
+// Work funded by US NAS and ONRG (IMPRESS-U).
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/example/executors.hpp> // provides onHost::allBackends

--- a/benchmark/alloc/src/alloc_benchmark.cpp
+++ b/benchmark/alloc/src/alloc_benchmark.cpp
@@ -1,12 +1,12 @@
 // Alpaka‑style micro‑benchmark for memory allocation
 // SPDX‑License‑Identifier: Apache‑2.0
 
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/executors.hpp> // provides onHost::allBackends
+
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
-
-#include <alpaka/alpaka.hpp>
-#include <alpaka/example/executors.hpp>   // provides onHost::allBackends
 
 #include <algorithm>
 #include <chrono>
@@ -35,12 +35,13 @@ static bool FuzzyEqual(T a, T b)
 
 // ---------- joinElements: convert vector -> "a, b, c" -----------------------------------
 template<typename T>
-static std::string joinElements(std::vector<T> const &vec, std::string const &delim)
+static std::string joinElements(std::vector<T> const& vec, std::string const& delim)
 {
     std::ostringstream oss;
     for(std::size_t i = 0; i < vec.size(); ++i)
     {
-        if(i) oss << delim;
+        if(i)
+            oss << delim;
         oss << std::setprecision(5) << vec[i];
     }
     return oss.str();
@@ -65,55 +66,84 @@ static std::string toStr(BMInfoDataType t)
 {
     switch(t)
     {
-    case BMInfoDataType::AcceleratorType:      return "Accelerator";
-    case BMInfoDataType::NumRuns:              return "Runs";
-    case BMInfoDataType::DataSize:             return "Bytes";
-    case BMInfoDataType::DeviceName:           return "Device";
-    case BMInfoDataType::KernelNames:          return "Kernels";
-    case BMInfoDataType::KernelDataUsageValues:return "Data(MB)";
-    case BMInfoDataType::KernelBandwidths:     return "BW(GB/s)";
-    case BMInfoDataType::KernelMinTimes:       return "Min(s)";
-    case BMInfoDataType::KernelMaxTimes:       return "Max(s)";
-    case BMInfoDataType::KernelAvgTimes:       return "Avg(s)";
+    case BMInfoDataType::AcceleratorType:
+        return "Accelerator";
+    case BMInfoDataType::NumRuns:
+        return "Runs";
+    case BMInfoDataType::DataSize:
+        return "Bytes";
+    case BMInfoDataType::DeviceName:
+        return "Device";
+    case BMInfoDataType::KernelNames:
+        return "Kernels";
+    case BMInfoDataType::KernelDataUsageValues:
+        return "Data(MB)";
+    case BMInfoDataType::KernelBandwidths:
+        return "BW(GB/s)";
+    case BMInfoDataType::KernelMinTimes:
+        return "Min(s)";
+    case BMInfoDataType::KernelMaxTimes:
+        return "Max(s)";
+    case BMInfoDataType::KernelAvgTimes:
+        return "Avg(s)";
     }
     return "";
 }
 
 class BenchmarkMetaData
 {
-    std::map<BMInfoDataType,std::string> m;
+    std::map<BMInfoDataType, std::string> m;
+
 public:
     template<typename T>
-    void setItem(BMInfoDataType key, T const &val)
+    void setItem(BMInfoDataType key, T const& val)
     {
-        std::ostringstream oss; oss<<val; m[key]=oss.str();
+        std::ostringstream oss;
+        oss << val;
+        m[key] = oss.str();
     }
+
     std::string serializeAsTable() const
     {
         std::ostringstream ss;
         // header fields (fixed order)
-        for(auto k: {BMInfoDataType::AcceleratorType,BMInfoDataType::DeviceName,BMInfoDataType::DataSize,BMInfoDataType::NumRuns})
-            if(auto it=m.find(k); it!=m.end()) ss<<toStr(k)<<":"<<it->second<<"\n";
+        for(auto k :
+            {BMInfoDataType::AcceleratorType,
+             BMInfoDataType::DeviceName,
+             BMInfoDataType::DataSize,
+             BMInfoDataType::NumRuns})
+            if(auto it = m.find(k); it != m.end())
+                ss << toStr(k) << ":" << it->second << "\n";
 
         // build table rows
         auto knames = m.at(BMInfoDataType::KernelNames);
-        auto split   = [](std::string const &s){ std::vector<std::string> v; std::stringstream ss(s); std::string tok; while(std::getline(ss,tok,',')){ if(tok.size()&&tok[0]==' ') tok.erase(0,1); v.push_back(tok);} return v; };
-        auto names  = split(knames);
-        auto datMB  = split(m.at(BMInfoDataType::KernelDataUsageValues));
-        auto bw     = split(m.at(BMInfoDataType::KernelBandwidths));
-        auto tmin   = split(m.at(BMInfoDataType::KernelMinTimes));
-        auto tmax   = split(m.at(BMInfoDataType::KernelMaxTimes));
-        auto tavg   = split(m.at(BMInfoDataType::KernelAvgTimes));
-
-        ss<<std::left<<std::setw(12)<<"Kernel"<<" "<<std::setw(10)<<"BW"<<" "<<std::setw(8)<<"Min"<<" "<<std::setw(8)<<"Max"<<" "<<std::setw(8)<<"Avg"<<" "<<"Data"<<"\n";
-        for(std::size_t i=0;i<names.size();++i)
+        auto split = [](std::string const& s)
         {
-            ss<<std::left<<std::setw(12)<<names[i]<<" "
-              <<std::setw(10)<<bw[i]<<" "
-              <<std::setw(8)<<tmin[i]<<" "
-              <<std::setw(8)<<tmax[i]<<" "
-              <<std::setw(8)<<tavg[i]<<" "
-              <<datMB[i]<<"\n";
+            std::vector<std::string> v;
+            std::stringstream ss(s);
+            std::string tok;
+            while(std::getline(ss, tok, ','))
+            {
+                if(tok.size() && tok[0] == ' ')
+                    tok.erase(0, 1);
+                v.push_back(tok);
+            }
+            return v;
+        };
+        auto names = split(knames);
+        auto datMB = split(m.at(BMInfoDataType::KernelDataUsageValues));
+        auto bw = split(m.at(BMInfoDataType::KernelBandwidths));
+        auto tmin = split(m.at(BMInfoDataType::KernelMinTimes));
+        auto tmax = split(m.at(BMInfoDataType::KernelMaxTimes));
+        auto tavg = split(m.at(BMInfoDataType::KernelAvgTimes));
+
+        ss << std::left << std::setw(12) << "Kernel" << " " << std::setw(10) << "BW" << " " << std::setw(8) << "Min"
+           << " " << std::setw(8) << "Max" << " " << std::setw(8) << "Avg" << " " << "Data" << "\n";
+        for(std::size_t i = 0; i < names.size(); ++i)
+        {
+            ss << std::left << std::setw(12) << names[i] << " " << std::setw(10) << bw[i] << " " << std::setw(8)
+               << tmin[i] << " " << std::setw(8) << tmax[i] << " " << std::setw(8) << tavg[i] << " " << datMB[i]
+               << "\n";
         }
         return ss.str();
     }
@@ -122,12 +152,12 @@ public:
 // =============================================================================
 // --------------- default parameters -----------------------------------------
 inline std::size_t allocBytesMain = 64ULL * 1024 * 1024; // 64 MiB
-inline std::size_t numberOfRuns   = 100;                 // iterations
+inline std::size_t numberOfRuns = 100; // iterations
 
 // ---------------- CLI parser -------------------------------------------------
-static void handleAllocArgs(int &argc, char *argv[])
+static void handleAllocArgs(int& argc, char* argv[])
 {
-    std::vector<char *> newArgv{argv[0]};
+    std::vector<char*> newArgv{argv[0]};
     for(int i = 1; i < argc; ++i)
     {
         std::string arg{argv[i]};
@@ -143,7 +173,8 @@ static void handleAllocArgs(int &argc, char *argv[])
             newArgv.push_back(argv[i]); // pass through to Catch2
     }
     argc = static_cast<int>(newArgv.size());
-    for(int i = 0; i < argc; ++i) argv[i] = newArgv[i];
+    for(int i = 0; i < argc; ++i)
+        argv[i] = newArgv[i];
 }
 
 // ---------------- helper: measure total time of N allocations ---------------
@@ -151,18 +182,18 @@ static void handleAllocArgs(int &argc, char *argv[])
 //   allocate buffer -> memset -> read first byte -> wait
 //   ensures the buffer is actually touched (no lazy allocation, no dead-code removal)
 template<class TQueue, class AllocFn>
-static double measureAlloc(TQueue &queue, std::size_t runs, AllocFn &&fn, uint8_t& returnValue)
+static double measureAlloc(TQueue& queue, std::size_t runs, AllocFn&& fn, uint8_t& returnValue)
 {
     using clock = std::chrono::high_resolution_clock;
     auto t0 = clock::now();
     uint8_t retval = uint8_t{1}; // to ensure buffer is used
-        for(std::size_t i = 0; i < runs; ++i)
-        {
-            auto buf = fn();                                // 1) allocate buffer
-            alpaka::onHost::memset(queue, buf, uint8_t{0}); // 2) touch buffer: zero-init
-            retval = static_cast<uint8_t>(buf[0]);          // 3) read first byte to enforce use
-            alpaka::onHost::wait(queue);                    // 4) sync memset + alloc
-        }
+    for(std::size_t i = 0; i < runs; ++i)
+    {
+        auto buf = fn(); // 1) allocate buffer
+        alpaka::onHost::memset(queue, buf, uint8_t{0}); // 2) touch buffer: zero-init
+        retval = static_cast<uint8_t>(buf[0]); // 3) read first byte to enforce use
+        alpaka::onHost::wait(queue); // 4) sync memset + alloc
+    }
     auto t1 = clock::now();
     returnValue = retval; // return the last value read from the buffer
     return std::chrono::duration<double>(t1 - t0).count(); // seconds total
@@ -171,38 +202,97 @@ static double measureAlloc(TQueue &queue, std::size_t runs, AllocFn &&fn, uint8_
 // ---------------- runtime container (2 "kernels": Host / Device) ----------
 struct AllocResults
 {
-    struct Entry { std::vector<double> times; double bytesMB{0}; };
+    struct Entry
+    {
+        std::vector<double> times;
+        double bytesMB{0};
+    };
+
     std::map<std::string, Entry> data;
 
-    void addKernel(std::string const &name, double bytes)
+    void addKernel(std::string const& name, double bytes)
     {
         data[name] = Entry{{}, bytes};
     }
-    void pushTime(std::string const &name, double t) { data[name].times.push_back(t); }
 
-    static double min(std::vector<double> const &v) { return v.size()>1? *std::min_element(v.begin()+1,v.end()):v.front(); }
-    static double max(std::vector<double> const &v) { return v.size()>1? *std::max_element(v.begin()+1,v.end()):v.front(); }
-    static double avg(std::vector<double> const &v) {
-        if(v.size()<=1) return v.front();
-        return std::accumulate(v.begin()+1,v.end(),0.0)/(v.size()-1);
+    void pushTime(std::string const& name, double t)
+    {
+        data[name].times.push_back(t);
+    }
+
+    static double min(std::vector<double> const& v)
+    {
+        return v.size() > 1 ? *std::min_element(v.begin() + 1, v.end()) : v.front();
+    }
+
+    static double max(std::vector<double> const& v)
+    {
+        return v.size() > 1 ? *std::max_element(v.begin() + 1, v.end()) : v.front();
+    }
+
+    static double avg(std::vector<double> const& v)
+    {
+        if(v.size() <= 1)
+            return v.front();
+        return std::accumulate(v.begin() + 1, v.end(), 0.0) / (v.size() - 1);
     }
 
     std::vector<double> bandwidths() const
     {
         std::vector<double> bw;
-        for(auto const &p: data) bw.push_back(p.second.bytesMB/1.0e3 / min(p.second.times));
+        for(auto const& p : data)
+            bw.push_back(p.second.bytesMB / 1.0e3 / min(p.second.times));
         return bw;
     }
-    std::vector<double> mins()  const { std::vector<double> r; for(auto const &p:data) r.push_back(min(p.second.times)); return r; }
-    std::vector<double> maxs()  const { std::vector<double> r; for(auto const &p:data) r.push_back(max(p.second.times)); return r; }
-    std::vector<double> avgs()  const { std::vector<double> r; for(auto const &p:data) r.push_back(avg(p.second.times)); return r; }
-    std::vector<double> bytes() const { std::vector<double> r; for(auto const &p:data) r.push_back(p.second.bytesMB); return r; }
-    std::string kernelNames() const  { std::string s; for(auto const &p:data){ if(!s.empty()) s += ", "; s += p.first;} return s; }
+
+    std::vector<double> mins() const
+    {
+        std::vector<double> r;
+        for(auto const& p : data)
+            r.push_back(min(p.second.times));
+        return r;
+    }
+
+    std::vector<double> maxs() const
+    {
+        std::vector<double> r;
+        for(auto const& p : data)
+            r.push_back(max(p.second.times));
+        return r;
+    }
+
+    std::vector<double> avgs() const
+    {
+        std::vector<double> r;
+        for(auto const& p : data)
+            r.push_back(avg(p.second.times));
+        return r;
+    }
+
+    std::vector<double> bytes() const
+    {
+        std::vector<double> r;
+        for(auto const& p : data)
+            r.push_back(p.second.bytesMB);
+        return r;
+    }
+
+    std::string kernelNames() const
+    {
+        std::string s;
+        for(auto const& p : data)
+        {
+            if(!s.empty())
+                s += ", ";
+            s += p.first;
+        }
+        return s;
+    }
 };
 
 // ---------------- per‑backend test body -------------------------------------
 template<typename DeviceSpec, typename Exec>
-void testAlloc(DeviceSpec const &spec, Exec const &exec)
+void testAlloc(DeviceSpec const& spec, Exec const& exec)
 {
     using namespace alpaka;
 
@@ -210,40 +300,45 @@ void testAlloc(DeviceSpec const &spec, Exec const &exec)
     if(!selector.isAvailable())
         return; // no device => skip
 
-    onHost::Device dev   = selector.makeDevice(0);
-    onHost::Queue  queue = dev.makeQueue();
+    onHost::Device dev = selector.makeDevice(0);
+    onHost::Queue queue = dev.makeQueue();
 
     AllocResults results;
-    results.addKernel("HostAlloc",   allocBytesMain * 1.0e-6);
+    results.addKernel("HostAlloc", allocBytesMain * 1.0e-6);
     results.addKernel("DeviceAlloc", allocBytesMain * 1.0e-6);
 
     uint8_t resultByte = uint8_t{1}; // to ensure buffer is used
 
-    double tHost = measureAlloc(queue, numberOfRuns, [&]{ return onHost::allocHost<std::byte>(allocBytesMain); }, resultByte);
+    double tHost
+        = measureAlloc(queue, numberOfRuns, [&] { return onHost::allocHost<std::byte>(allocBytesMain); }, resultByte);
     results.pushTime("HostAlloc", tHost);
 
     uint8_t resultByteDev = uint8_t{1}; // to ensure buffer is used
 
-    double tDev  = measureAlloc(queue, numberOfRuns, [&]{ return onHost::alloc<std::byte>(dev, allocBytesMain); }, resultByteDev);
+    double tDev = measureAlloc(
+        queue,
+        numberOfRuns,
+        [&] { return onHost::alloc<std::byte>(dev, allocBytesMain); },
+        resultByteDev);
     results.pushTime("DeviceAlloc", tDev);
 
     // meta‑data summary
     BenchmarkMetaData meta;
     meta.setItem(BMInfoDataType::AcceleratorType, alpaka::core::demangledName(exec));
-    meta.setItem(BMInfoDataType::DeviceName,      alpaka::onHost::getName(dev));
-    meta.setItem(BMInfoDataType::DataSize,        std::to_string(allocBytesMain));
-    meta.setItem(BMInfoDataType::NumRuns,         std::to_string(numberOfRuns));
-    meta.setItem(BMInfoDataType::KernelNames,     results.kernelNames());
+    meta.setItem(BMInfoDataType::DeviceName, alpaka::onHost::getName(dev));
+    meta.setItem(BMInfoDataType::DataSize, std::to_string(allocBytesMain));
+    meta.setItem(BMInfoDataType::NumRuns, std::to_string(numberOfRuns));
+    meta.setItem(BMInfoDataType::KernelNames, results.kernelNames());
     meta.setItem(BMInfoDataType::KernelDataUsageValues, joinElements(results.bytes(), ", "));
-    meta.setItem(BMInfoDataType::KernelBandwidths,       joinElements(results.bandwidths(), ", "));
-    meta.setItem(BMInfoDataType::KernelMinTimes,         joinElements(results.mins(), ", "));
-    meta.setItem(BMInfoDataType::KernelMaxTimes,         joinElements(results.maxs(), ", "));
-    meta.setItem(BMInfoDataType::KernelAvgTimes,         joinElements(results.avgs(), ", "));
+    meta.setItem(BMInfoDataType::KernelBandwidths, joinElements(results.bandwidths(), ", "));
+    meta.setItem(BMInfoDataType::KernelMinTimes, joinElements(results.mins(), ", "));
+    meta.setItem(BMInfoDataType::KernelMaxTimes, joinElements(results.maxs(), ", "));
+    meta.setItem(BMInfoDataType::KernelAvgTimes, joinElements(results.avgs(), ", "));
 
     std::cout << meta.serializeAsTable() << std::endl;
 
-    REQUIRE(resultByte == uint8_t{0});      // host buffer properly zero-initialized
-    REQUIRE(resultByteDev == uint8_t{0});   // device buffer properly zero-initialized
+    REQUIRE(resultByte == uint8_t{0}); // host buffer properly zero-initialized
+    REQUIRE(resultByteDev == uint8_t{0}); // device buffer properly zero-initialized
 }
 
 // ---------------- Catch2 integration  ---------------------------------------
@@ -256,7 +351,7 @@ TEMPLATE_LIST_TEST_CASE("Alloc benchmark", "[alloc]", Backends)
 }
 
 // ---------------- main -------------------------------------------------------
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
     handleAllocArgs(argc, argv);
     return Catch::Session().run(argc, argv);

--- a/benchmark/alloc/src/alloc_benchmark.cpp
+++ b/benchmark/alloc/src/alloc_benchmark.cpp
@@ -3,161 +3,21 @@
 // Authors: Ivan Andriievskyi, Jiří Vyskočil
 // Work funded by US NAS and ONRG (IMPRESS-U).
 
+#include "alloc_helpers.hpp"
+
 #include <alpaka/alpaka.hpp>
 #include <alpaka/onHost/demangledName.hpp>
-#include <alpaka/onHost/example/executors.hpp> // provides onHost::allBackends
+#include <alpaka/onHost/example/executors.hpp>
 
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <algorithm>
 #include <chrono>
-#include <cstddef>
-#include <iomanip>
 #include <iostream>
-#include <map>
-#include <numeric>
-#include <sstream>
-#include <string>
-#include <vector>
 #include <utility>
 
-// =============================================================================
-// Minimal helpers copied from BabelStreamCommon for self‑contained
-// =============================================================================
-
-// ---------- fuzzy float/int comparison -------------------------------------------------
-template<typename T>
-static bool FuzzyEqual(T a, T b)
-{
-    if constexpr(std::is_floating_point_v<T>)
-        return std::fabs(a - b) < (std::numeric_limits<T>::epsilon() * static_cast<T>(100.0));
-    else
-        return a == b;
-}
-
-// ---------- joinElements: convert vector -> "a, b, c" -----------------------------------
-template<typename T>
-static std::string joinElements(std::vector<T> const& vec, std::string const& delim)
-{
-    std::ostringstream oss;
-    for(std::size_t i = 0; i < vec.size(); ++i)
-    {
-        if(i)
-            oss << delim;
-        oss << std::setprecision(5) << vec[i];
-    }
-    return oss.str();
-}
-
-// ---------- minimal metadata container --------------------------------------------------
-enum class BMInfoDataType
-{
-    AcceleratorType,
-    NumRuns,
-    DataSize,
-    DeviceName,
-    KernelNames,
-    KernelDataUsageValues,
-    KernelBandwidths,
-    KernelMinTimes,
-    KernelMaxTimes,
-    KernelAvgTimes,
-    KernelColdTimes
-};
-
-static std::string toStr(BMInfoDataType t)
-{
-    switch(t)
-    {
-    case BMInfoDataType::AcceleratorType:
-        return "Accelerator";
-    case BMInfoDataType::NumRuns:
-        return "Runs";
-    case BMInfoDataType::DataSize:
-        return "Bytes";
-    case BMInfoDataType::DeviceName:
-        return "Device";
-    case BMInfoDataType::KernelNames:
-        return "Kernels";
-    case BMInfoDataType::KernelDataUsageValues:
-        return "Data(MB)";
-    case BMInfoDataType::KernelBandwidths:
-        return "BW(GB/s)";
-    case BMInfoDataType::KernelMinTimes:
-        return "Min(s)";
-    case BMInfoDataType::KernelMaxTimes:
-        return "Max(s)";
-    case BMInfoDataType::KernelAvgTimes:
-        return "Avg(s)";
-    case BMInfoDataType::KernelColdTimes:
-        return "Cold(s)";
-    }
-    return "";
-}
-
-class BenchmarkMetaData
-{
-    std::map<BMInfoDataType, std::string> m;
-
-public:
-    template<typename T>
-    void setItem(BMInfoDataType key, T const& val)
-    {
-        std::ostringstream oss;
-        oss << val;
-        m[key] = oss.str();
-    }
-
-    std::string serializeAsTable() const
-    {
-        std::ostringstream ss;
-        // header fields (fixed order)
-        for(auto k :
-            {BMInfoDataType::AcceleratorType,
-             BMInfoDataType::DeviceName,
-             BMInfoDataType::DataSize,
-             BMInfoDataType::NumRuns})
-            if(auto it = m.find(k); it != m.end())
-                ss << toStr(k) << ":" << it->second << "\n";
-
-        if(auto cold = m.find(BMInfoDataType::KernelColdTimes); cold != m.end())
-            ss << toStr(BMInfoDataType::KernelColdTimes) << ":" << cold->second << "\n";
-
-        // build table rows
-        auto knames = m.at(BMInfoDataType::KernelNames);
-        auto split = [](std::string const& s)
-        {
-            std::vector<std::string> v;
-            std::stringstream ss(s);
-            std::string tok;
-            while(std::getline(ss, tok, ','))
-            {
-                if(tok.size() && tok[0] == ' ')
-                    tok.erase(0, 1);
-                v.push_back(tok);
-            }
-            return v;
-        };
-        auto names = split(knames);
-        auto datMB = split(m.at(BMInfoDataType::KernelDataUsageValues));
-        auto bw = split(m.at(BMInfoDataType::KernelBandwidths));
-        auto tmin = split(m.at(BMInfoDataType::KernelMinTimes));
-        auto tmax = split(m.at(BMInfoDataType::KernelMaxTimes));
-        auto tavg = split(m.at(BMInfoDataType::KernelAvgTimes));
-
-        ss << std::left << std::setw(12) << "Kernel" << " " << std::setw(10) << "BW" << " " << std::setw(8) << "Min"
-           << " " << std::setw(8) << "Max" << " " << std::setw(8) << "Avg" << " " << "Data" << "\n";
-        for(std::size_t i = 0; i < names.size(); ++i)
-        {
-            ss << std::left << std::setw(12) << names[i] << " " << std::setw(10) << bw[i] << " " << std::setw(8)
-               << tmin[i] << " " << std::setw(8) << tmax[i] << " " << std::setw(8) << tavg[i] << " " << datMB[i]
-               << "\n";
-        }
-        return ss.str();
-    }
-};
+namespace alloc_bm = alpaka::benchmark::alloc;
 
 // =============================================================================
 // --------------- default parameters -----------------------------------------
@@ -191,9 +51,9 @@ static void handleAllocArgs(int& argc, char* argv[])
 // measureAlloc:
 //   allocate buffer -> memset -> wait
 //   ensures the buffer is touched via Alpaka and records per-run timings
-template<class TQueue, class AllocFn, class VerifyFn>
+template<typename T_Queue, typename T_AllocFn, typename T_VerifyFn>
 static std::pair<std::vector<double>, bool>
-measureAlloc(TQueue& queue, std::size_t runs, AllocFn&& fn, VerifyFn&& verify)
+measureAlloc(T_Queue& queue, std::size_t runs, T_AllocFn&& fn, T_VerifyFn&& verify)
 {
     using clock = std::chrono::high_resolution_clock;
 
@@ -218,125 +78,9 @@ measureAlloc(TQueue& queue, std::size_t runs, AllocFn&& fn, VerifyFn&& verify)
     return {std::move(perRun), allZero};
 }
 
-// ---------------- runtime container (2 "kernels": Host / Device) ----------
-struct AllocResults
-{
-    struct Entry
-    {
-        std::vector<double> times;
-        double bytesMB{0};
-    };
-
-    std::map<std::string, Entry> data;
-
-    void addKernel(std::string const& name, double bytes)
-    {
-        data[name] = Entry{{}, bytes};
-    }
-
-    void setTimes(std::string const& name, std::vector<double> values)
-    {
-        data[name].times = std::move(values);
-    }
-
-    static double min(std::vector<double> const& v)
-    {
-        if(v.empty())
-            return 0.0;
-        if(v.size() == 1)
-            return v.front();
-        return *std::min_element(v.begin() + 1, v.end());
-    }
-
-    static double max(std::vector<double> const& v)
-    {
-        if(v.empty())
-            return 0.0;
-        if(v.size() == 1)
-            return v.front();
-        return *std::max_element(v.begin() + 1, v.end());
-    }
-
-    static double avg(std::vector<double> const& v)
-    {
-        if(v.empty())
-            return 0.0;
-        auto const* beginHot = v.size() > 1 ? v.data() + 1 : v.data();
-        auto const count = static_cast<double>(v.size() > 1 ? v.size() - 1 : v.size());
-        return count > 0.0
-            ? std::accumulate(beginHot, v.data() + v.size(), 0.0) / count
-            : 0.0;
-    }
-
-    static double cold(std::vector<double> const& v)
-    {
-        return v.empty() ? 0.0 : v.front();
-    }
-
-    std::vector<double> bandwidths() const
-    {
-        std::vector<double> bw;
-        for(auto const& p : data)
-            bw.push_back(p.second.bytesMB / 1.0e3 / min(p.second.times));
-        return bw;
-    }
-
-    std::vector<double> mins() const
-    {
-        std::vector<double> r;
-        for(auto const& p : data)
-            r.push_back(min(p.second.times));
-        return r;
-    }
-
-    std::vector<double> maxs() const
-    {
-        std::vector<double> r;
-        for(auto const& p : data)
-            r.push_back(max(p.second.times));
-        return r;
-    }
-
-    std::vector<double> avgs() const
-    {
-        std::vector<double> r;
-        for(auto const& p : data)
-            r.push_back(avg(p.second.times));
-        return r;
-    }
-
-    std::vector<double> colds() const
-    {
-        std::vector<double> r;
-        for(auto const& p : data)
-            r.push_back(cold(p.second.times));
-        return r;
-    }
-
-    std::vector<double> bytes() const
-    {
-        std::vector<double> r;
-        for(auto const& p : data)
-            r.push_back(p.second.bytesMB);
-        return r;
-    }
-
-    std::string kernelNames() const
-    {
-        std::string s;
-        for(auto const& p : data)
-        {
-            if(!s.empty())
-                s += ", ";
-            s += p.first;
-        }
-        return s;
-    }
-};
-
 // ---------------- per‑backend test body -------------------------------------
-template<typename DeviceSpec, typename Exec>
-void testAlloc(DeviceSpec const& spec, Exec const& exec)
+template<typename T_DeviceSpec, typename T_Exec>
+void testAlloc(T_DeviceSpec const& spec, T_Exec const& exec)
 {
     using namespace alpaka;
 
@@ -347,7 +91,7 @@ void testAlloc(DeviceSpec const& spec, Exec const& exec)
     onHost::Device dev = selector.makeDevice(0);
     onHost::Queue queue = dev.makeQueue();
 
-    AllocResults results;
+    alloc_bm::AllocResults results;
     results.addKernel("HostAlloc", allocBytesMain * 1.0e-6);
     results.addKernel("DeviceAlloc", allocBytesMain * 1.0e-6);
 
@@ -376,18 +120,18 @@ void testAlloc(DeviceSpec const& spec, Exec const& exec)
     results.setTimes("DeviceAlloc", std::move(deviceTimes));
 
     // meta‑data summary
-    BenchmarkMetaData meta;
-    meta.setItem(BMInfoDataType::AcceleratorType, alpaka::onHost::demangledName(exec));
-    meta.setItem(BMInfoDataType::DeviceName, alpaka::onHost::getName(dev));
-    meta.setItem(BMInfoDataType::DataSize, std::to_string(allocBytesMain));
-    meta.setItem(BMInfoDataType::NumRuns, std::to_string(numberOfRuns));
-    meta.setItem(BMInfoDataType::KernelNames, results.kernelNames());
-    meta.setItem(BMInfoDataType::KernelDataUsageValues, joinElements(results.bytes(), ", "));
-    meta.setItem(BMInfoDataType::KernelBandwidths, joinElements(results.bandwidths(), ", "));
-    meta.setItem(BMInfoDataType::KernelMinTimes, joinElements(results.mins(), ", "));
-    meta.setItem(BMInfoDataType::KernelMaxTimes, joinElements(results.maxs(), ", "));
-    meta.setItem(BMInfoDataType::KernelAvgTimes, joinElements(results.avgs(), ", "));
-    meta.setItem(BMInfoDataType::KernelColdTimes, joinElements(results.colds(), ", "));
+    alloc_bm::BenchmarkMetaData meta;
+    meta.setItem(alloc_bm::BMInfoDataType::AcceleratorType, alpaka::onHost::demangledName(exec));
+    meta.setItem(alloc_bm::BMInfoDataType::DeviceName, alpaka::onHost::getName(dev));
+    meta.setItem(alloc_bm::BMInfoDataType::DataSize, std::to_string(allocBytesMain));
+    meta.setItem(alloc_bm::BMInfoDataType::NumRuns, std::to_string(numberOfRuns));
+    meta.setItem(alloc_bm::BMInfoDataType::KernelNames, results.kernelNames());
+    meta.setItem(alloc_bm::BMInfoDataType::KernelDataUsageValues, alloc_bm::joinElements(results.bytes(), ", "));
+    meta.setItem(alloc_bm::BMInfoDataType::KernelBandwidths, alloc_bm::joinElements(results.bandwidths(), ", "));
+    meta.setItem(alloc_bm::BMInfoDataType::KernelMinTimes, alloc_bm::joinElements(results.mins(), ", "));
+    meta.setItem(alloc_bm::BMInfoDataType::KernelMaxTimes, alloc_bm::joinElements(results.maxs(), ", "));
+    meta.setItem(alloc_bm::BMInfoDataType::KernelAvgTimes, alloc_bm::joinElements(results.avgs(), ", "));
+    meta.setItem(alloc_bm::BMInfoDataType::KernelColdTimes, alloc_bm::joinElements(results.colds(), ", "));
 
     std::cout << meta.serializeAsTable() << std::endl;
 

--- a/benchmark/alloc/src/alloc_benchmark.cpp
+++ b/benchmark/alloc/src/alloc_benchmark.cpp
@@ -52,8 +52,11 @@ static void handleAllocArgs(int& argc, char* argv[])
 //   allocate buffer -> memset -> wait
 //   ensures the buffer is touched via Alpaka and records per-run timings
 template<typename T_Queue, typename T_AllocFn, typename T_VerifyFn>
-static std::pair<std::vector<double>, bool>
-measureAlloc(T_Queue& queue, std::size_t runs, T_AllocFn&& fn, T_VerifyFn&& verify)
+static std::pair<std::vector<double>, bool> measureAlloc(
+    T_Queue& queue,
+    std::size_t runs,
+    T_AllocFn&& fn,
+    T_VerifyFn&& verify)
 {
     using clock = std::chrono::high_resolution_clock;
 
@@ -95,7 +98,8 @@ void testAlloc(T_DeviceSpec const& spec, T_Exec const& exec)
     results.addKernel("HostAlloc", allocBytesMain * 1.0e-6);
     results.addKernel("DeviceAlloc", allocBytesMain * 1.0e-6);
 
-    auto const hostVerifier = [](auto&, auto const& buf) {
+    auto const hostVerifier = [](auto&, auto const& buf)
+    {
         auto* raw = alpaka::onHost::data(buf);
         return raw && std::to_integer<uint8_t>(raw[0]) == 0;
     };
@@ -108,15 +112,19 @@ void testAlloc(T_DeviceSpec const& spec, T_Exec const& exec)
     results.setTimes("HostAlloc", std::move(hostTimes));
 
     auto deviceScratch = alpaka::onHost::allocHost<std::byte>(std::size_t{1});
-    auto deviceVerifier = [scratch = std::move(deviceScratch)](auto& q, auto const& buf) mutable {
+    auto deviceVerifier = [scratch = std::move(deviceScratch)](auto& q, auto const& buf) mutable
+    {
         alpaka::onHost::memcpy(q, scratch, buf, std::size_t{1});
         alpaka::onHost::wait(q);
         auto* raw = alpaka::onHost::data(scratch);
         return raw && std::to_integer<uint8_t>(raw[0]) == 0;
     };
 
-    auto [deviceTimes, deviceZeroed]
-        = measureAlloc(queue, numberOfRuns, [&] { return onHost::alloc<std::byte>(dev, allocBytesMain); }, deviceVerifier);
+    auto [deviceTimes, deviceZeroed] = measureAlloc(
+        queue,
+        numberOfRuns,
+        [&] { return onHost::alloc<std::byte>(dev, allocBytesMain); },
+        deviceVerifier);
     results.setTimes("DeviceAlloc", std::move(deviceTimes));
 
     // meta‑data summary
@@ -140,9 +148,8 @@ void testAlloc(T_DeviceSpec const& spec, T_Exec const& exec)
 }
 
 // ---------------- Catch2 integration  ---------------------------------------
-using Backends = std::decay_t<decltype(alpaka::onHost::allBackends(
-    alpaka::onHost::enabledApis,
-    alpaka::onHost::example::enabledExecutors))>;
+using Backends = std::decay_t<
+    decltype(alpaka::onHost::allBackends(alpaka::onHost::enabledApis, alpaka::onHost::example::enabledExecutors))>;
 
 TEMPLATE_LIST_TEST_CASE("Alloc benchmark", "[alloc]", Backends)
 {

--- a/benchmark/alloc/src/alloc_benchmark.cpp
+++ b/benchmark/alloc/src/alloc_benchmark.cpp
@@ -121,7 +121,7 @@ public:
 
 // =============================================================================
 // --------------- default parameters -----------------------------------------
-inline std::size_t allocBytesMain = 64ULL * 1024 * 1024; // 64 MiB
+inline std::size_t allocBytesMain = 64ULL * 1024 * 1024; // 64 MiB
 inline std::size_t numberOfRuns   = 100;                 // iterations
 
 // ---------------- CLI parser -------------------------------------------------
@@ -147,17 +147,25 @@ static void handleAllocArgs(int &argc, char *argv[])
 }
 
 // ---------------- helper: measure total time of N allocations ---------------
+// measureAlloc:
+//   allocate buffer -> memset -> read first byte -> wait
+//   ensures the buffer is actually touched (no lazy allocation, no dead-code removal)
 template<class TQueue, class AllocFn>
-static double measureAlloc(TQueue &queue, std::size_t runs, AllocFn &&fn)
+static double measureAlloc(TQueue &queue, std::size_t runs, AllocFn &&fn, uint8_t& returnValue)
 {
     using clock = std::chrono::high_resolution_clock;
     auto t0 = clock::now();
-    for(std::size_t i = 0; i < runs; ++i)
-    {
-        auto buf = fn();               // allocate buffer
-        alpaka::onHost::wait(queue);   // ensure operation finished
-    }
+    uint8_t retval = uint8_t{1}; // to ensure buffer is used
+        uint8_t retval = uint8_t{1}; // init non-zero (sanity)
+        for(std::size_t i = 0; i < runs; ++i)
+        {
+            auto buf = fn();                                // 1) allocate buffer
+            alpaka::onHost::memset(queue, buf, uint8_t{0}); // 2) touch buffer: zero-init
+            retval = static_cast<uint8_t>(buf[0]);          // 3) read first byte to enforce use
+            alpaka::onHost::wait(queue);                    // 4) sync memset + alloc
+        }
     auto t1 = clock::now();
+    returnValue = retval; // return the last value read from the buffer
     return std::chrono::duration<double>(t1 - t0).count(); // seconds total
 }
 
@@ -210,10 +218,14 @@ void testAlloc(DeviceSpec const &spec, Exec const &exec)
     results.addKernel("HostAlloc",   allocBytesMain * 1.0e-6);
     results.addKernel("DeviceAlloc", allocBytesMain * 1.0e-6);
 
-    double tHost = measureAlloc(queue, numberOfRuns, [&]{ return onHost::allocHost<std::byte>(allocBytesMain); });
+    uint8_t resultByte = uint8_t{1}; // to ensure buffer is used
+
+    double tHost = measureAlloc(queue, numberOfRuns, [&]{ return onHost::allocHost<std::byte>(allocBytesMain); }, resultByte);
     results.pushTime("HostAlloc", tHost);
 
-    double tDev  = measureAlloc(queue, numberOfRuns, [&]{ return onHost::alloc<std::byte>(dev, allocBytesMain); });
+    uint8_t resultByteDev = uint8_t{1}; // to ensure buffer is used
+
+    double tDev  = measureAlloc(queue, numberOfRuns, [&]{ return onHost::alloc<std::byte>(dev, allocBytesMain); }, resultByteDev);
     results.pushTime("DeviceAlloc", tDev);
 
     // meta‑data summary
@@ -231,7 +243,8 @@ void testAlloc(DeviceSpec const &spec, Exec const &exec)
 
     std::cout << meta.serializeAsTable() << std::endl;
 
-    REQUIRE(FuzzyEqual(0,0)); // mark as passed
+    REQUIRE(resultByte == uint8_t{0});      // host buffer properly zero-initialized
+    REQUIRE(resultByteDev == uint8_t{0});   // device buffer properly zero-initialized
 }
 
 // ---------------- Catch2 integration  ---------------------------------------

--- a/benchmark/alloc/src/alloc_helpers.hpp
+++ b/benchmark/alloc/src/alloc_helpers.hpp
@@ -1,0 +1,301 @@
+// Alpaka‑style micro‑benchmark helpers for memory allocation
+// SPDX‑License‑Identifier: MPL‑2.0
+// Authors: Ivan Andriievskyi, Jiří Vyskočil
+// Work funded by US NAS and ONRG (IMPRESS-U).
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <map>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace alpaka::benchmark::alloc
+{
+    enum class BMInfoDataType
+    {
+        AcceleratorType,
+        NumRuns,
+        DataSize,
+        DeviceName,
+        KernelNames,
+        KernelDataUsageValues,
+        KernelBandwidths,
+        KernelMinTimes,
+        KernelMaxTimes,
+        KernelAvgTimes,
+        KernelColdTimes
+    };
+
+    template<typename T>
+    inline bool FuzzyEqual(T a, T b)
+    {
+        if constexpr(std::is_floating_point_v<T>)
+        {
+            return std::fabs(a - b) < (std::numeric_limits<T>::epsilon() * static_cast<T>(100.0));
+        }
+        else
+        {
+            return a == b;
+        }
+    }
+
+    template<typename T>
+    inline std::string joinElements(std::vector<T> const& vec, std::string const& delim)
+    {
+        std::ostringstream oss;
+        for(std::size_t i = 0; i < vec.size(); ++i)
+        {
+            if(i != 0)
+            {
+                oss << delim;
+            }
+            oss << std::setprecision(5) << vec[i];
+        }
+        return oss.str();
+    }
+
+    inline std::string toStr(BMInfoDataType value)
+    {
+        switch(value)
+        {
+        case BMInfoDataType::AcceleratorType:
+            return "Accelerator";
+        case BMInfoDataType::NumRuns:
+            return "Runs";
+        case BMInfoDataType::DataSize:
+            return "Bytes";
+        case BMInfoDataType::DeviceName:
+            return "Device";
+        case BMInfoDataType::KernelNames:
+            return "Kernels";
+        case BMInfoDataType::KernelDataUsageValues:
+            return "Data(MB)";
+        case BMInfoDataType::KernelBandwidths:
+            return "BW(GB/s)";
+        case BMInfoDataType::KernelMinTimes:
+            return "Min(s)";
+        case BMInfoDataType::KernelMaxTimes:
+            return "Max(s)";
+        case BMInfoDataType::KernelAvgTimes:
+            return "Avg(s)";
+        case BMInfoDataType::KernelColdTimes:
+            return "Cold(s)";
+        }
+        return "";
+    }
+
+    class BenchmarkMetaData
+    {
+        std::map<BMInfoDataType, std::string> m_items;
+
+    public:
+        template<typename T_Value>
+        void setItem(BMInfoDataType key, T_Value const& value)
+        {
+            std::ostringstream oss;
+            oss << value;
+            m_items[key] = oss.str();
+        }
+
+        std::string serializeAsTable() const
+        {
+            std::ostringstream ss;
+
+            for(auto key :
+                {BMInfoDataType::AcceleratorType,
+                 BMInfoDataType::DeviceName,
+                 BMInfoDataType::DataSize,
+                 BMInfoDataType::NumRuns})
+            {
+                if(auto it = m_items.find(key); it != m_items.end())
+                {
+                    ss << toStr(key) << ':' << it->second << '\n';
+                }
+            }
+
+            if(auto cold = m_items.find(BMInfoDataType::KernelColdTimes); cold != m_items.end())
+            {
+                ss << toStr(BMInfoDataType::KernelColdTimes) << ':' << cold->second << '\n';
+            }
+
+            auto const& namesSerialized = m_items.at(BMInfoDataType::KernelNames);
+            auto const split = [](std::string const& str)
+            {
+                std::vector<std::string> values;
+                std::stringstream stream(str);
+                std::string token;
+                while(std::getline(stream, token, ','))
+                {
+                    if(!token.empty() && token.front() == ' ')
+                    {
+                        token.erase(token.begin());
+                    }
+                    values.push_back(token);
+                }
+                return values;
+            };
+
+            auto const names = split(namesSerialized);
+            auto const dataMegabytes = split(m_items.at(BMInfoDataType::KernelDataUsageValues));
+            auto const bandwidths = split(m_items.at(BMInfoDataType::KernelBandwidths));
+            auto const minTimes = split(m_items.at(BMInfoDataType::KernelMinTimes));
+            auto const maxTimes = split(m_items.at(BMInfoDataType::KernelMaxTimes));
+            auto const avgTimes = split(m_items.at(BMInfoDataType::KernelAvgTimes));
+
+            ss << std::left << std::setw(12) << "Kernel" << ' ' << std::setw(10) << "BW" << ' ' << std::setw(8)
+               << "Min" << ' ' << std::setw(8) << "Max" << ' ' << std::setw(8) << "Avg" << ' ' << "Data" << '\n';
+
+            for(std::size_t i = 0; i < names.size(); ++i)
+            {
+                ss << std::left << std::setw(12) << names[i] << ' ' << std::setw(10) << bandwidths[i] << ' '
+                   << std::setw(8) << minTimes[i] << ' ' << std::setw(8) << maxTimes[i] << ' ' << std::setw(8)
+                   << avgTimes[i] << ' ' << dataMegabytes[i] << '\n';
+            }
+
+            return ss.str();
+        }
+    };
+
+    struct AllocResults
+    {
+        struct Entry
+        {
+            std::vector<double> times;
+            double bytesMB{0.0};
+        };
+
+        std::map<std::string, Entry> data;
+
+        void addKernel(std::string const& name, double bytes)
+        {
+            data[name] = Entry{{}, bytes};
+        }
+
+        void setTimes(std::string const& name, std::vector<double> values)
+        {
+            data[name].times = std::move(values);
+        }
+
+        static double min(std::vector<double> const& values)
+        {
+            if(values.empty())
+            {
+                return 0.0;
+            }
+            if(values.size() == 1)
+            {
+                return values.front();
+            }
+            return *std::min_element(values.begin() + 1, values.end());
+        }
+
+        static double max(std::vector<double> const& values)
+        {
+            if(values.empty())
+            {
+                return 0.0;
+            }
+            if(values.size() == 1)
+            {
+                return values.front();
+            }
+            return *std::max_element(values.begin() + 1, values.end());
+        }
+
+        static double avg(std::vector<double> const& values)
+        {
+            if(values.empty())
+            {
+                return 0.0;
+            }
+            auto const* beginHot = values.size() > 1 ? values.data() + 1 : values.data();
+            auto const count = static_cast<double>(values.size() > 1 ? values.size() - 1 : values.size());
+            return count > 0.0 ? std::accumulate(beginHot, values.data() + values.size(), 0.0) / count : 0.0;
+        }
+
+        static double cold(std::vector<double> const& values)
+        {
+            return values.empty() ? 0.0 : values.front();
+        }
+
+        std::vector<double> bandwidths() const
+        {
+            std::vector<double> result;
+            for(auto const& [_, entry] : data)
+            {
+                result.push_back(entry.bytesMB / 1.0e3 / min(entry.times));
+            }
+            return result;
+        }
+
+        std::vector<double> mins() const
+        {
+            std::vector<double> result;
+            for(auto const& [_, entry] : data)
+            {
+                result.push_back(min(entry.times));
+            }
+            return result;
+        }
+
+        std::vector<double> maxs() const
+        {
+            std::vector<double> result;
+            for(auto const& [_, entry] : data)
+            {
+                result.push_back(max(entry.times));
+            }
+            return result;
+        }
+
+        std::vector<double> avgs() const
+        {
+            std::vector<double> result;
+            for(auto const& [_, entry] : data)
+            {
+                result.push_back(avg(entry.times));
+            }
+            return result;
+        }
+
+        std::vector<double> colds() const
+        {
+            std::vector<double> result;
+            for(auto const& [_, entry] : data)
+            {
+                result.push_back(cold(entry.times));
+            }
+            return result;
+        }
+
+        std::vector<double> bytes() const
+        {
+            std::vector<double> result;
+            for(auto const& [_, entry] : data)
+            {
+                result.push_back(entry.bytesMB);
+            }
+            return result;
+        }
+
+        std::string kernelNames() const
+        {
+            std::string names;
+            for(auto const& [name, _] : data)
+            {
+                if(!names.empty())
+                {
+                    names += ", ";
+                }
+                names += name;
+            }
+            return names;
+        }
+    };
+} // namespace alpaka::benchmark::alloc


### PR DESCRIPTION
## Summary
This PR adds a microbenchmark for host memory allocation under benchmark/alloc/.  
It measures the cost of:
1) malloc/new (allocation),
2) first-use/touch (memset over the whole buffer), and
3) a trivial read (to prevent dead-store elimination),

so results reflect realistic “allocate + initialize + first access” latency rather than raw allocator timing.

## What’s included
- benchmark/alloc/CMakeLists.txt
- benchmark/alloc/src/alloc_benchmark.cpp
- benchmark/CMakeLists.txt: add_subdirectory(alloc/)

All new files carry SPDX headers.

## How to build & run
```bash
cmake -S . -B build -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -Dalpaka_BENCHMARKS=ON -Dalpaka_TESTING=OFF
cmake --build build -j
./build/benchmark/alloc/alloc
```