### PR TITLE
fix kernel call without arguments

### DIFF
--- a/include/alpaka/KernelBundle.hpp
+++ b/include/alpaka/KernelBundle.hpp
@@ -64,8 +64,18 @@ namespace alpaka
         //! The function object type
         using KernelFn = std::decay_t<TKernelFn>;
         //! Tuple type to encapsulate kernel function argument types and argument values
-        using ArgTuple
-            = alpaka::Tuple<remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>...>;
+        using ArgTuple = std::conditional_t<
+            sizeof...(TArgs) == 0,
+            std::tuple<>,
+            alpaka::Tuple<remove_restrict_t<ALPAKA_TYPEOF(onHost::makeAccessibleOnAcc(std::declval<TArgs>()))>...>>;
+
+        // Constructor
+        constexpr KernelBundle(KernelFn const& kernelFn) : m_kernelFn{kernelFn}, m_args(std::tuple<>{})
+        {
+            static_assert(
+                alpaka::concepts::KernelFn<KernelFn>,
+                "Kernel functor must be trivially copyable or specialize trait::IsKernelTriviallyCopyable<>!");
+        }
 
         // Constructor
         constexpr KernelBundle(KernelFn const& kernelFn, auto&&... args)

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -15,7 +15,41 @@ using namespace alpaka;
 
 using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
 
-#if 1
+struct NoArgumentsKernel
+{
+    ALPAKA_FN_ACC void operator()(onAcc::concepts::Acc auto const& acc) const
+    {
+    }
+};
+
+/** test that we can execute a kernel which has no arguments
+ *
+ * All arguments could be stored e.g. as members.
+ */
+TEMPLATE_LIST_TEST_CASE("kernel no arguments", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+    std::cout << deviceSpec.getApi().getName() << std::endl;
+
+    onHost::Device device = devSelector.makeDevice(0);
+
+    std::cout << device.getName() << std::endl;
+
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
+
+    queue.enqueue(exec, onHost::FrameSpec{1, 1}, KernelBundle{NoArgumentsKernel{}});
+}
+
 struct IotaKernel
 {
     ALPAKA_FN_ACC void operator()(auto const& acc, auto out, uint32_t outSize) const
@@ -64,7 +98,6 @@ TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
     onHost::wait(queue);
     meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(idx.x() == hBuff[idx]); });
 }
-#endif
 
 struct IotaKernelND
 {


### PR DESCRIPTION
Calling a kernel without arguments was not working.

- add test that is calling an kernel that does not have arguments.