### PR TITLE
fix `ALPAKA_AMDGPU_ARCH`

### DIFF
--- a/include/alpaka/core/config.hpp
+++ b/include/alpaka/core/config.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "alpaka/core/PP.hpp"
+#include "alpaka/core/hipConfig.hpp"
 
 // guard cmake target alpaka
 #if defined(ALPAKA_CMAKE_TARGET_ALPAKA) && !defined(ALPAKA_CMAKE_TARGET_ALPAKA_FINALIZE_CALLED)

--- a/include/alpaka/core/hipConfig.hpp
+++ b/include/alpaka/core/hipConfig.hpp
@@ -6,7 +6,8 @@
 
 #include "alpaka/core/PP.hpp"
 
-#if ALPAKA_LANG_HIP
+// We can not use ALPAKA_LANG_HIP because this file is required by core/config.hpp where ALPAKA_LANG_HIP is defined.
+#if defined(__HIP__)
 
 #    include <hip/hip_version.h>
 


### PR DESCRIPTION
- fix missing include and cyclic dependency.
Because of this bug, the HIP memfence tests failed at runtime.