### PR TITLE
add CMake install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,461 +5,37 @@
 #
 
 cmake_minimum_required(VERSION 3.25)
-project(alpaka CXX)
+project(alpaka)
 
 # This file's directory.
 set(_alpaka_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
-include(${_alpaka_ROOT_DIR}/cmake/buildDependencies.cmake)
-include(${_alpaka_ROOT_DIR}/cmake/finalize.cmake)
-
-# Add append compiler flags to a variable or target
-#
-# This method is automatically documenting all compile flags added into the variables
-# alpaka_COMPILER_OPTIONS_HOST, alpaka_COMPILER_OPTIONS_DEVICE.
-#
-# scope - which compiler is effected: DEVICE, HOST, or HOST_DEVICE
-# type - type of 'name': var, list, or target
-#        var: space separated list
-#        list: is semicolon separated
-# name - name of the variable or target
-# ... - parameter to appended to the variable or target 'name'
-function(alpaka_set_compiler_options scope type name)
-    if(scope STREQUAL HOST)
-        set(alpaka_COMPILER_OPTIONS_HOST ${alpaka_COMPILER_OPTIONS_HOST} ${ARGN} PARENT_SCOPE)
-    elseif(scope STREQUAL DEVICE)
-        set(alpaka_COMPILER_OPTIONS_DEVICE ${alpaka_COMPILER_OPTIONS_DEVICE} ${ARGN} PARENT_SCOPE)
-    elseif(scope STREQUAL HOST_DEVICE)
-        set(alpaka_COMPILER_OPTIONS_HOST ${alpaka_COMPILER_OPTIONS_HOST} ${ARGN} PARENT_SCOPE)
-        set(alpaka_COMPILER_OPTIONS_DEVICE ${alpaka_COMPILER_OPTIONS_DEVICE} ${ARGN} PARENT_SCOPE)
-    else()
-        message(
-            FATAL_ERROR
-            "alpaka_set_compiler_option 'scope' unknown, value must be 'HOST', 'DEVICE', or 'HOST_DEVICE'."
-        )
-    endif()
-    if(type STREQUAL "list")
-        set(${name} ${${name}} ${ARGN} PARENT_SCOPE)
-    elseif(type STREQUAL "var")
-        foreach(arg IN LISTS ARGN)
-            set(tmp "${tmp} ${arg}")
-        endforeach()
-        set(${name} "${${name}} ${tmp}" PARENT_SCOPE)
-    elseif(type STREQUAL "target")
-        foreach(arg IN LISTS ARGN)
-            target_compile_options(${name} INTERFACE ${arg})
-        endforeach()
-    else()
-        message(
-            FATAL_ERROR
-            "alpaka_set_compiler_option 'type=${type}' unknown, value must be 'list', 'var', or 'target'."
-        )
-    endif()
-endfunction()
-
-# Compiler options
-macro(alpaka_compiler_option name description default)
-    if(NOT DEFINED alpaka_${name})
-        set(alpaka_${name} ${default} CACHE STRING "${description}")
-        set_property(CACHE alpaka_${name} PROPERTY STRINGS "DEFAULT;ON;OFF")
-    endif()
-endmacro()
-
-# Check if compiler supports required C++ standard.
-#
-# language - can be CXX, HIP or CUDA
-# min_cxx_standard - C++ standard which is the minimum requirement
-function(checkCompilerCXXSupport language min_cxx_standard)
-    string(TOUPPER "${language}" language_upper_case)
-    string(TOLOWER "${language}" language_lower_case)
-
-    if(NOT "${language_lower_case}_std_${min_cxx_standard}" IN_LIST CMAKE_${language_upper_case}_COMPILE_FEATURES)
-        message(
-            FATAL_ERROR
-            "The ${language_upper_case} compiler does not support C++ ${min_cxx_standard}. \
-        Please upgrade your compiler or use alpaka 3.0 which supports C++20."
-        )
-    endif()
-endfunction()
-
-set(alpaka_CXX_STANDARD 20 CACHE STRING "C++ standard")
-
-checkcompilercxxsupport(CXX ${alpaka_CXX_STANDARD})
-
-# check for CUDA/HIP language support
-include(CheckLanguage)
-
-option(alpaka_DEP_CUDA "Enable the CUDA as dependency, allows the usage of api::Cuda and exec::gpuCuda." OFF)
-option(alpaka_DEP_HIP "Enable the HIP as dependency, allows the usage of api::Hip and exec::gpuHip" OFF)
-option(alpaka_DEP_OMP "Enable the OpenMP as dependency, allows the usage of exec::cpuOmpBlocks" ON)
-option(alpaka_DEP_ONEAPI "Enable the Intel oneAPI SYCL dependency, allows using exec::oneApi" OFF)
-
-# Unified compiler options
-alpaka_compiler_option(FAST_MATH "Enable fast-math" DEFAULT)
-alpaka_compiler_option(FTZ "Set flush to zero" DEFAULT)
-
-alpaka_compiler_option(RELOCATABLE_DEVICE_CODE "Enable relocatable device code for CUDA, HIP and SYCL devices" DEFAULT)
-
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-    set(alpaka_GCC_CONCEPT_DEPTH
-        5
-        CACHE STRING
-        "Setup for GCC: How many nested concepts are displayed in the event of an error?"
-    )
-endif()
-
-if(NOT TARGET alpaka)
-    ## target: alpaka::header
-    add_library(alpaka_target_headers INTERFACE)
-    add_library(alpaka::headers ALIAS alpaka_target_headers)
-    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_CMAKE_TARGET_HEADERS)
-
-    add_library(alpaka INTERFACE)
-    add_library(alpaka::alpaka ALIAS alpaka)
-    target_compile_definitions(alpaka INTERFACE ALPAKA_CMAKE_TARGET_ALPAKA)
-
-    add_library(alpaka::host ALIAS alpaka_target_headers)
-
-    target_include_directories(
-        alpaka_target_headers
-        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    )
-    target_compile_features(alpaka_target_headers INTERFACE cxx_std_${alpaka_CXX_STANDARD})
-
-    target_link_libraries(alpaka INTERFACE alpaka_target_headers)
-endif()
-
-## GCC compiler
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-    alpaka_set_compiler_options(HOST target alpaka_target_headers "-fconcepts-diagnostics-depth=${alpaka_GCC_CONCEPT_DEPTH}")
-endif()
-
-## OpenMP
-if(alpaka_DEP_OMP)
-    find_package(OpenMP REQUIRED COMPONENTS CXX)
-    target_link_libraries(alpaka_target_headers INTERFACE OpenMP::OpenMP_CXX)
-    message(STATUS "OpenMP found: ${OpenMP_CXX_VERSION}")
-endif()
-
-set(alpaka_COUNT_API_DEPS 0)
-if(alpaka_DEP_CUDA)
-    math(EXPR alpaka_COUNT_API_DEPS "${alpaka_COUNT_API_DEPS} + 1")
-endif()
-if(alpaka_DEP_HIP)
-    math(EXPR alpaka_COUNT_API_DEPS "${alpaka_COUNT_API_DEPS} + 1")
-endif()
-if(alpaka_DEP_ONEAPI)
-    math(EXPR alpaka_COUNT_API_DEPS "${alpaka_COUNT_API_DEPS} + 1")
-endif()
-
-if((NOT alpaka_SUPPRESS_TARGET_WARNING) AND alpaka_COUNT_API_DEPS GREATER 1)
-    message(
-        WARNING
-        "More than one dependency of alpaka_DEP_CUDA, alpaka_DEP_HIP, or alpaka_DEP_ONEAPI is activated. \
-     The cmake taget 'alpaka::alpaka' and 'alpaka' will therefore not linked against any of these. \
-     Please link your app against alpaka::cuda, alpaka::hip, or alpaka::oneapi directly. \
-     This warning can be suppressed by setting 'alpaka_SUPPRESS_TARGET_WARNING'."
-    )
-endif()
-
-## CUDA
-if(alpaka_DEP_CUDA)
-    check_language(CUDA)
-
-    enable_language(CUDA)
-    checkcompilercxxsupport(CUDA ${alpaka_CXX_STANDARD})
-
-    add_library(alpaka_target_cuda INTERFACE)
-    add_library(alpaka::cuda ALIAS alpaka_target_cuda)
-    target_link_libraries(alpaka_target_cuda INTERFACE alpaka_target_headers)
-    set_property(TARGET alpaka_target_cuda PROPERTY CUDA_STANDARD ${alpaka_CXX_STANDARD})
-
-    alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--expt-relaxed-constexpr>")
-
-    option(alpaka_CUDA_EXPT_EXTENDED_LAMBDA "Enable CUDA extended lambda support " ON)
-    if(alpaka_CUDA_EXPT_EXTENDED_LAMBDA)
-        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--extended-lambda>")
-    endif()
-
-    alpaka_compiler_option(CUDA_SHOW_REGISTER "Show kernel registers and create device ASM" DEFAULT)
-
-    if(alpaka_CUDA_SHOW_REGISTER STREQUAL ON)
-        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xptxas -v>")
-    endif()
-
-    alpaka_compiler_option(CUDA_KEEP_FILES "Keep all intermediate files that are generated during internal compilation steps 'CMakeFiles/<targetname>.dir'" DEFAULT)
-    if(alpaka_CUDA_KEEP_FILES STREQUAL ON)
-        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--keep>")
-    endif()
-
-    option(
-        alpaka_CUDA_SHOW_CODELINES
-        "Show kernel lines in cuda-gdb and cuda-memcheck. If alpaka_CUDA_KEEP_FILES is enabled source code will be inlined in ptx."
-        OFF
-    )
-    if(alpaka_CUDA_SHOW_CODELINES)
-        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--source-in-ptx -lineinfo>")
-
-        # This is shaky - We currently don't have a way of checking for the host compiler ID.
-        # See https://gitlab.kitware.com/cmake/cmake/-/issues/20901
-        if(NOT MSVC)
-            alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -rdynamic>")
-        endif()
-        set(alpaka_CUDA_KEEP_FILES ON CACHE BOOL "activate keep files" FORCE)
-    endif()
-
-    if(alpaka_FAST_MATH STREQUAL ON)
-        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--use_fast_math>")
-    endif()
-
-    if(alpaka_FTZ STREQUAL ON)
-        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--ftz=true>")
-    elseif(alpaka_FTZ STREQUAL OFF)
-        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--ftz=false>")
-    endif()
-
-    if(alpaka_DEP_OMP)
-        if(NOT MSVC)
-            alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -fopenmp>")
-
-            # See https://github.com/alpaka-group/alpaka/issues/1755
-            if((${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") AND (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 13))
-                message(STATUS "clang >= 13 detected. Force-setting OpenMP to version 4.5.")
-                alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -fopenmp-version=45>")
-            endif()
-        else()
-            alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /openmp>")
-        endif()
-    endif()
-
-    target_compile_definitions(alpaka_target_cuda INTERFACE ALPAKA_CMAKE_TARGET_CUDA)
-    target_link_libraries(alpaka_target_cuda INTERFACE alpaka::headers)
-
-    if(alpaka_COUNT_API_DEPS EQUAL 1)
-        target_link_libraries(alpaka INTERFACE alpaka_target_cuda)
-    endif()
-endif()
-
-if(alpaka_DEP_HIP)
-    check_language(HIP)
-
-    if(CMAKE_HIP_COMPILER)
-        enable_language(HIP)
-        find_package(hip REQUIRED)
-
-        set(_alpaka_HIP_MIN_VER 6.0)
-        set(_alpaka_HIP_MAX_VER 7.0)
-
-        checkcompilercxxsupport(HIP ${alpaka_CXX_STANDARD})
-
-        # construct hip version only with major and minor level
-        # cannot use hip_VERSION because of the patch level
-        # 6.0 is smaller than 6.0.1234, so _alpaka_HIP_MAX_VER would have to be defined with a large patch level or
-        # the next minor level, e.g. 6.1, would have to be used.
-        set(_hip_MAJOR_MINOR_VERSION "${hip_VERSION_MAJOR}.${hip_VERSION_MINOR}")
-
-        if(
-            ${_hip_MAJOR_MINOR_VERSION} VERSION_LESS ${_alpaka_HIP_MIN_VER}
-            OR ${_hip_MAJOR_MINOR_VERSION} VERSION_GREATER ${_alpaka_HIP_MAX_VER}
-        )
-            message(
-                WARNING
-                "HIP ${_hip_MAJOR_MINOR_VERSION} is not official supported by alpaka. Supported versions: ${_alpaka_HIP_MIN_VER} - ${_alpaka_HIP_MAX_VER}"
-            )
-        endif()
-
-        add_library(alpaka_target_hip INTERFACE)
-        target_link_libraries(alpaka_target_hip INTERFACE alpaka_target_headers)
-        add_library(alpaka::hip ALIAS alpaka_target_hip)
-
-        # let the compiler find the HIP headers also when building host-only code
-        target_include_directories(alpaka_target_hip SYSTEM INTERFACE ${hip_INCLUDE_DIR})
-
-        target_link_libraries(alpaka_target_hip INTERFACE "$<$<LINK_LANGUAGE:CXX>:hip::host>")
-        alpaka_set_compiler_options(HOST_DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:CXX>:-D__HIP_PLATFORM_AMD__>")
-
-        alpaka_compiler_option(HIP_KEEP_FILES "Keep all intermediate files that are generated during internal compilation steps 'CMakeFiles/<targetname>.dir'" OFF)
-        if(alpaka_HIP_KEEP_FILES)
-            alpaka_set_compiler_options(HOST_DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-save-temps>")
-        endif()
-
-        if(alpaka_FAST_MATH STREQUAL ON)
-            alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-ffast-math>")
-        elseif(alpaka_MATH STREQUAL OFF)
-            alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fno-fast-math>")
-        endif()
-
-        if(alpaka_FTZ STREQUAL ON)
-            alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fgpu-flush-denormals-to-zero>")
-        elseif(alpaka_FTZ STREQUAL OFF)
-            alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fno-gpu-flush-denormals-to-zero>")
-        endif()
-
-        if(alpaka_RELOCATABLE_DEVICE_CODE STREQUAL ON)
-            alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fgpu-rdc>")
-            target_link_options(alpaka_target_hip INTERFACE "$<$<LINK_LANGUAGE:HIP>:SHELL:-fgpu-rdc --hip-link>")
-        elseif(alpaka_RELOCATABLE_DEVICE_CODE STREQUAL OFF)
-            alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fno-gpu-rdc>")
-        endif()
-    else()
-        message(FATAL_ERROR "Optional alpaka dependency HIP could not be found!")
-    endif()
-
-    target_compile_definitions(alpaka_target_hip INTERFACE ALPAKA_CMAKE_TARGET_HIP)
-    target_link_libraries(alpaka_target_hip INTERFACE alpaka::headers)
-
-    if(alpaka_COUNT_API_DEPS EQUAL 1)
-        target_link_libraries(alpaka INTERFACE alpaka_target_hip)
-    endif()
-endif()
-
-if(alpaka_DEP_ONEAPI)
-    find_package(IntelSYCL REQUIRED)
-
-    add_library(alpaka_target_oneapi INTERFACE)
-    add_library(alpaka::oneapi ALIAS alpaka_target_oneapi)
-    target_link_libraries(alpaka_target_oneapi INTERFACE alpaka_target_headers)
-    target_link_libraries(alpaka_target_oneapi INTERFACE IntelSYCL::SYCL_CXX)
-
-    if(alpaka_RELOCATABLE_DEVICE_CODE STREQUAL ON)
-        alpaka_set_compiler_options(DEVICE alpaka_target_oneapi alpaka "-fsycl-rdc")
-        target_link_options(alpaka_target_oneapi INTERFACE "-fsycl-rdc")
-    elseif(alpaka_RELOCATABLE_DEVICE_CODE STREQUAL OFF)
-        alpaka_set_compiler_options(DEVICE alpaka_target_oneapi alpaka "-fno-sycl-rdc")
-        target_link_options(alpaka_target_oneapi INTERFACE "-fno-sycl-rdc")
-    endif()
-
-    option(alpaka_ONEAPI_Cpu "Enable oneApi AMD Gpu support in examples/benchmarks and tests" ON)
-    option(alpaka_ONEAPI_IntelGpu "Enable oneAPI Intel Gpu support in examples/benchmarks and tests" ON)
-    option(alpaka_ONEAPI_NvidiaGpu "Enable oneAPI NVIDIA Gpu support in examples/benchmarks and tests" OFF)
-    option(alpaka_ONEAPI_AmdGpu "Enable oneAPI AMD Gpu support in examples/benchmarks and tests" OFF)
-
-    if(alpaka_ONEAPI_Cpu)
-        set(alpaka_ONEAPI_Cpu_ARCH "" CACHE STRING "OneAPI Cpu architecture")
-        list(APPEND custom_SYCL_TARGETS spir64_x86_64)
-        if(alpaka_ONEAPI_Cpu_ARCH)
-            target_link_options(
-                alpaka_target_oneapi
-                INTERFACE -Xsycl-target-backend=spir64_x86_64 -march=${alpaka_ONEAPI_Cpu_ARCH}
-            )
-        endif()
-    else()
-        target_compile_definitions(alpaka_target_oneapi INTERFACE ALPAKA_DISABLE_OneApi_Cpu)
-    endif()
-
-    if(alpaka_ONEAPI_IntelGpu)
-        # spir64 is required for Intel GPUs
-        list(APPEND custom_SYCL_TARGETS spir64)
-    else()
-        target_compile_definitions(alpaka_target_oneapi INTERFACE ALPAKA_DISABLE_OneApi_IntelGpu)
-    endif()
-
-    if(alpaka_ONEAPI_NvidiaGpu)
-        set(alpaka_ONEAPI_NvidiaGpu_ARCH "80" CACHE STRING "OneApi NVIDIA GPU architecture")
-
-        alpaka_set_compiler_options(HOST_DEVICE target alpaka_target_oneapi -Xsycl-target-backend=nvptx64-nvidia-cuda --offload-arch=sm_${alpaka_ONEAPI_NvidiaGpu_ARCH})
-        target_link_options(
-            alpaka_target_oneapi
-            INTERFACE -Xsycl-target-backend=nvptx64-nvidia-cuda --offload-arch=sm_${alpaka_ONEAPI_NvidiaGpu_ARCH}
-        )
-
-        list(APPEND custom_SYCL_TARGETS nvptx64-nvidia-cuda)
-    else()
-        target_compile_definitions(alpaka_target_oneapi INTERFACE ALPAKA_DISABLE_OneApi_NvidiaGpu)
-    endif()
-
-    if(alpaka_ONEAPI_AmdGpu)
-        set(alpaka_ONEAPI_AmdGpu_ARCH "gfx1100" CACHE STRING "OneApi AMD GPU architectures")
-
-        # bug if cuda and hip is used within one system: https://github.com/intel/llvm/issues/15632
-        alpaka_set_compiler_options(HOST_DEVICE target alpaka_target_oneapi -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${alpaka_ONEAPI_AmdGpu_ARCH})
-        target_link_options(
-            alpaka_target_oneapi
-            INTERFACE -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${alpaka_ONEAPI_AmdGpu_ARCH}
-        )
-        list(APPEND custom_SYCL_TARGETS amdgcn-amd-amdhsa)
-    else()
-        target_compile_definitions(alpaka_target_oneapi INTERFACE ALPAKA_DISABLE_OneApi_AmdGpu)
-    endif()
-
-    if(custom_SYCL_TARGETS)
-        # to enable compilation for multiple GPU architectures, we need to create a list of GPU targets
-        list(JOIN custom_SYCL_TARGETS "," custom_SYCL_TARGETS_CONCAT)
-        alpaka_set_compiler_options(HOST_DEVICE target alpaka_target_oneapi INTERFACE "-fsycl-targets=${custom_SYCL_TARGETS_CONCAT}")
-        target_link_options(alpaka_target_oneapi INTERFACE "-fsycl-targets=${custom_SYCL_TARGETS_CONCAT}")
-    endif()
-
-    if(alpaka_FAST_MATH STREQUAL ON)
-        alpaka_set_compiler_options(DEVICE target alpaka_target_oneapi "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-ffast-math>")
-    elseif(alpaka_MATH STREQUAL OFF)
-        alpaka_set_compiler_options(DEVICE target alpaka_target_oneapi "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-fno-fast-math>")
-    endif()
-
-    if(alpaka_FTZ STREQUAL ON)
-        alpaka_set_compiler_options(DEVICE target alpaka_target_oneapi "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-ftz>")
-    elseif(alpaka_FTZ STREQUAL OFF)
-        alpaka_set_compiler_options(DEVICE target alpaka_target_oneapi "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-no-ftz>")
-    endif()
-
-    target_compile_definitions(alpaka_target_oneapi INTERFACE ALPAKA_CMAKE_TARGET_ONEAPI)
-    target_link_libraries(alpaka_target_oneapi INTERFACE alpaka::headers)
-
-    if(alpaka_COUNT_API_DEPS EQUAL 1)
-        target_link_libraries(alpaka INTERFACE alpaka_target_oneapi)
-    endif()
-endif()
-
-## search for atomic ref
-
-# Check for C++20 std::atomic_ref first
-try_compile(
-    alpaka_HAS_STD_ATOMIC_REF # Result stored here
-    "${PROJECT_BINARY_DIR}/alpakaFeatureTests" # Binary directory for output file
-    SOURCES
-        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/tests/StdAtomicRef.cpp" # Source file
-    CXX_STANDARD 20
-    CXX_STANDARD_REQUIRED TRUE
-    CXX_EXTENSIONS FALSE
-)
-if(alpaka_HAS_STD_ATOMIC_REF AND (NOT alpaka_ACC_CPU_DISABLE_ATOMIC_REF))
-    message(STATUS "std::atomic_ref<T> found")
-    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_HAS_STD_ATOMIC_REF)
-else()
-    message(STATUS "std::atomic_ref<T> NOT found")
-endif()
-
-if(NOT alpaka_HAS_STD_ATOMIC_REF)
-    if(Boost_ATOMIC_FOUND)
-        message(STATUS "boost::atomic_ref<T> found")
-        target_link_libraries(alpaka_target_headers INTERFACE Boost::atomic)
-    else()
-        message(STATUS "boost::atomic_ref<T> NOT found")
-    endif()
-endif()
-
-if((NOT alpaka_HAS_STD_ATOMIC_REF) AND (NOT Boost_ATOMIC_FOUND))
-    message(
-        STATUS
-        "atomic_ref<T> or boost::atomic_ref<T> was not found or manually disabled. Falling back to lock-based CPU atomics."
-    )
-    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_ATOMIC_ATOMICREF)
-endif()
-
-# alpaka IDE target to make source browsable/editable in IDEs
-file(GLOB_RECURSE alpakaSources "${CMAKE_CURRENT_SOURCE_DIR}/include/**")
-add_custom_target("alpakaIde" SOURCES ${alpakaSources})
-source_group(TREE "${CMAKE_CURRENT_LIST_DIR}/include/alpaka" FILES ${alpakaSources})
-
+# Compiler feature tests.
+set(_alpaka_FEATURE_TESTS_DIR "${_alpaka_ROOT_DIR}/cmake/tests")
+set(_alpaka_CMAKE_DIR "${_alpaka_ROOT_DIR}/cmake")
+set(_alpaka_TESTING_DIR "${_alpaka_ROOT_DIR}/tests")
+# Set include directories
+set(_alpaka_INCLUDE_DIRECTORY "${_alpaka_ROOT_DIR}/include")
+
+# CMake Options
 option(alpaka_TESTING "Enable/Disable testing" OFF)
 option(alpaka_DOCS "Enable/Disable documentation code snippet testing" OFF)
 option(alpaka_BENCHMARKS "Enable/Disable benchmarks" OFF)
 option(alpaka_EXAMPLES "Enable/Disable examples" OFF)
 option(alpaka_HEADERCHECKS "Enable/Disable header check tests" OFF)
 
+# only check for compiler support if this cmake is called with add_subdirectory or examples, benchmarks, ... should be compiled too
+if(
+    NOT PROJECT_NAME STREQUAL CMAKE_PROJECT_NAME
+    OR (alpaka_TESTING OR alpaka_DOCS OR alpaka_BENCHMARKS OR alpaka_EXAMPLES OR alpaka_HEADERCHECKS)
+)
+    include(${_alpaka_CMAKE_DIR}/alpakaCommon.cmake)
+endif()
+
 if(alpaka_TESTING)
     include(CTest)
     enable_testing()
-    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tests")
+    add_subdirectory("${_alpaka_TESTING_DIR}")
 endif()
 
 if(alpaka_DOCS)
@@ -483,121 +59,34 @@ if(alpaka_HEADERCHECKS)
     add_subdirectory(headerCheck)
 endif()
 
-option(alpaka_EXEC_CpuSerial "Enable/Disable serial executor in examples/benchmarks and tests" ON)
-if(NOT alpaka_EXEC_CpuSerial)
-    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_EXEC_CpuSerial)
-endif()
-option(alpaka_EXEC_CpuOmpBlocks "Enable/Disable OpenMP blocks executor in examples/benchmarks and tests" ON)
-if(NOT alpaka_EXEC_CpuOmpBlocks)
-    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_EXEC_CpuOmpBlocks)
-endif()
-option(alpaka_EXEC_GpuCuda "Enable/Disable CUDA executor in examples/benchmarks and tests" ON)
-if(NOT alpaka_EXEC_GpuCuda)
-    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_EXEC_GpuCuda)
-endif()
-option(alpaka_EXEC_GpuHip "Enable/Disable HIP executor in examples/benchmarks and tests" ON)
-if(NOT alpaka_EXEC_GpuHip)
-    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_EXEC_GpuHip)
-endif()
-option(alpaka_EXEC_OneApi "Enable/Disable Intel OneAPI SYCL executor in examples/benchmarks and tests" ON)
-if(NOT alpaka_EXEC_OneApi)
-    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_EXEC_OneApi)
-endif()
+# Installation and config
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
-# These options are used in the alpaka_finalize call
-option(alpaka_ASAN "Enable/Disable linking the address sanitizer for cpu targets" OFF)
-option(alpaka_TSAN "Enable/Disable linking the thread sanitizer for cpu targets" OFF)
-option(alpaka_LSAN "Enable/Disable linking the memory leak sanitizer for cpu targets" OFF)
-option(alpaka_UBSAN "Enable/Disable linking the undefined behavior sanitizer for cpu targets" OFF)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-if(alpaka_TSAN)
-    message(
-        WARNING
-        "Thread sanitizer enabled: You should reduce mmap rnd bits to avoid compile issues: call as root 'sysctl vm.mmap_rnd_bits=28'"
-    )
-endif()
+install(
+    FILES
+        "${_alpaka_ROOT_DIR}/cmake/finalize.cmake"
+        "${_alpaka_ROOT_DIR}/cmake/alpakaCommon.cmake"
+        "${_alpaka_ROOT_DIR}/cmake/alpakaCuda.cmake"
+        "${_alpaka_ROOT_DIR}/cmake/alpakaHip.cmake"
+        "${_alpaka_ROOT_DIR}/cmake/alpakaOneApi.cmake"
+        "${_alpaka_ROOT_DIR}/cmake/buildDependencies.cmake"
+        "${_alpaka_ROOT_DIR}/cmake/common.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/alpaka
+)
 
-set(alpaka_LOG "OFF" CACHE STRING "Set how the logging should be compiled into alpaka")
-set_property(CACHE alpaka_LOG PROPERTY STRINGS "static;dynamic;OFF")
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/alpakaConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/alpakaConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/alpaka
+)
 
-if(${alpaka_LOG} STREQUAL "OFF")
-    set(alpaka_LOG_ENABLED OFF)
-else()
-    set(alpaka_LOG_ENABLED ON)
-endif()
-if(alpaka_LOG_ENABLED)
-    if(${alpaka_LOG} STREQUAL "static")
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_STATIC)
-    endif()
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/alpakaConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/alpaka)
 
-    if(${alpaka_LOG} STREQUAL "dynamic")
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_DYNAMIC)
-    endif()
+# copy tests to the installation
+install(DIRECTORY ${_alpaka_TESTING_DIR} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR} USE_SOURCE_PERMISSIONS)
 
-    option(alpaka_LOG_INDENT "Enable/Disable call stack indention for logging" ON)
-    if(alpaka_LOG_INDENT)
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_INDENT)
-    endif()
-
-    set(alpaka_LOG_DETAIL "short" CACHE STRING "Set how the logging should be compiled into alpaka")
-    set_property(CACHE alpaka_LOG_DETAIL PROPERTY STRINGS "short;long")
-    if(${alpaka_LOG_DETAIL} STREQUAL "short")
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_DETAIL_SHORT)
-    elseif(${alpaka_LOG_DETAIL} STREQUAL "long")
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_DETAIL_LONG)
-    endif()
-
-    option(alpaka_LOG_FUNCTIONS "Enable/Disable logging of function entry and exit" ON)
-    if(alpaka_LOG_FUNCTIONS)
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_ENABLE_LOG_FUNCTIONS)
-    endif()
-
-    option(alpaka_LOG_INFO "Enable/Disable logging of additional information" ON)
-    if(alpaka_LOG_INFO)
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_ENABLE_LOG_INFO)
-    endif()
-    if(${alpaka_LOG} STREQUAL "static")
-        # Set default options for each log level (Device, Event, Memory, Queue, Kernel)
-        option(alpaka_LOG_STATIC_Device "Enable Device logging" ON)
-        option(alpaka_LOG_STATIC_Event "Enable Event logging" ON)
-        option(alpaka_LOG_STATIC_Memory "Enable Memory logging" ON)
-        option(alpaka_LOG_STATIC_Queue "Enable Queue logging" ON)
-        option(alpaka_LOG_STATIC_Kernel "Enable Kernel logging" ON)
-
-        # Initialize bit mask to 0
-        set(alpaka_LOG_STATIC_LVL_MASK 0)
-
-        # Set bit mask based on user-selected options
-        if(alpaka_LOG_STATIC_Device)
-            math(EXPR alpaka_LOG_STATIC_LVL_MASK "${alpaka_LOG_STATIC_LVL_MASK} | 1")
-        endif()
-
-        if(alpaka_LOG_STATIC_Event)
-            math(EXPR alpaka_LOG_STATIC_LVL_MASK "${alpaka_LOG_STATIC_LVL_MASK} | 2")
-        endif()
-
-        if(alpaka_LOG_STATIC_Memory)
-            math(EXPR alpaka_LOG_STATIC_LVL_MASK "${alpaka_LOG_STATIC_LVL_MASK} | 4")
-        endif()
-
-        if(alpaka_LOG_STATIC_Queue)
-            math(EXPR alpaka_LOG_STATIC_LVL_MASK "${alpaka_LOG_STATIC_LVL_MASK} | 8")
-        endif()
-
-        if(alpaka_LOG_STATIC_Kernel)
-            math(EXPR alpaka_LOG_STATIC_LVL_MASK "${alpaka_LOG_STATIC_LVL_MASK} | 16")
-        endif()
-
-        # Convert bitmask string to a numeric value
-        math(EXPR alpaka_LOG_STATIC_LVL_MASK_VALUE "${alpaka_LOG_STATIC_LVL_MASK}")
-
-        # Pass the bit mask to the C++ code via target_compile_definitions
-        target_compile_definitions(
-            alpaka_target_headers
-            INTERFACE ALPAKA_LOG_STATIC_LVL_MASK=${alpaka_LOG_STATIC_LVL_MASK_VALUE}
-        )
-
-        # Print the final bit mask value (for debugging purposes)
-        message(STATUS "define ALPAKA_LOG_STATIC_LVL_MASK is set to: ${alpaka_LOG_STATIC_LVL_MASK_VALUE}")
-    endif()
-endif()
+# File is required to validate the C++20 feature std::atomic_ref
+install(FILES "${_alpaka_FEATURE_TESTS_DIR}/StdAtomicRef.cpp" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/alpaka/tests)

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -1,0 +1,344 @@
+#
+# Copyright 2014-2025 Benjamin Worpitz, René Widera
+# SPDX-License-Identifier: MPL-2.0
+#
+
+# enable CXX because this is not done in the CMakeLists.txt of alpaka
+enable_language(CXX)
+
+include(${_alpaka_CMAKE_DIR}/buildDependencies.cmake)
+include(${_alpaka_CMAKE_DIR}/finalize.cmake)
+include(${_alpaka_CMAKE_DIR}/common.cmake)
+
+# Add append compiler flags to a variable or target
+#
+# This method is automatically documenting all compile flags added into the variables
+# alpaka_COMPILER_OPTIONS_HOST, alpaka_COMPILER_OPTIONS_DEVICE.
+#
+# scope - which compiler is effected: DEVICE, HOST, or HOST_DEVICE
+# type - type of 'name': var, list, or target
+#        var: space separated list
+#        list: is semicolon separated
+# name - name of the variable or target
+# ... - parameter to appended to the variable or target 'name'
+function(alpaka_set_compiler_options scope type name)
+    if(scope STREQUAL HOST)
+        set(alpaka_COMPILER_OPTIONS_HOST ${alpaka_COMPILER_OPTIONS_HOST} ${ARGN} PARENT_SCOPE)
+    elseif(scope STREQUAL DEVICE)
+        set(alpaka_COMPILER_OPTIONS_DEVICE ${alpaka_COMPILER_OPTIONS_DEVICE} ${ARGN} PARENT_SCOPE)
+    elseif(scope STREQUAL HOST_DEVICE)
+        set(alpaka_COMPILER_OPTIONS_HOST ${alpaka_COMPILER_OPTIONS_HOST} ${ARGN} PARENT_SCOPE)
+        set(alpaka_COMPILER_OPTIONS_DEVICE ${alpaka_COMPILER_OPTIONS_DEVICE} ${ARGN} PARENT_SCOPE)
+    else()
+        message(
+            FATAL_ERROR
+            "alpaka_set_compiler_option 'scope' unknown, value must be 'HOST', 'DEVICE', or 'HOST_DEVICE'."
+        )
+    endif()
+    if(type STREQUAL "list")
+        set(${name} ${${name}} ${ARGN} PARENT_SCOPE)
+    elseif(type STREQUAL "var")
+        foreach(arg IN LISTS ARGN)
+            set(tmp "${tmp} ${arg}")
+        endforeach()
+        set(${name} "${${name}} ${tmp}" PARENT_SCOPE)
+    elseif(type STREQUAL "target")
+        foreach(arg IN LISTS ARGN)
+            target_compile_options(${name} INTERFACE ${arg})
+        endforeach()
+    else()
+        message(
+            FATAL_ERROR
+            "alpaka_set_compiler_option 'type=${type}' unknown, value must be 'list', 'var', or 'target'."
+        )
+    endif()
+endfunction()
+
+# Compiler options
+macro(alpaka_compiler_option name description default)
+    if(NOT DEFINED alpaka_${name})
+        set(alpaka_${name} ${default} CACHE STRING "${description}")
+        set_property(CACHE alpaka_${name} PROPERTY STRINGS "DEFAULT;ON;OFF")
+    endif()
+endmacro()
+
+# Check if compiler supports required C++ standard.
+#
+# language - can be CXX, HIP or CUDA
+# min_cxx_standard - C++ standard which is the minimum requirement
+function(checkCompilerCXXSupport language min_cxx_standard)
+    string(TOUPPER "${language}" language_upper_case)
+    string(TOLOWER "${language}" language_lower_case)
+
+    if(NOT "${language_lower_case}_std_${min_cxx_standard}" IN_LIST CMAKE_${language_upper_case}_COMPILE_FEATURES)
+        message(
+            FATAL_ERROR
+            "The ${language_upper_case} compiler does not support C++ ${min_cxx_standard}. \
+        Please upgrade your compiler or use alpaka 3.0 which supports C++20."
+        )
+    endif()
+endfunction()
+
+set(alpaka_CXX_STANDARD 20 CACHE STRING "C++ standard")
+
+checkcompilercxxsupport(CXX ${alpaka_CXX_STANDARD})
+
+# check for CUDA/HIP language support
+include(CheckLanguage)
+
+option(alpaka_DEP_CUDA "Enable the CUDA as dependency, allows the usage of api::Cuda and exec::gpuCuda." OFF)
+option(alpaka_DEP_HIP "Enable the HIP as dependency, allows the usage of api::Hip and exec::gpuHip" OFF)
+option(alpaka_DEP_OMP "Enable the OpenMP as dependency, allows the usage of exec::cpuOmpBlocks" ON)
+option(alpaka_DEP_ONEAPI "Enable the Intel oneAPI SYCL dependency, allows using exec::oneApi" OFF)
+
+# Unified compiler options
+alpaka_compiler_option(FAST_MATH "Enable fast-math" DEFAULT)
+alpaka_compiler_option(FTZ "Set flush to zero" DEFAULT)
+
+alpaka_compiler_option(RELOCATABLE_DEVICE_CODE "Enable relocatable device code for CUDA, HIP and SYCL devices" DEFAULT)
+
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    set(alpaka_GCC_CONCEPT_DEPTH
+        5
+        CACHE STRING
+        "Setup for GCC: How many nested concepts are displayed in the event of an error?"
+    )
+endif()
+
+# Create core targets
+if(NOT TARGET alpaka)
+    ## target: alpaka::header
+    add_library(alpaka_target_headers INTERFACE)
+    add_library(alpaka::headers ALIAS alpaka_target_headers)
+    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_CMAKE_TARGET_HEADERS)
+
+    add_library(alpaka INTERFACE)
+    add_library(alpaka::alpaka ALIAS alpaka)
+    target_compile_definitions(alpaka INTERFACE ALPAKA_CMAKE_TARGET_ALPAKA)
+
+    add_library(alpaka::host ALIAS alpaka_target_headers)
+
+    # the alpaka library itself
+    # SYSTEM voids showing warnings produced by alpaka when used in user applications.
+    if(BUILD_TESTING)
+        target_include_directories(
+            alpaka
+            INTERFACE $<BUILD_INTERFACE:${_alpaka_INCLUDE_DIRECTORY}> $<INSTALL_INTERFACE:include>
+        )
+    else()
+        target_include_directories(
+            alpaka
+            SYSTEM
+            INTERFACE $<BUILD_INTERFACE:${_alpaka_INCLUDE_DIRECTORY}> $<INSTALL_INTERFACE:include>
+        )
+    endif()
+
+    target_include_directories(
+        alpaka_target_headers
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+    target_compile_features(alpaka_target_headers INTERFACE cxx_std_${alpaka_CXX_STANDARD})
+
+    target_link_libraries(alpaka INTERFACE alpaka_target_headers)
+endif()
+
+set(alpaka_COUNT_API_DEPS 0)
+if(alpaka_DEP_CUDA)
+    math(EXPR alpaka_COUNT_API_DEPS "${alpaka_COUNT_API_DEPS} + 1")
+endif()
+if(alpaka_DEP_HIP)
+    math(EXPR alpaka_COUNT_API_DEPS "${alpaka_COUNT_API_DEPS} + 1")
+endif()
+if(alpaka_DEP_ONEAPI)
+    math(EXPR alpaka_COUNT_API_DEPS "${alpaka_COUNT_API_DEPS} + 1")
+endif()
+
+if((NOT alpaka_SUPPRESS_TARGET_WARNING) AND alpaka_COUNT_API_DEPS GREATER 1)
+    message(
+        WARNING
+        "More than one dependency of alpaka_DEP_CUDA, alpaka_DEP_HIP, or alpaka_DEP_ONEAPI is activated. \
+     The cmake taget 'alpaka::alpaka' and 'alpaka' will therefore not linked against any of these. \
+     Please link your app against alpaka::cuda, alpaka::hip, or alpaka::oneapi directly. \
+     This warning can be suppressed by setting 'alpaka_SUPPRESS_TARGET_WARNING'."
+    )
+endif()
+
+# compute device backends
+# required to be included after the alpaka target is available and alpaka_COUNT_API_DEPS is set
+if(alpaka_DEP_CUDA)
+    include(${_alpaka_CMAKE_DIR}/alpakaCuda.cmake)
+endif()
+if(alpaka_DEP_HIP)
+    include(${_alpaka_CMAKE_DIR}/alpakaHip.cmake)
+endif()
+if(alpaka_DEP_ONEAPI)
+    include(${_alpaka_CMAKE_DIR}/alpakaOneApi.cmake)
+endif()
+
+## GCC compiler
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    alpaka_set_compiler_options(HOST target alpaka_target_headers "-fconcepts-diagnostics-depth=${alpaka_GCC_CONCEPT_DEPTH}")
+endif()
+
+## OpenMP
+if(alpaka_DEP_OMP)
+    find_package(OpenMP REQUIRED COMPONENTS CXX)
+    target_link_libraries(alpaka_target_headers INTERFACE OpenMP::OpenMP_CXX)
+    message(STATUS "OpenMP found: ${OpenMP_CXX_VERSION}")
+endif()
+
+## search for atomic ref
+
+# Check for C++20 std::atomic_ref first
+try_compile(
+    alpaka_HAS_STD_ATOMIC_REF # Result stored here
+    "${PROJECT_BINARY_DIR}/alpakaFeatureTests" # Binary directory for output file
+    SOURCES
+        "${_alpaka_FEATURE_TESTS_DIR}/StdAtomicRef.cpp" # Source file
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED TRUE
+    CXX_EXTENSIONS FALSE
+)
+if(alpaka_HAS_STD_ATOMIC_REF AND (NOT alpaka_ACC_CPU_DISABLE_ATOMIC_REF))
+    message(STATUS "std::atomic_ref<T> found")
+    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_HAS_STD_ATOMIC_REF)
+else()
+    message(STATUS "std::atomic_ref<T> NOT found")
+endif()
+
+if(NOT alpaka_HAS_STD_ATOMIC_REF)
+    if(Boost_ATOMIC_FOUND)
+        message(STATUS "boost::atomic_ref<T> found")
+        target_link_libraries(alpaka_target_headers INTERFACE Boost::atomic)
+    else()
+        message(STATUS "boost::atomic_ref<T> NOT found")
+    endif()
+endif()
+
+if((NOT alpaka_HAS_STD_ATOMIC_REF) AND (NOT Boost_ATOMIC_FOUND))
+    message(
+        STATUS
+        "atomic_ref<T> or boost::atomic_ref<T> was not found or manually disabled. Falling back to lock-based CPU atomics."
+    )
+    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_ATOMIC_ATOMICREF)
+endif()
+
+# These options are used in the alpaka_finalize call
+option(alpaka_ASAN "Enable/Disable linking the address sanitizer for cpu targets" OFF)
+option(alpaka_TSAN "Enable/Disable linking the thread sanitizer for cpu targets" OFF)
+option(alpaka_LSAN "Enable/Disable linking the memory leak sanitizer for cpu targets" OFF)
+option(alpaka_UBSAN "Enable/Disable linking the undefined behavior sanitizer for cpu targets" OFF)
+
+if(alpaka_TSAN)
+    message(
+        WARNING
+        "Thread sanitizer enabled: You should reduce mmap rnd bits to avoid compile issues: call as root 'sysctl vm.mmap_rnd_bits=28'"
+    )
+endif()
+
+set(alpaka_LOG "OFF" CACHE STRING "Set how the logging should be compiled into alpaka")
+set_property(CACHE alpaka_LOG PROPERTY STRINGS "static;dynamic;OFF")
+
+if((${alpaka_LOG} STREQUAL "OFF"))
+    set(alpaka_LOG_ENABLED OFF)
+else()
+    set(alpaka_LOG_ENABLED ON)
+endif()
+if(alpaka_LOG_ENABLED)
+    if(${alpaka_LOG} STREQUAL "static")
+        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_STATIC)
+    endif()
+
+    if(${alpaka_LOG} STREQUAL "dynamic")
+        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_DYNAMIC)
+    endif()
+
+    option(alpaka_LOG_INDENT "Enable/Disable call stack indention for logging" ON)
+    if(alpaka_LOG_INDENT)
+        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_INDENT)
+    endif()
+
+    set(alpaka_LOG_DETAIL "short" CACHE STRING "Set how the logging should be compiled into alpaka")
+    set_property(CACHE alpaka_LOG_DETAIL PROPERTY STRINGS "short;long")
+    if(${alpaka_LOG_DETAIL} STREQUAL "short")
+        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_DETAIL_SHORT)
+    elseif(${alpaka_LOG_DETAIL} STREQUAL "long")
+        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_DETAIL_LONG)
+    endif()
+
+    option(alpaka_LOG_FUNCTIONS "Enable/Disable logging of function entry and exit" ON)
+    if(alpaka_LOG_FUNCTIONS)
+        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_ENABLE_LOG_FUNCTIONS)
+    endif()
+
+    option(alpaka_LOG_INFO "Enable/Disable logging of additional information" ON)
+    if(alpaka_LOG_INFO)
+        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_ENABLE_LOG_INFO)
+    endif()
+    if(${alpaka_LOG} STREQUAL "static")
+        # Set default options for each log level (Device, Event, Memory, Queue, Kernel)
+        option(alpaka_LOG_STATIC_Device "Enable Device logging" ON)
+        option(alpaka_LOG_STATIC_Event "Enable Event logging" ON)
+        option(alpaka_LOG_STATIC_Memory "Enable Memory logging" ON)
+        option(alpaka_LOG_STATIC_Queue "Enable Queue logging" ON)
+        option(alpaka_LOG_STATIC_Kernel "Enable Kernel logging" ON)
+
+        # Initialize bit mask to 0
+        set(alpaka_LOG_STATIC_LVL_MASK 0)
+
+        # Set bit mask based on user-selected options
+        if(alpaka_LOG_STATIC_Device)
+            math(EXPR alpaka_LOG_STATIC_LVL_MASK "${alpaka_LOG_STATIC_LVL_MASK} | 1")
+        endif()
+
+        if(alpaka_LOG_STATIC_Event)
+            math(EXPR alpaka_LOG_STATIC_LVL_MASK "${alpaka_LOG_STATIC_LVL_MASK} | 2")
+        endif()
+
+        if(alpaka_LOG_STATIC_Memory)
+            math(EXPR alpaka_LOG_STATIC_LVL_MASK "${alpaka_LOG_STATIC_LVL_MASK} | 4")
+        endif()
+
+        if(alpaka_LOG_STATIC_Queue)
+            math(EXPR alpaka_LOG_STATIC_LVL_MASK "${alpaka_LOG_STATIC_LVL_MASK} | 8")
+        endif()
+
+        if(alpaka_LOG_STATIC_Kernel)
+            math(EXPR alpaka_LOG_STATIC_LVL_MASK "${alpaka_LOG_STATIC_LVL_MASK} | 16")
+        endif()
+
+        # Convert bitmask string to a numeric value
+        math(EXPR alpaka_LOG_STATIC_LVL_MASK_VALUE "${alpaka_LOG_STATIC_LVL_MASK}")
+
+        # Pass the bit mask to the C++ code via target_compile_definitions
+        target_compile_definitions(
+            alpaka_target_headers
+            INTERFACE ALPAKA_LOG_STATIC_LVL_MASK=${alpaka_LOG_STATIC_LVL_MASK_VALUE}
+        )
+
+        # Print the final bit mask value (for debugging purposes)
+        message(STATUS "define ALPAKA_LOG_STATIC_LVL_MASK is set to: ${alpaka_LOG_STATIC_LVL_MASK_VALUE}")
+    endif()
+endif()
+
+# CMake executor options for tests/benchmarks and examples
+option(alpaka_EXEC_CpuSerial "Enable/Disable serial executor in examples/benchmarks and tests" ON)
+if(NOT alpaka_EXEC_CpuSerial)
+    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_EXEC_CpuSerial)
+endif()
+option(alpaka_EXEC_CpuOmpBlocks "Enable/Disable OpenMP blocks executor in examples/benchmarks and tests" ON)
+if(NOT alpaka_EXEC_CpuOmpBlocks)
+    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_EXEC_CpuOmpBlocks)
+endif()
+option(alpaka_EXEC_GpuCuda "Enable/Disable CUDA executor in examples/benchmarks and tests" ON)
+if(NOT alpaka_EXEC_GpuCuda)
+    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_EXEC_GpuCuda)
+endif()
+option(alpaka_EXEC_GpuHip "Enable/Disable HIP executor in examples/benchmarks and tests" ON)
+if(NOT alpaka_EXEC_GpuHip)
+    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_EXEC_GpuHip)
+endif()
+option(alpaka_EXEC_OneApi "Enable/Disable Intel OneAPI SYCL executor in examples/benchmarks and tests" ON)
+if(NOT alpaka_EXEC_OneApi)
+    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_EXEC_OneApi)
+endif()

--- a/cmake/alpakaConfig.cmake.in
+++ b/cmake/alpakaConfig.cmake.in
@@ -1,0 +1,33 @@
+#
+# Copyright 2025 René Widera
+# SPDX-License-Identifier: MPL-2.0
+#
+
+@PACKAGE_INIT@
+
+#-------------------------------------------------------------------------------
+# Common.
+
+# alpaka root directory
+set(_alpaka_ROOT_DIR "@CMAKE_INSTALL_PREFIX@")
+# Compiler feature tests.
+set(_alpaka_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+# Tests, this is required because the used compiler can differ compared to the compiler used for installation.
+set(_alpaka_FEATURE_TESTS_DIR "${_alpaka_CMAKE_DIR}/tests")
+set(_alpaka_TESTING_DIR "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_DATAROOTDIR@/tests")
+
+set(_alpaka_INCLUDE_DIRECTORY "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@")
+
+include("${_alpaka_CMAKE_DIR}/alpakaCommon.cmake")
+
+check_required_components(alpaka)
+
+# CMake Options to activate testing with the currently selected environment
+option(alpaka_TESTING "Enable/Disable testing" OFF)
+
+if(alpaka_TESTING)
+    include(CTest)
+    enable_testing()
+    add_subdirectory("${_alpaka_TESTING_DIR}" "${CMAKE_BINARY_DIR}/alpaka/tests")
+endif()

--- a/cmake/alpakaCuda.cmake
+++ b/cmake/alpakaCuda.cmake
@@ -1,0 +1,92 @@
+#
+# Copyright 2025 René Widera
+# SPDX-License-Identifier: MPL-2.0
+#
+
+# This file assumes that the alpaka target is available and alpaka_COUNT_API_DEPS is set
+if(NOT TARGET alpaka)
+    message(FATAL_ERROR "No alpaka target available.")
+endif()
+
+if(NOT DEFINED alpaka_COUNT_API_DEPS)
+    message(FATAL_ERROR "internal variable 'alpaka_COUNT_API_DEPS' must be defined.")
+endif()
+
+check_language(CUDA)
+
+if(CMAKE_CUDA_COMPILER)
+    enable_language(CUDA)
+    checkcompilercxxsupport(CUDA ${alpaka_CXX_STANDARD})
+
+    if(NOT TARGET alpaka::cuda)
+        add_library(alpaka_target_cuda INTERFACE)
+        add_library(alpaka::cuda ALIAS alpaka_target_cuda)
+        target_link_libraries(alpaka_target_cuda INTERFACE alpaka_target_headers)
+        set_property(TARGET alpaka_target_cuda PROPERTY CUDA_STANDARD ${alpaka_CXX_STANDARD})
+    endif()
+
+    alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--expt-relaxed-constexpr>")
+
+    option(alpaka_CUDA_EXPT_EXTENDED_LAMBDA "Enable CUDA extended lambda support " ON)
+    if(alpaka_CUDA_EXPT_EXTENDED_LAMBDA)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--extended-lambda>")
+    endif()
+
+    alpaka_compiler_option(CUDA_SHOW_REGISTER "Show kernel registers and create device ASM" DEFAULT)
+
+    if(alpaka_CUDA_SHOW_REGISTER STREQUAL ON)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xptxas -v>")
+    endif()
+
+    alpaka_compiler_option(CUDA_KEEP_FILES "Keep all intermediate files that are generated during internal compilation steps 'CMakeFiles/<targetname>.dir'" DEFAULT)
+    if(alpaka_CUDA_KEEP_FILES STREQUAL ON)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--keep>")
+    endif()
+
+    option(
+        alpaka_CUDA_SHOW_CODELINES
+        "Show kernel lines in cuda-gdb and cuda-memcheck. If alpaka_CUDA_KEEP_FILES is enabled source code will be inlined in ptx."
+        OFF
+    )
+    if(alpaka_CUDA_SHOW_CODELINES)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--source-in-ptx -lineinfo>")
+
+        # This is shaky - We currently don't have a way of checking for the host compiler ID.
+        # See https://gitlab.kitware.com/cmake/cmake/-/issues/20901
+        if(NOT MSVC)
+            alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -rdynamic>")
+        endif()
+        set(alpaka_CUDA_KEEP_FILES ON CACHE BOOL "activate keep files" FORCE)
+    endif()
+
+    if(alpaka_FAST_MATH STREQUAL ON)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--use_fast_math>")
+    endif()
+
+    if(alpaka_FTZ STREQUAL ON)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--ftz=true>")
+    elseif(alpaka_FTZ STREQUAL OFF)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--ftz=false>")
+    endif()
+
+    if(alpaka_DEP_OMP)
+        if(NOT MSVC)
+            alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -fopenmp>")
+
+            # See https://github.com/alpaka-group/alpaka/issues/1755
+            if((${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang") AND (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 13))
+                message(STATUS "clang >= 13 detected. Force-setting OpenMP to version 4.5.")
+                alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -fopenmp-version=45>")
+            endif()
+        else()
+            alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /openmp>")
+        endif()
+    endif()
+
+    target_compile_definitions(alpaka_target_cuda INTERFACE ALPAKA_CMAKE_TARGET_CUDA)
+    target_link_libraries(alpaka_target_cuda INTERFACE alpaka::headers)
+
+    if(alpaka_COUNT_API_DEPS EQUAL 1)
+        target_link_libraries(alpaka INTERFACE alpaka_target_cuda)
+    endif()
+endif()

--- a/cmake/alpakaHip.cmake
+++ b/cmake/alpakaHip.cmake
@@ -1,0 +1,86 @@
+#
+# Copyright 2025 René Widera
+# SPDX-License-Identifier: MPL-2.0
+#
+
+# This file assumes that the alpaka target is available and alpaka_COUNT_API_DEPS is set
+if(NOT TARGET alpaka)
+    message(FATAL_ERROR "No alpaka target available.")
+endif()
+
+if(NOT DEFINED alpaka_COUNT_API_DEPS)
+    message(FATAL_ERROR "internal variable 'alpaka_COUNT_API_DEPS' must be defined.")
+endif()
+
+check_language(HIP)
+
+if(CMAKE_HIP_COMPILER)
+    enable_language(HIP)
+    find_package(hip REQUIRED)
+
+    set(_alpaka_HIP_MIN_VER 6.0)
+    set(_alpaka_HIP_MAX_VER 7.0)
+
+    checkcompilercxxsupport(HIP ${alpaka_CXX_STANDARD})
+
+    # construct hip version only with major and minor level
+    # cannot use hip_VERSION because of the patch level
+    # 6.0 is smaller than 6.0.1234, so _alpaka_HIP_MAX_VER would have to be defined with a large patch level or
+    # the next minor level, e.g. 6.1, would have to be used.
+    set(_hip_MAJOR_MINOR_VERSION "${hip_VERSION_MAJOR}.${hip_VERSION_MINOR}")
+
+    if(
+        ${_hip_MAJOR_MINOR_VERSION} VERSION_LESS ${_alpaka_HIP_MIN_VER}
+        OR ${_hip_MAJOR_MINOR_VERSION} VERSION_GREATER ${_alpaka_HIP_MAX_VER}
+    )
+        message(
+            WARNING
+            "HIP ${_hip_MAJOR_MINOR_VERSION} is not official supported by alpaka. Supported versions: ${_alpaka_HIP_MIN_VER} - ${_alpaka_HIP_MAX_VER}"
+        )
+    endif()
+
+    if(NOT TARGET alpaka::hip)
+        add_library(alpaka_target_hip INTERFACE)
+        target_link_libraries(alpaka_target_hip INTERFACE alpaka_target_headers)
+        add_library(alpaka::hip ALIAS alpaka_target_hip)
+    endif()
+
+    # let the compiler find the HIP headers also when building host-only code
+    target_include_directories(alpaka_target_hip SYSTEM INTERFACE ${hip_INCLUDE_DIR})
+
+    target_link_libraries(alpaka_target_hip INTERFACE "$<$<LINK_LANGUAGE:CXX>:hip::host>")
+    alpaka_set_compiler_options(HOST_DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:CXX>:-D__HIP_PLATFORM_AMD__>")
+
+    alpaka_compiler_option(HIP_KEEP_FILES "Keep all intermediate files that are generated during internal compilation steps 'CMakeFiles/<targetname>.dir'" OFF)
+    if(alpaka_HIP_KEEP_FILES)
+        alpaka_set_compiler_options(HOST_DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-save-temps>")
+    endif()
+
+    if(alpaka_FAST_MATH STREQUAL ON)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-ffast-math>")
+    elseif(alpaka_MATH STREQUAL OFF)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fno-fast-math>")
+    endif()
+
+    if(alpaka_FTZ STREQUAL ON)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fgpu-flush-denormals-to-zero>")
+    elseif(alpaka_FTZ STREQUAL OFF)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fno-gpu-flush-denormals-to-zero>")
+    endif()
+
+    if(alpaka_RELOCATABLE_DEVICE_CODE STREQUAL ON)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fgpu-rdc>")
+        target_link_options(alpaka_target_hip INTERFACE "$<$<LINK_LANGUAGE:HIP>:SHELL:-fgpu-rdc --hip-link>")
+    elseif(alpaka_RELOCATABLE_DEVICE_CODE STREQUAL OFF)
+        alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fno-gpu-rdc>")
+    endif()
+else()
+    message(FATAL_ERROR "Optional alpaka dependency HIP could not be found!")
+endif()
+
+target_compile_definitions(alpaka_target_hip INTERFACE ALPAKA_CMAKE_TARGET_HIP)
+target_link_libraries(alpaka_target_hip INTERFACE alpaka::headers)
+
+if(alpaka_COUNT_API_DEPS EQUAL 1)
+    target_link_libraries(alpaka INTERFACE alpaka_target_hip)
+endif()

--- a/cmake/alpakaOneApi.cmake
+++ b/cmake/alpakaOneApi.cmake
@@ -1,0 +1,109 @@
+#
+# Copyright 2025 René Widera
+# SPDX-License-Identifier: MPL-2.0
+#
+
+# This file assumes that the alpaka target is available and alpaka_COUNT_API_DEPS is set
+if(NOT TARGET alpaka)
+    message(FATAL_ERROR "No alpaka target available.")
+endif()
+
+if(NOT DEFINED alpaka_COUNT_API_DEPS)
+    message(FATAL_ERROR "internal variable 'alpaka_COUNT_API_DEPS' must be defined.")
+endif()
+
+find_package(IntelSYCL REQUIRED)
+
+if(NOT TARGET alpaka::oneapi)
+    add_library(alpaka_target_oneapi INTERFACE)
+    add_library(alpaka::oneapi ALIAS alpaka_target_oneapi)
+    target_link_libraries(alpaka_target_oneapi INTERFACE alpaka_target_headers)
+    target_link_libraries(alpaka_target_oneapi INTERFACE IntelSYCL::SYCL_CXX)
+endif()
+
+if(alpaka_RELOCATABLE_DEVICE_CODE STREQUAL ON)
+    alpaka_set_compiler_options(DEVICE alpaka_target_oneapi alpaka "-fsycl-rdc")
+    target_link_options(alpaka_target_oneapi INTERFACE "-fsycl-rdc")
+elseif(alpaka_RELOCATABLE_DEVICE_CODE STREQUAL OFF)
+    alpaka_set_compiler_options(DEVICE alpaka_target_oneapi alpaka "-fno-sycl-rdc")
+    target_link_options(alpaka_target_oneapi INTERFACE "-fno-sycl-rdc")
+endif()
+
+option(alpaka_ONEAPI_Cpu "Enable oneApi AMD Gpu support in examples/benchmarks and tests" ON)
+option(alpaka_ONEAPI_IntelGpu "Enable oneAPI Intel Gpu support in examples/benchmarks and tests" ON)
+option(alpaka_ONEAPI_NvidiaGpu "Enable oneAPI NVIDIA Gpu support in examples/benchmarks and tests" OFF)
+option(alpaka_ONEAPI_AmdGpu "Enable oneAPI AMD Gpu support in examples/benchmarks and tests" OFF)
+
+if(alpaka_ONEAPI_Cpu)
+    set(alpaka_ONEAPI_Cpu_ARCH "" CACHE STRING "OneAPI Cpu architecture")
+    list(APPEND custom_SYCL_TARGETS spir64_x86_64)
+    if(alpaka_ONEAPI_Cpu_ARCH)
+        target_link_options(
+            alpaka_target_oneapi
+            INTERFACE -Xsycl-target-backend=spir64_x86_64 -march=${alpaka_ONEAPI_Cpu_ARCH}
+        )
+    endif()
+else()
+    target_compile_definitions(alpaka_target_oneapi INTERFACE ALPAKA_DISABLE_OneApi_Cpu)
+endif()
+
+if(alpaka_ONEAPI_IntelGpu)
+    # spir64 is required for Intel GPUs
+    list(APPEND custom_SYCL_TARGETS spir64)
+else()
+    target_compile_definitions(alpaka_target_oneapi INTERFACE ALPAKA_DISABLE_OneApi_IntelGpu)
+endif()
+
+if(alpaka_ONEAPI_NvidiaGpu)
+    set(alpaka_ONEAPI_NvidiaGpu_ARCH "80" CACHE STRING "OneApi NVIDIA GPU architecture")
+
+    alpaka_set_compiler_options(HOST_DEVICE target alpaka_target_oneapi -Xsycl-target-backend=nvptx64-nvidia-cuda --offload-arch=sm_${alpaka_ONEAPI_NvidiaGpu_ARCH})
+    target_link_options(
+        alpaka_target_oneapi
+        INTERFACE -Xsycl-target-backend=nvptx64-nvidia-cuda --offload-arch=sm_${alpaka_ONEAPI_NvidiaGpu_ARCH}
+    )
+
+    list(APPEND custom_SYCL_TARGETS nvptx64-nvidia-cuda)
+else()
+    target_compile_definitions(alpaka_target_oneapi INTERFACE ALPAKA_DISABLE_OneApi_NvidiaGpu)
+endif()
+
+if(alpaka_ONEAPI_AmdGpu)
+    set(alpaka_ONEAPI_AmdGpu_ARCH "gfx1100" CACHE STRING "OneApi AMD GPU architectures")
+
+    # bug if cuda and hip is used within one system: https://github.com/intel/llvm/issues/15632
+    alpaka_set_compiler_options(HOST_DEVICE target alpaka_target_oneapi -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${alpaka_ONEAPI_AmdGpu_ARCH})
+    target_link_options(
+        alpaka_target_oneapi
+        INTERFACE -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=${alpaka_ONEAPI_AmdGpu_ARCH}
+    )
+    list(APPEND custom_SYCL_TARGETS amdgcn-amd-amdhsa)
+else()
+    target_compile_definitions(alpaka_target_oneapi INTERFACE ALPAKA_DISABLE_OneApi_AmdGpu)
+endif()
+
+if(custom_SYCL_TARGETS)
+    # to enable compilation for multiple GPU architectures, we need to create a list of GPU targets
+    list(JOIN custom_SYCL_TARGETS "," custom_SYCL_TARGETS_CONCAT)
+    alpaka_set_compiler_options(HOST_DEVICE target alpaka_target_oneapi INTERFACE "-fsycl-targets=${custom_SYCL_TARGETS_CONCAT}")
+    target_link_options(alpaka_target_oneapi INTERFACE "-fsycl-targets=${custom_SYCL_TARGETS_CONCAT}")
+endif()
+
+if(alpaka_FAST_MATH STREQUAL ON)
+    alpaka_set_compiler_options(DEVICE target alpaka_target_oneapi "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-ffast-math>")
+elseif(alpaka_MATH STREQUAL OFF)
+    alpaka_set_compiler_options(DEVICE target alpaka_target_oneapi "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-fno-fast-math>")
+endif()
+
+if(alpaka_FTZ STREQUAL ON)
+    alpaka_set_compiler_options(DEVICE target alpaka_target_oneapi "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-ftz>")
+elseif(alpaka_FTZ STREQUAL OFF)
+    alpaka_set_compiler_options(DEVICE target alpaka_target_oneapi "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-no-ftz>")
+endif()
+
+target_compile_definitions(alpaka_target_oneapi INTERFACE ALPAKA_CMAKE_TARGET_ONEAPI)
+target_link_libraries(alpaka_target_oneapi INTERFACE alpaka::headers)
+
+if(alpaka_COUNT_API_DEPS EQUAL 1)
+    target_link_libraries(alpaka INTERFACE alpaka_target_oneapi)
+endif()

--- a/docs/source/basic/install.rst
+++ b/docs/source/basic/install.rst
@@ -3,9 +3,14 @@
 Installation
 ============
 
+.. note::
+
+  You will find in the documentation very often the name *alpaka* and for directories ``alpaka3``, you will maybe wonder why we are not consequent using ``alpaka3`` everywhere.
+  The reason for this is that the complete code base will be copied to https://github.com/alpaka-group/alpaka after the first release, therefore options are already named ``alpaka``.
+
 **Installing dependencies**
 
-*alpaka* requires a modern C++ compiler (g++, clang++, Visual C++, …).
+*alpaka* requires a modern C++ compiler (g++, clang++, nvcc, icpx).
 **CMake** is the preferred system for configuration the build tree, building and installing.
 
 In order to install **CMake**:
@@ -29,10 +34,88 @@ Download the installer from https://cmake.org/download/
 - AMD GPUs: ROCm / HIP (https://rocmdocs.amd.com/en/latest/index.html)
 - Intel GPUs: OneAPI Toolkit (https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html#gs.9x3lnh)
 
+alpaka as Dependency in Your Application
+++++++++++++++++++++++++++++++++++++++++
+
+There are two ways to integrate *alpaka* as dependency with CMake into your project.
+
+.. _install-alpaka:
+
+Install alpaka
+~~~~~~~~~~~~~~
+
+The installation must be performed once and can be reused until you require a new version of *alpaka*.
+If you only install *alpaka* without enabling tests, examples or benchmarks CMake will not check for compilers, this is postponed to the usage of the installation together with our application.
+
+.. code-block:: bash
+
+  # Clone alpaka from github.com
+  git clone --branch dev https://github.com/alpaka-group/alpaka3.git
+  mkdir build && cd build
+  # assumed folder structure
+  # ├── alpaka3
+  # └── build
+  # if not set, the default is CMAKE_INSTALL_PREFIX=/usr/local
+  cmake -DCMAKE_INSTALL_PREFIX=/install/alpaka3 ..
+  cmake --install .
+
+The next CMake code snipped shows you to integrate the installed *alpaka* library in your application.
+You have now the possibility to select the compiler, enable dependency's to target different compute devices.
+Examples and brief description can be found in the follow up section :ref:`tests-and-examples`
+
+.. code-block:: cmake
+
+  find_package(alpaka REQUIRED)
+  # ...
+  add_executable(myTarget src/my.cpp)
+  target_link_libraries(myTarget PUBLIC alpaka::alpaka)
+  alpaka_finalize(myTarget)
+  # ...
+
+The next commands should be executed in the terminal and assumes that you prepend the environment variable ``CMAKE_PREFIX_PATH``
+with the path `/install/alpaka3`, that CMake knows where *alpaka* can be found.
+
+.. code-block:: bash
+
+  cmake <path_to_you_appliction>
+  cmake --build . --parallel
+
+Use the Source Code Without Installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With CMake it is possible to use *alpaka* without installation, you can simply point to the cloned folder.
+
+.. code-block:: bash
+
+  # Clone alpaka from github.com
+  git clone --branch dev https://github.com/alpaka-group/alpaka3.git
+
+The next CMake code is very similar to the usage of a installed alpaka version with the difference that you should use ``add_subdirectory()`` instead of CMake's ``find_package()``
+
+.. code-block:: cmake
+
+  # `${CMAKE_BINARY_DIR}/alpaka` places the alpaka code in your build directory in the sub directory `alpaka`
+  add_subdirectory("<path_to_cloned_alpaka3>" "${CMAKE_BINARY_DIR}/alpaka")
+  # ...
+  add_executable(myTarget src/my.cpp)
+  target_link_libraries(myTarget PUBLIC alpaka::alpaka)
+  alpaka_finalize(myTarget)
+  # ...
+
+You should prepend the environment variable ``CMAKE_PREFIX_PATH`` with the path to the cloned *alpaka* folder.
+
+.. code-block:: bash
+
+  cmake <path_to_you_appliction>
+  cmake --build . --parallel
+
+.. _tests-and-examples:
+
 Tests and Examples
 ++++++++++++++++++
 
-The examples and tests can be compiled without installing alpaka. They will use alpaka headers from the source directory.
+The examples and tests can be compiled before the installation of alpaka see :ref:`install-alpaka`.
+They will use alpaka headers from the source directory.
 The recipies shown here assume you have installed spack packages for specific compiler versions and that alpaka is relative to the build folder available.
 
 **Load dependencies**
@@ -144,8 +227,3 @@ This allows the usage of the coresponding executor e.g. `gpuCuda`, `gpuHip` or `
 .. warning::
 
   If an api is selected in the source code that is not activated during CMake configuration time, a compiler error occurs.
-
-**Installing alpaka**
-
-Since alpaka is a header only library compilation is not needed before installation.
-Installing with CMake is currently not supported but will be provided soon.

--- a/docs/source/basic/intro.rst
+++ b/docs/source/basic/intro.rst
@@ -29,8 +29,8 @@ Heterogeneous
 
 Maintainable
    *alpaka* allows to provide a single version of the algorithm / kernel that can be used by all back-ends.
-  There is no need for "copy and paste" kernels with different API calls for different accelerators.
-  All the accelerator dependent implementation details are hidden within the *alpaka* library.
+   There is no need for "copy and paste" kernels with different API calls for different accelerators.
+   All the accelerator dependent implementation details are hidden within the *alpaka* library.
 
 Testable
    Due to the easy back-end switch, no special hardware is required for testing the kernels.

--- a/headerCheck/CMakeLists.txt
+++ b/headerCheck/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.25)
 project(Alpaka2HeaderTest)
 
 # Add common functions from alpaka.
-include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/common.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/alpakaCommon.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/finalize.cmake)
 
 set(_TARGET_NAME "headerCheckTest")


### PR DESCRIPTION
- allow installing alpaka3
- The installed version will still allow running all tests (not examples, benchmarks)
- for installation only, there is no need for a C++ compiler
- update documentation

Integration tests to check to validate that we do not break the install target will be provided asap in a separate PR.