### PR TITLE
for GCC as compiler: display more nested concepts in case of an error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,12 @@ alpaka_compiler_option(FTZ "Set flush to zero" DEFAULT)
 
 alpaka_compiler_option(RELOCATABLE_DEVICE_CODE "Enable relocatable device code for CUDA, HIP and SYCL devices" DEFAULT)
 
+set(alpaka_GCC_CONCEPT_DEPTH
+    5
+    CACHE STRING
+    "Setup for GCC: How many nested concepts are displayed in the event of an error?"
+)
+
 if(NOT TARGET alpaka)
     add_library(alpaka INTERFACE)
 
@@ -120,6 +126,11 @@ if(NOT TARGET alpaka)
     target_compile_features(alpaka_target_headers INTERFACE cxx_std_${alpaka_CXX_STANDARD})
 
     target_link_libraries(alpaka INTERFACE alpaka_target_headers)
+endif()
+
+## GCC compiler
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    alpaka_set_compiler_options(HOST target alpaka "-fconcepts-diagnostics-depth=${alpaka_GCC_CONCEPT_DEPTH}")
 endif()
 
 ## OpenMP


### PR DESCRIPTION
The default depth of GCC for nested compiler errors is 1. That's not a good value, because we use nested concepts nearly everywhere. Therefore increase the depth level by default to improve user experience.

# example

```c++
#include <concepts>

template<typename T>
concept Level2Concept = requires {
   requires std::same_as<T, int>;
};

template<typename T>
concept Level1Concept = requires {
   requires Level2Concept<T>;
};

int main(int argc, char **argv){
   static_assert(Level1Concept<float>);
   return 0;
}
```

```bash
g++ --std=c++20 main.cpp
main.cpp: In function ‘int main(int, char**)’:
main.cpp:14:18: error: static assertion failed
   14 |    static_assert(Level1Concept<float>);
      |                  ^~~~~~~~~~~~~~~~~~~~
main.cpp:14:18: note: constraints not satisfied
main.cpp:9:9:   required by the constraints of ‘template<class T> concept Level1Concept’
main.cpp:9:25:   in requirements  [with T = float]
main.cpp:10:13: note: nested requirement ‘Level2Concept<T>’ is not satisfied
   10 |    requires Level2Concept<T>;
      |    ~~~~~~~~~^~~~~~~~~~~~~~~~
cc1plus: note: set ‘-fconcepts-diagnostics-depth=’ to at least 2 for more detail
```

```bash
g++ --std=c++20 main.cpp -fconcepts-diagnostics-depth=3
main.cpp: In function ‘int main(int, char**)’:
main.cpp:14:18: error: static assertion failed
   14 |    static_assert(Level1Concept<float>);
      |                  ^~~~~~~~~~~~~~~~~~~~
main.cpp:14:18: note: constraints not satisfied
main.cpp:9:9:   required by the constraints of ‘template<class T> concept Level1Concept’
main.cpp:9:25:   in requirements  [with T = float]
main.cpp:10:13: note: nested requirement ‘Level2Concept<T>’ is not satisfied, because
   10 |    requires Level2Concept<T>;
      |    ~~~~~~~~~^~~~~~~~~~~~~~~~
main.cpp:4:9:   required for the satisfaction of ‘Level2Concept<T>’ [with T = float]
main.cpp:4:25:   in requirements  [with T = float]
main.cpp:5:13: note: nested requirement ‘same_as<T, int>’ is not satisfied, because
    5 |    requires std::same_as<T, int>;
      |    ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
In file included from main.cpp:1:
/usr/include/c++/15/concepts:59:15:   required for the satisfaction of ‘__same_as<_Tp, _Up>’ [with _Tp = float; _Up = int]
/usr/include/c++/15/concepts:64:13:   required for the satisfaction of ‘same_as<T, int>’ [with T = float]
/usr/include/c++/15/concepts:59:32: note: the expression ‘is_same_v<_Tp, _Up> [with _Tp = float; _Up = int]’ evaluated to ‘false’
   59 |       concept __same_as = std::is_same_v<_Tp, _Up>;
      |                           ~~~~~^~~~~~~~~~~~~~~~~~~
```