### PR TITLE
fix tsan warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,12 @@ jobs:
             export CC=clang
             export CXX=clang++
           fi
+          if [ "${{ matrix.config.sanitizer}}" == 'tsan' ]; then
+            # required to to avoid compile error: 'FATAL: ThreadSanitizer: unexpected memory mapping'
+            # see: https://stackoverflow.com/questions/77850769/fatal-threadsanitizer-unexpected-memory-mapping-when-running-on-linux-kernels
+            sysctl vm.mmap_rnd_bits=28
+          fi
+
           cmake -G Ninja \
                 -DCMAKE_BUILD_TYPE=Release \
                 ${alpaka_cmake_flags} -Dalpaka_DEP_OMP=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,3 +497,10 @@ option(alpaka_ASAN "Enable/Disable linking the address sanitizer for cpu targets
 option(alpaka_TSAN "Enable/Disable linking the thread sanitizer for cpu targets" OFF)
 option(alpaka_LSAN "Enable/Disable linking the memory leak sanitizer for cpu targets" OFF)
 option(alpaka_UBSAN "Enable/Disable linking the undefined behavior sanitizer for cpu targets" OFF)
+
+if(alpaka_TSAN)
+    message(
+        WARNING
+        "Threadsanitizers enabled: You should reduce mmap rnd bits to avoid compile issues: call as root 'sysctl vm.mmap_rnd_bits=28'"
+    )
+endif()

--- a/cmake/finalize.cmake
+++ b/cmake/finalize.cmake
@@ -224,6 +224,8 @@ function(alpaka_finalize target)
             message(STATUS "Linking TSAN to ${target}")
             target_compile_options(${target} PRIVATE -fsanitize=thread)
             target_link_options(${target} PRIVATE -fsanitize=thread)
+            # - to get nicer stack-traces:
+            target_link_options(${target} PRIVATE -fno-omit-frame-pointer)
             if(alpaka_LSAN OR alpaka_UBSAN)
                 message(
                     WARNING

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -92,10 +92,20 @@ namespace alpaka::onHost
                 {
                     std::lock_guard<std::mutex> lk(m_mutex);
                     fn();
+                    // silent tsan warnings: The promise is fulfilled directly and only a future which is true is
+                    // returned, there can not be a data race in between.
+#if defined(__GNUC__) && !defined(__clang__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wtsan"
+#endif
                     // return a ready future-like placeholder; reuse CallbackThread interface minimally
                     std::promise<void> p;
-                    auto f = p.get_future();
                     p.set_value();
+#if defined(__GNUC__) && !defined(__clang__)
+#    pragma GCC diagnostic pop
+#endif
+                    auto f = p.get_future();
+
                     // to keep the uniform interface with the non-blocking case,
                     // return by moving the f since it is move-only
                     return f;

--- a/sanitizers/tsan_suppressions.txt
+++ b/sanitizers/tsan_suppressions.txt
@@ -1,7 +1,7 @@
 # suppression list for the thread sanitizer
 
 # the active waiting in the events unit test is detected as a data race, but is fine
-race:unit_test_event
+race:unit_test_event_event
 race:docs_test_cheatsheet
 
 # omp library is not instrumented, exclude it


### PR DESCRIPTION
- silent false positive warning of tsan
- CMake:  warn user that the system must reconfigured if tsan is used
- add `-fno-omit-frame-pointer` for nicer messages