### PR TITLE
add memoryFence usage to the cheatsheet

### DIFF
--- a/docs/snippets/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet.cpp
@@ -126,6 +126,20 @@ struct KernelWait
     }
 };
 
+// Minimal example demonstrating memory fences at different scopes
+struct MemoryFenceKernel
+{
+    ALPAKA_FN_ACC void operator()(onAcc::concepts::Acc auto const& acc) const
+    {
+        // BEGIN-CHEATSHEET-memoryFence
+        // Scopes: All threads of the block, the device and the system(host and peer devices)
+        onAcc::memoryFence(acc, onAcc::memoryScope::block);
+        onAcc::memoryFence(acc, onAcc::memoryScope::device);
+        onAcc::memoryFence(acc, onAcc::memoryScope::system);
+        // END-CHEATSHEET-memoryFence
+    }
+};
+
 auto main() -> int
 {
     // BEGIN-CHEATSHEET-init
@@ -370,6 +384,9 @@ auto main() -> int
             };
             unused(foo);
         }
+
+        // Enqueue the memory fence kernel to ensure it compiles and links
+        queue.enqueue(frameSpec, KernelBundle{MemoryFenceKernel{}});
     }
     catch(...)
 

--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -351,6 +351,14 @@ Atomic operations
     :end-before: END-CHEATSHEET-atomicAdd
     :dedent:
 
+Memory fences on block-, device- or system level (guarantees LoadLoad and StoreStore ordering)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  .. literalinclude:: ../../snippets/cheatsheet.cpp
+    :language: cpp
+    :start-after: BEGIN-CHEATSHEET-memoryFence
+    :end-before: END-CHEATSHEET-memoryFence
+    :dedent:
+
 Math functions
 ~~~~~~~~~~~~~~
   .. literalinclude:: ../../snippets/cheatsheet.cpp


### PR DESCRIPTION
Adds memory fence usage to cheatsheet.

It is added **before math functions** and **after atomic operations** like in [alpaka mainline.](https://alpaka.readthedocs.io/en/stable/basic/cheatsheet.html)
