### PR TITLE
rename `memoryFence` to `memFence` and `namespace memoryScope` to `scope`

### DIFF
--- a/docs/snippets/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet.cpp
@@ -131,12 +131,12 @@ struct MemoryFenceKernel
 {
     ALPAKA_FN_ACC void operator()(onAcc::concepts::Acc auto const& acc) const
     {
-        // BEGIN-CHEATSHEET-memoryFence
+        // BEGIN-CHEATSHEET-memFence
         // Scopes: All threads of the block, the device and the system(host and peer devices)
-        onAcc::memoryFence(acc, onAcc::memoryScope::block);
-        onAcc::memoryFence(acc, onAcc::memoryScope::device);
-        onAcc::memoryFence(acc, onAcc::memoryScope::system);
-        // END-CHEATSHEET-memoryFence
+        onAcc::memFence(acc, onAcc::scope::block);
+        onAcc::memFence(acc, onAcc::scope::device);
+        onAcc::memFence(acc, onAcc::scope::system);
+        // END-CHEATSHEET-memFence
     }
 };
 

--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -355,8 +355,8 @@ Memory fences on block-, device- or system level (guarantees LoadLoad and StoreS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   .. literalinclude:: ../../snippets/cheatsheet.cpp
     :language: cpp
-    :start-after: BEGIN-CHEATSHEET-memoryFence
-    :end-before: END-CHEATSHEET-memoryFence
+    :start-after: BEGIN-CHEATSHEET-memFence
+    :end-before: END-CHEATSHEET-memFence
     :dedent:
 
 Math functions

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -30,7 +30,7 @@
 #include "alpaka/onAcc/SimdAlgo.hpp"
 #include "alpaka/onAcc/atomic.hpp"
 #include "alpaka/onAcc/interface.hpp"
-#include "alpaka/onAcc/memoryFence.hpp"
+#include "alpaka/onAcc/memFence.hpp"
 #include "alpaka/onAcc/tag.hpp"
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/onHost/DeviceSelector.hpp"

--- a/include/alpaka/api/cpu.hpp
+++ b/include/alpaka/api/cpu.hpp
@@ -10,4 +10,4 @@
 #include "alpaka/api/host/Platform.hpp"
 #include "alpaka/api/host/Queue.hpp"
 #include "alpaka/api/host/atomic.hpp"
-#include "alpaka/api/host/memoryFence.hpp"
+#include "alpaka/api/host/memFence.hpp"

--- a/include/alpaka/api/host/memFence.hpp
+++ b/include/alpaka/api/host/memFence.hpp
@@ -9,7 +9,7 @@
 #include "alpaka/api/host/tag.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/onAcc/Acc.hpp"
-#include "alpaka/onAcc/memoryScope.hpp"
+#include "alpaka/onAcc/scope.hpp"
 #include "alpaka/tag.hpp"
 
 #include <atomic>
@@ -27,32 +27,32 @@ namespace alpaka::onAcc::internalCompute
 
         // Serial executor fence implementation
         // Block scope: nothing to do for serial
-        inline void hostMemoryFenceImpl(exec::CpuSerial const&, memoryScope::Block const)
+        inline void hostMemoryFenceImpl(exec::CpuSerial const&, scope::Block const)
         {
             // Block scope: NO-OP since threads within a block
         }
 
-        inline void hostMemoryFenceImpl(exec::CpuSerial const&, memoryScope::Device const)
+        inline void hostMemoryFenceImpl(exec::CpuSerial const&, scope::Device const)
         {
             std::atomic_thread_fence(std::memory_order_acq_rel);
         }
 
-        inline void hostMemoryFenceImpl(exec::CpuSerial const&, memoryScope::System const)
+        inline void hostMemoryFenceImpl(exec::CpuSerial const&, scope::System const)
         {
             std::atomic_thread_fence(std::memory_order_acq_rel);
         }
 
-        inline void hostMemoryFenceImpl(exec::CpuOmpBlocks const&, memoryScope::Block const)
+        inline void hostMemoryFenceImpl(exec::CpuOmpBlocks const&, scope::Block const)
         {
             // Block scope: NO-OP for OMP since single-threaded within a block
         }
 
-        inline void hostMemoryFenceImpl(exec::CpuOmpBlocks const&, memoryScope::Device const)
+        inline void hostMemoryFenceImpl(exec::CpuOmpBlocks const&, scope::Device const)
         {
             std::atomic_thread_fence(std::memory_order_acq_rel);
         }
 
-        inline void hostMemoryFenceImpl(exec::CpuOmpBlocks const&, memoryScope::System const)
+        inline void hostMemoryFenceImpl(exec::CpuOmpBlocks const&, scope::System const)
         {
             std::atomic_thread_fence(std::memory_order_acq_rel);
         }

--- a/include/alpaka/api/oneApi.hpp
+++ b/include/alpaka/api/oneApi.hpp
@@ -13,4 +13,4 @@
 #include "alpaka/api/syclGeneric/Event.hpp"
 #include "alpaka/api/syclGeneric/atomic.hpp"
 #include "alpaka/api/syclGeneric/math.hpp"
-#include "alpaka/api/syclGeneric/memoryFence.hpp"
+#include "alpaka/api/syclGeneric/memFence.hpp"

--- a/include/alpaka/api/syclGeneric/memFence.hpp
+++ b/include/alpaka/api/syclGeneric/memFence.hpp
@@ -8,7 +8,7 @@
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/onAcc/Acc.hpp"
-#include "alpaka/onAcc/memoryScope.hpp"
+#include "alpaka/onAcc/scope.hpp"
 
 // Top-level guard needed because including sycl headers is needed
 #if ALPAKA_LANG_SYCL
@@ -24,15 +24,15 @@ namespace alpaka::onAcc::internalCompute
     {
         constexpr void operator()(onAcc::concepts::Acc auto const&, T_Scope const) const
         {
-            if constexpr(std::is_same_v<T_Scope, memoryScope::Block>)
+            if constexpr(std::is_same_v<T_Scope, scope::Block>)
             {
                 sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::work_group);
             }
-            else if constexpr(std::is_same_v<T_Scope, memoryScope::Device>)
+            else if constexpr(std::is_same_v<T_Scope, scope::Device>)
             {
                 sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::device);
             }
-            else if constexpr(std::is_same_v<T_Scope, memoryScope::System>)
+            else if constexpr(std::is_same_v<T_Scope, scope::System>)
             {
                 // System fences map to device scope for SYCL backends
                 sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::system);

--- a/include/alpaka/api/unifiedCudaHip.hpp
+++ b/include/alpaka/api/unifiedCudaHip.hpp
@@ -12,4 +12,4 @@
 #include "alpaka/api/unifiedCudaHip/Queue.hpp"
 #include "alpaka/api/unifiedCudaHip/atomic.hpp"
 #include "alpaka/api/unifiedCudaHip/math.hpp"
-#include "alpaka/api/unifiedCudaHip/memoryFence.hpp"
+#include "alpaka/api/unifiedCudaHip/memFence.hpp"

--- a/include/alpaka/api/unifiedCudaHip/memFence.hpp
+++ b/include/alpaka/api/unifiedCudaHip/memFence.hpp
@@ -7,7 +7,7 @@
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/onAcc/Acc.hpp"
-#include "alpaka/onAcc/memoryScope.hpp"
+#include "alpaka/onAcc/scope.hpp"
 
 #include <type_traits>
 
@@ -27,15 +27,15 @@ namespace alpaka::onAcc::internalCompute
         {
             // Host pass is not allowed.
 #    if ALPAKA_ARCH_PTX || ALPAKA_ARCH_AMD
-            if constexpr(std::is_same_v<T_Scope, memoryScope::Block>)
+            if constexpr(std::is_same_v<T_Scope, scope::Block>)
             {
                 __threadfence_block();
             }
-            else if constexpr(std::is_same_v<T_Scope, memoryScope::Device>)
+            else if constexpr(std::is_same_v<T_Scope, scope::Device>)
             {
                 __threadfence();
             }
-            else if constexpr(std::is_same_v<T_Scope, memoryScope::System>)
+            else if constexpr(std::is_same_v<T_Scope, scope::System>)
             {
                 __threadfence_system();
             }

--- a/include/alpaka/onAcc/memFence.hpp
+++ b/include/alpaka/onAcc/memFence.hpp
@@ -6,7 +6,7 @@
 
 #include "alpaka/core/common.hpp"
 #include "alpaka/onAcc/internal/interface.hpp"
-#include "alpaka/onAcc/memoryScope.hpp"
+#include "alpaka/onAcc/scope.hpp"
 
 #include <type_traits>
 
@@ -14,7 +14,7 @@ namespace alpaka::onAcc
 {
     // Main entry point for thread fences
     // The forwarder as a free function, forwarding to the internalCompute namespace
-    constexpr void memoryFence(auto const& acc, auto const scope)
+    constexpr void memFence(auto const& acc, auto const scope)
     {
         // All specialisations are in internalCompute namespace. Dispatching to the appropriate backend.
         internalCompute::MemoryFence::Op<ALPAKA_TYPEOF(acc.getApi()), ALPAKA_TYPEOF(scope)>{}(acc, scope);

--- a/include/alpaka/onAcc/scope.hpp
+++ b/include/alpaka/onAcc/scope.hpp
@@ -6,7 +6,7 @@
 
 #include <string>
 
-namespace alpaka::onAcc::memoryScope
+namespace alpaka::onAcc::scope
 {
     struct Block
     {
@@ -39,4 +39,4 @@ namespace alpaka::onAcc::memoryScope
 
     inline constexpr System system{};
 
-} // namespace alpaka::onAcc::memoryScope
+} // namespace alpaka::onAcc::scope

--- a/sanitizers/tsan_suppressions.txt
+++ b/sanitizers/tsan_suppressions.txt
@@ -2,8 +2,8 @@
 
 # the active waiting in the events unit test is detected as a data race, but is fine
 race:unit_test_event_event
-race:unit_test_mem_memoryFenceProducerConsumer
-race:unit_test_mem_memoryFenceBasic
+race:unit_test_mem_memFenceProducerConsumer
+race:unit_test_mem_memFenceBasic
 race:docs_test_cheatsheet
 
 # omp library is not instrumented, exclude it

--- a/tests/unit/mem/memFenceBasic.cpp
+++ b/tests/unit/mem/memFenceBasic.cpp
@@ -31,11 +31,11 @@ struct MemoryFenceTestKernel
             // Initial write; any subsequent fence must not block, just enforce visibility / ordering.
             out[idx.x()] = static_cast<uint32_t>(idx.x());
             // Explicit scope form.
-            memoryFence(acc, memoryScope::block);
-            memoryFence(acc, memoryScope::device);
+            memFence(acc, scope::block);
+            memFence(acc, scope::device);
             // Convenience helper forms (should map to identical implementations).
-            onAcc::memoryFence(acc, onAcc::memoryScope::Block{});
-            onAcc::memoryFence(acc, onAcc::memoryScope::Device{});
+            onAcc::memFence(acc, onAcc::scope::Block{});
+            onAcc::memFence(acc, onAcc::scope::Device{});
             // Post‑fence update. If fences caused unintended reordering, test value would mismatch.
             out[idx.x()] += 1u;
         }
@@ -43,7 +43,7 @@ struct MemoryFenceTestKernel
 };
 
 // Run over all enabled backend+executor combinations exposed via TestApis.
-TEMPLATE_LIST_TEST_CASE("thread fence operations", "[memoryFence][basic]", TestApis)
+TEMPLATE_LIST_TEST_CASE("thread fence operations", "[memFence][basic]", TestApis)
 {
     auto cfg = TestType::makeDict();
     auto deviceSpec = cfg[object::deviceSpec];

--- a/tests/unit/mem/memFenceProducerConsumer.cpp
+++ b/tests/unit/mem/memFenceProducerConsumer.cpp
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 /** @file
- * Unit tests for non-blocking memory visibility fences (memoryFence).
+ * Unit tests for non-blocking memory visibility fences (memFence).
  * Contains:
  *  - ProducerConsumerKernel: publication pattern using device-scope fences.
  *  - BlockSharedMemOrderKernel: shared-memory ordering using block-scope fences.
@@ -21,7 +21,7 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, 
 
 // Producer-Consumer kernel documentation:
 //  - Producer (thread 0) publishes a payload (value = iteration index) to global memory,
-//    then issues a device-scope memoryFence to ensure the data write becomes visible
+//    then issues a device-scope memFence to ensure the data write becomes visible
 //    before setting the corresponding ready flag to 1.
 //  - Consumer (thread 1) busy-waits on the ready flag becoming 1, then issues its own
 //    device-scope fence before reading the payload. This is like a typical acquire
@@ -58,7 +58,7 @@ struct ProducerConsumerKernel
                 // Publish payload value first.
                 atomicExch(acc, &payload[i], i);
                 // Ensure payload write is visible before flag store.
-                memoryFence(acc, memoryScope::device);
+                memFence(acc, scope::device);
                 atomicExch(acc, &readyFlags[i], 1u);
             }
             // consumer, only for tid == 1, second thread is consumer
@@ -76,7 +76,7 @@ struct ProducerConsumerKernel
                 // above the while-loop unless the flag read is treated as a dependency (atomic/volatile) and
                 // an acquire fence follows.
 
-                memoryFence(acc, memoryScope::device);
+                memFence(acc, scope::device);
                 auto v = payload[i];
                 if(v != i)
                 {
@@ -88,7 +88,7 @@ struct ProducerConsumerKernel
     }
 };
 
-TEMPLATE_LIST_TEST_CASE("memoryFence producer-consumer publication", "[memoryFence][producer-consumer]", TestApis)
+TEMPLATE_LIST_TEST_CASE("memFence producer-consumer publication", "[memFence][producer-consumer]", TestApis)
 {
     auto cfg = TestType::makeDict();
     auto deviceSpec = cfg[object::deviceSpec];
@@ -153,7 +153,7 @@ struct DeviceFenceTestKernelWriter
         if(idx == 0)
         {
             vars[0] = 10;
-            onAcc::memoryFence(acc, onAcc::memoryScope::Device{});
+            onAcc::memFence(acc, onAcc::scope::Device{});
             vars[1] = 20;
         }
     }
@@ -170,7 +170,7 @@ struct DeviceFenceTestKernelReader
         if(idx == 0)
         {
             auto const b = vars[1];
-            onAcc::memoryFence(acc, onAcc::memoryScope::Device{});
+            onAcc::memFence(acc, onAcc::scope::Device{});
             auto const a = vars[0];
 
             // If the fence is working correctly, the following case can never happen
@@ -194,12 +194,12 @@ struct DeviceFenceTestKernel
         if(idx == 0)
         {
             vars[0] = 10;
-            onAcc::memoryFence(acc, onAcc::memoryScope::Device{});
+            onAcc::memFence(acc, onAcc::scope::Device{});
             vars[1] = 20;
         }
 
         auto const b = vars[1];
-        onAcc::memoryFence(acc, onAcc::memoryScope::Device{});
+        onAcc::memFence(acc, onAcc::scope::Device{});
         auto const a = vars[0];
 
         // If the fence is working correctly, the following case can never happen
@@ -215,7 +215,7 @@ struct DeviceFenceTestKernel
 // Block shared-memory ordering test:
 // Validates that writes to dynamic shared memory from one thread become visible to sibling threads
 // in the same block after a block-scope fence. Pattern mirrors legacy BlockFenceTestKernel from the
-// original alpaka repo but adapted to memoryFence API and Catch2 style.
+// original alpaka repo but adapted to memFence API and Catch2 style.
 struct BlockSharedMemOrderKernel
 {
     // number of bytes of dynamic shared memory required by this kernel
@@ -245,7 +245,7 @@ struct BlockSharedMemOrderKernel
                 // publish new A
                 shared[0] = 10;
                 // ensure visibility of A before B write
-                memoryFence(acc, memoryScope::block);
+                memFence(acc, scope::block);
                 // publish B
                 shared[1] = 20;
             }
@@ -256,7 +256,7 @@ struct BlockSharedMemOrderKernel
             // All threads perform the read/validation (any non-producer could be consumer)
             auto b = shared[1];
             // acquire side
-            memoryFence(acc, memoryScope::block);
+            memFence(acc, scope::block);
             auto a = shared[0];
 
             // Forbidden outcome: observe updated B (20) but stale A (1)
@@ -269,7 +269,7 @@ struct BlockSharedMemOrderKernel
     }
 };
 
-TEMPLATE_LIST_TEST_CASE("memoryFence block shared-memory ordering", "[memoryFence][block-shared]", TestApis)
+TEMPLATE_LIST_TEST_CASE("memFence block shared-memory ordering", "[memFence][block-shared]", TestApis)
 {
     auto cfg = TestType::makeDict();
     auto deviceSpec = cfg[object::deviceSpec];


### PR DESCRIPTION
To harmonize the naming with other folders and functions, we will rename `memory` to `mem`.
Memory scope will become scope and in an separate PR used as substitution for atomic hierarchies too.