### PR TITLE
copy and move constructor for data sources which respects the const correctness of the data type

### DIFF
--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -757,7 +757,12 @@ namespace alpaka
 
     namespace internal
     {
-        template<typename T_To, typename T_Type, uint32_t T_dim, concepts::Alignment T_Alignment, typename T_Storage>
+        template<
+            typename T_To,
+            typename T_Type,
+            uint32_t T_dim,
+            alpaka::concepts::Alignment T_Alignment,
+            typename T_Storage>
         struct PCast::Op<T_To, alpaka::Simd<T_Type, T_dim, T_Alignment, T_Storage>>
         {
             constexpr decltype(auto) operator()(auto&& input) const

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -136,7 +136,11 @@ namespace alpaka
 
     namespace internal
     {
-        template<typename T_To, concepts::Vector T_End, concepts::Vector T_Begin, concepts::Vector T_Stride>
+        template<
+            typename T_To,
+            alpaka::concepts::Vector T_End,
+            alpaka::concepts::Vector T_Begin,
+            alpaka::concepts::Vector T_Stride>
         struct PCast::Op<T_To, IdxRange<T_End, T_Begin, T_Stride>>
         {
             constexpr decltype(auto) operator()(auto&& input) const

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -165,13 +165,6 @@ namespace alpaka
         // trait::IsKernelArgumentTriviallyCopyable<>!"
         // constexpr MdSpan& operator=(MdSpan&) = default;
 
-        template<typename T_Type_Other>
-        requires internal::concepts::InnerTypeAllowedCast<T_Type, T_Type_Other>
-        constexpr MdSpan(MdSpan<T_Type_Other, T_Extents, T_Pitches, T_MemAlignment>&& other)
-            : m_ptr(std::move(other.data()))
-            , m_extent(std::move(other.getExtents()))
-            , m_pitch(std::move(other.getPitches())){};
-        constexpr MdSpan(MdSpan&&) = default;
 
         constexpr MdSpan& operator=(MdSpan&&) = default;
 
@@ -223,6 +216,19 @@ namespace alpaka
                 this->getExtents(),
                 this->getPitches(),
                 T_MemAlignment{});
+        }
+
+        /** True if MdSpan is pointing to valid memory.
+         *
+         * @details
+         * An MdSpan remains valid even after being moved. The reason for this is that the MdSpan is simply copied.
+         * This is more efficient than a real move (e.g., setting the data pointer to nullptr). Implementing a real
+         * move is also not possible because MdSpan must be trivially copyable, which requires a default move
+         * constructor.
+         */
+        [[nodiscard]] constexpr explicit operator bool() const noexcept
+        {
+            return true;
         }
 
     protected:

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/mem/Alignment.hpp"
 #include "alpaka/mem/DataPitches.hpp"
 #include "alpaka/mem/MdForwardIter.hpp"
+#include "alpaka/mem/concepts/detail/InnerTypeAllowedCast.hpp"
 #include "alpaka/mem/trait.hpp"
 #include "alpaka/onHost/interface.hpp"
 #include "alpaka/trait.hpp"
@@ -152,15 +153,20 @@ namespace alpaka
         }
 
         template<typename T_Type_Other>
-        requires requires { requires !(std::is_const_v<T_Type_Other> && !std::is_const_v<T_Type>); }
+        requires internal::concepts::InnerTypeAllowedCast<T_Type, T_Type_Other>
         constexpr MdSpan(MdSpan<T_Type_Other, T_Extents, T_Pitches, T_MemAlignment> const& other)
             : m_ptr(other.data())
             , m_extent(other.getExtents())
             , m_pitch(other.getPitches()){};
         constexpr MdSpan(MdSpan const&) = default;
 
+        // causes a compiler error with nvcc
+        // error: static assertion failed with "All kernel arguments must be trivially copyable or specialize
+        // trait::IsKernelArgumentTriviallyCopyable<>!"
+        // constexpr MdSpan& operator=(MdSpan&) = default;
+
         template<typename T_Type_Other>
-        requires requires { requires !(std::is_const_v<T_Type_Other> && !std::is_const_v<T_Type>); }
+        requires internal::concepts::InnerTypeAllowedCast<T_Type, T_Type_Other>
         constexpr MdSpan(MdSpan<T_Type_Other, T_Extents, T_Pitches, T_MemAlignment>&& other)
             : m_ptr(std::move(other.data()))
             , m_extent(std::move(other.getExtents()))

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/mem/Alignment.hpp"
 #include "alpaka/mem/DataPitches.hpp"
 #include "alpaka/mem/MdForwardIter.hpp"
+#include "alpaka/mem/trait.hpp"
 #include "alpaka/onHost/interface.hpp"
 #include "alpaka/trait.hpp"
 
@@ -150,9 +151,22 @@ namespace alpaka
         {
         }
 
-        MdSpan(MdSpan const&) = default;
-        MdSpan(MdSpan&&) = default;
-        constexpr MdSpan& operator=(MdSpan const&) = default;
+        template<typename T_Type_Other>
+        requires requires { requires !(std::is_const_v<T_Type_Other> && !std::is_const_v<T_Type>); }
+        constexpr MdSpan(MdSpan<T_Type_Other, T_Extents, T_Pitches, T_MemAlignment> const& other)
+            : m_ptr(other.data())
+            , m_extent(other.getExtents())
+            , m_pitch(other.getPitches()){};
+        constexpr MdSpan(MdSpan const&) = default;
+
+        template<typename T_Type_Other>
+        requires requires { requires !(std::is_const_v<T_Type_Other> && !std::is_const_v<T_Type>); }
+        constexpr MdSpan(MdSpan<T_Type_Other, T_Extents, T_Pitches, T_MemAlignment>&& other)
+            : m_ptr(std::move(other.data()))
+            , m_extent(std::move(other.getExtents()))
+            , m_pitch(std::move(other.getPitches())){};
+        constexpr MdSpan(MdSpan&&) = default;
+
         constexpr MdSpan& operator=(MdSpan&&) = default;
 
         static constexpr auto getAlignment()
@@ -255,6 +269,17 @@ namespace alpaka
                  << ", pitches=" << mdSpan.getPitches().toString()
                  << " , alignment=" << T_MemAlignment::template get<T_Type>() << " }";
     }
+
+    template<
+        typename T_Type,
+        alpaka::concepts::Vector T_Extents,
+        alpaka::concepts::Vector T_Pitches,
+        alpaka::concepts::Alignment T_MemAlignment>
+    struct internal::CopyConstructableDataSource<MdSpan<T_Type, T_Extents, T_Pitches, T_MemAlignment>> : std::true_type
+    {
+        using InnerMutable = MdSpan<std::remove_const_t<T_Type>, T_Extents, T_Pitches, T_MemAlignment>;
+        using InnerConst = MdSpan<std::add_const_t<T_Type>, T_Extents, T_Pitches, T_MemAlignment>;
+    };
 
     /** access a C array with compile time extents via a runtime md index. */
     template<std::integral auto T_numDims, uint32_t T_dim = 0u>

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -9,6 +9,8 @@
 #include "alpaka/mem/BoundaryIter.hpp"
 #include "alpaka/mem/MdSpan.hpp"
 #include "alpaka/mem/concepts.hpp"
+#include "alpaka/mem/concepts/detail/InnerTypeAllowedCast.hpp"
+#include "alpaka/mem/trait.hpp"
 #include "alpaka/onHost/interface.hpp"
 
 #include <cstdint>
@@ -22,7 +24,7 @@ namespace alpaka
      * Const-ness of the view instance is propagated to the data region.
      */
     template<
-        typename T_Api,
+        alpaka::concepts::Api T_Api,
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment = Alignment<>>
@@ -62,7 +64,7 @@ namespace alpaka
     }
 
     template<
-        typename T_Api,
+        alpaka::concepts::Api T_Api,
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment>
@@ -99,8 +101,24 @@ namespace alpaka
                 "extent type and pitch type must be lossless convertible");
         }
 
+        template<typename T_Type_Other>
+        requires alpaka::internal::concepts::InnerTypeAllowedCast<T_Type, T_Type_Other>
+        constexpr View(View<T_Api, T_Type_Other, T_Extents, T_MemAlignment> const& other)
+            : BaseMdSpan{static_cast<BaseMdSpan>(other)}
+        {
+        }
+
         constexpr View(View const&) = default;
+
+        template<typename T_Type_Other>
+        requires alpaka::internal::concepts::InnerTypeAllowedCast<T_Type, T_Type_Other>
+        constexpr View(View<T_Api, T_Type_Other, T_Extents, T_MemAlignment>&& other)
+            : BaseMdSpan{std::move(static_cast<BaseMdSpan>(other))}
+        {
+        }
+
         constexpr View(View&&) = default;
+
         constexpr View& operator=(View const&) = default;
         constexpr View& operator=(View&&) = default;
 
@@ -265,5 +283,16 @@ namespace alpaka::internal
         {
             return T_Api{};
         }
+    };
+
+    template<
+        alpaka::concepts::Api T_Api,
+        typename T_Type,
+        alpaka::concepts::Vector T_Extents,
+        alpaka::concepts::Alignment T_MemAlignment>
+    struct CopyConstructableDataSource<View<T_Api, T_Type, T_Extents, T_MemAlignment>> : std::true_type
+    {
+        using InnerMutable = View<T_Api, std::remove_const_t<T_Type>, T_Extents, T_MemAlignment>;
+        using InnerConst = View<T_Api, std::add_const_t<T_Type>, T_Extents, T_MemAlignment>;
     };
 } // namespace alpaka::internal

--- a/include/alpaka/mem/concepts/ExpectedValueType.hpp
+++ b/include/alpaka/mem/concepts/ExpectedValueType.hpp
@@ -13,6 +13,6 @@ namespace alpaka::concepts
     /** Check whether the specified data type matches the expected type, or if the expected type is
      *`alpaka::NotRequired`, then all data types passes the concept.
      **/
-    template<typename TData, typename TExpected>
-    concept ExpectedValueType = std::same_as<TExpected, TData> || std::same_as<TExpected, alpaka::NotRequired>;
+    template<typename T_Data, typename T_Expected>
+    concept ExpectedValueType = std::same_as<T_Expected, T_Data> || std::same_as<T_Expected, alpaka::NotRequired>;
 } // namespace alpaka::concepts

--- a/include/alpaka/mem/concepts/IBuffer.hpp
+++ b/include/alpaka/mem/concepts/IBuffer.hpp
@@ -41,9 +41,9 @@ namespace alpaka::concepts
          * @endcode
          * - <b>t.destructorWaitFor</b>: Add an action to be executed when the shared_ptr is destroyed.
          **/
-        template<typename T, typename MutT, typename ConstT>
+        template<typename T, typename T_Mut, typename T_Const>
         concept IBuffer = requires(T t) {
-            requires IView<T, MutT, ConstT>;
+            requires IView<T, T_Mut, T_Const>;
             t.addDestructorAction(alpaka::concepts::empty_callable);
             t.destructorWaitFor(alpaka::concepts::empty_callable);
         };
@@ -54,7 +54,7 @@ namespace alpaka::concepts
      * `alpaka::buffer` like object has memory ownership and therefore manages memory lifetime according to the RAII
      * principle.
      *
-     * \attention Use `alpaka::IBuffer` to restrict types in your code. The actual interface is described in
+     * @attention Use `alpaka::IBuffer` to restrict types in your code. The actual interface is described in
      * alpaka::concepts::impl::IBuffer.
      *
      **/

--- a/include/alpaka/mem/concepts/IMdSpan.hpp
+++ b/include/alpaka/mem/concepts/IMdSpan.hpp
@@ -62,8 +62,9 @@ namespace alpaka::concepts
             typename T::index_type;
 
             requires std::movable<T_Mut>;
-            /// @todo add bool cast operator -> True if memory is valid. For example moved IMdSpan object are not valid
-            /// anymore.
+            /// The bool operator returns true if access to the memory is valid. For example, memory access may be
+            /// invalid after moving the DataSource.
+            static_cast<bool>(t);
 
             { T::dim() } -> std::same_as<uint32_t>;
             { *mut_t } -> std::same_as<typename T::reference>;

--- a/include/alpaka/mem/concepts/IMdSpan.hpp
+++ b/include/alpaka/mem/concepts/IMdSpan.hpp
@@ -62,6 +62,8 @@ namespace alpaka::concepts
             typename T::index_type;
 
             requires std::movable<T_Mut>;
+            /// @todo add bool cast operator -> True if memory is valid. For example moved IMdSpan object are not valid
+            /// anymore.
 
             { T::dim() } -> std::same_as<uint32_t>;
             { *mut_t } -> std::same_as<typename T::reference>;

--- a/include/alpaka/mem/concepts/IMdSpan.hpp
+++ b/include/alpaka/mem/concepts/IMdSpan.hpp
@@ -52,8 +52,8 @@ namespace alpaka::concepts
          *
          * @note The access operator [] with an integral as an argument is only available if the dimension is one.
          **/
-        template<typename T, typename MutT, typename ConstT>
-        concept IMdSpan = requires(T t, MutT mut_t, ConstT const_t, alpaka::Vec<uint32_t, T::dim()> vec) {
+        template<typename T, typename T_Mut, typename T_Const>
+        concept IMdSpan = requires(T t, T_Mut mut_t, T_Const const_t, alpaka::Vec<uint32_t, T::dim()> vec) {
             typename T::value_type;
             typename T::reference;
             typename T::const_reference;
@@ -61,7 +61,7 @@ namespace alpaka::concepts
             typename T::const_pointer;
             typename T::index_type;
 
-            requires std::movable<MutT>;
+            requires std::movable<T_Mut>;
 
             { T::dim() } -> std::same_as<uint32_t>;
             { *mut_t } -> std::same_as<typename T::reference>;
@@ -99,7 +99,7 @@ namespace alpaka::concepts
      * An object of type `alpaka::mdspan` does not store any information about the storage location, e.g., whether
      * the memory is located on a CPU or a GPU.
      *
-     * \attention Use `alpaka::IMdSpan` to restrict types in your code. The actual interface is described in
+     * @attention Use `alpaka::IMdSpan` to restrict types in your code. The actual interface is described in
      * alpaka::concepts::impl::IMdSpan.
      *
      **/

--- a/include/alpaka/mem/concepts/IView.hpp
+++ b/include/alpaka/mem/concepts/IView.hpp
@@ -23,9 +23,9 @@ namespace alpaka::concepts
          * the same interface.
          *
          **/
-        template<typename T, typename MutT, typename ConstT>
+        template<typename T, typename T_Mut, typename T_Const>
         concept IView = requires(T t) {
-            requires IMdSpan<T, MutT, ConstT>;
+            requires IMdSpan<T, T_Mut, T_Const>;
             { t.getApi() } -> alpaka::concepts::Api;
         };
     } // namespace impl
@@ -34,7 +34,7 @@ namespace alpaka::concepts
      * An `alpaka::view` like object contains information about the device(s) to which it is connected. The
      * `alpaka::view` like object has no memory ownership, and therefore it does not manage the memory lifetime.
      *
-     * \attention Use `alpaka::IView` to restrict types in your code. The actual interface is described in
+     * @attention Use `alpaka::IView` to restrict types in your code. The actual interface is described in
      * alpaka::concepts::impl::IView.
      *
      **/

--- a/include/alpaka/mem/concepts/detail/CopyConstructableDataSource.hpp
+++ b/include/alpaka/mem/concepts/detail/CopyConstructableDataSource.hpp
@@ -1,0 +1,58 @@
+/* Copyright 2025 Simeon Ehrig
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/mem/trait.hpp"
+
+#include <concepts>
+
+namespace alpaka::internal::concepts
+{
+    /** Check whether the copy constructor of the data source `T` respects the const correctness of the data type.
+     *
+     * @details
+     * Data sources have a data type that can be mutable or constant (marked with const). The following copies or
+     * assignments to a new object with the corresponding data type are possible:
+     *  - mutable -> mutable
+     *  - const -> const
+     *  - mutable -> const
+     **/
+    template<typename T>
+    concept CopyConstructableDataSource = requires {
+        requires alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::value;
+        /// copy constructor inner mutable -> inner mutable
+        requires std::constructible_from<
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerMutable,
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerMutable&>;
+        /// copy constructor inner const -> inner const
+        requires std::constructible_from<
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerConst,
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerConst&>;
+        /// copy constructor inner mutable -> inner const
+        requires std::constructible_from<
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerConst,
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerMutable&>;
+        /// not allowed: copy constructor inner const -> inner mutable
+        requires !std::constructible_from<
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerMutable,
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerConst&>;
+        /// copy assignment inner mutable -> inner mutable
+        requires std::assignable_from<
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerMutable&,
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerMutable>;
+        /// copy assignment inner const -> inner const
+        requires std::assignable_from<
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerConst&,
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerConst>;
+        /// copy assignment inner mutable -> inner const
+        requires std::assignable_from<
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerConst&,
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerMutable>;
+        /// not allowed: copy assignment inner const -> inner mutable
+        requires !std::assignable_from<
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerMutable&,
+            typename alpaka::internal::CopyConstructableDataSource<std::decay_t<T>>::InnerConst>;
+    };
+} // namespace alpaka::internal::concepts

--- a/include/alpaka/mem/concepts/detail/InnerTypeAllowedCast.hpp
+++ b/include/alpaka/mem/concepts/detail/InnerTypeAllowedCast.hpp
@@ -1,0 +1,33 @@
+/* Copyright 2025 Simeon Ehrig
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+
+#include <concepts>
+
+namespace alpaka::internal::concepts
+{
+    /** Concept to restrict copy or move constructor of a DataSource which creates a new object with a different inner
+     * type.
+     *
+     * @tparam T_Type element type of the new object
+     * @tparam T_Type_Other element type of the object which is copied or moved
+     *
+     * @details
+     * Needs to fulfill the following requirements
+     *  - the datatype without cv-qualifier needs to be the same
+     *  - following const/mutable conversion to const/mutable are allowed
+     *      - mutable -> mutable
+     *      - const -> const
+     *      - mutable -> const
+     */
+    template<typename T_Type, typename T_Type_Other>
+    concept InnerTypeAllowedCast = requires {
+        /// the raw type needs to be the same
+        requires std::same_as<std::decay_t<T_Type>, std::decay_t<T_Type_Other>>;
+        /// check the correct cast of a const/mutable inner type to another const/mutable inner type
+        requires !(std::is_const_v<T_Type_Other> && !std::is_const_v<T_Type>);
+    };
+} // namespace alpaka::internal::concepts

--- a/include/alpaka/mem/trait.hpp
+++ b/include/alpaka/mem/trait.hpp
@@ -11,30 +11,61 @@
 
 #include <cstdint>
 
-namespace alpaka::onAcc::internal
+namespace alpaka
 {
-    namespace trait
+    namespace onAcc::internal
     {
-        struct AutoIndexMapping
+        namespace trait
         {
-            template<typename T_Acc, typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
-            struct Op
+            struct AutoIndexMapping
             {
-                constexpr auto operator()(T_Acc const&, T_Api, T_DeviceKind) const
+                template<typename T_Acc, typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+                struct Op
                 {
-                    return layout::Strided{};
-                }
+                    constexpr auto operator()(T_Acc const&, T_Api, T_DeviceKind) const
+                    {
+                        return layout::Strided{};
+                    }
+                };
             };
-        };
-    } // namespace trait
+        } // namespace trait
 
-    constexpr auto adjustMapping(auto const& acc)
+        constexpr auto adjustMapping(auto const& acc)
+        {
+            return trait::AutoIndexMapping::
+                Op<ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(acc.getApi()), ALPAKA_TYPEOF(acc.getDeviceKind())>{}(
+                    acc,
+                    acc.getApi(),
+                    acc.getDeviceKind());
+        }
+
+    } // namespace onAcc::internal
+
+    namespace internal
     {
-        return trait::AutoIndexMapping::
-            Op<ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(acc.getApi()), ALPAKA_TYPEOF(acc.getDeviceKind())>{}(
-                acc,
-                acc.getApi(),
-                acc.getDeviceKind());
-    }
+        /** Specialize the trait for DataSource class if the object is copyable.
+         *
+         * @tparam TDataSource The DataSource class.
+         *
+         * @details
+         *
+         * The trait is used in the alpaka::internal::concepts::CopyConstructableDataSource concept to check whether
+         * the copy constructor respects the const correctness of the data type.
+         *
+         * Example specialization:
+         *
+         * @code
+         * template<typename T_Type>
+         * struct CopyConstructableDataSource<Storage<T_Type> : std::true_type {
+         *      using InnerMutable = Storage<std::remove_const_t<T_Type>>;
+         *      using InnerConst = Storage<std::add_const_t<T_Type>>;
+         * };
+         * @endcode
+         */
+        template<typename TDataSource>
+        struct CopyConstructableDataSource : std::false_type
+        {
+        };
 
-} // namespace alpaka::onAcc::internal
+    }; // namespace internal
+} // namespace alpaka

--- a/include/alpaka/onHost/mem/SharedBuffer.hpp
+++ b/include/alpaka/onHost/mem/SharedBuffer.hpp
@@ -93,7 +93,7 @@ namespace alpaka::onHost
 
         template<typename T_Type_Other>
         requires alpaka::internal::concepts::InnerTypeAllowedCast<T_Type, T_Type_Other>
-        explicit SharedBuffer(SharedBuffer<T_Api, T_Type_Other, T_Extents, T_MemAlignment> const& other)
+        SharedBuffer(SharedBuffer<T_Api, T_Type_Other, T_Extents, T_MemAlignment> const& other)
             : BaseView{static_cast<BaseView>(other)}
             , m_deleter(other.m_deleter)
         {
@@ -101,7 +101,7 @@ namespace alpaka::onHost
 
         SharedBuffer(SharedBuffer const&) = default;
 
-        auto& operator=(auto const& otherSharedBuffer) const
+        SharedBuffer& operator=(SharedBuffer const& otherSharedBuffer)
         {
             *this = otherSharedBuffer.getConstSharedBuffer();
             return *this;
@@ -109,7 +109,7 @@ namespace alpaka::onHost
 
         template<typename T_Type_Other>
         requires alpaka::internal::concepts::InnerTypeAllowedCast<T_Type, T_Type_Other>
-        explicit SharedBuffer(SharedBuffer<T_Api, T_Type_Other, T_Extents, T_MemAlignment>&& other)
+        SharedBuffer(SharedBuffer<T_Api, T_Type_Other, T_Extents, T_MemAlignment>&& other)
             : BaseView{std::move(static_cast<BaseView>(other))}
             , m_deleter(std::move(other.m_deleter))
 

--- a/include/alpaka/onHost/mem/SharedBuffer.hpp
+++ b/include/alpaka/onHost/mem/SharedBuffer.hpp
@@ -9,6 +9,8 @@
 #include "alpaka/core/config.hpp"
 #include "alpaka/internal/interface.hpp"
 #include "alpaka/mem/View.hpp"
+#include "alpaka/mem/concepts/detail/InnerTypeAllowedCast.hpp"
+#include "alpaka/mem/trait.hpp"
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/onHost/Handle.hpp"
 #include "alpaka/onHost/concepts.hpp"
@@ -89,11 +91,34 @@ namespace alpaka::onHost
                 "extent type and pitch type must be lossless convertible");
         }
 
+        template<typename T_Type_Other>
+        requires alpaka::internal::concepts::InnerTypeAllowedCast<T_Type, T_Type_Other>
+        explicit SharedBuffer(SharedBuffer<T_Api, T_Type_Other, T_Extents, T_MemAlignment> const& other)
+            : BaseView{static_cast<BaseView>(other)}
+            , m_deleter(other.m_deleter)
+        {
+        }
+
+        SharedBuffer(SharedBuffer const&) = default;
+
         auto& operator=(auto const& otherSharedBuffer) const
         {
             *this = otherSharedBuffer.getConstSharedBuffer();
             return *this;
         }
+
+        template<typename T_Type_Other>
+        requires alpaka::internal::concepts::InnerTypeAllowedCast<T_Type, T_Type_Other>
+        explicit SharedBuffer(SharedBuffer<T_Api, T_Type_Other, T_Extents, T_MemAlignment>&& other)
+            : BaseView{std::move(static_cast<BaseView>(other))}
+            , m_deleter(std::move(other.m_deleter))
+
+        {
+        }
+
+        SharedBuffer(SharedBuffer&&) = default;
+
+        SharedBuffer& operator=(SharedBuffer&&) = default;
 
         auto getView() const
         {
@@ -212,6 +237,18 @@ namespace alpaka::onHost
             addDestructorAction([any]() { onHost::wait(any); });
         }
 
+        /** Return the number of SharedBuffers which points to the same memory */
+        [[nodiscard]] constexpr long getUseCount() const noexcept
+        {
+            return m_deleter.use_count();
+        }
+
+        /** True if SharedBuffer is pointing to valid memory. */
+        constexpr explicit operator bool() const noexcept
+        {
+            return static_cast<bool>(m_deleter);
+        }
+
     private:
         /** @todo move this to trais or somewhere else that it can be used everywhere */
         template<alpaka::concepts::IsPointer T>
@@ -293,6 +330,18 @@ namespace alpaka::internal
             return T_Api{};
         }
     };
+
+    template<
+        alpaka::concepts::Api T_Api,
+        typename T_Type,
+        alpaka::concepts::Vector T_Extents,
+        alpaka::concepts::Alignment T_MemAlignment>
+    struct CopyConstructableDataSource<onHost::SharedBuffer<T_Api, T_Type, T_Extents, T_MemAlignment>> : std::true_type
+    {
+        using InnerMutable = onHost::SharedBuffer<T_Api, std::remove_const_t<T_Type>, T_Extents, T_MemAlignment>;
+        using InnerConst = onHost::SharedBuffer<T_Api, std::add_const_t<T_Type>, T_Extents, T_MemAlignment>;
+    };
+
 } // namespace alpaka::internal
 
 namespace alpaka::trait

--- a/include/alpaka/onHost/mem/SharedBuffer.hpp
+++ b/include/alpaka/onHost/mem/SharedBuffer.hpp
@@ -244,7 +244,7 @@ namespace alpaka::onHost
         }
 
         /** True if SharedBuffer is pointing to valid memory. */
-        constexpr explicit operator bool() const noexcept
+        [[nodiscard]] constexpr explicit operator bool() const noexcept
         {
             return static_cast<bool>(m_deleter);
         }

--- a/tests/unit/mem/SharedBuffer.cpp
+++ b/tests/unit/mem/SharedBuffer.cpp
@@ -1,0 +1,175 @@
+/* Copyright 2025 Simeon Ehrig
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace alpaka;
+
+TEST_CASE("copy SharedBuffer", "[mem][SharedBuffer]")
+{
+    onHost::SharedBuffer buffer = onHost::allocHost<int>(Vec<unsigned int, 1>{10});
+    REQUIRE(buffer.getUseCount() == 1);
+
+    onHost::SharedBuffer buffer2 = buffer;
+    REQUIRE(buffer.getUseCount() == 2);
+    REQUIRE(buffer);
+    REQUIRE(buffer2.getUseCount() == 2);
+    REQUIRE(buffer2);
+}
+
+TEST_CASE("move SharedBuffer", "[mem][SharedBuffer]")
+{
+    onHost::SharedBuffer buffer = onHost::allocHost<int>(Vec<unsigned int, 1>{10});
+    REQUIRE(buffer.getUseCount() == 1);
+
+    onHost::SharedBuffer buffer2 = std::move(buffer);
+    REQUIRE_FALSE(buffer);
+    REQUIRE(buffer2.getUseCount() == 1);
+    REQUIRE(buffer2);
+
+    onHost::SharedBuffer buffer3(std::move(buffer2));
+    REQUIRE_FALSE(buffer);
+    REQUIRE_FALSE(buffer2);
+    REQUIRE(buffer3.getUseCount() == 1);
+    REQUIRE(buffer3);
+}
+
+struct LivingMemory
+{
+    // live counter:
+    // 1 -> alive
+    // 0 -> freed
+    // negative -> double free
+    int live_counter = 1;
+};
+
+TEST_CASE("lifetime of shared memory", "[mem][SharedBuffer]")
+{
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(1);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    LivingMemory lv_mem1;
+    auto lv_mem_deleter1 = [&lv_mem1] { lv_mem1.live_counter -= 1; };
+    {
+        onHost::SharedBuffer buffer(api::host, &lv_mem1, extents, pitches, lv_mem_deleter1);
+        REQUIRE(lv_mem1.live_counter == 1);
+    }
+    REQUIRE(lv_mem1.live_counter == 0);
+
+    LivingMemory lv_mem2;
+    auto lv_mem_deleter2 = [&lv_mem2] { lv_mem2.live_counter -= 1; };
+    onHost::SharedBuffer buffer2(api::host, &lv_mem2, extents, pitches, lv_mem_deleter2);
+    {
+        onHost::SharedBuffer buffer = buffer2;
+        REQUIRE(buffer2.getUseCount() == 2);
+        REQUIRE(lv_mem2.live_counter == 1);
+    }
+    REQUIRE(lv_mem2.live_counter == 1);
+    REQUIRE(buffer2.getUseCount() == 1);
+
+    LivingMemory lv_mem3;
+    auto lv_mem_deleter3 = [&lv_mem3] { lv_mem3.live_counter -= 1; };
+    onHost::SharedBuffer buffer3(api::host, &lv_mem3, extents, pitches, lv_mem_deleter3);
+    {
+        onHost::SharedBuffer buffer(std::move(buffer3));
+        REQUIRE(buffer.getUseCount() == 1);
+        REQUIRE(lv_mem3.live_counter == 1);
+    }
+    REQUIRE(lv_mem3.live_counter == 0);
+    REQUIRE_FALSE(buffer3);
+}
+
+void funcCopyByValue(auto buffer, long const expected_use_count)
+{
+    REQUIRE(buffer);
+    REQUIRE(buffer.getUseCount() == expected_use_count);
+}
+
+void funcReference(auto& buffer, long const expected_use_count)
+{
+    REQUIRE(buffer);
+    REQUIRE(buffer.getUseCount() == expected_use_count);
+}
+
+void funcConstReference(auto const& buffer, long const expected_use_count)
+{
+    REQUIRE(buffer);
+    REQUIRE(buffer.getUseCount() == expected_use_count);
+}
+
+/** Takes the buffer as universal reference but do not assign to a lvalue.
+ * Therefore, the buffer is still valid after the function call.
+ *
+ * see: https://alagner.github.io/2024/03/14/Passing-arguments-by-move.html
+ */
+void funcUniversalRefBorrow(auto&& buffer, long const expected_use_count)
+{
+    REQUIRE(buffer);
+    REQUIRE(buffer.getUseCount() == expected_use_count);
+}
+
+/** Takes the buffer as universal reference and assign it to a lvalue.
+ * Therefore, the buffer is not valid after the function call anymore.
+ *
+ */
+void funcUniversalRefMoved(auto&& buffer, long const expected_use_count)
+{
+    REQUIRE(buffer);
+    auto tmp_buffer = std::move(buffer);
+    REQUIRE_FALSE(buffer);
+    REQUIRE(tmp_buffer);
+    REQUIRE(tmp_buffer.getUseCount() == expected_use_count);
+}
+
+TEST_CASE("pass shared memory to function", "[mem][SharedBuffer]")
+{
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(1);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    LivingMemory lv_mem1;
+    auto lv_mem_deleter1 = [&lv_mem1] { lv_mem1.live_counter -= 1; };
+    onHost::SharedBuffer buffer1(api::host, &lv_mem1, extents, pitches, lv_mem_deleter1);
+
+    REQUIRE(buffer1.getUseCount() == 1);
+    funcCopyByValue(buffer1, 2);
+    REQUIRE(buffer1);
+    REQUIRE(buffer1.getUseCount() == 1);
+    REQUIRE(lv_mem1.live_counter == 1);
+
+    REQUIRE(buffer1.getUseCount() == 1);
+    funcReference(buffer1, 1);
+    REQUIRE(buffer1);
+    REQUIRE(buffer1.getUseCount() == 1);
+    REQUIRE(lv_mem1.live_counter == 1);
+
+    REQUIRE(buffer1.getUseCount() == 1);
+    funcConstReference(buffer1, 1);
+    REQUIRE(buffer1);
+    REQUIRE(buffer1.getUseCount() == 1);
+    REQUIRE(lv_mem1.live_counter == 1);
+
+    REQUIRE(buffer1.getUseCount() == 1);
+    funcUniversalRefBorrow(buffer1, 1);
+    REQUIRE(buffer1);
+    REQUIRE(buffer1.getUseCount() == 1);
+    REQUIRE(lv_mem1.live_counter == 1);
+
+    REQUIRE(buffer1.getUseCount() == 1);
+    funcUniversalRefBorrow(std::move(buffer1), 1);
+    REQUIRE(buffer1);
+    REQUIRE(buffer1.getUseCount() == 1);
+    REQUIRE(lv_mem1.live_counter == 1);
+
+    REQUIRE(buffer1.getUseCount() == 1);
+    funcUniversalRefMoved(std::move(buffer1), 1);
+    REQUIRE_FALSE(buffer1);
+    REQUIRE(lv_mem1.live_counter == 0);
+
+    LivingMemory lv_mem2;
+    auto lv_mem_deleter2 = [&lv_mem2] { lv_mem2.live_counter -= 1; };
+    funcUniversalRefMoved(onHost::SharedBuffer{api::host, &lv_mem2, extents, pitches, lv_mem_deleter2}, 1);
+    REQUIRE(lv_mem2.live_counter == 0);
+}

--- a/tests/unit/mem/constCorrectness.cpp
+++ b/tests/unit/mem/constCorrectness.cpp
@@ -122,7 +122,7 @@ TEST_CASE("mdspan inner const move operator", "[mem][correctness]")
 
 template<typename TExpectedValueType, typename TExpectedReferenceType, typename TMdSpan>
 requires internal::concepts::CopyConstructableDataSource<TMdSpan> && concepts::IMdSpan<TMdSpan>
-void func_copy_by_value(TMdSpan mdspan)
+void funcCopyByValue(TMdSpan mdspan)
 {
     STATIC_REQUIRE(std::same_as<typename decltype(mdspan)::value_type, TExpectedValueType>);
     auto& val = mdspan[0];
@@ -131,7 +131,7 @@ void func_copy_by_value(TMdSpan mdspan)
 
 template<typename TExpectedValueType, typename TExpectedReferenceType, typename TMdSpan>
 requires internal::concepts::CopyConstructableDataSource<TMdSpan> && concepts::IMdSpan<TMdSpan>
-void func_reference(TMdSpan& mdspan)
+void funcReference(TMdSpan& mdspan)
 {
     STATIC_REQUIRE(std::same_as<typename std::remove_reference_t<decltype(mdspan)>::value_type, TExpectedValueType>);
     auto& val = mdspan[0];
@@ -140,7 +140,7 @@ void func_reference(TMdSpan& mdspan)
 
 template<typename TExpectedValueType, typename TExpectedReferenceType, typename TMdSpan>
 requires internal::concepts::CopyConstructableDataSource<TMdSpan> && concepts::IMdSpan<TMdSpan>
-void func_const_reference(TMdSpan const& mdspan)
+void funcConstReference(TMdSpan const& mdspan)
 {
     STATIC_REQUIRE(std::same_as<typename std::remove_reference_t<decltype(mdspan)>::value_type, TExpectedValueType>);
     auto& val = mdspan[0];
@@ -149,7 +149,7 @@ void func_const_reference(TMdSpan const& mdspan)
 
 template<typename TExpectedValueType, typename TExpectedReferenceType, typename TMdSpan>
 requires internal::concepts::CopyConstructableDataSource<TMdSpan> && concepts::IMdSpan<TMdSpan>
-void func_universal_ref(TMdSpan&& mdspan)
+void funcUniversalRef(TMdSpan&& mdspan)
 {
     STATIC_REQUIRE(std::same_as<typename std::remove_reference_t<decltype(mdspan)>::value_type, TExpectedValueType>);
     auto& val = mdspan[0];
@@ -165,29 +165,29 @@ TEST_CASE("function calls with mdspan object", "[mem][correctness]")
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     MdSpan mdspan{ptr, extents, pitches};
-    func_copy_by_value<int, int&>(mdspan);
-    func_reference<int, int&>(mdspan);
-    func_const_reference<int, int const&>(mdspan);
-    func_universal_ref<int, int&>(mdspan);
-    func_universal_ref<int, int&>(MdSpan{ptr, extents, pitches});
+    funcCopyByValue<int, int&>(mdspan);
+    funcReference<int, int&>(mdspan);
+    funcConstReference<int, int const&>(mdspan);
+    funcUniversalRef<int, int&>(mdspan);
+    funcUniversalRef<int, int&>(MdSpan{ptr, extents, pitches});
 
     MdSpan const const_mdspan{ptr, extents, pitches};
-    func_copy_by_value<int, int&>(const_mdspan);
-    func_reference<int, int const&>(const_mdspan);
-    func_const_reference<int, int const&>(const_mdspan);
+    funcCopyByValue<int, int&>(const_mdspan);
+    funcReference<int, int const&>(const_mdspan);
+    funcConstReference<int, int const&>(const_mdspan);
 
     MdSpan mdspan_inner_const{const_ptr, extents, pitches};
-    func_copy_by_value<int const, int const&>(mdspan_inner_const);
-    func_reference<int const, int const&>(mdspan_inner_const);
-    func_const_reference<int const, int const&>(mdspan_inner_const);
-    func_universal_ref<int const, int const&>(mdspan_inner_const);
-    func_universal_ref<int const, int const&>(MdSpan{const_ptr, extents, pitches});
+    funcCopyByValue<int const, int const&>(mdspan_inner_const);
+    funcReference<int const, int const&>(mdspan_inner_const);
+    funcConstReference<int const, int const&>(mdspan_inner_const);
+    funcUniversalRef<int const, int const&>(mdspan_inner_const);
+    funcUniversalRef<int const, int const&>(MdSpan{const_ptr, extents, pitches});
 
     MdSpan const const_mdspan_inner_const{const_ptr, extents, pitches};
-    func_copy_by_value<int const, int const&>(const_mdspan_inner_const);
-    func_reference<int const, int const&>(const_mdspan_inner_const);
-    func_const_reference<int const, int const&>(const_mdspan_inner_const);
-    func_universal_ref<int const, int const&>(const_mdspan_inner_const);
+    funcCopyByValue<int const, int const&>(const_mdspan_inner_const);
+    funcReference<int const, int const&>(const_mdspan_inner_const);
+    funcConstReference<int const, int const&>(const_mdspan_inner_const);
+    funcUniversalRef<int const, int const&>(const_mdspan_inner_const);
 }
 
 TEST_CASE("sharedBuffer copy and move construct", "[mem][correctness]")
@@ -195,6 +195,73 @@ TEST_CASE("sharedBuffer copy and move construct", "[mem][correctness]")
     // TODO(SimeonEhrig): check if shared_ptr is moved and not accidentally copied
     // compare ref counter before and after copy
     STATIC_REQUIRE(true);
+}
+
+TEST_CASE("sharedBuffer inner const copy constructor", "[mem][correctness]")
+{
+    constexpr size_t size = 10;
+    int* ptr = nullptr;
+    int const* const_ptr = nullptr;
+    concepts::Vector auto extents = Vec<uint32_t, 3>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    using MutSharedBuffer = onHost::SharedBuffer<alpaka::api::Host, int, decltype(extents)>;
+    using ConstSharedBuffer = onHost::SharedBuffer<alpaka::api::Host, int const, decltype(extents)>;
+
+    STATIC_REQUIRE(internal::CopyConstructableDataSource<MutSharedBuffer>::value);
+
+    // TODO(SimeonEhrig): enable me, when alpaka::View copy constructor allows different element types
+    // STATIC_REQUIRE(internal::concepts::CopyConstructableDataSource<MutSharedBuffer>);
+    // STATIC_REQUIRE(internal::concepts::CopyConstructableDataSource<ConstSharedBuffer>);
+
+    MutSharedBuffer mut_shared_buffer(api::host, ptr, extents, pitches, [] {});
+    ConstSharedBuffer const_shared_buffer(api::host, const_ptr, extents, pitches, [] {});
+
+    STATIC_REQUIRE(std::constructible_from<MutSharedBuffer, MutSharedBuffer&>);
+    [[maybe_unused]] MutSharedBuffer mut_shared_buffer_copy(mut_shared_buffer);
+
+    STATIC_REQUIRE(std::constructible_from<ConstSharedBuffer, ConstSharedBuffer&>);
+    [[maybe_unused]] ConstSharedBuffer const_shared_buffer_copy(const_shared_buffer);
+
+    // TODO(SimeonEhrig): enable me, when alpaka::View copy constructor allows different element types
+    // STATIC_REQUIRE(std::constructible_from<ConstSharedBuffer, MutSharedBuffer&>);
+    // [[maybe_unused]] ConstSharedBuffer mut_to_const_shared_buffer(mut_shared_buffer);
+    //
+    STATIC_REQUIRE_FALSE(std::constructible_from<MutSharedBuffer, ConstSharedBuffer&>);
+    // should not compile
+    // MdSpan const_to_mud_shared_buffer(const_shared_buffer);
+}
+
+TEST_CASE("sharedBuffer inner const move operator", "[mem][correctness]")
+{
+    constexpr size_t size = 10;
+    int* ptr = nullptr;
+    int const* const_ptr = nullptr;
+    concepts::Vector auto extents = Vec<uint32_t, 3>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    using MutSharedBuffer = onHost::SharedBuffer<alpaka::api::Host, int, decltype(extents)>;
+    using ConstSharedBuffer = onHost::SharedBuffer<alpaka::api::Host, int const, decltype(extents)>;
+
+    MutSharedBuffer copy_mut_shared_buffer(api::host, ptr, extents, pitches, [] {});
+    ConstSharedBuffer copy_const_shared_buffer(api::host, const_ptr, extents, pitches, [] {});
+
+    MutSharedBuffer copy_mut_shared_buffer2(std::move(copy_mut_shared_buffer));
+    ConstSharedBuffer copy_const_shared_buffer2(std::move(copy_const_shared_buffer));
+    // TODO(SimeonEhrig): enable me, when alpaka::View move constructor allows different element types
+    // [[maybe_unused]] ConstSharedBuffer copy_const_shared_buffer3(std::move(copy_mut_shared_buffer2));
+    // should not compile
+    // MutSharedBuffer copy_mut_shared_buffer3(std::move(copy_const_shared_buffer3));
+
+    MutSharedBuffer assign_mut_shared_buffer(api::host, ptr, extents, pitches, [] {});
+    ConstSharedBuffer assign_const_shared_buffer(api::host, const_ptr, extents, pitches, [] {});
+
+    MutSharedBuffer assign_mut_shared_buffer2 = std::move(assign_mut_shared_buffer);
+    ConstSharedBuffer assign_const_shared_buffer2 = std::move(assign_const_shared_buffer);
+    // TODO(SimeonEhrig): enable me, when alpaka::View move constructor allows different element types
+    //[[maybe_unused]] ConstSharedBuffer assign_const_shared_buffer3 = std::move(assign_mut_shared_buffer2);
+    // should not compile
+    // Mutshared_buffer assign_mut_shared_buffer3 = std::move(assign_const_shared_buffer3);
 }
 
 TEST_CASE("buffer const correctness MD", "[mem][correctness]")

--- a/tests/unit/mem/constCorrectness.cpp
+++ b/tests/unit/mem/constCorrectness.cpp
@@ -290,9 +290,8 @@ TEST_CASE("sharedBuffer inner const copy constructor", "[mem][correctness]")
 
     STATIC_REQUIRE(internal::CopyConstructableDataSource<MutSharedBuffer>::value);
 
-    // TODO(SimeonEhrig): enable me, when alpaka::View copy constructor allows different element types
-    // STATIC_REQUIRE(internal::concepts::CopyConstructableDataSource<MutSharedBuffer>);
-    // STATIC_REQUIRE(internal::concepts::CopyConstructableDataSource<ConstSharedBuffer>);
+    STATIC_REQUIRE(internal::concepts::CopyConstructableDataSource<MutSharedBuffer>);
+    STATIC_REQUIRE(internal::concepts::CopyConstructableDataSource<ConstSharedBuffer>);
 
     MutSharedBuffer mut_shared_buffer(api::host, ptr, extents, pitches, [] {});
     ConstSharedBuffer const_shared_buffer(api::host, const_ptr, extents, pitches, [] {});
@@ -303,13 +302,36 @@ TEST_CASE("sharedBuffer inner const copy constructor", "[mem][correctness]")
     STATIC_REQUIRE(std::constructible_from<ConstSharedBuffer, ConstSharedBuffer&>);
     [[maybe_unused]] ConstSharedBuffer const_shared_buffer_copy(const_shared_buffer);
 
-    // TODO(SimeonEhrig): enable me, when alpaka::View copy constructor allows different element types
-    // STATIC_REQUIRE(std::constructible_from<ConstSharedBuffer, MutSharedBuffer&>);
-    // [[maybe_unused]] ConstSharedBuffer mut_to_const_shared_buffer(mut_shared_buffer);
-    //
+    STATIC_REQUIRE(std::constructible_from<ConstSharedBuffer, MutSharedBuffer&>);
+    [[maybe_unused]] ConstSharedBuffer mut_to_const_shared_buffer(mut_shared_buffer);
+
     STATIC_REQUIRE_FALSE(std::constructible_from<MutSharedBuffer, ConstSharedBuffer&>);
     // should not compile
-    // MdSpan const_to_mud_shared_buffer(const_shared_buffer);
+    // MutSharedBuffer const_to_mud_shared_buffer(const_shared_buffer);
+}
+
+TEST_CASE("sharedBuffer inner const assignment operator", "[mem][correctness]")
+{
+    constexpr size_t size = 10;
+    int* ptr = nullptr;
+    int const* const_ptr = nullptr;
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    using MutSharedBuffer = onHost::SharedBuffer<alpaka::api::Host, int, decltype(extents)>;
+    using ConstSharedBuffer = onHost::SharedBuffer<alpaka::api::Host, int const, decltype(extents)>;
+
+    MutSharedBuffer mut_shared_buffer(api::host, ptr, extents, pitches, [] {});
+    ConstSharedBuffer const_shared_buffer(api::host, const_ptr, extents, pitches, [] {});
+
+    STATIC_REQUIRE(std::assignable_from<MutSharedBuffer&, MutSharedBuffer>);
+    [[maybe_unused]] MutSharedBuffer mut_shared_buffer2 = mut_shared_buffer;
+    STATIC_REQUIRE(std::assignable_from<ConstSharedBuffer&, ConstSharedBuffer>);
+    [[maybe_unused]] ConstSharedBuffer const_shared_buffer2 = const_shared_buffer;
+    STATIC_REQUIRE(std::assignable_from<ConstSharedBuffer&, MutSharedBuffer>);
+    [[maybe_unused]] ConstSharedBuffer const_shared_buffer3 = mut_shared_buffer;
+    STATIC_REQUIRE_FALSE(std::assignable_from<MutSharedBuffer&, ConstSharedBuffer>);
+    // MutSharedBuffer mut_shared_buffer3 = const_shared_buffer;
 }
 
 TEST_CASE("sharedBuffer inner const move operator", "[mem][correctness]")
@@ -328,8 +350,7 @@ TEST_CASE("sharedBuffer inner const move operator", "[mem][correctness]")
 
     MutSharedBuffer copy_mut_shared_buffer2(std::move(copy_mut_shared_buffer));
     ConstSharedBuffer copy_const_shared_buffer2(std::move(copy_const_shared_buffer));
-    // TODO(SimeonEhrig): enable me, when alpaka::View move constructor allows different element types
-    // [[maybe_unused]] ConstSharedBuffer copy_const_shared_buffer3(std::move(copy_mut_shared_buffer2));
+    [[maybe_unused]] ConstSharedBuffer copy_const_shared_buffer3(std::move(copy_mut_shared_buffer2));
     // should not compile
     // MutSharedBuffer copy_mut_shared_buffer3(std::move(copy_const_shared_buffer3));
 
@@ -338,10 +359,9 @@ TEST_CASE("sharedBuffer inner const move operator", "[mem][correctness]")
 
     MutSharedBuffer assign_mut_shared_buffer2 = std::move(assign_mut_shared_buffer);
     ConstSharedBuffer assign_const_shared_buffer2 = std::move(assign_const_shared_buffer);
-    // TODO(SimeonEhrig): enable me, when alpaka::View move constructor allows different element types
-    //[[maybe_unused]] ConstSharedBuffer assign_const_shared_buffer3 = std::move(assign_mut_shared_buffer2);
+    [[maybe_unused]] ConstSharedBuffer assign_const_shared_buffer3 = std::move(assign_mut_shared_buffer2);
     // should not compile
-    // Mutshared_buffer assign_mut_shared_buffer3 = std::move(assign_const_shared_buffer3);
+    // MutSharedBuffer assign_mut_shared_buffer3 = std::move(assign_const_shared_buffer3);
 }
 
 TEST_CASE("buffer const correctness MD", "[mem][correctness]")

--- a/tests/unit/mem/constCorrectness.cpp
+++ b/tests/unit/mem/constCorrectness.cpp
@@ -3,12 +3,14 @@
  */
 
 #include <alpaka/alpaka.hpp>
+#include <alpaka/mem/concepts/detail/CopyConstructableDataSource.hpp>
 #include <alpaka/onHost/example/executors.hpp>
 #include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <concepts>
 #include <iostream>
 
 using namespace alpaka;
@@ -31,93 +33,171 @@ void requiresMutableBufferMd(concepts::MdSpan auto buffer)
     static_assert(!std::is_const_v<std::remove_reference_t<decltype(buffer[Vec{0, 0}])>>);
 }
 
-TEST_CASE("buffer const correctness 1D", "")
+TEST_CASE("mdspan inner const copy constructor", "[mem][correctness]")
 {
-    auto buffer0 = onHost::allocHost<int>(10);
-    static_assert(!std::is_const_v<std::remove_pointer_t<decltype(buffer0.data())>>);
-    // mutable views
-    {
-        [[maybe_unused]] auto subBuffer0 = buffer0.getSubSharedBuffer(2);
-        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
-        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subBuffer0[0])>>);
+    constexpr size_t size = 10;
+    int* ptr = nullptr;
+    int const* const_ptr = nullptr;
+    concepts::Vector auto extents = Vec<uint32_t, 3>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
-        [[maybe_unused]] auto subOffsetBuffer0 = buffer0.getSubSharedBuffer(1, 2);
-        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
-        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[0])>>);
+    using MutMdSpan = MdSpan<int, decltype(extents), decltype(pitches)>;
+    using ConstMdSpan = MdSpan<int const, decltype(extents), decltype(pitches)>;
 
-        [[maybe_unused]] auto subView0 = buffer0.getSubView(2);
-        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subView0.data())>>);
-        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subView0[0])>>);
+    STATIC_REQUIRE(internal::CopyConstructableDataSource<MutMdSpan>::value);
 
-        [[maybe_unused]] auto subOffsetView0 = buffer0.getSubView(1, 2);
-        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(subOffsetView0.data())>>);
-        static_assert(!std::is_const_v<std::remove_reference_t<decltype(subOffsetView0[0])>>);
+    STATIC_REQUIRE(internal::concepts::CopyConstructableDataSource<MutMdSpan>);
+    STATIC_REQUIRE(internal::concepts::CopyConstructableDataSource<ConstMdSpan>);
 
-        [[maybe_unused]] View view = buffer0.getView();
-        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(view.data())>>);
-        static_assert(!std::is_const_v<std::remove_reference_t<decltype(view[0])>>);
+    MutMdSpan mut_mdspan(ptr, extents, pitches);
+    ConstMdSpan const_mdspan(const_ptr, extents, pitches);
 
-        [[maybe_unused]] MdSpan mdSpan = buffer0.getMdSpan();
-        static_assert(!std::is_const_v<std::remove_pointer_t<decltype(mdSpan.data())>>);
-        static_assert(!std::is_const_v<std::remove_reference_t<decltype(mdSpan[0])>>);
-    }
-    // non-mutable views
-    {
-        onHost::SharedBuffer innerConstBuffer0 = buffer0.getConstSharedBuffer();
-        [[maybe_unused]] auto subBuffer0 = innerConstBuffer0.getSubSharedBuffer(2);
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(subBuffer0[0])>>);
+    STATIC_REQUIRE(std::constructible_from<MutMdSpan, MutMdSpan&>);
+    [[maybe_unused]] MutMdSpan mut_mdspan_copy(mut_mdspan);
 
-        [[maybe_unused]] auto subOffsetBuffer0 = innerConstBuffer0.getSubSharedBuffer(1, 2);
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[0])>>);
+    STATIC_REQUIRE(std::constructible_from<ConstMdSpan, ConstMdSpan&>);
+    [[maybe_unused]] ConstMdSpan const_mdspan_copy(const_mdspan);
 
-        [[maybe_unused]] auto subView0 = innerConstBuffer0.getSubView(2);
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subView0.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(subView0[0])>>);
+    STATIC_REQUIRE(std::constructible_from<ConstMdSpan, MutMdSpan&>);
+    [[maybe_unused]] ConstMdSpan mut_to_const_mdspan(mut_mdspan);
 
-        [[maybe_unused]] auto subOffsetView0 = innerConstBuffer0.getSubView(1, 2);
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetView0.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetView0[0])>>);
-
-        [[maybe_unused]] View view = innerConstBuffer0.getView();
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(view.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(view[0])>>);
-
-        [[maybe_unused]] MdSpan mdSpan = innerConstBuffer0.getMdSpan();
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(mdSpan.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(mdSpan[0])>>);
-    }
-    // non-mutable views (outer const)
-    {
-        onHost::SharedBuffer const outerConstBuffer0 = buffer0;
-        [[maybe_unused]] auto subBuffer0 = outerConstBuffer0.getSubSharedBuffer(2);
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subBuffer0.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(subBuffer0[0])>>);
-
-        [[maybe_unused]] auto subOffsetBuffer0 = outerConstBuffer0.getSubSharedBuffer(1, 2);
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetBuffer0.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetBuffer0[0])>>);
-
-        [[maybe_unused]] auto subView0 = outerConstBuffer0.getSubView(2);
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subView0.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(subView0[0])>>);
-
-        [[maybe_unused]] auto subOffsetView0 = outerConstBuffer0.getSubView(1, 2);
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(subOffsetView0.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(subOffsetView0[0])>>);
-
-        [[maybe_unused]] View view = outerConstBuffer0.getView();
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(view.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(view[0])>>);
-
-        [[maybe_unused]] MdSpan mdSpan = outerConstBuffer0.getMdSpan();
-        static_assert(std::is_const_v<std::remove_pointer_t<decltype(mdSpan.data())>>);
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(mdSpan[0])>>);
-    }
+    STATIC_REQUIRE_FALSE(std::constructible_from<MutMdSpan, ConstMdSpan&>);
+    // should not compile
+    // MdSpan const_to_mud_mdspan(const_mdspan);
 }
 
-TEST_CASE("buffer const correctness MD", "")
+TEST_CASE("mdspan inner const assignment operator", "[mem][correctness]")
+{
+    constexpr size_t size = 10;
+    int* ptr = nullptr;
+    int const* const_ptr = nullptr;
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    using MutMdSpan = MdSpan<int, decltype(extents), decltype(pitches)>;
+    using ConstMdSpan = MdSpan<int const, decltype(extents), decltype(pitches)>;
+
+    MutMdSpan mut_mdspan(ptr, extents, pitches);
+    ConstMdSpan const_mdspan(const_ptr, extents, pitches);
+
+    STATIC_REQUIRE(std::assignable_from<MutMdSpan&, MutMdSpan>);
+    [[maybe_unused]] MutMdSpan mut_mdspan2 = mut_mdspan;
+    STATIC_REQUIRE(std::assignable_from<ConstMdSpan&, ConstMdSpan>);
+    [[maybe_unused]] ConstMdSpan const_mdspan2 = const_mdspan;
+    STATIC_REQUIRE(std::assignable_from<ConstMdSpan&, MutMdSpan>);
+    [[maybe_unused]] ConstMdSpan const_mdspan3 = mut_mdspan;
+    STATIC_REQUIRE_FALSE(std::assignable_from<MutMdSpan&, ConstMdSpan>);
+    // MutMdSpan mut_mdspan3 = const_mdspan;
+}
+
+TEST_CASE("mdspan inner const move operator", "[mem][correctness]")
+{
+    constexpr size_t size = 10;
+    int* ptr = nullptr;
+    int const* const_ptr = nullptr;
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    using MutMdSpan = MdSpan<int, decltype(extents), decltype(pitches)>;
+    using ConstMdSpan = MdSpan<int const, decltype(extents), decltype(pitches)>;
+
+    MutMdSpan copy_mut_mdspan(ptr, extents, pitches);
+    ConstMdSpan copy_const_mdspan(const_ptr, extents, pitches);
+
+    MutMdSpan copy_mut_mdspan2(std::move(copy_mut_mdspan));
+    ConstMdSpan copy_const_mdspan2(std::move(copy_const_mdspan));
+    [[maybe_unused]] ConstMdSpan copy_const_mdspan3(std::move(copy_mut_mdspan2));
+    // should not compile
+    // MutMdSpan copy_mut_mdspan3(std::move(copy_const_mdspan3));
+
+    MutMdSpan assign_mut_mdspan(ptr, extents, pitches);
+    ConstMdSpan assign_const_mdspan(const_ptr, extents, pitches);
+
+    MutMdSpan assign_mut_mdspan2 = std::move(assign_mut_mdspan);
+    ConstMdSpan assign_const_mdspan2 = std::move(assign_const_mdspan);
+    [[maybe_unused]] ConstMdSpan assign_const_mdspan3 = std::move(assign_mut_mdspan2);
+    // should not compile
+    // MutMdSpan assign_mut_mdspan3 = std::move(assign_const_mdspan3);
+}
+
+template<typename TExpectedValueType, typename TExpectedReferenceType, typename TMdSpan>
+requires internal::concepts::CopyConstructableDataSource<TMdSpan> && concepts::IMdSpan<TMdSpan>
+void func_copy_by_value(TMdSpan mdspan)
+{
+    STATIC_REQUIRE(std::same_as<typename decltype(mdspan)::value_type, TExpectedValueType>);
+    auto& val = mdspan[0];
+    STATIC_CHECK(std::same_as<decltype(val), TExpectedReferenceType&>);
+}
+
+template<typename TExpectedValueType, typename TExpectedReferenceType, typename TMdSpan>
+requires internal::concepts::CopyConstructableDataSource<TMdSpan> && concepts::IMdSpan<TMdSpan>
+void func_reference(TMdSpan& mdspan)
+{
+    STATIC_REQUIRE(std::same_as<typename std::remove_reference_t<decltype(mdspan)>::value_type, TExpectedValueType>);
+    auto& val = mdspan[0];
+    STATIC_CHECK(std::same_as<decltype(val), TExpectedReferenceType&>);
+}
+
+template<typename TExpectedValueType, typename TExpectedReferenceType, typename TMdSpan>
+requires internal::concepts::CopyConstructableDataSource<TMdSpan> && concepts::IMdSpan<TMdSpan>
+void func_const_reference(TMdSpan const& mdspan)
+{
+    STATIC_REQUIRE(std::same_as<typename std::remove_reference_t<decltype(mdspan)>::value_type, TExpectedValueType>);
+    auto& val = mdspan[0];
+    STATIC_CHECK(std::same_as<decltype(val), TExpectedReferenceType&>);
+}
+
+template<typename TExpectedValueType, typename TExpectedReferenceType, typename TMdSpan>
+requires internal::concepts::CopyConstructableDataSource<TMdSpan> && concepts::IMdSpan<TMdSpan>
+void func_universal_ref(TMdSpan&& mdspan)
+{
+    STATIC_REQUIRE(std::same_as<typename std::remove_reference_t<decltype(mdspan)>::value_type, TExpectedValueType>);
+    auto& val = mdspan[0];
+    STATIC_CHECK(std::same_as<decltype(val), TExpectedReferenceType&>);
+}
+
+TEST_CASE("function calls with mdspan object", "[mem][correctness]")
+{
+    constexpr size_t size = 10;
+    int* ptr = nullptr;
+    int const* const_ptr = nullptr;
+    concepts::Vector auto extents = Vec<uint32_t, 1>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    MdSpan mdspan{ptr, extents, pitches};
+    func_copy_by_value<int, int&>(mdspan);
+    func_reference<int, int&>(mdspan);
+    func_const_reference<int, int const&>(mdspan);
+    func_universal_ref<int, int&>(mdspan);
+    func_universal_ref<int, int&>(MdSpan{ptr, extents, pitches});
+
+    MdSpan const const_mdspan{ptr, extents, pitches};
+    func_copy_by_value<int, int&>(const_mdspan);
+    func_reference<int, int const&>(const_mdspan);
+    func_const_reference<int, int const&>(const_mdspan);
+
+    MdSpan mdspan_inner_const{const_ptr, extents, pitches};
+    func_copy_by_value<int const, int const&>(mdspan_inner_const);
+    func_reference<int const, int const&>(mdspan_inner_const);
+    func_const_reference<int const, int const&>(mdspan_inner_const);
+    func_universal_ref<int const, int const&>(mdspan_inner_const);
+    func_universal_ref<int const, int const&>(MdSpan{const_ptr, extents, pitches});
+
+    MdSpan const const_mdspan_inner_const{const_ptr, extents, pitches};
+    func_copy_by_value<int const, int const&>(const_mdspan_inner_const);
+    func_reference<int const, int const&>(const_mdspan_inner_const);
+    func_const_reference<int const, int const&>(const_mdspan_inner_const);
+    func_universal_ref<int const, int const&>(const_mdspan_inner_const);
+}
+
+TEST_CASE("sharedBuffer copy and move construct", "[mem][correctness]")
+{
+    // TODO(SimeonEhrig): check if shared_ptr is moved and not accidentally copied
+    // compare ref counter before and after copy
+    STATIC_REQUIRE(true);
+}
+
+TEST_CASE("buffer const correctness MD", "[mem][correctness]")
 {
     auto buffer0 = onHost::allocHost<int>(Vec{10, 10});
     requiresMutableBufferMd(buffer0);

--- a/tests/unit/mem/constCorrectness.cpp
+++ b/tests/unit/mem/constCorrectness.cpp
@@ -33,7 +33,7 @@ void requiresMutableBufferMd(concepts::MdSpan auto buffer)
     static_assert(!std::is_const_v<std::remove_reference_t<decltype(buffer[Vec{0, 0}])>>);
 }
 
-TEST_CASE("mdspan inner const copy constructor", "[mem][correctness]")
+TEST_CASE("mdspan inner const copy constructor", "[mem][mdspan][correctness][copyConstruct]")
 {
     constexpr size_t size = 10;
     int* ptr = nullptr;
@@ -66,7 +66,7 @@ TEST_CASE("mdspan inner const copy constructor", "[mem][correctness]")
     // MdSpan const_to_mud_mdspan(const_mdspan);
 }
 
-TEST_CASE("mdspan inner const assignment operator", "[mem][correctness]")
+TEST_CASE("mdspan inner const assignment operator", "[mem][mdspan][correctness][copyConstruct]")
 {
     constexpr size_t size = 10;
     int* ptr = nullptr;
@@ -90,7 +90,7 @@ TEST_CASE("mdspan inner const assignment operator", "[mem][correctness]")
     // MutMdSpan mut_mdspan3 = const_mdspan;
 }
 
-TEST_CASE("mdspan inner const move operator", "[mem][correctness]")
+TEST_CASE("mdspan inner const move operator", "[mem][mdspan][correctness][moveConstruct]")
 {
     constexpr size_t size = 10;
     int* ptr = nullptr;
@@ -156,7 +156,7 @@ void funcUniversalRef(TMdSpan&& mdspan)
     STATIC_CHECK(std::same_as<decltype(val), TExpectedReferenceType&>);
 }
 
-TEST_CASE("function calls with mdspan object", "[mem][correctness]")
+TEST_CASE("function calls with mdspan object", "[mem][mdspan][correctness]")
 {
     constexpr size_t size = 10;
     int* ptr = nullptr;
@@ -190,7 +190,7 @@ TEST_CASE("function calls with mdspan object", "[mem][correctness]")
     funcUniversalRef<int const, int const&>(const_mdspan_inner_const);
 }
 
-TEST_CASE("View inner const copy constructor", "[mem][correctness]")
+TEST_CASE("View inner const copy constructor", "[mem][view][correctness][copyConstruct]")
 {
     constexpr size_t size = 10;
     int* ptr = nullptr;
@@ -223,7 +223,7 @@ TEST_CASE("View inner const copy constructor", "[mem][correctness]")
     // MutView const_to_mud_view(const_view);
 }
 
-TEST_CASE("View inner const assignment operator", "[mem][correctness]")
+TEST_CASE("View inner const assignment operator", "[mem][view][correctness][copyConstruct]")
 {
     constexpr size_t size = 10;
     int* ptr = nullptr;
@@ -247,7 +247,7 @@ TEST_CASE("View inner const assignment operator", "[mem][correctness]")
     // MutView mut_view3 = const_view;
 }
 
-TEST_CASE("View inner const move constructor and move assignment operator", "[mem][correctness]")
+TEST_CASE("View inner const move constructor and move assignment operator", "[mem][view][correctness][moveConstruct]")
 {
     constexpr size_t size = 10;
     int* ptr = nullptr;
@@ -277,7 +277,7 @@ TEST_CASE("View inner const move constructor and move assignment operator", "[me
     // MutView assign_mut_view3 = std::move(assign_const_view3);
 }
 
-TEST_CASE("sharedBuffer inner const copy constructor", "[mem][correctness]")
+TEST_CASE("sharedBuffer inner const copy constructor", "[mem][sharedBuffer][correctness][copyConstruct]")
 {
     constexpr size_t size = 10;
     int* ptr = nullptr;
@@ -310,7 +310,7 @@ TEST_CASE("sharedBuffer inner const copy constructor", "[mem][correctness]")
     // MutSharedBuffer const_to_mud_shared_buffer(const_shared_buffer);
 }
 
-TEST_CASE("sharedBuffer inner const assignment operator", "[mem][correctness]")
+TEST_CASE("sharedBuffer inner const assignment operator", "[mem][sharedBuffer][correctness][copyConstruct]")
 {
     constexpr size_t size = 10;
     int* ptr = nullptr;
@@ -334,7 +334,7 @@ TEST_CASE("sharedBuffer inner const assignment operator", "[mem][correctness]")
     // MutSharedBuffer mut_shared_buffer3 = const_shared_buffer;
 }
 
-TEST_CASE("sharedBuffer inner const move operator", "[mem][correctness]")
+TEST_CASE("sharedBuffer inner const move operator", "[mem][sharedBuffer][correctness][moveConstruct]")
 {
     constexpr size_t size = 10;
     int* ptr = nullptr;
@@ -364,7 +364,7 @@ TEST_CASE("sharedBuffer inner const move operator", "[mem][correctness]")
     // MutSharedBuffer assign_mut_shared_buffer3 = std::move(assign_const_shared_buffer3);
 }
 
-TEST_CASE("buffer const correctness MD", "[mem][correctness]")
+TEST_CASE("buffer const correctness MD", "[mem][sharedBuffer][correctness]")
 {
     auto buffer0 = onHost::allocHost<int>(Vec{10, 10});
     requiresMutableBufferMd(buffer0);

--- a/tests/unit/mem/constCorrectness.cpp
+++ b/tests/unit/mem/constCorrectness.cpp
@@ -190,11 +190,91 @@ TEST_CASE("function calls with mdspan object", "[mem][correctness]")
     funcUniversalRef<int const, int const&>(const_mdspan_inner_const);
 }
 
-TEST_CASE("sharedBuffer copy and move construct", "[mem][correctness]")
+TEST_CASE("View inner const copy constructor", "[mem][correctness]")
 {
-    // TODO(SimeonEhrig): check if shared_ptr is moved and not accidentally copied
-    // compare ref counter before and after copy
-    STATIC_REQUIRE(true);
+    constexpr size_t size = 10;
+    int* ptr = nullptr;
+    int const* const_ptr = nullptr;
+    concepts::Vector auto extents = Vec<uint32_t, 3>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    using MutView = View<alpaka::api::Host, int, decltype(extents)>;
+    using ConstView = View<alpaka::api::Host, int const, decltype(extents)>;
+
+    STATIC_REQUIRE(internal::CopyConstructableDataSource<MutView>::value);
+
+    STATIC_REQUIRE(internal::concepts::CopyConstructableDataSource<MutView>);
+    STATIC_REQUIRE(internal::concepts::CopyConstructableDataSource<ConstView>);
+
+    MutView mut_view(api::host, ptr, extents, pitches);
+    ConstView const_view(api::host, const_ptr, extents, pitches);
+
+    STATIC_REQUIRE(std::constructible_from<MutView, MutView&>);
+    [[maybe_unused]] MutView mut_view_copy(mut_view);
+
+    STATIC_REQUIRE(std::constructible_from<ConstView, ConstView&>);
+    [[maybe_unused]] ConstView const_view_copy(const_view);
+
+    STATIC_REQUIRE(std::constructible_from<ConstView, MutView&>);
+    [[maybe_unused]] ConstView mut_to_const_view(mut_view);
+
+    STATIC_REQUIRE_FALSE(std::constructible_from<MutView, ConstView&>);
+    // should not compile
+    // MutView const_to_mud_view(const_view);
+}
+
+TEST_CASE("View inner const assignment operator", "[mem][correctness]")
+{
+    constexpr size_t size = 10;
+    int* ptr = nullptr;
+    int const* const_ptr = nullptr;
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    using MutView = View<alpaka::api::Host, int, decltype(extents)>;
+    using ConstView = View<alpaka::api::Host, int const, decltype(extents)>;
+
+    MutView mut_view(api::host, ptr, extents, pitches);
+    ConstView const_view(api::host, const_ptr, extents, pitches);
+
+    STATIC_REQUIRE(std::assignable_from<MutView&, MutView>);
+    [[maybe_unused]] MutView mut_view2 = mut_view;
+    STATIC_REQUIRE(std::assignable_from<ConstView&, ConstView>);
+    [[maybe_unused]] ConstView const_view2 = const_view;
+    STATIC_REQUIRE(std::assignable_from<ConstView&, MutView>);
+    [[maybe_unused]] ConstView const_view3 = mut_view;
+    STATIC_REQUIRE_FALSE(std::assignable_from<MutView&, ConstView>);
+    // MutView mut_view3 = const_view;
+}
+
+TEST_CASE("View inner const move constructor and move assignment operator", "[mem][correctness]")
+{
+    constexpr size_t size = 10;
+    int* ptr = nullptr;
+    int const* const_ptr = nullptr;
+    concepts::Vector auto extents = Vec<uint32_t, 3>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    using MutView = View<alpaka::api::Host, int, decltype(extents)>;
+    using ConstView = View<alpaka::api::Host, int const, decltype(extents)>;
+
+    MutView construct_mut_view(api::host, ptr, extents, pitches);
+    ConstView construct_const_view(api::host, const_ptr, extents, pitches);
+
+    MutView construct_mut_view2(std::move(construct_mut_view));
+    ConstView construct_const_view2(std::move(construct_const_view));
+    [[maybe_unused]] ConstView construct_const_view3(std::move(construct_mut_view2));
+    // should not compile
+    // MutView construct_mut_view3(std::move(construct_const_view3));
+
+    MutView assign_mut_view(api::host, ptr, extents, pitches);
+    ConstView assign_const_view(api::host, const_ptr, extents, pitches);
+
+    MutView assign_mut_view2 = std::move(assign_mut_view);
+    ConstView assign_const_view2 = std::move(assign_const_view);
+    [[maybe_unused]] ConstView assign_const_view3 = std::move(assign_mut_view2);
+    // should not compile
+    // MutView assign_mut_view3 = std::move(assign_const_view3);
 }
 
 TEST_CASE("sharedBuffer inner const copy constructor", "[mem][correctness]")

--- a/tests/unit/mem/lifetime.cpp
+++ b/tests/unit/mem/lifetime.cpp
@@ -6,9 +6,74 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <vector>
+
 using namespace alpaka;
 
-TEST_CASE("copy SharedBuffer", "[mem][SharedBuffer]")
+template<typename T>
+requires(std::is_trivially_copyable_v<T>)
+void foo()
+{
+}
+
+TEST_CASE("move MdSpan", "[mem][mdspan][lifetime]")
+{
+    constexpr size_t size = 10;
+    std::vector<int> data(size);
+    int* ptr = data.data();
+    concepts::Vector auto extents = Vec<uint32_t, 1>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    using MutMdSpan = MdSpan<int, decltype(extents), decltype(pitches)>;
+    using ConstMdSpan = MdSpan<int const, decltype(extents), decltype(pitches)>;
+
+    // static_assert(std::is_trivially_copyable_v<MutMdSpan>);
+    foo<MutMdSpan>();
+
+    MutMdSpan mdspan = MdSpan(ptr, extents, pitches);
+    REQUIRE(mdspan);
+    REQUIRE(mdspan.data() != nullptr);
+
+    [[maybe_unused]] ConstMdSpan other_mdspan = std::move(mdspan);
+    REQUIRE(mdspan);
+    REQUIRE(mdspan.data() != nullptr);
+    REQUIRE(other_mdspan);
+    REQUIRE(other_mdspan.data() != nullptr);
+
+    // because moving a mdspan does a copy, the original mdspan should be still valid after the move
+    REQUIRE(mdspan.data() == other_mdspan.data());
+    REQUIRE(mdspan.getExtents() == other_mdspan.getExtents());
+    REQUIRE(mdspan.getPitches() == other_mdspan.getPitches());
+}
+
+TEST_CASE("move View", "[mem][view][lifetime]")
+{
+    constexpr size_t size = 10;
+    std::vector<int> data(size);
+    int* ptr = data.data();
+    concepts::Vector auto extents = Vec<uint32_t, 1>{}.all(size);
+    concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
+
+    using MutView = View<alpaka::api::Host, int, decltype(extents)>;
+    using ConstView = View<alpaka::api::Host, int const, decltype(extents)>;
+
+    MutView view(api::host, ptr, extents, pitches);
+    REQUIRE(view);
+    REQUIRE(view.data() != nullptr);
+
+    [[maybe_unused]] ConstView const_view = std::move(view);
+    REQUIRE(view);
+    REQUIRE(view.data() != nullptr);
+    REQUIRE(const_view);
+    REQUIRE(const_view.data() != nullptr);
+
+    // because moving a view does a copy, the original view should be still valid after the move
+    REQUIRE(view.data() == const_view.data());
+    REQUIRE(view.getExtents() == const_view.getExtents());
+    REQUIRE(view.getPitches() == const_view.getPitches());
+}
+
+TEST_CASE("copy SharedBuffer", "[mem][sharedBuffer][lifetime]")
 {
     onHost::SharedBuffer buffer = onHost::allocHost<int>(Vec<unsigned int, 1>{10});
     REQUIRE(buffer.getUseCount() == 1);
@@ -20,7 +85,7 @@ TEST_CASE("copy SharedBuffer", "[mem][SharedBuffer]")
     REQUIRE(buffer2);
 }
 
-TEST_CASE("move SharedBuffer", "[mem][SharedBuffer]")
+TEST_CASE("move SharedBuffer", "[mem][sharedBuffer][lifetime]")
 {
     onHost::SharedBuffer buffer = onHost::allocHost<int>(Vec<unsigned int, 1>{10});
     REQUIRE(buffer.getUseCount() == 1);
@@ -46,7 +111,7 @@ struct LivingMemory
     int live_counter = 1;
 };
 
-TEST_CASE("lifetime of shared memory", "[mem][SharedBuffer]")
+TEST_CASE("lifetime of shared memory", "[mem][sharedBuffer][lifetime]")
 {
     concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(1);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
@@ -124,7 +189,7 @@ void funcUniversalRefMoved(auto&& buffer, long const expected_use_count)
     REQUIRE(tmp_buffer.getUseCount() == expected_use_count);
 }
 
-TEST_CASE("pass shared memory to function", "[mem][SharedBuffer]")
+TEST_CASE("pass shared memory to function", "[mem][sharedBuffer][lifetime]")
 {
     concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(1);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);

--- a/tests/unit/mem/lifetime.cpp
+++ b/tests/unit/mem/lifetime.cpp
@@ -10,12 +10,6 @@
 
 using namespace alpaka;
 
-template<typename T>
-requires(std::is_trivially_copyable_v<T>)
-void foo()
-{
-}
-
 TEST_CASE("move MdSpan", "[mem][mdspan][lifetime]")
 {
     constexpr size_t size = 10;
@@ -27,8 +21,9 @@ TEST_CASE("move MdSpan", "[mem][mdspan][lifetime]")
     using MutMdSpan = MdSpan<int, decltype(extents), decltype(pitches)>;
     using ConstMdSpan = MdSpan<int const, decltype(extents), decltype(pitches)>;
 
-    // static_assert(std::is_trivially_copyable_v<MutMdSpan>);
-    foo<MutMdSpan>();
+    // mdspan needs to be trivial copyable, otherwise it cannot be passed to the kernel
+    static_assert(std::is_trivially_copyable_v<MutMdSpan>);
+    static_assert(std::is_trivially_copyable_v<ConstMdSpan>);
 
     MutMdSpan mdspan = MdSpan(ptr, extents, pitches);
     REQUIRE(mdspan);


### PR DESCRIPTION
We allow to copy/move data sources with the following inner data types to other objects with the same type with the corresponding (different) inner data type
  - mutable -> mutable
  - const -> const
  - mutable -> const

# ToDo
- [x] merge #270 
- [x] implement constructors for `alpaka::SharedBuffer`
- [x] verify that move of `alpaka::SharedBuffer` is working and no copy is done
- [x] implement constructors for `alpaka::View`
- [x] finish `alpaka::SharedBuffer` tests
- [x] implement bool operator for `alpaka::mdspan` and `alpaka::View` and extent `alpaka::concepts::impl::IMdSpan`