### PR TITLE
fix CMake argument forwarding to compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,23 +62,27 @@ alpaka is providing Cmake targets based on the optional activated dependencies `
 
 - targets:
     - `alpaka::headers`
-      - set include dependencies and provides access to `host` API 
+      - set include dependencies 
+      - activate headre code based on the CMake option `alpaka_EXEC_*` (required for examples/tests/benchmarks)
+      - set `CXX` standard
     - `alpaka::host` 
-      - alias for `alpaka::headers`
-    - `alpaka`, `alpaka::alpaka`
-      - links `alpaka::headers` and provides access to an API activated the dependency switch 
-      - if at least two of the dependencies `alpaka_DEP_CUDA`, `alpaka_DEP_HIP`, or `alpaka_DEP_ONEAPI` are activated
-        - **none** of the APIs (expept `host`) will be added because these dependencies are mutual exclusive
-        - you should add the required executor targets manually
+      - links `alpaka::headers`
+      - sets compiler flags those are generic for CUDA/HIP and C++ targets
+      - sets special compiler flags those are for C++ targets only
     - `alpaka::cuda`
       - is available if `-Dalpaka_DEP_CUDA=ON` is set
       - activates support for NVIDIA GPUs
-    - `alpaka::hip` 
+    - `alpaka::hip`
       - is available if `-Dalpaka_DEP_HIP=ON` is set
       - activates support for AMD GPUs
-    - `alpaka::oneapi` 
-      - available if `-Dalpaka_DEP_ONEAPI=ON` is set
-      - activates support for CPUs, NVIDIA GPUs, AMD GPUs, and Intel GPUs
+    - `alpaka::oneapi`
+        - available if `-Dalpaka_DEP_ONEAPI=ON` is set
+        - activates support for CPUs, NVIDIA GPUs, AMD GPUs, and Intel GPUs
+    - `alpaka`, `alpaka::alpaka`
+      - links `alpaka::headers` and provides access to an API's activated by dependency switches
+      - if at least two of the dependencies `alpaka_DEP_CUDA`, `alpaka_DEP_HIP`, or `alpaka_DEP_ONEAPI` are activated
+        - **none** of the APIs (expect `host`) will be added because these dependencies are mutual exclusive
+        - you should add the required executor targets manually
 
 Note `alpaka_DEP_OMP` is linked into the target `alpaka::headers` because it influences only `host` executors but is not providing additional alpaka API support.
 

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -116,7 +116,11 @@ if(NOT TARGET alpaka)
     add_library(alpaka::alpaka ALIAS alpaka)
     target_compile_definitions(alpaka INTERFACE ALPAKA_CMAKE_TARGET_ALPAKA)
 
-    add_library(alpaka::host ALIAS alpaka_target_headers)
+    add_library(alpaka_target_host INTERFACE)
+    add_library(alpaka::host ALIAS alpaka_target_host)
+    target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_CMAKE_TARGET_HOST)
+    target_link_libraries(alpaka_target_host INTERFACE alpaka_target_headers)
+    target_link_libraries(alpaka INTERFACE alpaka::host)
 
     # the alpaka library itself
     # SYSTEM voids showing warnings produced by alpaka when used in user applications.
@@ -134,12 +138,12 @@ if(NOT TARGET alpaka)
     endif()
 
     target_include_directories(
-        alpaka_target_headers
+        alpaka_target_host
         INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
     target_compile_features(alpaka_target_headers INTERFACE cxx_std_${alpaka_CXX_STANDARD})
 
-    target_link_libraries(alpaka INTERFACE alpaka_target_headers)
+    target_link_libraries(alpaka INTERFACE alpaka_target_host)
 endif()
 
 set(alpaka_COUNT_API_DEPS 0)
@@ -175,21 +179,23 @@ if(alpaka_DEP_ONEAPI)
     include(${_alpaka_CMAKE_DIR}/alpakaOneApi.cmake)
 endif()
 
-## GCC compiler
+## GCC compiler flag to show a longer stack for concept diagnostics
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-    alpaka_set_compiler_options(HOST target alpaka_target_headers "-fconcepts-diagnostics-depth=${alpaka_GCC_CONCEPT_DEPTH}")
+    alpaka_set_compiler_options(HOST target alpaka_target_host "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-fconcepts-diagnostics-depth=${alpaka_GCC_CONCEPT_DEPTH}>")
 endif()
 
 ## OpenMP
+# Thereis no way to get the correct flags for the language CUDA or HIP
 if(alpaka_DEP_OMP)
     find_package(OpenMP REQUIRED COMPONENTS CXX)
-    target_link_libraries(alpaka_target_headers INTERFACE OpenMP::OpenMP_CXX)
+    target_link_libraries(alpaka_target_host INTERFACE OpenMP::OpenMP_CXX)
     message(STATUS "OpenMP found: ${OpenMP_CXX_VERSION}")
 endif()
 
 ## search for atomic ref
 
 # Check for C++20 std::atomic_ref first
+# we only check the CXX compiler, equal to OpenMP which is checked for the CXX compiler only too.
 try_compile(
     alpaka_HAS_STD_ATOMIC_REF # Result stored here
     "${PROJECT_BINARY_DIR}/alpakaFeatureTests" # Binary directory for output file
@@ -201,7 +207,7 @@ try_compile(
 )
 if(alpaka_HAS_STD_ATOMIC_REF AND (NOT alpaka_ACC_CPU_DISABLE_ATOMIC_REF))
     message(STATUS "std::atomic_ref<T> found")
-    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_HAS_STD_ATOMIC_REF)
+    target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_HAS_STD_ATOMIC_REF)
 else()
     message(STATUS "std::atomic_ref<T> NOT found")
 endif()
@@ -209,7 +215,7 @@ endif()
 if(NOT alpaka_HAS_STD_ATOMIC_REF)
     if(Boost_ATOMIC_FOUND)
         message(STATUS "boost::atomic_ref<T> found")
-        target_link_libraries(alpaka_target_headers INTERFACE Boost::atomic)
+        target_link_libraries(alpaka_target_host INTERFACE Boost::atomic)
     else()
         message(STATUS "boost::atomic_ref<T> NOT found")
     endif()
@@ -220,7 +226,7 @@ if((NOT alpaka_HAS_STD_ATOMIC_REF) AND (NOT Boost_ATOMIC_FOUND))
         STATUS
         "atomic_ref<T> or boost::atomic_ref<T> was not found or manually disabled. Falling back to lock-based CPU atomics."
     )
-    target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_ATOMIC_ATOMICREF)
+    target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_DISABLE_ATOMIC_ATOMICREF)
 endif()
 
 # These options are used in the alpaka_finalize call
@@ -246,34 +252,34 @@ else()
 endif()
 if(alpaka_LOG_ENABLED)
     if(${alpaka_LOG} STREQUAL "static")
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_STATIC)
+        target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_LOG_STATIC)
     endif()
 
     if(${alpaka_LOG} STREQUAL "dynamic")
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_DYNAMIC)
+        target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_LOG_DYNAMIC)
     endif()
 
     option(alpaka_LOG_INDENT "Enable/Disable call stack indention for logging" ON)
     if(alpaka_LOG_INDENT)
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_INDENT)
+        target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_LOG_INDENT)
     endif()
 
     set(alpaka_LOG_DETAIL "short" CACHE STRING "Set how the logging should be compiled into alpaka")
     set_property(CACHE alpaka_LOG_DETAIL PROPERTY STRINGS "short;long")
     if(${alpaka_LOG_DETAIL} STREQUAL "short")
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_DETAIL_SHORT)
+        target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_LOG_DETAIL_SHORT)
     elseif(${alpaka_LOG_DETAIL} STREQUAL "long")
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_LOG_DETAIL_LONG)
+        target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_LOG_DETAIL_LONG)
     endif()
 
     option(alpaka_LOG_FUNCTIONS "Enable/Disable logging of function entry and exit" ON)
     if(alpaka_LOG_FUNCTIONS)
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_ENABLE_LOG_FUNCTIONS)
+        target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_ENABLE_LOG_FUNCTIONS)
     endif()
 
     option(alpaka_LOG_INFO "Enable/Disable logging of additional information" ON)
     if(alpaka_LOG_INFO)
-        target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_ENABLE_LOG_INFO)
+        target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_ENABLE_LOG_INFO)
     endif()
     if(${alpaka_LOG} STREQUAL "static")
         # Set default options for each log level (Device, Event, Memory, Queue, Kernel)
@@ -312,7 +318,7 @@ if(alpaka_LOG_ENABLED)
 
         # Pass the bit mask to the C++ code via target_compile_definitions
         target_compile_definitions(
-            alpaka_target_headers
+            alpaka_target_host
             INTERFACE ALPAKA_LOG_STATIC_LVL_MASK=${alpaka_LOG_STATIC_LVL_MASK_VALUE}
         )
 
@@ -322,6 +328,7 @@ if(alpaka_LOG_ENABLED)
 endif()
 
 # CMake executor options for tests/benchmarks and examples
+# The follwoing option influences the alpaka header target
 option(alpaka_EXEC_CpuSerial "Enable/Disable serial executor in examples/benchmarks and tests" ON)
 if(NOT alpaka_EXEC_CpuSerial)
     target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_DISABLE_EXEC_CpuSerial)

--- a/cmake/alpakaCuda.cmake
+++ b/cmake/alpakaCuda.cmake
@@ -12,6 +12,16 @@ if(NOT DEFINED alpaka_COUNT_API_DEPS)
     message(FATAL_ERROR "internal variable 'alpaka_COUNT_API_DEPS' must be defined.")
 endif()
 
+# evaluating CMAKE_CUDA_HOST_COMPILER_ID must be performed before check_language() is called.
+# check_language() is removing the variable CMAKE_CUDA_HOST_COMPILER and CMAKE_CUDA_HOST_COMPILER_ID
+if(NOT CMAKE_CUDA_HOST_COMPILER_ID)
+    set(_alpaka_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER_ID}")
+else()
+    if(${CMAKE_CUDA_HOST_COMPILER_ID} STREQUAL "GNU")
+        set(_alpaka_CUDA_HOST_COMPILER "GNU")
+    endif()
+endif()
+
 check_language(CUDA)
 
 if(CMAKE_CUDA_COMPILER)
@@ -21,7 +31,7 @@ if(CMAKE_CUDA_COMPILER)
     if(NOT TARGET alpaka::cuda)
         add_library(alpaka_target_cuda INTERFACE)
         add_library(alpaka::cuda ALIAS alpaka_target_cuda)
-        target_link_libraries(alpaka_target_cuda INTERFACE alpaka_target_headers)
+        target_link_libraries(alpaka_target_cuda INTERFACE alpaka::host)
         set_property(TARGET alpaka_target_cuda PROPERTY CUDA_STANDARD ${alpaka_CXX_STANDARD})
     endif()
 
@@ -84,9 +94,15 @@ if(CMAKE_CUDA_COMPILER)
     endif()
 
     target_compile_definitions(alpaka_target_cuda INTERFACE ALPAKA_CMAKE_TARGET_CUDA)
-    target_link_libraries(alpaka_target_cuda INTERFACE alpaka::headers)
 
     if(alpaka_COUNT_API_DEPS EQUAL 1)
         target_link_libraries(alpaka INTERFACE alpaka_target_cuda)
+    endif()
+
+    message(STATUS "cuda" ${_alpaka_CUDA_HOST_COMPILER})
+
+    ## GCC compiler flag to show a longer stack for concept diagnostics
+    if(${_alpaka_CUDA_HOST_COMPILER} STREQUAL "GNU")
+        alpaka_set_compiler_options(HOST target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-fconcepts-diagnostics-depth=${alpaka_GCC_CONCEPT_DEPTH}>")
     endif()
 endif()

--- a/cmake/alpakaHip.cmake
+++ b/cmake/alpakaHip.cmake
@@ -41,7 +41,7 @@ if(CMAKE_HIP_COMPILER)
 
     if(NOT TARGET alpaka::hip)
         add_library(alpaka_target_hip INTERFACE)
-        target_link_libraries(alpaka_target_hip INTERFACE alpaka_target_headers)
+        target_link_libraries(alpaka_target_hip INTERFACE alpaka::host)
         add_library(alpaka::hip ALIAS alpaka_target_hip)
     endif()
 

--- a/cmake/alpakaOneApi.cmake
+++ b/cmake/alpakaOneApi.cmake
@@ -17,7 +17,7 @@ find_package(IntelSYCL REQUIRED)
 if(NOT TARGET alpaka::oneapi)
     add_library(alpaka_target_oneapi INTERFACE)
     add_library(alpaka::oneapi ALIAS alpaka_target_oneapi)
-    target_link_libraries(alpaka_target_oneapi INTERFACE alpaka_target_headers)
+    target_link_libraries(alpaka_target_oneapi INTERFACE alpaka::host)
     target_link_libraries(alpaka_target_oneapi INTERFACE IntelSYCL::SYCL_CXX)
 endif()
 

--- a/cmake/finalize.cmake
+++ b/cmake/finalize.cmake
@@ -6,7 +6,7 @@
 ### Provide the alpaka target names linked to a target
 ##
 ## The target alpaka::alpaka and alpaka will insecurely be resolved to the actual targets linked to it.
-## target names are: ALPAKA, CUDA, HIP, ONEAPI, HEADERS
+## target names are: ALPAKA, CUDA, HIP, ONEAPI, HEADERS, HOST
 ##
 ## The output will be appended to the list variable provided as alpaka_target_list.
 function(alpaka_get_targets_recursive target alpaka_target_list)
@@ -31,7 +31,11 @@ function(alpaka_get_targets_recursive target alpaka_target_list)
             alpaka_get_targets_recursive(${lib} sub_targets)
             list(APPEND ${alpaka_target_list} "ONEAPI")
             list(APPEND ${alpaka_target_list} ${sub_targets})
-        elseif(lib MATCHES "alpaka_target_headers|alpaka::headers|alpaka::host")
+        elseif(lib MATCHES "alpaka_target_host|alpaka::host")
+            alpaka_get_targets_recursive(${lib} sub_targets)
+            list(APPEND ${alpaka_target_list} "HOST")
+            list(APPEND ${alpaka_target_list} ${sub_targets})
+        elseif(lib MATCHES "alpaka_target_headers|alpaka::headers")
             list(APPEND ${alpaka_target_list} "HEADERS")
         endif()
     endforeach()
@@ -119,6 +123,7 @@ function(alpaka_finalize target)
     list(FIND alpaka_target_list "ONEAPI" index_oneapi)
     list(FIND alpaka_target_list "HEADERS" index_headers)
     list(FIND alpaka_target_list "ALPAKA" index_alpaka)
+    list(FIND alpaka_target_list "HOST" index_host)
 
     # CUDA and HIP can not be used together
     if((NOT index_cuda EQUAL -1) AND (NOT index_hip EQUAL -1))
@@ -139,6 +144,7 @@ function(alpaka_finalize target)
         AND index_oneapi EQUAL -1
         AND index_headers EQUAL -1
         AND index_alpaka EQUAL -1
+        AND index_HOST EQUAL -1
     )
         message(
             FATAL_ERROR
@@ -207,6 +213,9 @@ function(alpaka_finalize target)
     endif()
     if(NOT index_headers EQUAL -1)
         target_compile_definitions(${target} PRIVATE ALPAKA_CMAKE_TARGET_HEADERS_FINALIZE_CALLED)
+    endif()
+    if(NOT index_host EQUAL -1)
+        target_compile_definitions(${target} PRIVATE ALPAKA_CMAKE_TARGET_HOST_FINALIZE_CALLED)
     endif()
     if(NOT index_alpaka EQUAL -1)
         target_compile_definitions(${target} PRIVATE ALPAKA_CMAKE_TARGET_ALPAKA_FINALIZE_CALLED)

--- a/example/alpaka-ls/CMakeLists.txt
+++ b/example/alpaka-ls/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 
 add_executable(${_TARGET_NAME} src/ls.cpp)
 target_link_libraries(${_TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS})
-target_link_libraries(${_TARGET_NAME} PUBLIC alpaka::headers)
+target_link_libraries(${_TARGET_NAME} PUBLIC alpaka::host)
 alpaka_finalize(${_TARGET_NAME})
 add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})
 

--- a/include/alpaka/core/config.hpp
+++ b/include/alpaka/core/config.hpp
@@ -14,8 +14,7 @@
 #endif
 // guard cmake target alpaka::headers
 #if defined(ALPAKA_CMAKE_TARGET_HEADERS) && !defined(ALPAKA_CMAKE_TARGET_HEADERS_FINALIZE_CALLED)
-#    error                                                                                                            \
-        "After adding the cmake target alpaka::headers or alpaka::host you should call 'alpaka_finalize(targetName)'"
+#    error "After adding the cmake target alpaka::headers you should call 'alpaka_finalize(targetName)'"
 #endif
 // guard cmake target alpaka::cuda
 #if defined(ALPAKA_CMAKE_TARGET_CUDA) && !defined(ALPAKA_CMAKE_TARGET_CUDA_FINALIZE_CALLED)
@@ -28,6 +27,10 @@
 // guard cmake target alpaka::onapi
 #if defined(ALPAKA_CMAKE_TARGET_ONEAPI) && !defined(ALPAKA_CMAKE_TARGET_ONEAPI_FINALIZE_CALLED)
 #    error "After adding the cmake target alpaka::oneapi you should call 'alpaka_finalize(targetName)'"
+#endif
+// guard cmake target alpaka::host
+#if defined(ALPAKA_CMAKE_TARGET_HOST) && !defined(ALPAKA_CMAKE_TARGET_HOST_FINALIZE_CALLED)
+#    error "After adding the cmake target alpaka::host you should call 'alpaka_finalize(targetName)'"
 #endif
 
 #ifdef __INTEL_COMPILER


### PR DESCRIPTION
- `alpaka::host` is now a clean target with host specifications e.g. compiler flags for OpenMP
- `alpaka::headers` - contains the C++ standard, include information and generic defines
- fix that nvcc was forwarding GNU compiler settings to the CUDA host compiler even if it was clang