### PR TITLE
Add a meaningful error message for invalid kernel operators

### DIFF
--- a/include/alpaka/KernelBundle.hpp
+++ b/include/alpaka/KernelBundle.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/core/config.hpp"
 #include "alpaka/trait.hpp"
 #include "alpaka/utility.hpp"
+#include "onHost/demangledName.hpp"
 
 #include <alpaka/mem/concepts.hpp>
 
@@ -100,14 +101,26 @@ namespace alpaka
         template<typename TAcc>
         requires(
             alpaka::concepts::KernelFn<KernelFn>
-            && std::same_as<
-                void,
-                std::invoke_result_t<
-                    KernelFn,
-                    TAcc,
-                    remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>...>>)
+            && std::is_invocable_v<
+                std::remove_const_t<KernelFn>,
+                TAcc,
+                remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>...>)
         constexpr auto operator()(TAcc const& acc) const
         {
+            static_assert(
+                std::is_invocable_v<
+                    std::add_const_t<KernelFn>,
+                    TAcc,
+                    remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>...>,
+                "the operator() function of a kernel must be marked const");
+            static_assert(
+                std::same_as<
+                    void,
+                    std::invoke_result_t<
+                        std::add_const_t<KernelFn>,
+                        TAcc,
+                        remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>...>>,
+                "the return type of the operator() function of a kernel must be void");
             alpaka::apply(
                 /* It is required to take the arguments as const reference.
                  * The reason is that these arguments are shared between threads in a block. If the user like to mutate

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -239,7 +239,7 @@ namespace alpaka::onHost
             extentsVec);
     }
 
-    /** Allocate pinned memory on the host which is mapped into the adress space of the device
+    /** Allocate pinned memory on the host which is mapped into the address space of the device
      *
      * Mapped memory is located on the host and is transferred for each access via the PCIe/Nvlink bus. The performance
      * on the device is mostly pure. Mapped memory should be used for host memory if you transfer memory between host

--- a/include/alpaka/onHost/demangledName.hpp
+++ b/include/alpaka/onHost/demangledName.hpp
@@ -23,7 +23,7 @@ namespace alpaka::onHost
     /// https://www.reddit.com/r/cpp/comments/lfi6jt/finally_a_possibly_portable_way_to_convert_types/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button
 
     template<typename T>
-    inline auto EmbedTypeIntoSignature()
+    constexpr auto EmbedTypeIntoSignature()
     {
         return std::string_view{std::source_location::current().function_name()};
     }
@@ -31,7 +31,7 @@ namespace alpaka::onHost
     template<typename T>
     struct Demangled
     {
-        static auto name()
+        static constexpr auto name()
         {
             constexpr size_t testSignatureLength = sizeof("AlpakaDemangleReferenceType") - 1;
             auto const DummySignature = EmbedTypeIntoSignature<AlpakaDemangleReferenceType>();
@@ -46,13 +46,13 @@ namespace alpaka::onHost
     };
 
     template<typename T>
-    inline auto demangledName()
+    constexpr auto demangledName()
     {
         return std::string(Demangled<T>::name());
     }
 
     template<typename T>
-    inline auto demangledName(T const&)
+    constexpr auto demangledName(T const&)
     {
         return std::string(Demangled<T>::name());
     }


### PR DESCRIPTION
This is now catching two types of invalid operators:
- The operator is defined but not marked const, giving an error message like `alpaka3/include/alpaka/KernelBundle.hpp:111:22: error: static assertion failed: the operator() function of a kernel must be marked const`
- The operator is defined but returns something other than void, giving an error message like `alpaka3/include/alpaka/KernelBundle.hpp:117:22: error: static assertion failed: the return type of the operator() function of a kernel must be void`

It does not catch errors when the function is not callable because the arguments are wrong or similar. Maybe this case could also be caught with a nicer error message.

I also made the demangledName functions constexpr, they could be used to make the static_assert string print out the invalid kernel's name, but currently that's a c++26 feature or compiler extension, which throws a warning, so I didn't do that yet.