### PR TITLE
Work on documentation

### DIFF
--- a/docs/snippets/cheatsheet/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet/cheatsheet.cpp
@@ -198,7 +198,7 @@ auto main() -> int
     }
 
     concepts::Api auto const api = api::host;
-    deviceKind::concepts::DeviceKind auto const deviceKind = deviceKind::cpu;
+    concepts::DeviceKind auto const deviceKind = deviceKind::cpu;
     uint32_t index = 0;
 
     auto task = []() {};

--- a/example/scan/src/scan_improved.hpp
+++ b/example/scan/src/scan_improved.hpp
@@ -19,7 +19,7 @@
 namespace alpaka::example::scan
 {
 
-    template<alpaka::deviceKind::concepts::DeviceKind TDeviceKind>
+    template<alpaka::concepts::DeviceKind TDeviceKind>
     consteval auto maximumMiniBlockSize()
     {
         if constexpr(TDeviceKind{} == deviceKind::nvidiaGpu)

--- a/include/alpaka/CVec.hpp
+++ b/include/alpaka/CVec.hpp
@@ -16,50 +16,79 @@
 
 namespace alpaka
 {
+    /** @brief A vector with compile-time known values
+     *
+     * @details
+     * A CVec is guaranteed to be constexpr, because all of its values are stored in the type. A CVec instance
+     * satisfies the alpaka::concept::Vector. Some ways to create common types of vectors are fillCVec() and
+     * iotaCVec().
+     *
+     * @tparam T The type of the vector's stored values
+     * @tparam T_values List of values of type T that the vector stores; the length of the vector is inferred from the
+     * length of this list
+     */
     template<typename T, T... T_values>
     using CVec = Vec<T, sizeof...(T_values), detail::CVec<T, T_values...>>;
 
     namespace detail
     {
         template<typename T, T... T_values>
-        constexpr auto integerSequenceToCVec(std::integer_sequence<T, T_values...>)
+        [[nodiscard]] constexpr auto integerSequenceToCVec(std::integer_sequence<T, T_values...>)
         {
             return alpaka::CVec<T, T_values...>{};
-        };
+        }
 
         template<typename T, T... T_values>
-        constexpr auto toIntegerSequence(alpaka::CVec<T, T_values...>)
+        [[nodiscard]] constexpr auto toIntegerSequence(alpaka::CVec<T, T_values...>)
         {
             return std::integer_sequence<T, T_values...>{};
-        };
+        }
 
         template<typename Int, Int... Is1, Int... Is2>
-        constexpr auto combine(std::integer_sequence<Int, Is1...>, std::integer_sequence<Int, Is2...>)
+        [[nodiscard]] constexpr auto combine(std::integer_sequence<Int, Is1...>, std::integer_sequence<Int, Is2...>)
         {
             return std::integer_sequence<Int, Is1..., Is2...>{};
-        };
+        }
 
         template<typename Last>
-        constexpr auto concatenate(Last last)
+        [[nodiscard]] constexpr auto concatenate(Last last)
         {
             return last;
-        };
+        }
 
         template<typename First, typename... Rest>
-        constexpr auto concatenate(First first, Rest... rest)
+        [[nodiscard]] constexpr auto concatenate(First first, Rest... rest)
         {
             return combine(first, concatenate(rest...));
-        };
+        }
 
         template<bool pred, typename T, T T_v>
         using selectValue = std::conditional_t<pred, std::integer_sequence<T>, std::integer_sequence<T, T_v>>;
 
-        template<typename T_BinaryOp, typename T, T... T_values>
-        constexpr auto filterValues(T_BinaryOp op, std::integer_sequence<T, T_values...>)
+        /** @brief Return all values of an integer sequence for which a filter returns true
+         *
+         * @tparam T_UnaryOp The type of the function or functor to filter with. Must take one argument and return a
+         * boolean.
+         * @tparam T The type of the given values.
+         * @tparam T_values The values to filter.
+         * @param op The filter function/functor.
+         * @param _ An integer sequence of values to filter
+         * @return The filtered integer sequence
+         */
+        template<typename T_UnaryOp, typename T, T... T_values>
+        [[nodiscard]] constexpr auto filterValues(T_UnaryOp const op, std::integer_sequence<T, T_values...> _)
         {
             return concatenate(selectValue<op(T_values), T, T_values>{}...);
         }
 
+        /** A functor that can check for any of the contained values
+         *
+         * @details
+         * The functor contains the given sequence of values and implements an `operator()(T value)`, which returns
+         * true if the `value` is part of the sequence.
+         *
+         * @tparam T_Seq The sequence to check against
+         */
         template<typename T_Seq>
         struct Contains;
 
@@ -91,15 +120,36 @@ namespace alpaka
         };
     } // namespace detail
 
+    /** Create and return a CVector of the given length with values 1, 2, ...
+     *
+     * @details
+     * The function is defined consteval, so the result can and should always be constexpr.
+     *
+     * @tparam T Type of the stored values
+     * @tparam T_dim Length of the vector
+     *
+     * @return The vector containing the iota sequence
+     */
     template<typename T, uint32_t T_dim>
-    consteval auto iotaCVec()
+    [[nodiscard]] consteval auto iotaCVec()
     {
         using IotaSeq = std::make_integer_sequence<T, T_dim>;
         return detail::integerSequenceToCVec(IotaSeq{});
     }
 
+    /** Create and return a CVector of some length, filled with the given value
+     *
+     * @details
+     * The function is defined consteval, so the result can and should always be constexpr.
+     *
+     * @tparam T Type of the stored values
+     * @tparam T_dim Length of the vector
+     * @tparam T_val Values to fill the vector with
+     *
+     * @return The filled vector
+     */
     template<typename T, uint32_t T_dim, T T_val>
-    consteval auto fillCVec()
+    [[nodiscard]] consteval auto fillCVec()
     {
         auto concatCVec
             = []<T... T_values>(CVec<T, T_values...> cvec) -> auto { return CVec<T, T_values..., T_val>{}; };
@@ -111,33 +161,18 @@ namespace alpaka
             return concatCVec(fillCVec<T, T_dim - 1, T_val>());
     }
 
-    /** Find all values only exists in the left vector
+    /** Filter the left vector with the right vector's values
+     *
+     * @return A CVec that contains all values of the left vector that don't exist in the right vector. Preserves
+     * original order.
      */
-    constexpr auto leftJoin(concepts::CVector auto left, concepts::CVector auto right)
+    [[nodiscard]] constexpr auto filter(concepts::CVector auto left, concepts::CVector auto right)
     {
         using namespace detail;
         constexpr auto rightSeq = toIntegerSequence(right);
 
         return integerSequenceToCVec(
             filterValues(detail::Contains<ALPAKA_TYPEOF(rightSeq)>{}, toIntegerSequence(left)));
-    }
-
-    constexpr auto rightJoin(concepts::CVector auto left, concepts::CVector auto right)
-    {
-        using namespace detail;
-        constexpr auto leftSeq = toIntegerSequence(left);
-
-        return integerSequenceToCVec(
-            filterValues(detail::Contains<ALPAKA_TYPEOF(leftSeq)>{}, toIntegerSequence(right)));
-    }
-
-    constexpr auto innerJoin(concepts::CVector auto left, concepts::CVector auto right)
-    {
-        using namespace detail;
-        constexpr auto leftSeq = toIntegerSequence(left);
-
-        return integerSequenceToCVec(
-            filterValues(std::not_fn(detail::Contains<ALPAKA_TYPEOF(leftSeq)>{}), toIntegerSequence(right)));
     }
 
 } // namespace alpaka

--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -204,7 +204,7 @@ namespace alpaka
          * @param value Value which is set for all dimensions
          * @return new Simd<...>
          */
-        static constexpr auto all(concepts::IsConvertible<T_Type> auto const& value)
+        static constexpr auto all(concepts::Convertible<T_Type> auto const& value)
         {
             Simd result([=](uint32_t const) { return static_cast<T_Type>(value); });
             return result;
@@ -252,7 +252,7 @@ namespace alpaka
         }                                                                                                             \
         return *this;                                                                                                 \
     }                                                                                                                 \
-    constexpr Simd& operator op(concepts::IsLosslessConvertible<T_Type> auto const value)                             \
+    constexpr Simd& operator op(concepts::LosslesslyConvertible<T_Type> auto const value)                             \
     {                                                                                                                 \
         for(uint32_t i = 0u; i < T_dim; i++)                                                                          \
         {                                                                                                             \
@@ -659,7 +659,7 @@ namespace alpaka
                                                                                                                       \
     template<                                                                                                         \
         typenameOrConcept T_Type,                                                                                     \
-        concepts::IsLosslessConvertible<T_Type> T_ValueType,                                                          \
+        concepts::LosslesslyConvertible<T_Type> T_ValueType,                                                          \
         uint32_t T_dim,                                                                                               \
         concepts::Alignment T_Alignment,                                                                              \
         typename T_Storage>                                                                                           \
@@ -675,7 +675,7 @@ namespace alpaka
     }                                                                                                                 \
     template<                                                                                                         \
         typenameOrConcept T_Type,                                                                                     \
-        concepts::IsLosslessConvertible<T_Type> T_ValueType,                                                          \
+        concepts::LosslesslyConvertible<T_Type> T_ValueType,                                                          \
         uint32_t T_dim,                                                                                               \
         concepts::Alignment T_Alignment,                                                                              \
         typename T_Storage>                                                                                           \
@@ -737,7 +737,7 @@ namespace alpaka
         concept TypeOrSimd = (isSimd_v<T> || std::is_same_v<T, T_RequiredComponent>);
 
         template<typename T, typename T_RequiredComponent>
-        concept SimdOrConvertableType = (isSimd_v<T> || std::is_convertible_v<T, T_RequiredComponent>);
+        concept SimdOrConvertibleType = (isSimd_v<T> || std::is_convertible_v<T, T_RequiredComponent>);
     } // namespace concepts
 
     namespace trait

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -63,6 +63,11 @@ namespace alpaka
                                  && (std::same_as<T_ValueType, trait::GetValueType_t<std::decay_t<T>>>
                                      || std::same_as<T_ValueType, alpaka::NotRequired>);
 
+        /** Concept to check if a type is a CVector
+         *
+         * @details
+         * Checks whether the given type is a CVector. For more information, refer to the implementation alpaka::CVec.
+         */
         template<typename T, typename T_ValueType = alpaka::NotRequired>
         concept CVector = isCVector_v<T>
                           && (std::same_as<T_ValueType, trait::GetValueType_t<std::decay_t<T>>>
@@ -77,7 +82,7 @@ namespace alpaka
         concept TypeOrVector = (isVector_v<T> || std::is_same_v<T, T_RequiredComponent>);
 
         template<typename T, typename T_RequiredComponent>
-        concept VectorOrConvertableType = (isVector_v<T> || std::is_convertible_v<T, T_RequiredComponent>);
+        concept VectorOrConvertibleType = (isVector_v<T> || std::is_convertible_v<T, T_RequiredComponent>);
     } // namespace concepts
 
     /** Array storge for vector data
@@ -161,17 +166,17 @@ namespace alpaka
         };
 
         template<typename T>
-        struct IsTemplateSignatureStorage : std::false_type
+        struct TemplateSignatureStorage : std::false_type
         {
         };
 
         template<typename T_Type, T_Type... T_values>
-        struct IsTemplateSignatureStorage<CVec<T_Type, T_values...>> : std::true_type
+        struct TemplateSignatureStorage<CVec<T_Type, T_values...>> : std::true_type
         {
         };
 
         template<typename T>
-        constexpr bool isTemplateSignatureStorage_v = IsTemplateSignatureStorage<T>::value;
+        constexpr bool TemplateSignatureStorage_v = TemplateSignatureStorage<T>::value;
     } // namespace detail
 
     template<typename T_Type, uint32_t T_dim, typename T_Storage = ArrayStorage<T_Type, T_dim>>
@@ -268,9 +273,9 @@ namespace alpaka
          * @param value Value which is set for all dimensions
          * @return new Vec<...>
          */
-        static constexpr auto all(concepts::IsConvertible<T_Type> auto const& value)
+        static constexpr auto all(concepts::Convertible<T_Type> auto const& value)
         {
-            if constexpr(requires { detail::isTemplateSignatureStorage_v<T_Storage>; })
+            if constexpr(requires { detail::TemplateSignatureStorage_v<T_Storage>; })
             {
                 UniVec result([=](uint32_t const) { return static_cast<T_Type>(value); });
                 return result;
@@ -332,7 +337,7 @@ namespace alpaka
         }                                                                                                             \
         return *this;                                                                                                 \
     }                                                                                                                 \
-    constexpr Vec& operator op(concepts::IsLosslessConvertible<T_Type> auto const value)                              \
+    constexpr Vec& operator op(concepts::LosslesslyConvertible<T_Type> auto const value)                              \
     {                                                                                                                 \
         for(uint32_t i = 0u; i < T_dim; i++)                                                                          \
         {                                                                                                             \
@@ -778,7 +783,7 @@ namespace alpaka
                                                                                                                       \
     template<                                                                                                         \
         typenameOrConcept T_Type,                                                                                     \
-        concepts::IsLosslessConvertible<T_Type> T_ValueType,                                                          \
+        concepts::LosslesslyConvertible<T_Type> T_ValueType,                                                          \
         uint32_t T_dim,                                                                                               \
         typename T_Storage>                                                                                           \
     constexpr auto operator op(const Vec<T_Type, T_dim, T_Storage>& lhs, T_ValueType rhs)                             \
@@ -793,7 +798,7 @@ namespace alpaka
     }                                                                                                                 \
     template<                                                                                                         \
         typenameOrConcept T_Type,                                                                                     \
-        concepts::IsLosslessConvertible<T_Type> T_ValueType,                                                          \
+        concepts::LosslesslyConvertible<T_Type> T_ValueType,                                                          \
         uint32_t T_dim,                                                                                               \
         typename T_Storage>                                                                                           \
     constexpr auto operator op(T_ValueType lhs, const Vec<T_Type, T_dim, T_Storage>& rhs)                             \

--- a/include/alpaka/api/concepts/api.hpp
+++ b/include/alpaka/api/concepts/api.hpp
@@ -30,6 +30,14 @@ namespace alpaka
 
     namespace concepts
     {
+        /** @brief Concept to check for APIs
+         *
+         * @details
+         * This concept requires that the template is an API. An API in alpaka is the representation of a software
+         * library that can target one or multiple accelerators. Examples of APIs are alpaka::api::Cuda and
+         * alpaka::api::Host. An Api together with an alpaka::concepts::DeviceKind can make up an
+         * alpaka::onHost::Device.
+         */
         template<typename T>
         concept Api = isApi_v<T> && requires(T t) { requires HasStaticName<T>; };
     } // namespace concepts

--- a/include/alpaka/api/cuda/Device.hpp
+++ b/include/alpaka/api/cuda/Device.hpp
@@ -26,7 +26,7 @@ namespace alpaka::onHost
 
 namespace alpaka::onHost::internal
 {
-    template<alpaka::deviceKind::concepts::DeviceKind T_DeviceKind, typename T_Any>
+    template<alpaka::concepts::DeviceKind T_DeviceKind, typename T_Any>
     struct IsDataAccessible::SecondPath<api::Cuda, T_DeviceKind, T_Any>
     {
         bool operator()(api::Cuda usedApi, T_DeviceKind deviceKind, T_Any const& view) const

--- a/include/alpaka/api/cuda/Platform.hpp
+++ b/include/alpaka/api/cuda/Platform.hpp
@@ -19,7 +19,7 @@ namespace alpaka::onHost
 {
     namespace internal
     {
-        template<deviceKind::concepts::DeviceKind T_DeviceKind>
+        template<alpaka::concepts::DeviceKind T_DeviceKind>
         struct MakePlatform::Op<api::Cuda, T_DeviceKind>
         {
             auto operator()(api::Cuda, T_DeviceKind) const
@@ -32,7 +32,7 @@ namespace alpaka::onHost
 
 namespace alpaka::internal
 {
-    template<deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<alpaka::concepts::DeviceKind T_DeviceKind>
     struct GetApi::Op<onHost::unifiedCudaHip::Platform<ApiCudaRt, T_DeviceKind>>
     {
         inline constexpr auto operator()(auto&& platform) const
@@ -41,7 +41,7 @@ namespace alpaka::internal
         }
     };
 
-    template<deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<alpaka::concepts::DeviceKind T_DeviceKind>
     struct GetDeviceType::Op<onHost::unifiedCudaHip::Platform<ApiCudaRt, T_DeviceKind>>
     {
         decltype(auto) operator()(auto&& platform) const

--- a/include/alpaka/api/hip/Device.hpp
+++ b/include/alpaka/api/hip/Device.hpp
@@ -26,7 +26,7 @@ namespace alpaka::onHost
 
 namespace alpaka::onHost::internal
 {
-    template<alpaka::deviceKind::concepts::DeviceKind T_DeviceKind, typename T_Any>
+    template<alpaka::concepts::DeviceKind T_DeviceKind, typename T_Any>
     struct IsDataAccessible::SecondPath<api::Hip, T_DeviceKind, T_Any>
     {
         bool operator()(api::Hip usedApi, T_DeviceKind deviceKind, T_Any const& view) const

--- a/include/alpaka/api/hip/Platform.hpp
+++ b/include/alpaka/api/hip/Platform.hpp
@@ -20,7 +20,7 @@ namespace alpaka::onHost
     namespace internal
     {
 
-        template<deviceKind::concepts::DeviceKind T_DeviceKind>
+        template<alpaka::concepts::DeviceKind T_DeviceKind>
         struct MakePlatform::Op<api::Hip, T_DeviceKind>
         {
             auto operator()(api::Hip, T_DeviceKind) const
@@ -33,7 +33,7 @@ namespace alpaka::onHost
 
 namespace alpaka::internal
 {
-    template<deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<alpaka::concepts::DeviceKind T_DeviceKind>
     struct GetApi::Op<onHost::unifiedCudaHip::Platform<ApiHipRt, T_DeviceKind>>
     {
         inline constexpr auto operator()(auto&& platform) const
@@ -42,7 +42,7 @@ namespace alpaka::internal
         }
     };
 
-    template<deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<alpaka::concepts::DeviceKind T_DeviceKind>
     struct GetDeviceType::Op<onHost::unifiedCudaHip::Platform<ApiHipRt, T_DeviceKind>>
     {
         decltype(auto) operator()(auto&& platform) const

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -113,7 +113,7 @@ namespace alpaka::onHost
 
             friend struct internal::MakeQueue;
 
-            Handle<cpu::Queue<Device>> makeQueue(queueKind::concepts::QueueKind auto kind)
+            Handle<cpu::Queue<Device>> makeQueue(alpaka::concepts::QueueKind auto kind)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
                 static_assert(

--- a/include/alpaka/api/host/Platform.hpp
+++ b/include/alpaka/api/host/Platform.hpp
@@ -19,7 +19,7 @@ namespace alpaka::onHost
 {
     namespace cpu
     {
-        template<deviceKind::concepts::DeviceKind T_DeviceKind>
+        template<alpaka::concepts::DeviceKind T_DeviceKind>
         struct Platform : std::enable_shared_from_this<Platform<T_DeviceKind>>
         {
         public:
@@ -99,7 +99,7 @@ namespace alpaka::onHost
 
     namespace internal
     {
-        template<deviceKind::concepts::DeviceKind T_DeviceKind>
+        template<alpaka::concepts::DeviceKind T_DeviceKind>
         struct MakePlatform::Op<api::Host, T_DeviceKind>
         {
             auto operator()(api::Host, T_DeviceKind) const
@@ -108,7 +108,7 @@ namespace alpaka::onHost
             }
         };
 
-        template<deviceKind::concepts::DeviceKind T_DeviceKind>
+        template<alpaka::concepts::DeviceKind T_DeviceKind>
         struct GetDeviceProperties::Op<cpu::Platform<T_DeviceKind>>
         {
             DeviceProperties operator()(cpu::Platform<T_DeviceKind> const& platform, uint32_t deviceIdx) const
@@ -128,7 +128,7 @@ namespace alpaka::onHost
 
 namespace alpaka::internal
 {
-    template<deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<alpaka::concepts::DeviceKind T_DeviceKind>
     struct GetApi::Op<onHost::cpu::Platform<T_DeviceKind>>
     {
         inline constexpr auto operator()(auto&& platform) const

--- a/include/alpaka/api/oneApi/Api.hpp
+++ b/include/alpaka/api/oneApi/Api.hpp
@@ -95,7 +95,7 @@ namespace alpaka
         };
 
         // for GPU
-        template<typename T_Type, concepts::IsGpuType T_DeviceKind>
+        template<typename T_Type, concepts::GpuType T_DeviceKind>
         struct GetArchSimdWidth::Op<T_Type, api::OneApi, T_DeviceKind>
         {
             constexpr uint32_t operator()(api::OneApi const, T_DeviceKind const) const
@@ -107,7 +107,7 @@ namespace alpaka
             }
         };
 
-        template<concepts::IsGpuType T_DeviceKind>
+        template<concepts::GpuType T_DeviceKind>
         struct GetNumPipelines::Op<api::OneApi, T_DeviceKind>
         {
             constexpr uint32_t operator()(api::OneApi const, T_DeviceKind const) const
@@ -120,7 +120,7 @@ namespace alpaka
             }
         };
 
-        template<concepts::IsGpuType T_DeviceKind>
+        template<concepts::GpuType T_DeviceKind>
         struct GetCachelineSize::Op<api::OneApi, T_DeviceKind>
         {
             constexpr uint32_t operator()(api::OneApi const, T_DeviceKind const) const

--- a/include/alpaka/api/oneApi/Platform.hpp
+++ b/include/alpaka/api/oneApi/Platform.hpp
@@ -69,7 +69,7 @@ namespace alpaka
     {
         namespace internal
         {
-            template<deviceKind::concepts::DeviceKind T_DeviceKind>
+            template<alpaka::concepts::DeviceKind T_DeviceKind>
             struct MakePlatform::Op<api::OneApi, T_DeviceKind>
             {
                 auto operator()(api::OneApi const&, T_DeviceKind) const
@@ -82,7 +82,7 @@ namespace alpaka
 
     namespace internal
     {
-        template<deviceKind::concepts::DeviceKind T_DeviceKind>
+        template<alpaka::concepts::DeviceKind T_DeviceKind>
         struct GetApi::Op<onHost::syclGeneric::Platform<api::OneApi, T_DeviceKind>>
         {
             decltype(auto) operator()(auto&& platform) const
@@ -91,7 +91,7 @@ namespace alpaka
             }
         };
 
-        template<deviceKind::concepts::DeviceKind T_DeviceKind>
+        template<alpaka::concepts::DeviceKind T_DeviceKind>
         struct GetDeviceType::Op<onHost::syclGeneric::Platform<api::OneApi, T_DeviceKind>>
         {
             decltype(auto) operator()(auto&& platform) const
@@ -104,7 +104,7 @@ namespace alpaka
 
 namespace alpaka::onHost::internal
 {
-    template<alpaka::deviceKind::concepts::DeviceKind T_DeviceKind, typename T_Any>
+    template<alpaka::concepts::DeviceKind T_DeviceKind, typename T_Any>
     struct IsDataAccessible::SecondPath<api::OneApi, T_DeviceKind, T_Any>
     {
         static void getPtrType(auto const& platform, auto& sycl_data_alloc_type, auto const& view)

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -55,7 +55,7 @@ namespace alpaka::onHost
                 return this->shared_from_this();
             }
 
-            [[nodiscard]] Handle<syclGeneric::Queue<Device>> makeQueue(queueKind::concepts::QueueKind auto kind)
+            [[nodiscard]] Handle<syclGeneric::Queue<Device>> makeQueue(alpaka::concepts::QueueKind auto kind)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue + onHost::logger::device);
                 static_assert(

--- a/include/alpaka/api/syclGeneric/Platform.hpp
+++ b/include/alpaka/api/syclGeneric/Platform.hpp
@@ -98,7 +98,7 @@ namespace alpaka
     {
         namespace syclGeneric
         {
-            template<typename T_ApiInterface, deviceKind::concepts::DeviceKind T_DeviceKind>
+            template<typename T_ApiInterface, alpaka::concepts::DeviceKind T_DeviceKind>
             struct Platform : std::enable_shared_from_this<Platform<T_ApiInterface, T_DeviceKind>>
             {
             public:
@@ -210,7 +210,7 @@ namespace alpaka
 
         namespace internal
         {
-            template<typename T_ApiInterface, deviceKind::concepts::DeviceKind T_DeviceKind>
+            template<typename T_ApiInterface, alpaka::concepts::DeviceKind T_DeviceKind>
             struct GetDeviceProperties::Op<syclGeneric::Platform<T_ApiInterface, T_DeviceKind>>
             {
                 DeviceProperties operator()(

--- a/include/alpaka/api/syclGeneric/memFence.hpp
+++ b/include/alpaka/api/syclGeneric/memFence.hpp
@@ -3,6 +3,7 @@
  */
 
 #pragma once
+#include "alpaka/api/concepts/api.hpp"
 #include "alpaka/api/oneApi/executor.hpp"
 #include "alpaka/api/syclGeneric/tag.hpp"
 #include "alpaka/core/common.hpp"
@@ -18,7 +19,7 @@
 
 namespace alpaka::onAcc::internalCompute
 {
-    template<typename T_Api, typename T_Scope>
+    template<alpaka::concepts::Api T_Api, typename T_Scope>
     requires(std::is_base_of_v<api::GenericSycl<T_Api>, T_Api>)
     struct MemoryFence::Op<T_Api, T_Scope>
     {

--- a/include/alpaka/api/trait.hpp
+++ b/include/alpaka/api/trait.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/api/concepts/api.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/math/internal/math.hpp"
 #include "alpaka/tag.hpp"
@@ -18,7 +19,7 @@ namespace alpaka
         /** Map's all API's by default to stl math functions. */
         struct GetMathImpl
         {
-            template<typename T_Api>
+            template<alpaka::concepts::Api T_Api>
             struct Op
             {
                 constexpr decltype(auto) operator()(T_Api const) const
@@ -28,7 +29,7 @@ namespace alpaka
             };
         };
 
-        template<typename T_Api>
+        template<alpaka::concepts::Api T_Api>
         constexpr decltype(auto) getMathImpl(T_Api const api)
         {
             return GetMathImpl::Op<T_Api>{}(api);
@@ -36,7 +37,7 @@ namespace alpaka
 
         struct GetArchSimdWidth
         {
-            template<typename T_Type, typename T_Api, deviceKind::concepts::DeviceKind T_DeviceKind>
+            template<typename T_Type, alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
             struct Op
             {
                 consteval uint32_t operator()(T_Api const, T_DeviceKind const) const
@@ -50,7 +51,7 @@ namespace alpaka
         /** Number of commands a CPU can issue at the same time. */
         struct GetNumPipelines
         {
-            template<typename T_Api, deviceKind::concepts::DeviceKind T_DeviceKind>
+            template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
             struct Op
             {
                 /** @return the return value must be >= 1 */
@@ -64,7 +65,7 @@ namespace alpaka
 
         struct GetCachelineSize
         {
-            template<typename T_Api, deviceKind::concepts::DeviceKind T_DeviceKind>
+            template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
             struct Op
             {
                 consteval uint32_t operator()(T_Api const, T_DeviceKind const) const
@@ -87,6 +88,12 @@ namespace alpaka
 
     namespace concepts
     {
+        /** @brief Concept to check for an executor
+         *
+         * @details
+         * An executor in alpaka is a specific way of executing on an alpaka::onHost::Device. Examples of executors are
+         * alpaka::exec::GpuCuda or alpaka::onHost::cpu::OmpBlocks.
+         */
         template<typename T>
         concept Executor = alpaka::isExecutor<T>;
     } // namespace concepts
@@ -101,24 +108,29 @@ namespace alpaka
         return !(lhs == rhs);
     }
 
-    /** get SIMD with in bytes for the
+    /** Get the SIMD width in bytes for an API and device kind combination.
      *
      * @tparam T_Type data type
      * @return number of elements that can be processed in parallel in a vector register
      */
     template<typename T_Type>
-    consteval uint32_t getArchSimdWidth(auto const api, deviceKind::concepts::DeviceKind auto const deviceType)
+    consteval uint32_t getArchSimdWidth(
+        concepts::Api auto const api,
+        alpaka::concepts::DeviceKind auto const deviceType)
     {
         return trait::GetArchSimdWidth::Op<T_Type, ALPAKA_TYPEOF(api), ALPAKA_TYPEOF(deviceType)>{}(api, deviceType);
     }
 
-    /** get the number of instruction can be issued in parallel */
-    consteval uint32_t getNumPipelines(auto const api, deviceKind::concepts::DeviceKind auto const deviceType)
+    /** Get the number of instructions that can be issued in parallel
+     */
+    consteval uint32_t getNumPipelines(
+        concepts::Api auto const api,
+        alpaka::concepts::DeviceKind auto const deviceType)
     {
         return trait::GetNumPipelines::Op<ALPAKA_TYPEOF(api), ALPAKA_TYPEOF(deviceType)>{}(api, deviceType);
     }
 
-    /**  Get the number of elements to compute per thread.
+    /**  Get the number of elements to compute per thread
      *
      * This function considers the SIMD width for the corresponding data type and the potential for instruction
      * parallelism.
@@ -127,7 +139,9 @@ namespace alpaka
      * @return The minimum number of elements a thread should compute to achieve optimal utilization.
      */
     template<typename T_Type>
-    consteval uint32_t getNumElemPerThread(auto const api, deviceKind::concepts::DeviceKind auto const deviceType)
+    consteval uint32_t getNumElemPerThread(
+        concepts::Api auto const api,
+        alpaka::concepts::DeviceKind auto const deviceType)
     {
         return getArchSimdWidth<T_Type>(api, deviceType) * getNumPipelines(api, deviceType);
     }
@@ -138,7 +152,9 @@ namespace alpaka
      *
      * @return cacheline size in bytes
      */
-    consteval uint32_t getCachelineSize(auto const api, deviceKind::concepts::DeviceKind auto const deviceType)
+    consteval uint32_t getCachelineSize(
+        concepts::Api auto const api,
+        alpaka::concepts::DeviceKind auto const deviceType)
     {
         return trait::GetCachelineSize::Op<ALPAKA_TYPEOF(api), ALPAKA_TYPEOF(deviceType)>{}(api, deviceType);
     }

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -106,7 +106,7 @@ namespace alpaka::onHost
 
             friend struct onHost::internal::MakeQueue;
 
-            Handle<unifiedCudaHip::Queue<Device>> makeQueue(queueKind::concepts::QueueKind auto kind)
+            Handle<unifiedCudaHip::Queue<Device>> makeQueue(alpaka::concepts::QueueKind auto kind)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
                 static_assert(

--- a/include/alpaka/api/unifiedCudaHip/Platform.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Platform.hpp
@@ -24,7 +24,7 @@ namespace alpaka::onHost
 {
     namespace unifiedCudaHip
     {
-        template<typename T_ApiInterface, deviceKind::concepts::DeviceKind T_DeviceKind>
+        template<typename T_ApiInterface, alpaka::concepts::DeviceKind T_DeviceKind>
         struct Platform : std::enable_shared_from_this<Platform<T_ApiInterface, T_DeviceKind>>
         {
             using ApiInterface = T_ApiInterface;
@@ -115,7 +115,7 @@ namespace alpaka::onHost
 
     namespace internal
     {
-        template<typename T_ApiInterface, deviceKind::concepts::DeviceKind T_DeviceKind>
+        template<typename T_ApiInterface, alpaka::concepts::DeviceKind T_DeviceKind>
         struct GetDeviceProperties::Op<unifiedCudaHip::Platform<T_ApiInterface, T_DeviceKind>>
         {
             DeviceProperties operator()(

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -1,15 +1,12 @@
 /* Copyright 2024 René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
-
-
-#pragma once
-
 #pragma once
 
 #include "alpaka/core/config.hpp"
 
 #if ALPAKA_LANG_CUDA || ALPAKA_LANG_HIP
+#    include "alpaka/api/concepts/api.hpp"
 #    include "alpaka/api/cuda/IdxLayer.hpp"
 #    include "alpaka/api/generic.hpp"
 #    include "alpaka/api/hip/IdxLayer.hpp"
@@ -169,8 +166,8 @@ namespace alpaka::onHost
         };
 
         template<
-            typename T_Api,
-            deviceKind::concepts::DeviceKind T_DeviceKind,
+            alpaka::concepts::Api T_Api,
+            alpaka::concepts::DeviceKind T_DeviceKind,
             alpaka::concepts::Executor T_Executor,
             typename TKernelBundle,
             typename T_OptimizedThreadSpec,
@@ -197,8 +194,8 @@ namespace alpaka::onHost
         }
 
         template<
-            typename T_Api,
-            deviceKind::concepts::DeviceKind T_DeviceKind,
+            alpaka::concepts::Api T_Api,
+            alpaka::concepts::DeviceKind T_DeviceKind,
             alpaka::concepts::Executor T_Executor,
             typename TKernelBundle,
             typename T_OptimizedThreadSpec>

--- a/include/alpaka/api/unifiedCudaHip/trait.hpp
+++ b/include/alpaka/api/unifiedCudaHip/trait.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "alpaka/api/concepts/api.hpp"
 #include "alpaka/api/trait.hpp"
 
 #include <type_traits>
@@ -16,7 +17,7 @@ namespace alpaka::unifiedCudaHip::trait
     {
     };
 
-    template<typename T_Api>
+    template<alpaka::concepts::Api T_Api>
     struct IsUnifiedApi : std::false_type
     {
     };

--- a/include/alpaka/api/util.hpp
+++ b/include/alpaka/api/util.hpp
@@ -137,7 +137,7 @@ namespace alpaka::api::util
      * @return the best alignment in bytes, will be a power of two value
      */
     template<typename T_ValueType>
-    inline constexpr auto simdOptimizedAlignment(auto api, alpaka::deviceKind::concepts::DeviceKind auto deviceKind)
+    inline constexpr auto simdOptimizedAlignment(auto api, alpaka::concepts::DeviceKind auto deviceKind)
     {
         constexpr uint32_t typeAlignmentBytes = alignof(T_ValueType);
         constexpr uint32_t simdPackBytes

--- a/include/alpaka/cast.hpp
+++ b/include/alpaka/cast.hpp
@@ -56,7 +56,7 @@ namespace alpaka
      */
     template<typename T_To>
     constexpr decltype(auto) lpCast(auto&& input)
-        requires(isLosslessConvertible_v<typename ALPAKA_TYPEOF(input)::type, T_To>)
+        requires(isLosslesslyConvertible_v<typename ALPAKA_TYPEOF(input)::type, T_To>)
     {
         return internal::LPCast::Op<T_To, ALPAKA_TYPEOF(input)>{}(input);
     }

--- a/include/alpaka/concepts.hpp
+++ b/include/alpaka/concepts.hpp
@@ -13,32 +13,46 @@
 #include "alpaka/tag.hpp"
 
 #include <concepts>
-#include <string>
 
 namespace alpaka
 {
     namespace concepts
     {
+        /** @brief Concept to check if the given type has a `get()` function.
+         */
         template<typename T>
         concept HasGet = requires(T t) { t.get(); };
 
+        /** @brief Concept to check if the given type has a static `dim()` function
+         */
         template<typename T>
         concept HasStaticDim = requires(T t) { T::dim(); };
 
+        /** @brief Concept to check if the given type is of the given dimensionality
+         *
+         * @details
+         * The checked type must also fulfill HasStaticDim.
+         *
+         * @tparam T The type to check
+         * @tparam T_dim The dimension the checked type should have
+         */
         template<typename T, unsigned int T_dim>
         concept Dim = requires { T::dim() == T_dim; };
 
-
+        /** @brief Concept to check if the given type is a GPU DeviceKind
+         */
         template<typename T>
-        concept IsGpuType
-            = deviceKind::concepts::DeviceKind<T>
+        concept GpuType
+            = alpaka::concepts::DeviceKind<T>
               && (T{} == deviceKind::nvidiaGpu || T{} == deviceKind::amdGpu || T{} == deviceKind::intelGpu);
 
-
+        /** @brief Concept to check if the given type is a pointer, using std::is_pointer
+         */
         template<typename T>
-        concept IsPointer = std::is_pointer_v<T>;
+        concept Pointer = std::is_pointer_v<T>;
 
-
+        /** @todo Replace usage with alpaka::concepts::IView
+         */
         template<typename T, typename T_ValueType = alpaka::NotRequired>
         concept View = MdSpan<T, T_ValueType> && requires(T t) {
             { getApi(t) } -> alpaka::concepts::Api;

--- a/include/alpaka/concepts/hasName.hpp
+++ b/include/alpaka/concepts/hasName.hpp
@@ -11,6 +11,8 @@
 
 namespace alpaka::concepts
 {
+    /**
+     */
     template<typename T>
     concept HasStaticName = requires(T t) {
         { internal::GetStaticName::Op<std::decay_t<T>>{}(t) } -> std::convertible_to<std::string>;

--- a/include/alpaka/interface.hpp
+++ b/include/alpaka/interface.hpp
@@ -31,6 +31,8 @@ namespace alpaka
 
     namespace concepts
     {
+        /** Concept to check if the given type implements the `getApi(T x)` function returning an alpaka::concepts::Api
+         */
         template<typename T_Any>
         concept HasApi = requires(T_Any&& any) {
             { getApi(any) } -> alpaka::concepts::Api;
@@ -59,7 +61,7 @@ namespace alpaka
     /** @} */
 
 
-    /**  Get the number of elements to compute per thread.
+    /** Get the number of elements to compute per thread.
      *
      * This function considers the SIMD width for the corresponding data type and the potential for instruction
      * parallelism.

--- a/include/alpaka/mem/Alignment.hpp
+++ b/include/alpaka/mem/Alignment.hpp
@@ -10,14 +10,28 @@
 
 namespace alpaka
 {
-
+    /** @brief Strongly typed and constexpr representation of a byte-alignment of memory
+     *
+     * @details
+     * The number of bytes is stored at compile-time using a value template parameter. Therefore, alignments should
+     * always be declared `constexpr`. If no explicit alignment is given, a default will be set.
+     *
+     * To use the alignment, the Alignment::get() function can be called for a given type parameter, returning either
+     * the object's set alignment, or the given type's alignment, if the default was used.
+     *
+     * @tparam T_byte The number of bytes in uint32_t.
+     */
     template<uint32_t T_byte = std::numeric_limits<uint32_t>::max()>
     struct Alignment
     {
-        /** Get the alignment value.
+        /** Get the byte-alignment of a given type when using this alignment.
+         *
+         * @details
+         * Trying to use an alignment with a smaller value than the alignment of the given `T_Type` results in a failed
+         * `static_assert`.
          *
          * @tparam T_Type The type for which to get the alignment.
-         * @return If T_byte is zero alignment of T_Type else value of T_byte
+         * @return If T_byte is not specifically set: alignment of T_Type, else: value of T_byte
          */
         template<typename T_Type>
         static consteval uint32_t get()
@@ -26,7 +40,12 @@ namespace alpaka
             if constexpr(T_byte == std::numeric_limits<uint32_t>::max())
                 return static_cast<uint32_t>(alignof(T_Type));
             else
+            {
+                static_assert(
+                    value >= alignof(T_Type),
+                    "tried to use alignment that is smaller than the alignment of the type it's for");
                 return value;
+            }
         }
 
     private:
@@ -58,8 +77,15 @@ namespace alpaka
 
     namespace concepts
     {
+        /** @brief Concept to check for an alignment object
+         *
+         * @details
+         * An alignment represents a byte alignment of memory. The class is used for strong typing.
+         * For more information, refer to the struct alpaka::Alignment or the general documentation.
+         *
+         * @todo link to alignment documentation in the general docs
+         */
         template<typename T>
         concept Alignment = trait::IsAlignment<T>::value;
     } // namespace concepts
-
 } // namespace alpaka

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -20,7 +20,7 @@
 
 namespace alpaka
 {
-    /** Lightweight view to data in a n-dimensional array
+    /** Lightweight view to data in an n-dimensional array.
      *
      * Const-ness of the MdSpan instance is propagated to the data region.
      * A constant MdSpan can be used to access non-const data.

--- a/include/alpaka/mem/ThreadSpace.hpp
+++ b/include/alpaka/mem/ThreadSpace.hpp
@@ -65,7 +65,7 @@ namespace alpaka
             constexpr uint32_t dim = T_ThreadIdx::dim();
 
             auto allElements = iotaCVec<IdxType, dim>();
-            constexpr auto notSelectedDims = leftJoin(allElements, T_CSelect{});
+            constexpr auto notSelectedDims = filter(allElements, T_CSelect{});
 
             auto threadIndex = m_threadIdx;
             auto numThreads = m_threadCount;

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/api/concepts/api.hpp"
 #include "alpaka/interface.hpp"
 #include "alpaka/internal/interface.hpp"
 #include "alpaka/mem/BoundaryIter.hpp"
@@ -18,10 +19,12 @@
 
 namespace alpaka
 {
-    /** Non owning view to data
+    /** @brief Non owning view to data
      *
-     * This view is only holding a points to real data, copying the view is cheap.
+     * This view is only holding a pointer to real data, copying the view is cheap.
      * Const-ness of the view instance is propagated to the data region.
+     *
+     * This satisfies the alpaka::concepts::IView concept and, therefore, also the alpaka::concepts::IMdSpan concept.
      */
     template<
         alpaka::concepts::Api T_Api,
@@ -74,11 +77,11 @@ namespace alpaka
         using BaseMdSpan = MdSpan<T_Type, typename T_Extents::UniVec, typename T_Extents::UniVec, T_MemAlignment>;
 
     public:
-        /** creates a view
+        /** Creates a view
          *
          * @param data handle to the physical data
-         * @param extents M-dimensional extents in elements of the view. Must be <= number of elements in the dat
-         * handle.
+         * @param extents n-dimensional extents in elements of the view. Must satisfy `n <= number_of_elements` in the
+         * data handle.
          */
         template<
             alpaka::concepts::HasApi T_Any,
@@ -97,7 +100,7 @@ namespace alpaka
                   memAlignment}
         {
             static_assert(
-                isLosslessConvertible_v<typename T_UserPitches::type, typename T_UserExtents::type>,
+                isLosslesslyConvertible_v<typename T_UserPitches::type, typename T_UserExtents::type>,
                 "extent type and pitch type must be lossless convertible");
         }
 
@@ -271,9 +274,9 @@ namespace alpaka
 
 namespace alpaka::internal
 {
-    // external define the API trait to support constexpr evaluation
+    // externally define the API trait to support constexpr evaluation
     template<
-        typename T_Api,
+        alpaka::concepts::Api T_Api,
         typename T_Type,
         alpaka::concepts::Vector T_Extents,
         alpaka::concepts::Alignment T_MemAlignment>

--- a/include/alpaka/mem/concepts.hpp
+++ b/include/alpaka/mem/concepts.hpp
@@ -11,11 +11,15 @@
 
 namespace alpaka::concepts
 {
+    /** @todo Replace usage with alpaka::concepts::IMdSpan
+     */
     template<typename T, typename T_ValueType = alpaka::NotRequired>
     concept MdSpan = alpaka::isMdSpan_v<T>
                      && (std::same_as<T_ValueType, trait::GetValueType_t<std::decay_t<T>>>
                          || std::same_as<T_ValueType, alpaka::NotRequired>);
 
+    /** Concept to check if the given type is a reference, using std::is_reference
+     */
     template<typename T>
     concept Reference = std::is_reference_v<T>;
 

--- a/include/alpaka/mem/concepts/IBuffer.hpp
+++ b/include/alpaka/mem/concepts/IBuffer.hpp
@@ -23,13 +23,14 @@ namespace alpaka::concepts
 
     namespace impl
     {
-        /** Interface concept that describes how multidimensional memory can be accessed on the host and device side.
-         * An `alpaka::buffer` like object contains information about the device(s) to which it is connected. The
-         * `alpaka::buffer` like object has memory ownership and therefore manages memory lifetime according to the
-         * RAII principle.
+        /** @brief Interface concept for objects describing multidimensional owned memory.
          *
-         * The concept fulfills all requirements of the alpaka::concepts::impl::IView concept and therefore offers
-         * the same interface.
+         * @details
+         * An `alpaka::buffer`-like object contains information about the device(s) to which it is connected. The
+         * `alpaka::buffer`-like object has memory ownership and therefore manages memory lifetime according to the
+         * RAII principle. The represented memory can have any dimensionality.
+         *
+         * Any object that fulfills the `IBuffer` concept is also an `IView` and `IMdSpan`.
          *
          * @section memberfunction member functions
          *
@@ -49,14 +50,15 @@ namespace alpaka::concepts
         };
     } // namespace impl
 
-    /** Interface concept that describes how multidimensional memory can be accessed on the host and device side.
-     * An `alpaka::buffer` like object contains information about the device(s) to which it is connected. The
-     * `alpaka::buffer` like object has memory ownership and therefore manages memory lifetime according to the RAII
+    /** @brief Interface concept for objects describing multidimensional owned memory.
+     *
+     * @details
+     * An `alpaka::buffer`-like object contains information about the device(s) to which it is connected. The
+     * `alpaka::buffer`-like object has memory ownership and therefore manages memory lifetime according to the RAII
      * principle.
      *
      * @attention Use `alpaka::IBuffer` to restrict types in your code. The actual interface is described in
      * alpaka::concepts::impl::IBuffer.
-     *
      **/
     template<typename T, typename T_ValueType = alpaka::NotRequired>
     concept IBuffer = requires(T t) {

--- a/include/alpaka/mem/concepts/IMdSpan.hpp
+++ b/include/alpaka/mem/concepts/IMdSpan.hpp
@@ -15,7 +15,7 @@ namespace alpaka::concepts
 {
     namespace impl
     {
-        /** Interface concept that describes how multidimensional memory can be accessed on the host and device side.
+        /** @brief Interface concept for objects describing multidimensional memory access.
          *
          * @details
          *
@@ -41,13 +41,13 @@ namespace alpaka::concepts
          * alpaka::concepts::Alignment
          *
          * @section membertypes Member types
-         * - <b>T::value_type</b>: The element type. Can be const or not.
+         * - <b>T::value_type</b>: The element type. May or may not be const.
          * - <b>T::reference</b>: The element reference type is either const or non-const, depending on
          *`T::value_type`.
          * - <b>T::const_reference</b>: The constant reference type for an element. Always const.
          * - <b>T::pointer</b>: The element pointer type is either const or non-const, depending on
          *`T::value_type`.
-         * - <b>T::const_pointer</b>: The constant pointer type for an element. Always const.
+         * - <b>T::const_pointer</b>: The constant pointer type for an element. Always pointer-to-const.
          * - <b>T::index_type</b>: The index type of the pitch.
          *
          * @note The access operator [] with an integral as an argument is only available if the dimension is one.
@@ -98,13 +98,14 @@ namespace alpaka::concepts
 
     } // namespace impl
 
-    /** Interface concept that describes how multidimensional memory can be accessed on the host and device side.
+    /** @brief Interface concept for objects describing multidimensional memory access.
+     *
+     * @details
      * An object of type `alpaka::mdspan` does not store any information about the storage location, e.g., whether
      * the memory is located on a CPU or a GPU.
      *
      * @attention Use `alpaka::IMdSpan` to restrict types in your code. The actual interface is described in
      * alpaka::concepts::impl::IMdSpan.
-     *
      **/
     template<typename T, typename T_ValueType = alpaka::NotRequired>
     concept IMdSpan = requires {

--- a/include/alpaka/mem/concepts/IView.hpp
+++ b/include/alpaka/mem/concepts/IView.hpp
@@ -15,13 +15,14 @@ namespace alpaka::concepts
 {
     namespace impl
     {
-        /** Interface concept that describes how multidimensional memory can be accessed on the host and device side.
-         * An `alpaka::view` like object contains information about the device(s) to which it is connected. The
-         * `alpaka::view` like object has no memory ownership, and therefore it does not manage the memory lifetime.
+        /** @brief Interface concept for objects describing api-related multidimensional memory access.
          *
-         * The concept fulfills all requirements of the alpaka::concepts::impl::IMdSpan concept and therefore offers
-         * the same interface.
+         * @details
+         * An `alpaka::view`-like object contains information about the device(s) to which it is connected. The
+         * `alpaka::view`-like object has no memory ownership, and therefore, it does not manage the memory lifetime.
+         * The represented memory can have any dimensionality.
          *
+         * Any object fitting the `IView` concept is also an `IMdSpan`.
          **/
         template<typename T, typename T_Mut, typename T_Const>
         concept IView = requires(T t) {
@@ -30,13 +31,15 @@ namespace alpaka::concepts
         };
     } // namespace impl
 
-    /** Interface concept that describes how multidimensional memory can be accessed on the host and device side.
-     * An `alpaka::view` like object contains information about the device(s) to which it is connected. The
-     * `alpaka::view` like object has no memory ownership, and therefore it does not manage the memory lifetime.
+    /** @brief Interface concept for objects describing api-related multidimensional memory access.
+     *
+     * @details
+     * An `alpaka::view`-like object contains information about the device(s) to which it is connected. The
+     * `alpaka::view`-like object has no memory ownership, and, therefore, it does not manage the memory lifetime.
+     * The represented memory can have any dimensionality.
      *
      * @attention Use `alpaka::IView` to restrict types in your code. The actual interface is described in
      * alpaka::concepts::impl::IView.
-     *
      **/
     template<typename T, typename T_ValueType = alpaka::NotRequired>
     concept IView = requires(T t) {

--- a/include/alpaka/mem/trait.hpp
+++ b/include/alpaka/mem/trait.hpp
@@ -19,7 +19,7 @@ namespace alpaka
         {
             struct AutoIndexMapping
             {
-                template<typename T_Acc, typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+            template<typename T_Acc, typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
                 struct Op
                 {
                     constexpr auto operator()(T_Acc const&, T_Api, T_DeviceKind) const

--- a/include/alpaka/mem/trait.hpp
+++ b/include/alpaka/mem/trait.hpp
@@ -19,7 +19,7 @@ namespace alpaka
         {
             struct AutoIndexMapping
             {
-            template<typename T_Acc, typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
+                template<typename T_Acc, typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
                 struct Op
                 {
                     constexpr auto operator()(T_Acc const&, T_Api, T_DeviceKind) const

--- a/include/alpaka/onAcc/Acc.hpp
+++ b/include/alpaka/onAcc/Acc.hpp
@@ -29,7 +29,7 @@ namespace alpaka::onAcc
         constexpr Acc& operator=(Acc const&) = delete;
         constexpr Acc& operator=(Acc&&) = delete;
 
-        /** get the M-dimensional indices within the origin in the quantity of the selected unit */
+        /** Get the n-dimensional indices within the origin in the quantity of the selected unit */
         constexpr alpaka::concepts::Vector auto getIdxWithin(concepts::Origin auto origin, concepts::Unit auto unit)
             const
         {
@@ -39,7 +39,7 @@ namespace alpaka::onAcc
                 unit);
         }
 
-        /** get the M-dimensional extents of an origin in the quantity of the selected unit */
+        /** Get the n-dimensional extents of an origin in the quantity of the selected unit */
         constexpr alpaka::concepts::Vector auto getExtentsOf(concepts::Origin auto origin, concepts::Unit auto unit)
             const
         {
@@ -68,10 +68,10 @@ namespace alpaka::onAcc
 
     namespace concepts
     {
-        /** Concept to check if a type is a accelerator
+        /** Concept to check if a type is an accelerator
          *
          * @tparam T_Acc Type to check
-         * @tparam T_Api enforce an api type, if not provided api type is not checked
+         * @tparam T_Api Enforce an API type, if not provided api type is not checked
          */
         template<typename T_Acc, typename T_Api = alpaka::NotRequired>
         concept Acc = alpaka::isSpecializationOf_v<T_Acc, alpaka::onAcc::Acc>
@@ -79,32 +79,32 @@ namespace alpaka::onAcc
                           || std::same_as<T_Api, alpaka::NotRequired>);
     } // namespace concepts
 
-    /** synchronize all threads within a given scope */
-    template<alpaka::layer::concepts::Layer T_Scope>
+    /** Synchronize all threads within a given scope */
+    template<alpaka::concepts::Layer T_Scope>
     constexpr void sync(concepts::Acc auto const& acc, T_Scope scope)
     {
         internalCompute::sync(acc, scope);
     }
 
-    /** synchronize all threads within a thread block */
+    /** Synchronize all threads within a thread block */
     constexpr void syncBlockThreads(concepts::Acc auto const& acc)
     {
         internalCompute::sync(acc, alpaka::layer::block);
     }
 
-    /** create a variable located in the thread blocks shared memory
+    /** Create a variable located in the thread blocks shared memory
      *
      * @code{.cpp}
      * // creates a reference to a float value
      * auto& foo = declareSharedVar<float, uniqueId()>(acc);
      * @endcode
      *
-     * @attention The data is not initialized it can contains garbage.
+     * @attention The data is not initialized; it can contain garbage.
      *
-     * @tparam T type which should be created, the constructor is not called
-     * @tparam T_uniqueId id those is unique inside a kernel.
+     * @tparam T The type that should be created; the constructor is not called
+     * @tparam T_uniqueId ID that is unique inside a kernel.
      *                  Reusing the id will return the same memory declared before with the same id.
-     * @return result should be taken as reference
+     * @return Result should be taken by reference
      */
     template<typename T, size_t T_uniqueId>
     constexpr decltype(auto) declareSharedVar(concepts::Acc auto const& acc)

--- a/include/alpaka/onAcc/internal/interface.hpp
+++ b/include/alpaka/onAcc/internal/interface.hpp
@@ -16,14 +16,14 @@ namespace alpaka::onAcc
     {
         struct Sync
         {
-            template<typename T_Acc, alpaka::layer::concepts::Layer T_Scope>
+            template<typename T_Acc, alpaka::concepts::Layer T_Scope>
             struct Op
             {
                 constexpr auto operator()(T_Acc const& acc, T_Scope const scope) const;
             };
         };
 
-        constexpr void sync(auto const& acc, alpaka::layer::concepts::Layer auto const scope)
+        constexpr void sync(auto const& acc, alpaka::concepts::Layer auto const scope)
         {
             Sync::Op<ALPAKA_TYPEOF(acc), ALPAKA_TYPEOF(scope)>{}(acc, scope);
         }

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -18,7 +18,16 @@
 
 namespace alpaka::onHost
 {
-    template<typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    /** @brief Description of a specific device that one can schedule kernels on.
+     *
+     * @details
+     * A device is the combination of an alpaka::deviceKind::onHost::DeviceKind and an alpaka::concepts::Api,
+     * representing an entity that one can schedule work on.
+     *
+     * @tparam T_Api The Api powering this device.
+     * @tparam T_DeviceKind The kind of device it is.
+     */
+    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     struct Device
     {
     private:
@@ -73,23 +82,23 @@ namespace alpaka::onHost
 
         /** Create a queue for this device.
          *
-         * @attention If you call this method multiple times it is allowed that you get always the same handle
+         * @attention If you call this method multiple times it is allowed that you always get the same handle
          * back. There is no guarantee that you will get independent queues.
          *
-         * Enqueuing tasks into two different queues is not guaranteeing that these tasks running in parallel.
-         * Running tasks from different tasks sequential is a valid behaviour. Enqueuing into two queues only
-         * providing the information that the tasks are independent of each other.
+         * Enqueuing tasks into two different queues does not guarantee that these tasks run in parallel.
+         * Running tasks from different tasks sequentially is valid behavior. Enqueuing into two individual queues only
+         * signifies that the tasks are independent of each other and their order of execution is independent.
          *
          * @param kind
          *   Blocking behaviour:
-         *    - queueKind::nonBlocking (default): enqueue returns immediately; completion must be ensured via
-         * onHost::wait(queue) or by enqueuing dependent operations onto the same queue.
-         *    - queueKind::nonBlocking: each enqueue only returns after the operation is complete and its effects are
+         *    - queueKind::nonBlocking (default): enqueue returns immediately; completion of the enqueued operation
+         * must be ensured via onHost::wait(queue) or by enqueuing dependent operations onto the same queue.
+         *    - queueKind::blocking: each enqueue only returns after the operation is complete and its effects are
          * host-visible.
          *
-         * @return onHost::Queue where task and memory operations can be enqueues to
+         * @return A onHost::Queue that tasks and memory operations can be enqueued on.
          */
-        auto makeQueue(queueKind::concepts::QueueKind auto kind)
+        auto makeQueue(alpaka::concepts::QueueKind auto kind)
         {
             return Queue{
                 internal::MakeQueue::Op<ALPAKA_TYPEOF(*m_device.get()), ALPAKA_TYPEOF(kind)>{}(*m_device.get(), kind),
@@ -101,30 +110,16 @@ namespace alpaka::onHost
             return makeQueue(queueKind::nonBlocking);
         }
 
-    public:
         auto makeEvent()
         {
             return Event{internal::MakeEvent::Op<std::decay_t<decltype(*m_device.get())>>{}(*m_device.get())};
         }
 
-        /** blocks the caller until the given handle executes all work
-         *
-         * @param any currently only queue handles are supported
+        /** Blocks the caller until the given handle executes all work
          */
         void wait()
         {
             return internal::wait(*m_device.get());
-        }
-
-        /** Get the native handle type
-         *
-         * The handle can be used with native API function from the underlying used parism library.
-         *
-         * @return the type depends on the used API
-         */
-        inline auto getNativeHandle(auto const& any)
-        {
-            return internal::getNativeHandle(*m_device.get());
         }
 
         /** Properties of a given device
@@ -146,6 +141,12 @@ namespace alpaka::onHost
 
     namespace concepts
     {
+        /** @brief Concept to check if something is a device.
+         *
+         * @details
+         * This concept checks for specializations of alpaka::onHost::Device. For more information on devices in
+         * alpaka, refer to the class documentation.
+         */
         template<typename T_Device>
         concept Device = alpaka::isSpecializationOf_v<T_Device, onHost::Device>;
     } // namespace concepts
@@ -197,7 +198,7 @@ namespace alpaka::onHost
 
     /** Allocates unified memory on the device associated with the given queue.
      *
-     * This memory can be accessed from all devices with the same Api and device kind. Depending of the backend e.g.
+     * This memory can be accessed from all devices with the same Api and device kind. Depending on the backend e.g.
      * OneApi memory can be accessed by other device kind devices if they are using the same native context. It is not
      * allowed to access the data on two devices at the same time, this must be avoided by explicit synchronizations.
      * Unified memory follows the rules of UVM memory of the device backend e.g. CUDA, HIP, ...
@@ -208,7 +209,7 @@ namespace alpaka::onHost
      * @param queue queue handle
      * @param extents number of elements for each dimension
      */
-    template<typename T_Type, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Type, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline auto allocUnified(
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
@@ -220,7 +221,7 @@ namespace alpaka::onHost
                 extentsVec);
     }
 
-    /** Allocate pinned memory on the host which is mapped into the adress space of the device
+    /** Allocate pinned memory on the host which is mapped into the address space of the device
      *
      * Mapped memory is located on the host and is transferred for each access via the PCIe/Nvlink bus. The performance
      * on the device is mostly pure. Mapped memory should be used for host memory if you transfer memory between host
@@ -249,7 +250,7 @@ namespace alpaka::onHost
      * @param queue queue handle
      * @param extents number of elements for each dimension
      */
-    template<typename T_Type, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Type, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline auto allocMapped(
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
@@ -257,7 +258,7 @@ namespace alpaka::onHost
         return allocMapped<T_Type>(queue.getDevice(), extents);
     }
 
-    /** allocate memory on the given device based on a view
+    /** Allocate memory on the given device based on a view
      *
      * Derives type and extents of the memory from the view.
      * The content of the memory is NOT copied to the created allocated memory.
@@ -274,7 +275,7 @@ namespace alpaka::onHost
 
     ///@}
 
-    /** check if the given view is accessible on the given device
+    /** Check if the given view is accessible on the given device
      *
      * @param device device handle
      * @param view memory where properties will be derived from
@@ -294,11 +295,11 @@ namespace alpaka::onHost
                    ALPAKA_TYPEOF(view)>{}(getApi(view), getDeviceKind(device), view);
     }
 
-    /** check if the given view is accessible on the given device of the queue.
+    /** Check if the given view is accessible on the device of the given queue
      *
      * @param queue queue handle
      */
-    template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline bool isDataAccessible(Queue<T_Device, T_QueueKind> const& queue, alpaka::concepts::View auto const& view)
     {
         return internal::IsDataAccessible::FirstPath<ALPAKA_TYPEOF(*queue.getDevice().get()), ALPAKA_TYPEOF(view)>{}(
@@ -310,14 +311,14 @@ namespace alpaka::onHost
                    ALPAKA_TYPEOF(view)>{}(getApi(view), getDeviceKind(queue.getDevice()), view);
     }
 
-    /** provides a frame specification to operator on a given index range
+    /** Provides a frame specification to operate on a given index range
      *
      * The frame specification will be optimized for SIMD executions in the highest dimension.
      *
      * @param extents size of the index range
      * @return frame specification
      */
-    template<typename T_DataType, typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<typename T_DataType, typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     inline constexpr auto getFrameSpec(onHost::Device<T_Api, T_DeviceKind> const& device, auto&& extents)
     {
         using ExtentVecType = ALPAKA_TYPEOF(extents);

--- a/include/alpaka/onHost/DeviceSelector.hpp
+++ b/include/alpaka/onHost/DeviceSelector.hpp
@@ -11,11 +11,21 @@
 
 namespace alpaka::onHost
 {
-    template<alpaka::concepts::Api T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    /** @brief Concept for a combination of an API and device kind
+     *
+     * @details
+     * A device specification means the combination of an API and a device kind. Multiple instances of
+     * alpaka::onHost::Device can exist for the same device specification, for example in the form of multiple GPUs of
+     * the same type in one system.
+     *
+     * To check whether a specific combination is valid, i.e., whether an API can target a device kind, the static
+     * isValid() method can be used.
+     */
+    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     struct DeviceSpec
     {
     public:
-        constexpr DeviceSpec(T_Api api, T_DeviceKind devType) : m_api(api), m_deviceType(devType)
+        constexpr DeviceSpec(T_Api api, T_DeviceKind deviceType) : m_api(api), m_deviceType(deviceType)
         {
         }
 
@@ -39,7 +49,7 @@ namespace alpaka::onHost
         /** Checks if the device kind and api combination is valid
          *
          * Reasons why a combination is valid can be that the api does not know how to talk to a device or that the
-         * required dependencies e.g. CUDA, HIP, OneApi are not fulfilled.
+         * required dependencies e.g. CUDA, HIP, or OneApi are not fulfilled.
          *
          * @return true if the device kind and api combination is valid, else false
          */
@@ -53,7 +63,7 @@ namespace alpaka::onHost
         T_DeviceKind m_deviceType;
     };
 
-    template<alpaka::concepts::Api T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     struct DeviceSelector
     {
     public:
@@ -103,15 +113,13 @@ namespace alpaka::onHost
     };
 
     /** create a object to get access to devices */
-    template<typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     inline auto makeDeviceSelector(DeviceSpec<T_Api, T_DeviceKind> deviceSpec)
     {
         return DeviceSelector{deviceSpec};
     }
 
-    inline auto makeDeviceSelector(
-        alpaka::concepts::Api auto api,
-        alpaka::deviceKind::concepts::DeviceKind auto deviceTag)
+    inline auto makeDeviceSelector(alpaka::concepts::Api auto api, alpaka::concepts::DeviceKind auto deviceTag)
     {
         return DeviceSelector{api, deviceTag};
     }
@@ -127,6 +135,8 @@ namespace alpaka::onHost
 
     namespace concepts
     {
+        /** Concept to check for specializations of alpaka::onHost::DeviceSpec
+         */
         template<typename T>
         concept DeviceSpec = isSpecializationOf_v<T, onHost::DeviceSpec>;
     } // namespace concepts

--- a/include/alpaka/onHost/Event.hpp
+++ b/include/alpaka/onHost/Event.hpp
@@ -12,13 +12,13 @@
 
 namespace alpaka::onHost
 {
-    template<typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     struct Device;
 
     template<typename T_Device>
     struct Event;
 
-    template<typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     struct Event<Device<T_Api, T_DeviceKind>>
     {
     private:

--- a/include/alpaka/onHost/FrameSpec.hpp
+++ b/include/alpaka/onHost/FrameSpec.hpp
@@ -17,17 +17,22 @@ namespace alpaka::onHost
     /** @brief Device/Api-agnostic description of an execution pattern for a kernel.
      *
      * @details
-     * A frame specification describes how threads on an execution device are distributed across the
-     * given problem space. The specification contains three parameters:
-     * - `numFrames`: The n-dimensional number of frames to cover the whole problem instance.
-     * - `frameExtents`: The n-dimensional size of one execution unit.
-     * - `threadSpec` (optional): Back-end specific specification of the actual execution resources,
-     * consisting of a number of blocks and number of threads. By default, this is automatically chosen
-     * by alpaka when starting a kernel to fit the alpaka::onHost::Device and alpaka::exec, ensuring
-     * compatibility. User-provided specifications might reduce the (performance-)portability.
+     * A frame specification describes how a multidimensional index range [0; K) is divided into fixed-size chunks,
+     * called frames (NF), each with a frame extent (FE), where `K = NF * FE`.
+     * K does not need to match the problem size (P), e.g., the number of elements in a buffer you want to process in a
+     * kernel. How NF and FE are mapped to physical worker threads and thread blocks within the kernel depends entirely
+     * on the kernel implementation. Often, the best performance of a kernel can be achieved if `K <= P`, and if the
+     * kernel uses SIMD operations, `K <= P/(SIMD width)`. A kernel enqueued with a frame specification should always
+     * be written to be executable with any `FrameSpec` and should not depend on hard-coded thread numbers, to ensure
+     * portability between devices.
      *
-     * A kernel should always be written to be executable with any FrameSpec, and not depend
-     * on hard-coded thread numbers etc., to ensure portability between devices.
+     * The specification contains three parameters:
+     * - `numFrames`: The n-dimensional number of frames.
+     * - `frameExtents`: The n-dimensional size of one execution unit.
+     * - `threadSpec` (optional): Backend-specific specification of the actual execution resources,
+     * consisting of the number of blocks and threads. By default, this is automatically chosen
+     * by alpaka when starting a kernel to fit the `alpaka::onHost::Device` and `alpaka::exec`, ensuring
+     * compatibility. User-provided specifications might reduce the (performance-)portability.
      */
     template<
         alpaka::concepts::Vector T_NumFrames,
@@ -117,7 +122,6 @@ namespace alpaka::onHost
         struct IsFrameSpec<onHost::FrameSpec<T_NumFrames, T_FrameExtents, T_ThreadExtents>> : std::true_type
         {
         };
-
     } // namespace trait
 
     template<typename T>
@@ -151,4 +155,5 @@ namespace alpaka::onHost
         return s << "FrameSpec{ frames=" << d.m_numFrames << ", frameExtent=" << d.m_frameExtent << ", "
                  << d.getThreadSpec() << " }";
     }
+
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/FrameSpec.hpp
+++ b/include/alpaka/onHost/FrameSpec.hpp
@@ -14,6 +14,21 @@
 
 namespace alpaka::onHost
 {
+    /** @brief Device/Api-agnostic description of an execution pattern for a kernel.
+     *
+     * @details
+     * A frame specification describes how threads on an execution device are distributed across the
+     * given problem space. The specification contains three parameters:
+     * - `numFrames`: The n-dimensional number of frames to cover the whole problem instance.
+     * - `frameExtents`: The n-dimensional size of one execution unit.
+     * - `threadSpec` (optional): Back-end specific specification of the actual execution resources,
+     * consisting of a number of blocks and number of threads. By default, this is automatically chosen
+     * by alpaka when starting a kernel to fit the alpaka::onHost::Device and alpaka::exec, ensuring
+     * compatibility. User-provided specifications might reduce the (performance-)portability.
+     *
+     * A kernel should always be written to be executable with any FrameSpec, and not depend
+     * on hard-coded thread numbers etc., to ensure portability between devices.
+     */
     template<
         alpaka::concepts::Vector T_NumFrames,
         alpaka::concepts::Vector<typename T_NumFrames::type, T_NumFrames::dim()> T_FrameExtents,

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -15,16 +15,16 @@
 
 namespace alpaka::onHost
 {
-    template<typename T_Api, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind>
+    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     struct Device;
 
-    template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     struct Queue;
 
     template<
-        typename T_Api,
-        alpaka::deviceKind::concepts::DeviceKind T_DeviceKind,
-        queueKind::concepts::QueueKind T_QueueKind>
+        alpaka::concepts::Api T_Api,
+        alpaka::concepts::DeviceKind T_DeviceKind,
+        alpaka::concepts::QueueKind T_QueueKind>
     struct Queue<Device<T_Api, T_DeviceKind>, T_QueueKind>
     {
     private:
@@ -172,7 +172,7 @@ namespace alpaka::onHost
         }
     };
 
-    template<typename T_Queue, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Queue, alpaka::concepts::QueueKind T_QueueKind>
     Queue(Handle<T_Queue>&&, T_QueueKind) -> Queue<
         Device<
             ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Queue>())),
@@ -192,7 +192,7 @@ namespace alpaka::onHost
      * @param[in,out] dest can be a container/view where the data should be written to
      * @param[in] source can be a container/view from which the data will be copied
      */
-    template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void memcpy(Queue<T_Device, T_QueueKind> const& queue, auto&& dest, auto const& source)
     {
         memcpy(queue, ALPAKA_FORWARD(dest), source, internal::getExtents(dest));
@@ -205,7 +205,7 @@ namespace alpaka::onHost
      * @param[in] source can be a container/view from which the data will be copied
      * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
      */
-    template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void memcpy(
         Queue<T_Device, T_QueueKind> const& queue,
         auto&& dest,
@@ -228,7 +228,7 @@ namespace alpaka::onHost
      * is finished.
      * @param byteValue value to be written to each byte
      */
-    template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void memset(Queue<T_Device, T_QueueKind> const& queue, auto&& dest, uint8_t byteValue)
     {
         memset(queue, ALPAKA_FORWARD(dest), byteValue, internal::getExtents(dest));
@@ -243,7 +243,7 @@ namespace alpaka::onHost
      * @param byteValue value to be written to each byte
      * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
      */
-    template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void memset(
         Queue<T_Device, T_QueueKind> const& queue,
         auto&& dest,
@@ -265,7 +265,7 @@ namespace alpaka::onHost
      * is finished.
      * @param elementValue value to be written to each element
      */
-    template<typename T_Value, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Value, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void fill(Queue<T_Device, T_QueueKind> const& queue, auto&& dest, T_Value elementValue) requires(
         std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
         && std::same_as<ALPAKA_TYPEOF(alpaka::internal::getApi(queue)), ALPAKA_TYPEOF(alpaka::internal::getApi(dest))>)
@@ -283,7 +283,7 @@ namespace alpaka::onHost
      * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
      */
 
-    template<typename T_Value, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Value, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void fill(
         Queue<T_Device, T_QueueKind> const& queue,
         auto&& dest,
@@ -327,7 +327,7 @@ namespace alpaka::onHost
      * memory is destroyed. The deallocation is asynchronous performed in the the queue which is used for the
      * allocation.
      */
-    template<typename T_Type, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Type, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline auto allocDeferred(
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
@@ -355,7 +355,7 @@ namespace alpaka::onHost
      * memory is destroyed. The deallocation is asynchronous performed in the the queue which is used for the
      * allocation.
      */
-    template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline auto allocLikeAsync(Queue<T_Device, T_QueueKind> const& queue, auto const& view)
     {
         return allocDeferred<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(queue, getExtents(view));

--- a/include/alpaka/onHost/algo/concurrent.hpp
+++ b/include/alpaka/onHost/algo/concurrent.hpp
@@ -41,7 +41,7 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<typename T_DataType, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void concurrent(
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::Executor auto const exec,
@@ -56,7 +56,7 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is an executor with most
      * parallelism/performance.
      */
-    template<typename T_DataType, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void concurrent(
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents,

--- a/include/alpaka/onHost/algo/iota.hpp
+++ b/include/alpaka/onHost/algo/iota.hpp
@@ -26,7 +26,7 @@ namespace alpaka::onHost
      * kind of alpaka View/MdSpan is supported.
      * @{
      */
-    template<typename T_DataType, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     requires(std::is_fundamental_v<T_DataType>)
     inline void iota(
         Queue<T_Device, T_QueueKind> const& queue,
@@ -52,7 +52,7 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is the executor with the most
      * parallelism/performance.
      */
-    template<typename T_DataType, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     requires(std::is_fundamental_v<T_DataType>)
     inline void iota(
         Queue<T_Device, T_QueueKind> const& queue,

--- a/include/alpaka/onHost/algo/reduce.hpp
+++ b/include/alpaka/onHost/algo/reduce.hpp
@@ -26,7 +26,7 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<typename DataType, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void reduce(
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::Executor auto const exec,
@@ -49,7 +49,7 @@ namespace alpaka::onHost
      * A available default executor will be selected automaticlally. The default executor is a executor with most
      * parallelism/performance.
      */
-    template<typename DataType, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void reduce(
         Queue<T_Device, T_QueueKind> const& queue,
         DataType const& neutralElement,

--- a/include/alpaka/onHost/algo/transform.hpp
+++ b/include/alpaka/onHost/algo/transform.hpp
@@ -46,7 +46,7 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void transform(
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::Executor auto const exec,
@@ -58,10 +58,10 @@ namespace alpaka::onHost
     }
 
     /**
-     * A available default executor will be selected automaticlally. The default executor is a executor with most
+     * A available default executor will be selected automatically. The default executor is a executor with most
      * parallelism/performance.
      */
-    template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void transform(Queue<T_Device, T_QueueKind> const& queue, auto&& out, auto&& fn, auto&&... in)
     {
         auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -56,7 +56,7 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<typename DataType, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void transformReduce(
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::Executor auto const exec,
@@ -80,7 +80,7 @@ namespace alpaka::onHost
      * A available default executor will be selected automaticlally. The default executor is a executor with most
      * parallelism/performance.
      */
-    template<typename DataType, typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+    template<typename DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
     inline void transformReduce(
         Queue<T_Device, T_QueueKind> const& queue,
         DataType const& neutralElement,

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -19,14 +19,14 @@ namespace alpaka::onHost
     {
         struct MakePlatform
         {
-            template<typename T_Api, deviceKind::concepts::DeviceKind T_DeviceKind>
+            template<typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
             struct Op
             {
                 auto operator()(T_Api api, T_DeviceKind deviceType) const;
             };
         };
 
-        static auto makePlatform(auto api, deviceKind::concepts::DeviceKind auto deviceType)
+        static auto makePlatform(auto api, alpaka::concepts::DeviceKind auto deviceType)
         {
             return MakePlatform::Op<ALPAKA_TYPEOF(api), ALPAKA_TYPEOF(deviceType)>{}(api, deviceType);
         }
@@ -91,7 +91,7 @@ namespace alpaka::onHost
 
         struct MakeQueue
         {
-            template<typename T_Device, queueKind::concepts::QueueKind T_QueueKind>
+            template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
             struct Op
             {
                 auto operator()(T_Device& device, T_QueueKind) const
@@ -330,7 +330,7 @@ namespace alpaka::onHost
                 bool operator()(T_Device& device, T_Any const& any) const;
             };
 
-            template<typename T_DataApi, alpaka::deviceKind::concepts::DeviceKind T_DeviceKind, typename T_Any>
+            template<typename T_DataApi, alpaka::concepts::DeviceKind T_DeviceKind, typename T_Any>
             struct SecondPath
             {
                 bool operator()(T_DataApi, T_DeviceKind, T_Any const& any) const

--- a/include/alpaka/onHost/internal/logger.hpp
+++ b/include/alpaka/onHost/internal/logger.hpp
@@ -114,7 +114,7 @@ namespace alpaka::onHost::logger::internal
     }
 
     /** Log the entry and exit of a scope */
-    template<logger::concepts::Lvl T_LogLvl, typename T_Writer = StdErr>
+    template<logger::concepts::Level T_LogLvl, typename T_Writer = StdErr>
     struct Scoped
     {
     public:
@@ -163,7 +163,7 @@ namespace alpaka::onHost::logger::internal
      *
      * @tparam T_Callable callable without arguments which provides a string which should be written to the output
      */
-    template<logger::concepts::Lvl T_LogLvl, typename T_Callable, typename T_Writer = StdErr>
+    template<logger::concepts::Level T_LogLvl, typename T_Callable, typename T_Writer = StdErr>
     requires(std::is_invocable_r_v<std::string, T_Callable>)
     struct Info
     {

--- a/include/alpaka/onHost/logger/logger.hpp
+++ b/include/alpaka/onHost/logger/logger.hpp
@@ -22,7 +22,7 @@ namespace alpaka::onHost::logger
      * @param logLvl log level or a sum of log levels
      */
     inline auto scope(
-        concepts::Lvl auto logLvl,
+        concepts::Level auto logLvl,
         std::source_location const& location = std::source_location::current())
     {
 #if defined(ALPAKA_LOG_STATIC)
@@ -58,7 +58,7 @@ namespace alpaka::onHost::logger
      * @param callable callable without arguments which provides a string which should be written to the output
      */
     inline void info(
-        concepts::Lvl auto logLvl,
+        concepts::Level auto logLvl,
         auto const& callable,
         std::source_location const& location = std::source_location::current())
     {

--- a/include/alpaka/onHost/logger/lvl.hpp
+++ b/include/alpaka/onHost/logger/lvl.hpp
@@ -45,21 +45,23 @@ namespace alpaka::onHost::logger
 
     namespace concepts
     {
+        /** Concept for log level types
+         */
         template<typename T_DeviceKind>
-        concept Lvl = isLogLvl_v<T_DeviceKind>;
+        concept Level = isLogLvl_v<T_DeviceKind>;
     } // namespace concepts
 
-    constexpr bool operator==(concepts::Lvl auto lhs, concepts::Lvl auto rhs)
+    constexpr bool operator==(concepts::Level auto lhs, concepts::Level auto rhs)
     {
         return std::is_same_v<ALPAKA_TYPEOF(lhs), ALPAKA_TYPEOF(rhs)>;
     }
 
-    constexpr bool operator!=(concepts::Lvl auto lhs, concepts::Lvl auto rhs)
+    constexpr bool operator!=(concepts::Level auto lhs, concepts::Level auto rhs)
     {
         return !(lhs == rhs);
     }
 
-    constexpr auto operator+(concepts::Lvl auto lhs, concepts::Lvl auto rhs)
+    constexpr auto operator+(concepts::Level auto lhs, concepts::Level auto rhs)
     {
         return detail::AggregatedLogger<ALPAKA_TYPEOF(lhs), ALPAKA_TYPEOF(rhs)>{};
     }

--- a/include/alpaka/onHost/mem/SharedBuffer.hpp
+++ b/include/alpaka/onHost/mem/SharedBuffer.hpp
@@ -87,7 +87,7 @@ namespace alpaka::onHost
             , m_deleter{std::make_shared<internal::ManagedDealloc>(deleter)}
         {
             static_assert(
-                isLosslessConvertible_v<typename T_UserPitches::type, typename T_UserExtents::type>,
+                isLosslesslyConvertible_v<typename T_UserPitches::type, typename T_UserExtents::type>,
                 "extent type and pitch type must be lossless convertible");
         }
 
@@ -251,7 +251,7 @@ namespace alpaka::onHost
 
     private:
         /** @todo move this to trais or somewhere else that it can be used everywhere */
-        template<alpaka::concepts::IsPointer T>
+        template<alpaka::concepts::Pointer T>
         using ConstPtr_t = std::add_pointer_t<std::add_const_t<std::remove_pointer_t<T>>>;
 
         std::shared_ptr<internal::ManagedDealloc> m_deleter;

--- a/include/alpaka/onHost/trait.hpp
+++ b/include/alpaka/onHost/trait.hpp
@@ -42,7 +42,7 @@ namespace alpaka::onHost
 
         struct IsDeviceSupportedBy
         {
-            template<deviceKind::concepts::DeviceKind T_DeviceKind, typename T_Api>
+            template<alpaka::concepts::DeviceKind T_DeviceKind, typename T_Api>
             struct Op : std::false_type
             {
             };

--- a/include/alpaka/tag.hpp
+++ b/include/alpaka/tag.hpp
@@ -54,24 +54,33 @@ namespace alpaka
 
         template<typename T_QueueKind>
         constexpr bool isQueueKind_v = trait::IsQueueKind<T_QueueKind>::value;
+    } // namespace queueKind
 
-        namespace concepts
-        {
-            template<typename T_QueueKind>
-            concept QueueKind = isQueueKind_v<T_QueueKind>;
-        } // namespace concepts
+    namespace concepts
+    {
+        /** Concept to check if a type is a queue kind
+         *
+         * @details
+         * Example queue kinds are alpaka::queueKind::Blocking or alpaka::queueKind::NonBlocking.
+         */
+        template<typename T_QueueKind>
+        concept QueueKind = queueKind::isQueueKind_v<T_QueueKind>;
+    } // namespace concepts
 
-        constexpr bool operator==(concepts::QueueKind auto lhs, concepts::QueueKind auto rhs)
+    namespace queueKind
+    {
+        constexpr bool operator==(alpaka::concepts::QueueKind auto lhs, alpaka::concepts::QueueKind auto rhs)
         {
             return std::is_same_v<ALPAKA_TYPEOF(lhs), ALPAKA_TYPEOF(rhs)>;
         }
 
-        constexpr bool operator!=(concepts::QueueKind auto lhs, concepts::QueueKind auto rhs)
+        constexpr bool operator!=(alpaka::concepts::QueueKind auto lhs, alpaka::concepts::QueueKind auto rhs)
         {
             return !(lhs == rhs);
         }
 
-        /// Queue should block during the task execution
+        /** Queue should block during the task execution
+         */
         struct Blocking : detail::QueueKindBase
         {
             static std::string getName()
@@ -82,7 +91,8 @@ namespace alpaka
 
         constexpr auto blocking = Blocking{};
 
-        /// Queue should process task asynchronous
+        /** Queue should process task asynchronously
+         */
         struct NonBlocking : detail::QueueKindBase
         {
             static std::string getName()
@@ -113,13 +123,23 @@ namespace alpaka
 
         template<typename T_DeviceKind>
         constexpr bool isDeviceKind_v = trait::IsDeviceKind<T_DeviceKind>::value;
+    } // namespace deviceKind
 
-        namespace concepts
-        {
-            template<typename T_DeviceKind>
-            concept DeviceKind = isDeviceKind_v<T_DeviceKind>;
-        } // namespace concepts
+    namespace concepts
+    {
+        /** @brief Concept to check if something is a device kind
+         *
+         * @details
+         * A device kind in alpaka is a type of acceleration device, such as a GPU vendor. Examples are
+         * alpaka::deviceKind::amdGpu or alpaka::deviceKind::cpu. Together with an alpaka::onHost::Api, it can make
+         * up an alpaka::onHost::Device.
+         */
+        template<typename T_DeviceKind>
+        concept DeviceKind = deviceKind::isDeviceKind_v<T_DeviceKind>;
+    } // namespace concepts
 
+    namespace deviceKind
+    {
         constexpr bool operator==(concepts::DeviceKind auto lhs, concepts::DeviceKind auto rhs)
         {
             return std::is_same_v<ALPAKA_TYPEOF(lhs), ALPAKA_TYPEOF(rhs)>;
@@ -192,14 +212,23 @@ namespace alpaka
         } // namespace trait
 
         template<typename T_Layer>
-        constexpr bool isIsLayer_v = trait::IsLayer<T_Layer>::value;
+        constexpr bool isLayer_v = trait::IsLayer<T_Layer>::value;
+    } // namespace layer
 
-        namespace concepts
-        {
-            template<typename T_Layer>
-            concept Layer = isIsLayer_v<T_Layer>;
-        } // namespace concepts
+    namespace concepts
+    {
+        /** @brief Concept to check for a compute layer of an accelerator
+         *
+         * @details
+         * A layer is one specific part of the compute hierarchy of accelerators, for example alpaka::layer::Thread or
+         * alpaka::layer::Block.
+         */
+        template<typename T_Layer>
+        concept Layer = layer::isLayer_v<T_Layer>;
+    } // namespace concepts
 
+    namespace layer
+    {
         struct Thread : detail::LayerBase
         {
         };

--- a/include/alpaka/trait.hpp
+++ b/include/alpaka/trait.hpp
@@ -13,7 +13,8 @@
 
 namespace alpaka
 {
-    /** This types is used in cases where the type is not required and can be given optionally into a trait or concept.
+    /** This type is used in cases where a template type parameter is not required and can optionally be passed to a
+     * trait or concept.
      */
     struct NotRequired
     {
@@ -69,33 +70,35 @@ namespace alpaka
         {
         };
 
-        //! Check if a type used as kernel argument is trivially copyable
-        //!
-        //! \attention In case this trait is specialized for a user type the user should be sure that the result of
-        //! calling the copy constructor is equal to use memcpy to duplicate the object. An existing destructor should
-        //! be free of side effects.
-        //!
-        //! It's implementation defined whether the closure type of a lambda is trivially copyable.
-        //! Therefor the default implementation is true for trivially copyable or empty (stateless) types.
-        //!
-        //! @tparam T type to check
+        /** Check if a type used as kernel argument is trivially copyable
+         *
+         * @attention In case this trait is specialized for a user type, the user should be sure that the result of
+         * calling the copy constructor is equivalent to using memcpy to duplicate the object. An existing destructor
+         * must be free of side effects.
+         *
+         * It is implementation defined whether the closure type of a lambda is trivially copyable.
+         * Therefore, the default implementation is true for trivially copyable or empty (stateless) types.
+         *
+         * @tparam T type to check
+         */
         template<typename T, typename = void>
         struct IsKernelArgumentTriviallyCopyable
             : std::bool_constant<std::is_empty_v<T> || std::is_trivially_copyable_v<T>>
         {
         };
 
-        //! Check if the kernel type is trivially copyable
-        //!
-        //! \attention In case this trait is specialized for a user type the user should be sure that the result of
-        //! calling the copy constructor is equal to use memcpy to duplicate the object. An existing destructor should
-        //! be free of side effects.
-        //!
-        //! The default implementation is true for trivially copyable types (or for extended lambda expressions for
-        //! CUDA).
-        //!
-        //! @tparam T type to check
-        //! @{
+        /** Check if the kernel type is trivially copyable
+         *
+         * @attention In case this trait is specialized for a user type, the user should be sure that the result of
+         * calling the copy constructor is equivalent to using memcpy to duplicate the object. An existing destructor
+         * must be free of side effects.
+         *
+         * The default implementation is true for trivially copyable types (or for extended lambda expressions for
+         * CUDA).
+         *
+         * @tparam T type to check
+         * @{
+         */
         template<typename T, typename = void>
         struct IsKernelTriviallyCopyable
 #if ALPAKA_COMP_NVCC
@@ -116,25 +119,35 @@ namespace alpaka
     inline constexpr bool isKernelTriviallyCopyable_v = trait::IsKernelTriviallyCopyable<T>::value;
 
     template<typename T>
-    consteval uint32_t getDim([[maybe_unused]] T const& any)
+    [[nodiscard]] consteval uint32_t getDim([[maybe_unused]] T const& any)
     {
         return trait::getDim_v<T>;
     }
 
     template<typename T_From, typename T_To>
-    constexpr bool isLosslessConvertible_v = concepts::IsLosslessConvertible<T_From, T_To>;
+    constexpr bool isLosslesslyConvertible_v = concepts::LosslesslyConvertible<T_From, T_To>;
 
     template<typename T_From, typename T_To>
-    constexpr bool isConvertible_v = concepts::IsConvertible<T_From, T_To>;
+    constexpr bool isConvertible_v = concepts::Convertible<T_From, T_To>;
 
     template<typename T>
     constexpr bool isMdSpan_v = trait::IsMdSpan<T>::value;
 
     namespace concepts
     {
+        /** @brief Concept to check for a kernel function object
+         *
+         * @details
+         * The kernel function object must be trivially copyable.
+         */
         template<typename T>
         concept KernelFn = isKernelArgumentTriviallyCopyable_v<T>;
 
+        /** @brief Concept to check for a kernel argument object
+         *
+         * @details
+         * A kernel call requires that its arguments are trivially copyable, which this concept requires.
+         */
         template<typename T>
         concept KernelArg = isKernelArgumentTriviallyCopyable_v<T>;
     } // namespace concepts

--- a/include/alpaka/vecConcepts.hpp
+++ b/include/alpaka/vecConcepts.hpp
@@ -50,12 +50,12 @@ namespace alpaka
          * @tparam T_To The target type to which the source type is converted.
          */
         template<typename T_From, typename T_To>
-        concept IsLosslessConvertible
+        concept LosslesslyConvertible
             = std::convertible_to<T_From, T_To>
               && (detail::integralIntegralLossless<T_From, T_To> || detail::floatFloatLossless<T_From, T_To>
                   || detail::integralFloatLossless<T_From, T_To>);
 
         template<typename T_From, typename T_To>
-        concept IsConvertible = requires { std::is_convertible_v<T_From, T_To>; };
+        concept Convertible = requires { std::is_convertible_v<T_From, T_To>; };
     }; // namespace concepts
 } // namespace alpaka

--- a/tests/unit/vec/concepts.cpp
+++ b/tests/unit/vec/concepts.cpp
@@ -17,25 +17,25 @@ TEST_CASE("vec concepts", "[vector]")
 {
     using namespace alpaka;
 
-    // lossless convertable
-    static_assert(concepts::IsLosslessConvertible<int32_t, int32_t>);
-    static_assert(concepts::IsLosslessConvertible<uint32_t, uint32_t>);
-    static_assert(concepts::IsLosslessConvertible<int16_t, int16_t>);
-    static_assert(concepts::IsLosslessConvertible<uint16_t, uint16_t>);
-    static_assert(concepts::IsLosslessConvertible<uint16_t, uint32_t>);
-    static_assert(concepts::IsLosslessConvertible<uint16_t, int32_t>);
-    static_assert(concepts::IsLosslessConvertible<uint32_t, int64_t>);
-    static_assert(concepts::IsLosslessConvertible<int16_t, float>);
-    static_assert(concepts::IsLosslessConvertible<uint16_t, float>);
-    static_assert(concepts::IsLosslessConvertible<int32_t, double>);
-    static_assert(concepts::IsLosslessConvertible<uint32_t, double>);
-    static_assert(concepts::IsLosslessConvertible<float, double>);
+    // losslessly convertible
+    static_assert(concepts::LosslesslyConvertible<int32_t, int32_t>);
+    static_assert(concepts::LosslesslyConvertible<uint32_t, uint32_t>);
+    static_assert(concepts::LosslesslyConvertible<int16_t, int16_t>);
+    static_assert(concepts::LosslesslyConvertible<uint16_t, uint16_t>);
+    static_assert(concepts::LosslesslyConvertible<uint16_t, uint32_t>);
+    static_assert(concepts::LosslesslyConvertible<uint16_t, int32_t>);
+    static_assert(concepts::LosslesslyConvertible<uint32_t, int64_t>);
+    static_assert(concepts::LosslesslyConvertible<int16_t, float>);
+    static_assert(concepts::LosslesslyConvertible<uint16_t, float>);
+    static_assert(concepts::LosslesslyConvertible<int32_t, double>);
+    static_assert(concepts::LosslesslyConvertible<uint32_t, double>);
+    static_assert(concepts::LosslesslyConvertible<float, double>);
 
-    // not lossless convertable
-    static_assert(!concepts::IsLosslessConvertible<int32_t, uint32_t>);
-    static_assert(!concepts::IsLosslessConvertible<uint32_t, int32_t>);
-    static_assert(!concepts::IsLosslessConvertible<int32_t, int16_t>);
-    static_assert(!concepts::IsLosslessConvertible<double, float>);
-    static_assert(!concepts::IsLosslessConvertible<int32_t, float>);
-    static_assert(!concepts::IsLosslessConvertible<uint32_t, float>);
+    // not losslessly convertible
+    static_assert(!concepts::LosslesslyConvertible<int32_t, uint32_t>);
+    static_assert(!concepts::LosslesslyConvertible<uint32_t, int32_t>);
+    static_assert(!concepts::LosslesslyConvertible<int32_t, int16_t>);
+    static_assert(!concepts::LosslesslyConvertible<double, float>);
+    static_assert(!concepts::LosslesslyConvertible<int32_t, float>);
+    static_assert(!concepts::LosslesslyConvertible<uint32_t, float>);
 }

--- a/tests/unit/vec/vec.cpp
+++ b/tests/unit/vec/vec.cpp
@@ -224,19 +224,13 @@ struct CompileTimeKernel3D
         constexpr auto selectRes2 = vec[selectVec2];
         static_assert(selectRes2 == Vec{7, 5});
 
-        // cvec left and right join, empty result is currently not supported because zero dimensional vector is not
-        // allowed
+        // cvec filter
+        // empty results are undefined because zero length vectors don't exist
         auto m0 = CVec<int, 1, 2, 0>{};
         auto m1 = CVec<int, 1, 5>{};
 
-        constexpr auto l = leftJoin(m0, m1);
+        constexpr auto l = filter(m0, m1);
         static_assert(l == Vec{2, 0});
-
-        constexpr auto r = rightJoin(m0, m1);
-        static_assert(r == Vec{5});
-
-        constexpr auto inner = innerJoin(m0, m1);
-        static_assert(inner == Vec{1});
 
         constexpr auto vecSrcApply = CVec<int, 1, 2>{};
         constexpr auto vecResApply


### PR DESCRIPTION
This PR adds/improves documentation on some of the existing concepts and classes.

# List of added/extended Doc strings (concepts)
- `alpaka::concepts::API` (new)
- `alpaka::concepts::IMdSpan` (extented)
- `alpaka::concepts::IView` (extented)
- `alpaka::concepts::IBuffer` (extented) -> should be moved to `alpaka::onHost::concepts::IBuffer`?
- `alpaka::concepts::DeviceKind` (new)
- `alpaka::concepts::Device` (new)
- `alpaka::concepts::Alignment` (new)
- `alpaka::concepts::Executor` (new)

# List of added/extended Doc strings (classes)
- `alpaka::onHost::Device` (new)
- `alpaka::onHost::FrameSpec` (new)
- `alpaka::Alignment` (new)
- `alpaka::CVec` (new, and some of its related functions)


Also some cleanup:
- Rename concepts from `IsSomething` to just `Something`
- Spelling mistakes/inconsistencies