### PR TITLE
rename `*Mapping*` to `*Exector*`

### DIFF
--- a/include/alpaka/api/cuda/Device.hpp
+++ b/include/alpaka/api/cuda/Device.hpp
@@ -18,7 +18,7 @@ namespace alpaka::onHost
     namespace trait
     {
         template<typename T_Platform>
-        struct IsMappingSupportedBy::Op<exec::GpuCuda, unifiedCudaHip::Device<T_Platform>> : std::true_type
+        struct IsExecutorSupportedBy::Op<exec::GpuCuda, unifiedCudaHip::Device<T_Platform>> : std::true_type
         {
         };
     } // namespace trait

--- a/include/alpaka/api/hip/Device.hpp
+++ b/include/alpaka/api/hip/Device.hpp
@@ -18,7 +18,7 @@ namespace alpaka::onHost
     namespace trait
     {
         template<typename T_Platform>
-        struct IsMappingSupportedBy::Op<exec::GpuHip, unifiedCudaHip::Device<T_Platform>> : std::true_type
+        struct IsExecutorSupportedBy::Op<exec::GpuHip, unifiedCudaHip::Device<T_Platform>> : std::true_type
         {
         };
     } // namespace trait

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -153,12 +153,12 @@ namespace alpaka::onHost
 
     {
         template<typename T_Platform>
-        struct IsMappingSupportedBy::Op<exec::CpuSerial, cpu::Device<T_Platform>> : std::true_type
+        struct IsExecutorSupportedBy::Op<exec::CpuSerial, cpu::Device<T_Platform>> : std::true_type
         {
         };
 #if ALPAKA_OMP
         template<typename T_Platform>
-        struct IsMappingSupportedBy::Op<exec::CpuOmpBlocks, cpu::Device<T_Platform>> : std::true_type
+        struct IsExecutorSupportedBy::Op<exec::CpuOmpBlocks, cpu::Device<T_Platform>> : std::true_type
         {
         };
 #endif
@@ -264,17 +264,17 @@ namespace alpaka::onHost
 
         template<
             typename T_Platform,
-            typename T_Mapping,
+            alpaka::concepts::Executor T_Executor,
             onHost::concepts::FrameSpec T_FrameSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
-        requires exec::trait::isSeqExecutor_v<T_Mapping>
-        struct AdjustThreadSpec::Op<cpu::Device<T_Platform>, T_Mapping, T_FrameSpec, T_KernelBundle>
+        requires exec::isSeqExecutor_v<T_Executor>
+        struct AdjustThreadSpec::Op<cpu::Device<T_Platform>, T_Executor, T_FrameSpec, T_KernelBundle>
         {
             using T_NumThreads = T_FrameSpec::ThreadExtentsVecType;
 
             auto operator()(
                 cpu::Device<T_Platform> const& device,
-                T_Mapping const& executor,
+                T_Executor const& executor,
                 T_FrameSpec const& dataBlocking,
                 T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_NumThreads>
             {
@@ -284,7 +284,7 @@ namespace alpaka::onHost
 
             auto operator()(
                 cpu::Device<T_Platform> const& device,
-                T_Mapping const& executor,
+                T_Executor const& executor,
                 T_FrameSpec const& dataBlocking,
                 T_KernelBundle const& kernelBundle) const
             {

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -150,12 +150,12 @@ namespace alpaka::onHost
             }
 
             template<
-                typename T_Mapping,
+                alpaka::concepts::Executor T_Executor,
                 alpaka::concepts::Vector T_NumFrames,
                 alpaka::concepts::Vector T_FrameExtents,
                 alpaka::concepts::Vector T_ThreadExtents>
             void enqueue(
-                T_Mapping const executor,
+                T_Executor const executor,
                 FrameSpec<T_NumFrames, T_FrameExtents, T_ThreadExtents> const& frameSpec,
                 auto const& kernelBundle)
             {
@@ -415,7 +415,7 @@ namespace alpaka::onHost
                 const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
                                && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
             {
-                auto executors = supportedMappings(getDevice(queue), exec::allExecutors);
+                auto executors = supportedExecutors(getDevice(queue), exec::allExecutors);
                 // avoid that we pass a SharedBuffer and convert non alpaka data views
                 alpaka::concepts::MdSpan<T_Value> auto dataView = makeView(dest);
 

--- a/include/alpaka/api/oneApi/Device.hpp
+++ b/include/alpaka/api/oneApi/Device.hpp
@@ -13,7 +13,7 @@ namespace alpaka::onHost::trait
 {
 #if ALPAKA_LANG_ONEAPI
     template<typename T_Platform>
-    struct IsMappingSupportedBy::Op<alpaka::exec::OneApi, alpaka::onHost::syclGeneric::Device<T_Platform>>
+    struct IsExecutorSupportedBy::Op<alpaka::exec::OneApi, alpaka::onHost::syclGeneric::Device<T_Platform>>
         : std::true_type
     {
     };

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -119,7 +119,7 @@ namespace alpaka::onHost::internal
             requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
                      && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
         {
-            auto executors = supportedMappings(getDevice(queue), exec::allExecutors);
+            auto executors = supportedExecutors(getDevice(queue), exec::allExecutors);
             // avoid that we pass a SharedBuffer and convert non alpaka data views
             auto dataView = makeView(dest);
 
@@ -195,7 +195,7 @@ namespace alpaka::onHost::internal
 
     template<
         typename T_Device,
-        typename T_Executor,
+        alpaka::concepts::Executor T_Executor,
         onHost::concepts::ThreadSpec T_ThreadSpec,
         alpaka::concepts::KernelBundle T_KernelBundle>
     struct Enqueue::Kernel<syclGeneric::Queue<T_Device>, T_Executor, T_ThreadSpec, T_KernelBundle>
@@ -267,7 +267,7 @@ namespace alpaka::onHost::internal
 
     template<
         typename T_Device,
-        typename T_Executor,
+        alpaka::concepts::Executor T_Executor,
         onHost::concepts::FrameSpec T_FrameSpec,
         alpaka::concepts::KernelBundle T_KernelBundle>
     struct Enqueue::Kernel<syclGeneric::Queue<T_Device>, T_Executor, T_FrameSpec, T_KernelBundle>

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -278,16 +278,16 @@ namespace alpaka::onHost
 
         template<
             typename T_Platform,
-            typename T_Mapping,
+            alpaka::concepts::Executor T_Executor,
             onHost::concepts::FrameSpec T_FrameSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
-        struct AdjustThreadSpec::Op<syclGeneric::Device<T_Platform>, T_Mapping, T_FrameSpec, T_KernelBundle>
+        struct AdjustThreadSpec::Op<syclGeneric::Device<T_Platform>, T_Executor, T_FrameSpec, T_KernelBundle>
         {
             using T_NumThreads = T_FrameSpec::ThreadExtentsVecType;
 
             auto operator()(
                 syclGeneric::Device<T_Platform> const& device,
-                T_Mapping const& executor,
+                T_Executor const& executor,
                 T_FrameSpec const& dataBlocking,
                 T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_NumThreads>
             {
@@ -306,7 +306,7 @@ namespace alpaka::onHost
 
             auto operator()(
                 syclGeneric::Device<T_Platform> const& device,
-                T_Mapping const& executor,
+                T_Executor const& executor,
                 T_FrameSpec const& dataBlocking,
                 T_KernelBundle const& kernelBundle) const
             {

--- a/include/alpaka/api/trait.hpp
+++ b/include/alpaka/api/trait.hpp
@@ -148,7 +148,7 @@ namespace alpaka
         /** Defines the implementation used for atomic operations toghether with the used executor */
         struct GetAtomicImpl
         {
-            template<typename T_Executor>
+            template<alpaka::concepts::Executor T_Executor>
             struct Op
             {
                 constexpr decltype(auto) operator()(T_Executor const) const
@@ -161,7 +161,7 @@ namespace alpaka
             };
         };
 
-        template<typename T_Executor>
+        template<alpaka::concepts::Executor T_Executor>
         constexpr decltype(auto) getAtomicImpl(T_Executor const executor)
         {
             return GetAtomicImpl::Op<T_Executor>{}(executor);

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -354,16 +354,16 @@ namespace alpaka::onHost
 
         template<
             typename T_Platform,
-            typename T_Mapping,
+            alpaka::concepts::Executor T_Executor,
             onHost::concepts::FrameSpec T_FrameSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
-        struct AdjustThreadSpec::Op<unifiedCudaHip::Device<T_Platform>, T_Mapping, T_FrameSpec, T_KernelBundle>
+        struct AdjustThreadSpec::Op<unifiedCudaHip::Device<T_Platform>, T_Executor, T_FrameSpec, T_KernelBundle>
         {
             using T_NumThreads = T_FrameSpec::ThreadExtentsVecType;
 
             auto operator()(
                 unifiedCudaHip::Device<T_Platform> const& device,
-                T_Mapping const& executor,
+                T_Executor const& executor,
                 T_FrameSpec const& dataBlocking,
                 T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_NumThreads>
             {
@@ -382,7 +382,7 @@ namespace alpaka::onHost
 
             auto operator()(
                 unifiedCudaHip::Device<T_Platform> const& device,
-                T_Mapping const& executor,
+                T_Executor const& executor,
                 T_FrameSpec const& dataBlocking,
                 T_KernelBundle const& kernelBundle) const
             {

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -169,7 +169,7 @@ namespace alpaka::onHost
         template<
             typename T_Api,
             deviceKind::concepts::DeviceKind T_DeviceKind,
-            typename T_Executor,
+            alpaka::concepts::Executor T_Executor,
             typename TKernelBundle,
             typename T_OptimizedThreadSpec,
             typename T_NumFrames,
@@ -197,7 +197,7 @@ namespace alpaka::onHost
         template<
             typename T_Api,
             deviceKind::concepts::DeviceKind T_DeviceKind,
-            typename T_Executor,
+            alpaka::concepts::Executor T_Executor,
             typename TKernelBundle,
             typename T_OptimizedThreadSpec>
         __global__ void gpuKernel(TKernelBundle const kernelBundle, T_OptimizedThreadSpec const optimizedThreadSpec)
@@ -247,7 +247,7 @@ namespace alpaka::onHost
             };
 
             template<
-                typename T_Executor,
+                alpaka::concepts::Executor T_Executor,
                 typename T_Device,
                 typename T_NumBlocks,
                 typename T_NumThreads,
@@ -599,7 +599,7 @@ namespace alpaka::onHost
                 requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
                          && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
             {
-                auto executors = supportedMappings(getDevice(queue), exec::allExecutors);
+                auto executors = supportedExecutors(getDevice(queue), exec::allExecutors);
                 // avoid that we pass a SharedBuffer and convert non alpaka data views
                 auto dataView = makeView(dest);
 

--- a/include/alpaka/api/unifiedCudaHip/trait.hpp
+++ b/include/alpaka/api/unifiedCudaHip/trait.hpp
@@ -5,11 +5,13 @@
 
 #pragma once
 
+#include "alpaka/api/trait.hpp"
+
 #include <type_traits>
 
 namespace alpaka::unifiedCudaHip::trait
 {
-    template<typename T_Executor>
+    template<alpaka::concepts::Executor T_Executor>
     struct IsUnifiedExecutor : std::false_type
     {
     };

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -128,7 +128,7 @@ namespace alpaka::onHost
             onHost::concepts::ThreadOrFrameSpec auto const& specification,
             KernelBundle<TKernelFn, TArgs...> const& kernelBundle) const
         {
-            auto executor = supportedMappings(internal::getDevice(*m_queue.get()), exec::allExecutors);
+            auto executor = supportedExecutors(internal::getDevice(*m_queue.get()), exec::allExecutors);
             internal::enqueue(*m_queue.get(), std::get<0>(executor), specification, kernelBundle);
         }
 

--- a/include/alpaka/onHost/algo/concurrent.hpp
+++ b/include/alpaka/onHost/algo/concurrent.hpp
@@ -63,7 +63,7 @@ namespace alpaka::onHost
         auto&& fn,
         auto&&... inOut)
     {
-        auto executor = supportedMappings(queue.getDevice(), exec::allExecutors);
+        auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         internal::concurrent<T_DataType>(
             queue,
             std::get<0>(executor),

--- a/include/alpaka/onHost/algo/iota.hpp
+++ b/include/alpaka/onHost/algo/iota.hpp
@@ -64,7 +64,7 @@ namespace alpaka::onHost
             && std::conjunction_v<
                 std::is_convertible<T_DataType, typename alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(outOther)>>...>)
     {
-        auto executor = supportedMappings(queue.getDevice(), exec::allExecutors);
+        auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         internal::iota<T_DataType>(
             queue,
             std::get<0>(executor),

--- a/include/alpaka/onHost/algo/reduce.hpp
+++ b/include/alpaka/onHost/algo/reduce.hpp
@@ -57,7 +57,7 @@ namespace alpaka::onHost
         auto&& binaryReduceFn,
         auto&& in) requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
     {
-        auto executor = supportedMappings(queue.getDevice(), exec::allExecutors);
+        auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         reduce(queue, std::get<0>(executor), neutralElement, out, ALPAKA_FORWARD(binaryReduceFn), ALPAKA_FORWARD(in));
     }
 

--- a/include/alpaka/onHost/algo/transform.hpp
+++ b/include/alpaka/onHost/algo/transform.hpp
@@ -64,7 +64,7 @@ namespace alpaka::onHost
     template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
     inline void transform(Queue<T_Device, T_QueueKind> const& queue, auto&& out, auto&& fn, auto&&... in)
     {
-        auto executor = supportedMappings(queue.getDevice(), exec::allExecutors);
+        auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         transform(queue, std::get<0>(executor), ALPAKA_FORWARD(out), ALPAKA_FORWARD(fn), ALPAKA_FORWARD(in)...);
     }
 

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -89,7 +89,7 @@ namespace alpaka::onHost
         auto&& transformFn,
         auto&&... in) requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
     {
-        auto executor = supportedMappings(queue.getDevice(), exec::allExecutors);
+        auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         transformReduce(
             queue,
             std::get<0>(executor),

--- a/include/alpaka/onHost/interface.hpp
+++ b/include/alpaka/onHost/interface.hpp
@@ -218,8 +218,8 @@ namespace alpaka::onHost
     {
         using DevSelectorType = decltype(makeDeviceSelector(deviceSpec));
         using DeviceType = decltype(std::declval<DevSelectorType>().makeDevice(0));
-        using AutoDeviceMappings = decltype(supportedMappings(std::declval<DeviceType>(), listOfExecutors));
-        return AutoDeviceMappings{};
+        using ExecutorListType = decltype(supportedExecutors(std::declval<DeviceType>(), listOfExecutors));
+        return ExecutorListType{};
     }
 
     /** Create a tuple of device specifications for a single API.

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/KernelBundle.hpp"
+#include "alpaka/api/trait.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/onHost/DeviceProperties.hpp"
 #include "alpaka/onHost/FrameSpec.hpp"
@@ -167,14 +168,14 @@ namespace alpaka::onHost
         {
             template<
                 typename T_Queue,
-                typename T_Mapping,
+                alpaka::concepts::Executor T_Executor,
                 onHost::concepts::ThreadOrFrameSpec T_BlockCfg,
                 alpaka::concepts::KernelBundle T_KernelBundle>
             struct Kernel
             {
                 void operator()(
                     T_Queue& queue,
-                    T_Mapping const executor,
+                    T_Executor const executor,
                     T_BlockCfg const& blockCfg,
                     T_KernelBundle const& kernelBundle) const
                 {
@@ -224,14 +225,14 @@ namespace alpaka::onHost
         {
             template<
                 typename T_Device,
-                typename T_Mapping,
+                alpaka::concepts::Executor T_Executor,
                 onHost::concepts::FrameSpec T_FrameSpec,
                 alpaka::concepts::KernelBundle T_KernelBundle>
             struct Op
             {
                 auto operator()(
                     T_Device const&,
-                    T_Mapping const& executor,
+                    T_Executor const& executor,
                     T_FrameSpec const& frameSpec,
                     T_KernelBundle const& kernelBundle) const
                 {

--- a/include/alpaka/onHost/trait.hpp
+++ b/include/alpaka/onHost/trait.hpp
@@ -26,17 +26,17 @@ namespace alpaka::onHost
             };
         };
 
-        struct IsMappingSupportedBy
+        struct IsExecutorSupportedBy
         {
-            template<typename T_Mapping, typename T_Device>
+            template<alpaka::concepts::Executor T_Executor, typename T_Device>
             struct Op : std::false_type
             {
             };
         };
 
-        template<typename T_Mapping, internal::concepts::DeviceHandle T_DeviceHandle>
-        struct IsMappingSupportedBy::Op<T_Mapping, T_DeviceHandle>
-            : IsMappingSupportedBy::Op<T_Mapping, typename T_DeviceHandle::element_type>
+        template<alpaka::concepts::Executor T_Executor, internal::concepts::DeviceHandle T_DeviceHandle>
+        struct IsExecutorSupportedBy::Op<T_Executor, T_DeviceHandle>
+            : IsExecutorSupportedBy::Op<T_Executor, typename T_DeviceHandle::element_type>
         {
         };
 
@@ -64,7 +64,7 @@ namespace alpaka::onHost
         };
 
         template<
-            typename T_Executor,
+            alpaka::concepts::Executor T_Executor,
             onHost::concepts::ThreadSpec T_ThreadSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
         struct GetDynSharedMemBytes
@@ -80,7 +80,7 @@ namespace alpaka::onHost
             }
         };
 
-        template<typename T_Executor, typename T_Spec, typename T_KernelFn, typename... T_Args>
+        template<alpaka::concepts::Executor T_Executor, typename T_Spec, typename T_KernelFn, typename... T_Args>
         requires requires() { std::declval<T_KernelFn>().dynSharedMemBytes; } || requires() {
             BlockDynSharedMemBytes<T_KernelFn, T_Spec>{std::declval<T_KernelFn>(), std::declval<T_Spec>()}(
                 std::declval<T_Executor>(),
@@ -116,7 +116,7 @@ namespace alpaka::onHost
         };
 
         template<
-            typename T_Executor,
+            alpaka::concepts::Executor T_Executor,
             onHost::concepts::ThreadSpec T_ThreadSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
         struct HasUserDefinedDynSharedMemBytes : std::true_type
@@ -124,7 +124,7 @@ namespace alpaka::onHost
         };
 
         template<
-            typename T_Executor,
+            alpaka::concepts::Executor T_Executor,
             onHost::concepts::ThreadSpec T_ThreadSpec,
             alpaka::concepts::KernelBundle T_KernelBundle>
         requires(trait::GetDynSharedMemBytes<T_Executor, T_ThreadSpec, T_KernelBundle>::zeroSharedMemory == true)
@@ -140,16 +140,16 @@ namespace alpaka::onHost
 
     consteval bool isExecutorSupportedBy(auto executor, internal::concepts::DeviceHandle auto const& deviceHandle)
     {
-        return trait::IsMappingSupportedBy::Op<ALPAKA_TYPEOF(executor), ALPAKA_TYPEOF(deviceHandle)>::value;
+        return trait::IsExecutorSupportedBy::Op<ALPAKA_TYPEOF(executor), ALPAKA_TYPEOF(deviceHandle)>::value;
     }
 
-    constexpr auto supportedMappings(internal::concepts::DeviceHandle auto deviceHandle, auto const listOfExecutors)
+    constexpr auto supportedExecutors(internal::concepts::DeviceHandle auto deviceHandle, auto const listOfExecutors)
     {
         return meta::filter(
             // we can not use isExecutorSupportedBy() because gcc14 is stricter in the detection which functions can
             // be evaluated at compile time
             [&](auto executor) constexpr
-            { return trait::IsMappingSupportedBy::Op<ALPAKA_TYPEOF(executor), ALPAKA_TYPEOF(deviceHandle)>::value; },
+            { return trait::IsExecutorSupportedBy::Op<ALPAKA_TYPEOF(executor), ALPAKA_TYPEOF(deviceHandle)>::value; },
             listOfExecutors);
     }
 
@@ -164,7 +164,7 @@ namespace alpaka::onHost
     }
 
     template<
-        typename T_Executor,
+        alpaka::concepts::Executor T_Executor,
         onHost::concepts::ThreadSpec T_ThreadSpec,
         alpaka::concepts::KernelBundle T_KernelBundle>
     constexpr uint32_t getDynSharedMemBytes(
@@ -176,7 +176,7 @@ namespace alpaka::onHost
     }
 
     template<
-        typename T_Executor,
+        alpaka::concepts::Executor T_Executor,
         onHost::concepts::ThreadSpec T_ThreadSpec,
         alpaka::concepts::KernelBundle T_KernelBundle>
     consteval bool hasUserDefinedDynSharedMemBytes(

--- a/include/alpaka/tag.hpp
+++ b/include/alpaka/tag.hpp
@@ -231,17 +231,19 @@ namespace alpaka
     {
     };
 
-    namespace exec::trait
+    namespace exec
     {
-        template<typename T_Mapping>
-        struct IsSeqExecutor : std::false_type
+        namespace trait
         {
-        };
+            template<typename T_Executor>
+            struct IsSeqExecutor : std::false_type
+            {
+            };
+        } // namespace trait
 
         template<typename T_Exec>
-        constexpr bool isSeqExecutor_v = IsSeqExecutor<T_Exec>::value;
-
-    } // namespace exec::trait
+        constexpr bool isSeqExecutor_v = trait::IsSeqExecutor<T_Exec>::value;
+    } // namespace exec
 
     /** check if a executor can only be used with a single thred per block
      *
@@ -250,6 +252,6 @@ namespace alpaka
     template<typename T_Exec>
     consteval bool isSeqExecutor(T_Exec exec)
     {
-        return exec::trait::isSeqExecutor_v<T_Exec>;
+        return exec::isSeqExecutor_v<T_Exec>;
     }
 } // namespace alpaka


### PR DESCRIPTION
In the very beginning of alpaka3 the exectors was called mapping. This was still reflacted within naming.

This PR renames mapping to exector.