### PR TITLE
rename `allocAsync()` to `allocDeffered()`

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -332,7 +332,7 @@ void testKernels(auto const deviceSpec, auto const exec)
         if(kernelsToBeExecuted == KernelsToRun::All)
         {
             // Vector of sums of each block
-            auto bufAccSumPerBlock = onHost::allocAsync<DataType>(queue, 1u);
+            auto bufAccSumPerBlock = onHost::allocDeferred<DataType>(queue, 1u);
             auto bufHostSumPerBlock = onHost::allocHostLike(bufAccSumPerBlock);
 
             // Test Dot kernel with specific blocksize which is larger than one

--- a/docs/snippets/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet.cpp
@@ -309,6 +309,8 @@ auto main() -> int
             // allocate memory can be accessed from host and device (unified memory),
             // the real location depends on the native backend e.g. CUDA, OneApi, ...
             concepts::View auto devUnifiedBuffer = onHost::allocUnified<DataType>(device, extentMd);
+            // allocate memory that is accessible after it is processed in the queue
+            concepts::View auto devDeferredBuffer = onHost::allocDeferred<DataType>(queue, extentMd);
             // allocate memory accessible from host
             concepts::View auto hostBuffer = onHost::allocHost<DataType>(extentMd);
             // Data will not be automatically freed, user must take care that
@@ -316,7 +318,7 @@ auto main() -> int
             concepts::View auto devNonOwningView = devBuffer.getView();
             // END-CHEATSHEET-allocBuffer
 
-            unused(devMappedBuffer, devUnifiedBuffer, devNonOwningView);
+            unused(devMappedBuffer, devUnifiedBuffer, devNonOwningView, devDeferredBuffer);
 
             auto dstBuffer = devBuffer;
             auto srcBuffer = devMappedBuffer;

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -143,7 +143,7 @@ namespace alpaka::onHost
             friend struct alpaka::internal::GetApi;
             friend struct internal::GetDeviceProperties;
             friend struct internal::AdjustThreadSpec;
-            friend struct internal::AllocAsync;
+            friend struct internal::AllocDeferred;
             friend struct internal::AllocUnified;
             friend struct internal::AllocMapped;
         };

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -209,7 +209,7 @@ namespace alpaka::onHost
             friend struct internal::Memcpy;
             friend struct internal::Memset;
             friend struct alpaka::internal::GetApi;
-            friend struct internal::AllocAsync;
+            friend struct internal::AllocDeferred;
         };
     } // namespace cpu
 
@@ -428,13 +428,10 @@ namespace alpaka::onHost
         };
 
         /** The code is a copy of the Alloc::Op with the difference that the memory is allocated and freed
-         * asynchronously
-         *
-         * @todo check if we can reduce the duplication by having a common function for the computation of the extents
-         * and pitches and seperate the View creation.
+         * within a queue
          */
         template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
-        struct AllocAsync::Op<T_Type, cpu::Queue<T_Device>, T_Extents>
+        struct AllocDeferred::Op<T_Type, cpu::Queue<T_Device>, T_Extents>
         {
             static consteval uint32_t highestPowerOfTwo(uint32_t value)
             {

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -125,7 +125,7 @@ namespace alpaka::onHost
             friend struct alpaka::internal::GetApi;
             friend struct internal::GetDeviceProperties;
             friend struct internal::AdjustThreadSpec;
-            friend struct onHost::internal::AllocAsync;
+            friend struct onHost::internal::AllocDeferred;
             friend struct onHost::internal::AllocUnified;
             friend struct onHost::internal::AllocMapped;
             friend struct onHost::internal::IsDataAccessible;

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -112,7 +112,7 @@ namespace alpaka::onHost
         private:
             friend struct alpaka::internal::GetDeviceType;
             friend struct alpaka::onHost::internal::Enqueue;
-            friend struct onHost::internal::AllocAsync;
+            friend struct onHost::internal::AllocDeferred;
 
             auto getDeviceKind() const
             {
@@ -244,13 +244,10 @@ namespace alpaka::onHost
     };
 
     /** The code is a copy of the Alloc::Op with the difference that the memory is allocated and freed
-     * asynchronously
-     *
-     * @todo check if we can reduce the duplication by having a common function for the computation of the extents
-     * and pitches and separate the View creation.
+     * within a queue
      */
     template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
-    struct internal::AllocAsync::Op<T_Type, syclGeneric::Queue<T_Device>, T_Extents>
+    struct internal::AllocDeferred::Op<T_Type, syclGeneric::Queue<T_Device>, T_Extents>
     {
         auto operator()(syclGeneric::Queue<T_Device>& queue, T_Extents const& extents) const
         {

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -141,7 +141,7 @@ namespace alpaka::onHost
             }
 
             friend struct onHost::internal::Alloc;
-            friend struct onHost::internal::AllocAsync;
+            friend struct onHost::internal::AllocDeferred;
             friend struct onHost::internal::AllocUnified;
             friend struct onHost::internal::AllocMapped;
             friend struct alpaka::internal::GetApi;

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -162,7 +162,7 @@ namespace alpaka::onHost
             friend struct alpaka::internal::GetApi;
             friend struct onHost::internal::Memcpy;
             friend struct onHost::internal::Memset;
-            friend struct onHost::internal::AllocAsync;
+            friend struct onHost::internal::AllocDeferred;
             friend struct CallKernel;
         };
 
@@ -612,13 +612,10 @@ namespace alpaka::onHost
         };
 
         /** The code is a copy of the Alloc::Op with the difference that the memory is allocated and freed
-         * asynchronously
-         *
-         * @todo check if we can reduce the duplication by having a common function for the computation of the extents
-         * and pitches and separate the View creation.
+         * within a queue
          */
         template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
-        struct AllocAsync::Op<T_Type, unifiedCudaHip::Queue<T_Device>, T_Extents>
+        struct AllocDeferred::Op<T_Type, unifiedCudaHip::Queue<T_Device>, T_Extents>
         {
             auto operator()(unifiedCudaHip::Queue<T_Device>& queue, T_Extents const& extents) const
             {

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -305,54 +305,60 @@ namespace alpaka::onHost
     /** @} */
 
     /** @{
-     * @name Async Device allocations
+     * @name Deferred device allocations
      */
-    /** allocate memory asynchronously in the given queue
+    /** allocate memory that is accessible after it is processed in the queue
+     *
+     * Deferred allocation means that the pointer in the returned buffer is valid after the function is returning.
+     * It is allowed to slice the buffer or use the encapsulated pointer for address calculations.
+     * In any cases the pointer is not allowed to be dereferenced before the memory allocation is processed in the
+     * queue. All tasks performing any memory access must be executed after the memory allocation is processed in the
+     * queue. This can be archived by waiting on the queue or describing queue dependencies via @c waitFor(). The
+     * memory is allowed to be used in other queues too. To avoid that a view to the memory is still in use during the
+     * deallocation you can use @see addDestructorAction() and wait for a queue if it **differs** to the queue used for
+     * the allocation.
      *
      * @attention It is allowed that the function is blocking the caller until the memory is created.
-     *
-     * The memory is allowed to be used in other queues too.
-     * To avoid that a view to the memory is still in use during the deallocation you can use @see
-     * addDestructorAction() and wait for a queue if it differs to the queue used for the allocation.
      *
      * @tparam T_Type type of the data elements
      * @param queue queue handle
      * @param extents number of elements for each dimension
-     * @return Memory owning view to the allocated memory. You are not allowed to derefence the view to access the
-     * memory before the allocation within the queue is finished. The view will be freed after the last instance to the
+     * @return Shared buffer to the allocated memory. The buffer will be freed after the last instance to the
      * memory is destroyed. The deallocation is asynchronous performed in the the queue which is used for the
      * allocation.
      */
     template<typename T_Type, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
-    inline auto allocAsync(
+    inline auto allocDeferred(
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
         Vec const extentsVec = extents;
-        return internal::AllocAsync::Op<T_Type, std::decay_t<decltype(*queue.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
+        return internal::AllocDeferred::Op<T_Type, std::decay_t<decltype(*queue.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
             *queue.get(),
             extentsVec);
     }
 
-    /** allocate memory asynchronously in the given queue
+    /** allocate memory that is accessible after it is processed in the queue
+     *
+     * In any cases the pointer is not allowed to be dereferenced before the memory allocation is processed in the
+     * queue. All tasks performing any memory access must be executed after the memory allocation is processed in the
+     * queue. This can be archived by waiting on the queue or describing queue dependencies via @c waitFor(). The
+     * memory is allowed to be used in other queues too. To avoid that a view to the memory is still in use during the
+     * deallocation you can use @see addDestructorAction() and wait for a queue if it **differs** to the queue used for
+     * the allocation.
      *
      * @attention It is allowed that the function is blocking the caller until the memory is created.
      *
-     * The memory is allowed to be used in other queues too.
-     * To avoid that a view to the memory is still in use during the deallocation you can use @see
-     * addDestructorAction() and wait for a queue if it differs to the queue used for the allocation.
-     *
      * @param queue queue handle
      * @param[in] view other memory where the extents will be derived from
-     * @return Memory owning view to the allocated memory. You are not allowed to derefence the view to access the
-     * memory before the allocation within the queue is finished. The view will be freed after the last instance to the
+     * @return Shared buffer to the allocated memory. The buffer will be freed after the last instance to the
      * memory is destroyed. The deallocation is asynchronous performed in the the queue which is used for the
      * allocation.
      */
     template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
     inline auto allocLikeAsync(Queue<T_Device, T_QueueKind> const& queue, auto const& view)
     {
-        return allocAsync<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(queue, getExtents(view));
+        return allocDeferred<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(queue, getExtents(view));
     }
 
     /** @} */

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -286,7 +286,7 @@ namespace alpaka::onHost
             };
         };
 
-        struct AllocAsync
+        struct AllocDeferred
         {
             template<typename T_Type, typename T_Any, typename T_Extents>
             struct Op

--- a/tests/unit/algorithm/reduce.cpp
+++ b/tests/unit/algorithm/reduce.cpp
@@ -62,8 +62,8 @@ void executeTest(
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
     using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
-    onHost::SharedBuffer computeBufferOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd.all(1));
-    onHost::SharedBuffer computeBufferIn = onHost::allocAsync<DataType>(computeQueue, extentMd);
+    onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd.all(1));
+    onHost::SharedBuffer computeBufferIn = onHost::allocDeferred<DataType>(computeQueue, extentMd);
     onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn);
     onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);
 

--- a/tests/unit/algorithm/transform.cpp
+++ b/tests/unit/algorithm/transform.cpp
@@ -77,8 +77,8 @@ void executeTest(
     auto computeDev = computeQueue.getDevice();
     using DataType = T_DataType;
     using OutDataType = decltype(functorPair.second(std::declval<DataType>(), std::declval<DataType>()));
-    onHost::SharedBuffer computeBufferOut = onHost::allocAsync<OutDataType>(computeQueue, extentMd);
-    onHost::SharedBuffer computeBufferIn0 = onHost::allocAsync<DataType>(computeQueue, extentMd);
+    onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd);
+    onHost::SharedBuffer computeBufferIn0 = onHost::allocDeferred<DataType>(computeQueue, extentMd);
     onHost::SharedBuffer computeBufferIn1 = onHost::allocLikeAsync(computeQueue, computeBufferIn0);
     onHost::SharedBuffer hostBufferIota = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
     onHost::SharedBuffer hostBufferOut = onHost::allocLike(onHost::makeHostDevice(), computeBufferOut);

--- a/tests/unit/mem/alloc.cpp
+++ b/tests/unit/mem/alloc.cpp
@@ -48,7 +48,7 @@ void validateAccess(auto device, alpaka::concepts::Executor auto exec, concepts:
     REQUIRE(hostStatus[0] == deviceAccessibleData.getExtents().x());
 }
 
-void allocAsyncImplicitWait(auto device, alpaka::concepts::Executor auto exec)
+void allocDeferredImplicitWait(auto device, alpaka::concepts::Executor auto exec)
 {
     onHost::Queue queue0 = device.makeQueue();
 
@@ -121,7 +121,7 @@ TEMPLATE_LIST_TEST_CASE("alloc", "", TestBackends)
 
     std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
 
-    allocAsyncImplicitWait(device, exec);
+    allocDeferredImplicitWait(device, exec);
 }
 
 using TestDeviceSpecs = std::decay_t<decltype(onHost::getDeviceSpecsFor(onHost::enabledApis))>;
@@ -147,10 +147,10 @@ TEMPLATE_LIST_TEST_CASE("alloc zero bytes", "", TestDeviceSpecs)
     int dataSize = 0;
 
     [[maybe_unused]] auto hostBuffer = onHost::allocHost<int>(dataSize);
-    [[maybe_unused]] auto hostBufferAsync = onHost::allocAsync<int>(onHost::makeHostDevice().makeQueue(), dataSize);
+    [[maybe_unused]] auto hostBufferAsync = onHost::allocDeferred<int>(onHost::makeHostDevice().makeQueue(), dataSize);
     [[maybe_unused]] auto hostBufferMapped = onHost::allocMapped<int>(device, dataSize);
     [[maybe_unused]] auto deviceView = onHost::alloc<int>(device, dataSize);
-    [[maybe_unused]] auto deviceViewAsync = onHost::allocAsync<int>(device.makeQueue(), dataSize);
+    [[maybe_unused]] auto deviceViewAsync = onHost::allocDeferred<int>(device.makeQueue(), dataSize);
     [[maybe_unused]] auto unifiedView = onHost::allocUnified<int>(device, dataSize);
 }
 
@@ -184,13 +184,13 @@ void prepareAlignmentValidation(auto& device, alpaka::concepts::Vector auto exte
 {
     auto hostBuffer = onHost::allocHost<T_DataType>(extents);
     validateAlignment(hostBuffer);
-    auto hostBufferAsync = onHost::allocAsync<T_DataType>(onHost::makeHostDevice().makeQueue(), extents);
+    auto hostBufferAsync = onHost::allocDeferred<T_DataType>(onHost::makeHostDevice().makeQueue(), extents);
     validateAlignment(hostBufferAsync);
     auto hostBufferMapped = onHost::allocMapped<T_DataType>(device, extents);
     validateAlignment(hostBufferMapped);
     auto deviceView = onHost::alloc<T_DataType>(device, extents);
     validateAlignment(deviceView);
-    auto deviceViewAsync = onHost::allocAsync<T_DataType>(device.makeQueue(), extents);
+    auto deviceViewAsync = onHost::allocDeferred<T_DataType>(device.makeQueue(), extents);
     validateAlignment(deviceViewAsync);
     auto unifiedView = onHost::allocUnified<T_DataType>(device, extents);
     validateAlignment(unifiedView);
@@ -224,10 +224,10 @@ void volatileBuffers(auto& device, alpaka::concepts::Vector auto extents)
 {
     // just test if they can be allocated and destructed again
     auto hostBuffer = onHost::allocHost<T_DataType volatile>(extents);
-    auto hostBufferAsync = onHost::allocAsync<T_DataType volatile>(onHost::makeHostDevice().makeQueue(), extents);
+    auto hostBufferAsync = onHost::allocDeferred<T_DataType volatile>(onHost::makeHostDevice().makeQueue(), extents);
     auto hostBufferMapped = onHost::allocMapped<T_DataType volatile>(device, extents);
     auto deviceView = onHost::alloc<T_DataType volatile>(device, extents);
-    auto deviceViewAsync = onHost::allocAsync<T_DataType volatile>(device.makeQueue(), extents);
+    auto deviceViewAsync = onHost::allocDeferred<T_DataType volatile>(device.makeQueue(), extents);
     auto unifiedView = onHost::allocUnified<T_DataType volatile>(device, extents);
 }
 

--- a/tests/unit/mem/allocDeffered.cpp
+++ b/tests/unit/mem/allocDeffered.cpp
@@ -28,7 +28,7 @@ struct RaceCheckKernel
     }
 };
 
-void allocAsyncImplicitWait(auto device, auto exec)
+void allocDeferredImplicitWait(auto device, auto exec)
 {
     onHost::Queue queue0 = device.makeQueue();
 
@@ -39,7 +39,7 @@ void allocAsyncImplicitWait(auto device, auto exec)
     onHost::wait(queue0);
     {
         // Asynchronous allocation memory is in the destructor waiting for all work enqueued in the creator queue.
-        auto sharedBuffer = onHost::allocAsync<float>(queue0, 10ul);
+        auto sharedBuffer = onHost::allocDeferred<float>(queue0, 10ul);
         onHost::fill(queue0, sharedBuffer, 3.14159265f);
         queue0.enqueue(
             exec,
@@ -52,7 +52,7 @@ void allocAsyncImplicitWait(auto device, auto exec)
          */
     }
     {
-        auto sharedBuffer = onHost::allocAsync<float>(queue0, 10ul);
+        auto sharedBuffer = onHost::allocDeferred<float>(queue0, 10ul);
         onHost::fill(queue0, sharedBuffer, 42.0f);
     }
 
@@ -61,7 +61,7 @@ void allocAsyncImplicitWait(auto device, auto exec)
     REQUIRE(hBufferResults[0] == 1);
 }
 
-void allocAsyncExplicitWait(auto device, auto exec)
+void allocDeferredExplicitWait(auto device, auto exec)
 {
     onHost::Queue queue0 = device.makeQueue();
     onHost::Queue queue1 = device.makeQueue();
@@ -72,7 +72,7 @@ void allocAsyncExplicitWait(auto device, auto exec)
     onHost::fill(queue0, dBufferResults, 1);
     onHost::wait(queue0);
     {
-        auto sharedBuffer = onHost::allocAsync<float>(queue1, 10ul);
+        auto sharedBuffer = onHost::allocDeferred<float>(queue1, 10ul);
         // set an action that the destructor is waiting for all work enqueued in queue0
         sharedBuffer.destructorWaitFor(queue0);
         // wait for the allocation
@@ -95,7 +95,7 @@ void allocAsyncExplicitWait(auto device, auto exec)
     REQUIRE(hBufferResults[0] == 1);
 }
 
-TEMPLATE_LIST_TEST_CASE("allocAsync", "", TestApis)
+TEMPLATE_LIST_TEST_CASE("allocDeferred", "", TestApis)
 {
     auto cfg = TestType::makeDict();
     auto deviceSpec = cfg[object::deviceSpec];
@@ -115,8 +115,8 @@ TEMPLATE_LIST_TEST_CASE("allocAsync", "", TestApis)
     // repeat the test multiple times to increase the change to trigger data races
     constexpr int testRounds = 10;
     for(int i = 0; i < testRounds; ++i)
-        allocAsyncImplicitWait(device, exec);
+        allocDeferredImplicitWait(device, exec);
 
     for(int i = 0; i < testRounds; ++i)
-        allocAsyncExplicitWait(device, exec);
+        allocDeferredExplicitWait(device, exec);
 }

--- a/tests/unit/queue/blockingQueue.cpp
+++ b/tests/unit/queue/blockingQueue.cpp
@@ -95,7 +95,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue memory operations", "[bq][memory]", Test
 // -----------------------------------------------------------------------------
 // Test validates that a blocking-queue guarantees host-visible completion after each
 // enqueue (kernel -> kernel -> memcpy) and produces the final result without calling wait().
-// Also exercises allocAsync under the blocking policy.
+// Also exercises allocDeferred under the blocking policy.
 // -----------------------------------------------------------------------------
 struct WriteValueKernel
 {
@@ -163,9 +163,9 @@ TEMPLATE_LIST_TEST_CASE("blocking queue chained operations", "[bq][chain]", Test
     onHost::memcpy(qBlocking2, hBufBlocking, dBufBlocking);
     meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(hBufBlocking[idx] == 11u); });
 
-    // 2) allocAsync chain on blocking queue: allocate asynchronously, immediately fill then memcpy.
+    // 2) allocDeferred chain on blocking queue: allocate asynchronously, immediately fill then memcpy.
     // should be ready due to blocking policy of the queue
-    auto dBufAsync = onHost::allocAsync<uint32_t>(qBlocking0, extent);
+    auto dBufAsync = onHost::allocDeferred<uint32_t>(qBlocking0, extent);
     qBlocking1.enqueue(exec, frameSpec, KernelBundle{WriteValueKernel{kTestFillValue}, dBufAsync});
     auto hBufAsync = onHost::allocHostLike(dBufAsync);
     onHost::memcpy(qBlocking2, hBufAsync, dBufAsync);


### PR DESCRIPTION
The name alloc async was misleading in cases where a blocking queue was used because if it is executed asynchronously depends on the queue properties.
The name deferred is more clear, or at least forces the user to check the documentation instead of assuming any asynchronous execution.