### PR TITLE
SIMD generator support

### DIFF
--- a/include/alpaka/SimdPtr.hpp
+++ b/include/alpaka/SimdPtr.hpp
@@ -6,10 +6,10 @@
 
 #include "alpaka/Simd.hpp"
 #include "alpaka/Vec.hpp"
-#include "alpaka/cast.hpp"
-#include "alpaka/core/util.hpp"
+#include "alpaka/internal/interface.hpp"
 #include "alpaka/mem/Alignment.hpp"
 #include "alpaka/mem/concepts.hpp"
+#include "alpaka/mem/concepts/IMdSpan.hpp"
 #include "alpaka/trait.hpp"
 
 #include <array>
@@ -25,7 +25,6 @@ namespace alpaka
         struct IsSimdPtr : std::false_type
         {
         };
-
     } // namespace trait
 
     template<typename T>
@@ -33,7 +32,6 @@ namespace alpaka
 
     namespace concepts
     {
-
         /** Concept to check if a type is a SIMD pointer
          *
          * @tparam T Type to check
@@ -45,7 +43,6 @@ namespace alpaka
                           && (std::same_as<T_ValueType, trait::GetValueType_t<std::decay_t<T>>>
                               || std::same_as<T_ValueType, alpaka::NotRequired>)
                           && ((T_width == alpaka::notRequiredWidth) || (T::width() == T_width));
-
     } // namespace concepts
 
     /** pointer to a SIMD pack with the width T_SimdWidth
@@ -58,7 +55,7 @@ namespace alpaka
      * @tparam T_SimdWidth width of the SIMD pack
      */
     template<
-        alpaka::concepts::MdSpan T_MdSpan,
+        typename T_MdSpan,
         alpaka::concepts::Vector T_IdxType,
         alpaka::concepts::Alignment T_MemAlignment,
         alpaka::concepts::CVector T_SimdWidth>
@@ -111,12 +108,12 @@ namespace alpaka
 
         constexpr decltype(auto) load() const
         {
-            return copyFrom(T_MdSpan::operator[](m_idx));
+            return internal::loadAsSimd<width()>(static_cast<T_MdSpan const&>(*this), getAlignment(), m_idx);
         }
 
         constexpr decltype(auto) load()
         {
-            return copyFrom(T_MdSpan::operator[](m_idx));
+            return internal::loadAsSimd<width()>(static_cast<T_MdSpan&>(*this), getAlignment(), m_idx);
         }
 
         /** get the alignment of the memory the pointer is pointing to
@@ -186,21 +183,36 @@ namespace alpaka
         }
 
     private:
-        constexpr decltype(auto) copyFrom(auto&& data) const
-        {
-            using DataTypeType = std::remove_reference_t<decltype(data)>;
-            using DstType = std::conditional_t<
-                std::is_const_v<DataTypeType>,
-                Simd<ALPAKA_TYPEOF(data), T_SimdWidth{}.back()> const,
-                Simd<ALPAKA_TYPEOF(data), T_SimdWidth{}.back()>>;
-
-            auto result = DstType{};
-            result.copyFrom(&data, getAlignment());
-            return result;
-        }
-
         IdxType m_idx;
     };
+
+    namespace internal
+    {
+        template<
+            alpaka::concepts::IMdSpan T_MdSpan,
+            alpaka::concepts::Alignment T_MdSpanAlignment,
+            alpaka::concepts::Vector T_Idx>
+        struct LoadAsSimd::Op<T_MdSpan, T_MdSpanAlignment, T_Idx>
+        {
+            template<uint32_t T_simdWidth>
+            constexpr auto load(auto&& dataSource, T_MdSpanAlignment alignment, T_Idx const& idx) const
+            {
+                static_assert(
+                    std::is_same_v<T_MdSpan, ALPAKA_TYPEOF(dataSource)>,
+                    "Data source type must match the class template signature.");
+                auto&& d = dataSource[idx];
+                using DataTypeType = std::remove_reference_t<decltype(d)>;
+                using DstType = std::conditional_t<
+                    std::is_const_v<DataTypeType>,
+                    Simd<std::decay_t<DataTypeType>, T_simdWidth> const,
+                    Simd<std::decay_t<DataTypeType>, T_simdWidth>>;
+
+                alpaka::concepts::Simd auto dest = DstType{};
+                dest.copyFrom(&d, alignment);
+                return dest;
+            }
+        };
+    } // namespace internal
 
     namespace trait
     {

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -25,6 +25,7 @@
 #include "alpaka/math/internal/Complex.hpp"
 #include "alpaka/mem/BoundaryIter.hpp"
 #include "alpaka/mem/Iter.hpp"
+#include "alpaka/mem/LinearizedIdxGenerator.hpp"
 #include "alpaka/onAcc/Acc.hpp"
 #include "alpaka/onAcc/GlobalMem.hpp"
 #include "alpaka/onAcc/SimdAlgo.hpp"

--- a/include/alpaka/internal/interface.hpp
+++ b/include/alpaka/internal/interface.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/KernelBundle.hpp"
+#include "alpaka/Vec.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/mem/Alignment.hpp"
 #include "alpaka/onHost/Handle.hpp"
@@ -107,6 +108,44 @@ namespace alpaka
         constexpr auto getAlignment(auto&& any)
         {
             return GetAlignment::Op<std::decay_t<decltype(any)>>{}(any);
+        }
+
+        /** Load data from a data source as SIMD vector
+         *
+         * A data source is not required to have physical stored data, it can also be a generator, therefore only the
+         * data source knows how load create aSIMD vector.
+         */
+        struct LoadAsSimd
+        {
+            template<typename T_AnyDataSource, alpaka::concepts::Alignment T_Alignment, alpaka::concepts::Vector T_Idx>
+            struct Op
+            {
+                /** Get data as SIMD vector
+                 *
+                 * @see loadAsSimd for more details.
+                 */
+                template<uint32_t T_simdWidth>
+                constexpr auto load(auto&& anyDataSource, T_Alignment dataAlignment, T_Idx const& index) const;
+            };
+        };
+
+        /** Get data as SIMD vector
+         *
+         * Load T_simdWidth contiguous data staring from index. The data is contiguous in the fast moving dimension of
+         * index.
+         *
+         * @tparam T_simdWidth number of elements in the SIMD vector
+         * @param anyDataSource data source to load data from
+         * @param dataAlignment Alignment of the data source resulting SIMD vector. This can be smaller or equal
+         * compared to the data source alignment due to possible offsets applied before.
+         * @param index Offset index relative to the first element of data source.
+         * @return SIMD vector with data loaded from the data source, aligned to dataAlignment
+         */
+        template<uint32_t T_simdWidth>
+        constexpr auto loadAsSimd(auto&& anyDataSource, auto dataAlignment, auto const& index)
+        {
+            return LoadAsSimd::Op<ALPAKA_TYPEOF(anyDataSource), ALPAKA_TYPEOF(dataAlignment), ALPAKA_TYPEOF(index)>{}
+                .template load<T_simdWidth>(ALPAKA_FORWARD(anyDataSource), dataAlignment, index);
         }
     } // namespace internal
 } // namespace alpaka

--- a/include/alpaka/mem/LinearizedIdxGenerator.hpp
+++ b/include/alpaka/mem/LinearizedIdxGenerator.hpp
@@ -1,0 +1,127 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/Simd.hpp"
+#include "alpaka/internal/interface.hpp"
+#include "alpaka/mem/concepts/IGenerator.hpp"
+
+namespace alpaka
+{
+    /** Generate a linearized scalar index.
+     *
+     * The generator behaves like an n-dimensional data container, but it is not pointing to any memory.
+     * The index to access the generator is linearized based on the provided extents.
+     */
+    template<typename T_IndexType, uint32_t T_dim>
+    struct LinearizedIdxGenerator
+    {
+        constexpr LinearizedIdxGenerator(alpaka::concepts::VectorOrScalar auto const& size) : m_extents{size}
+        {
+        }
+
+        using value_type = T_IndexType;
+        using index_type = value_type;
+
+        static consteval uint32_t dim()
+        {
+            return T_dim;
+        }
+
+        /** Get alignment of the generators value_type */
+        static constexpr auto getAlignment()
+        {
+            return alpaka::Alignment<alignof(value_type)>{};
+        }
+
+        /** Get value at the given index
+         *
+         * @param idx n-dimensional offset, range [0, extents)
+         * @return linearized index
+         */
+        constexpr value_type operator[](alpaka::concepts::Vector auto const& idx) const
+        {
+            return linearize(m_extents, idx);
+        }
+
+        /** Get value at the given index
+         *
+         * @param idx n-dimensional offset, range [0, extents)
+         * @return linearized index
+         */
+        constexpr value_type operator[](alpaka::concepts::Vector auto const& idx)
+        {
+            return linearize(m_extents, idx);
+        }
+
+        /** Get value at the given index
+         *
+         * @param idx n-dimensional offset, range [0, extents)
+         * @return linearized index
+         */
+        constexpr value_type operator[](std::integral auto const& idx) const requires(dim() == 1u)
+        {
+            return idx;
+        }
+
+        /** Get value at the given index
+         *
+         * @param idx n-dimensional offset, range [0, extents)
+         * @return linearized index
+         */
+        constexpr value_type operator[](std::integral auto const& idx) requires(dim() == 1u)
+        {
+            return idx;
+        }
+
+        /** supported index range
+         *
+         * @return virtual extents of the generator
+         */
+        constexpr auto getExtents() const
+        {
+            return m_extents;
+        }
+
+    private:
+        alpaka::Vec<T_IndexType, T_dim> m_extents;
+    };
+
+    template<concepts::VectorOrScalar T_Extents>
+    ALPAKA_FN_HOST_ACC LinearizedIdxGenerator(T_Extents const&)
+        -> LinearizedIdxGenerator<trait::GetValueType_t<T_Extents>, trait::getDim_v<T_Extents>>;
+
+    namespace internal
+    {
+        /** Add support to use the generator with SimdPtr. */
+        template<
+            typename T_IndexType,
+            uint32_t T_dim,
+            alpaka::concepts::Alignment T_MdSpanAlignment,
+            alpaka::concepts::Vector T_Idx>
+        struct LoadAsSimd::Op<LinearizedIdxGenerator<T_IndexType, T_dim>, T_MdSpanAlignment, T_Idx>
+        {
+            template<uint32_t T_simdWidth>
+            constexpr auto load(auto&& linearIdxGenerator, T_MdSpanAlignment alignment, T_Idx const& idx) const
+            {
+                static_assert(
+                    std::is_same_v<LinearizedIdxGenerator<T_IndexType, T_dim>, ALPAKA_TYPEOF(linearIdxGenerator)>,
+                    "Type of linearIdxGenerator must match the class template signature.");
+                using DataTypeType = std::remove_reference_t<decltype(linearIdxGenerator[idx])>;
+                using DstType = std::conditional_t<
+                    std::is_const_v<DataTypeType>,
+                    Simd<std::decay_t<DataTypeType>, T_simdWidth> const,
+                    Simd<std::decay_t<DataTypeType>, T_simdWidth>>;
+
+                return DstType(
+                    [&](auto i)
+                    {
+                        // rAssign() is used because, SIMD vectors can only be loaded from the fast moving index
+                        return linearIdxGenerator[idx + T_Idx::all(0).rAssign(i)];
+                    });
+            }
+        };
+    } // namespace internal
+} // namespace alpaka

--- a/include/alpaka/mem/concepts/IGenerator.hpp
+++ b/include/alpaka/mem/concepts/IGenerator.hpp
@@ -1,0 +1,79 @@
+/* Copyright 2025 Simeon Ehrig
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/Vec.hpp"
+#include "alpaka/mem/Alignment.hpp"
+#include "alpaka/mem/concepts/ExpectedValueType.hpp"
+#include "alpaka/trait.hpp"
+
+#include <concepts>
+
+namespace alpaka::concepts
+{
+    namespace impl
+    {
+        /** @brief Interface concept for objects describing multidimensional generator
+         *
+         * @details
+         *
+         * @param t may or may not have a const modifier.
+         * @param mut_t Mutable generator. Does not have a const modifier.
+         * @param const_t Constant generator. Does have a const modifier.
+         * @param vec Vector with the same number of components as the dimension of the generator like object.
+         * Used to call the access operator.
+         *
+         * A generator is always read only.
+         * It is allowed that a generator derives values from another data source.
+         * Even if a generator is not limited in the number of elements it can generate, it must provide the extents
+         *via getExtents().
+         *
+         * @section membertypes Member types
+         * - <b>T::value_type</b>: The element type. May or may not be const.
+         * - <b>T::index_type</b>: The index type of the extents.
+         *
+         * @note The access operator [] with an integral as an argument is only available if the dimension is one.
+         **/
+        template<typename T, typename T_Mut, typename T_Const>
+        concept IGenerator
+            = requires(T t, T_Mut mut_t, T_Const const_t, alpaka::Vec<typename T::index_type, T::dim()> vec) {
+                  typename T::value_type;
+                  typename T::index_type;
+                  requires std::movable<T_Mut>;
+
+                  { mut_t[vec] } -> std::same_as<typename T::value_type>;
+                  { const_t[vec] } -> std::same_as<typename T::value_type>;
+                  // only for 1D, the access operator with an integral is available
+                  requires(T::dim() > 1) || requires {
+                      { mut_t[0] } -> std::same_as<typename T::value_type>;
+                  };
+                  requires(T::dim() > 1) || requires {
+                      { const_t[0] } -> std::same_as<typename T::value_type>;
+                  };
+
+                  // typically the alignment of the value_type.
+                  { t.getAlignment() } -> alpaka::concepts::Alignment;
+                  /** @todo implement concept alpaka::concepts::Extents and use it as return value
+                   * @todo in general a generator is not required to have extents but our algorithm e.g. onHost::reduce
+                   *will not work without extents
+                   **/
+                  t.getExtents();
+              };
+    } // namespace impl
+
+    /** @brief Interface concept for objects describing multidimensional generator
+     *
+     * @attention Use `alpaka::IGenerator` to restrict types in your code. The actual interface is described in
+     * alpaka::concepts::impl::IGenerator.
+     **/
+    template<typename T, typename T_ValueType = alpaka::NotRequired>
+    concept IGenerator = requires {
+        requires impl::IGenerator<
+            std::remove_reference_t<T>,
+            std::remove_const_t<std::remove_reference_t<T>>,
+            std::add_const_t<std::remove_reference_t<T>>>;
+        requires ExpectedValueType<trait::GetValueType_t<std::decay_t<T>>, T_ValueType>;
+    };
+} // namespace alpaka::concepts

--- a/include/alpaka/mem/concepts/IGeneratorOrMdSpan.hpp
+++ b/include/alpaka/mem/concepts/IGeneratorOrMdSpan.hpp
@@ -1,0 +1,17 @@
+/* Copyright 2025 Simeon Ehrig
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/mem/concepts/IGenerator.hpp"
+#include "alpaka/mem/concepts/IMdSpan.hpp"
+
+namespace alpaka::concepts
+{
+    /** @brief Interface concept for objects describing multidimensional memory access or a generator.
+     */
+    template<typename T, typename T_ValueType = alpaka::NotRequired>
+    concept IGeneratorOrMdSpan = (IGenerator<T, T_ValueType> || IMdSpan<T, T_ValueType>);
+    ;
+} // namespace alpaka::concepts

--- a/include/alpaka/onAcc/SimdAlgo.hpp
+++ b/include/alpaka/onAcc/SimdAlgo.hpp
@@ -71,8 +71,8 @@ namespace alpaka::onAcc
         ALPAKA_FN_INLINE ALPAKA_FN_ACC constexpr void concurrent(
             auto const& acc,
             auto&& func,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             concurrent(acc, data0.getExtents(), ALPAKA_FORWARD(func), ALPAKA_FORWARD(data0), ALPAKA_FORWARD(dataN)...);
         }
@@ -84,8 +84,8 @@ namespace alpaka::onAcc
             auto const& acc,
             alpaka::concepts::Vector auto extents,
             auto&& func,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
             concurrent<
@@ -124,8 +124,8 @@ namespace alpaka::onAcc
         ALPAKA_FN_INLINE ALPAKA_FN_ACC constexpr void concurrent(
             auto const& acc,
             auto&& func,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             concurrent<T_maxConcurrencyInByte, T_MemAlignment>(
                 acc,
@@ -143,8 +143,8 @@ namespace alpaka::onAcc
             auto const& acc,
             alpaka::concepts::Vector auto extents,
             auto&& func,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             ConcurrentAlgo::template concurrent<T_maxConcurrencyInByte, T_MemAlignment>(
                 acc,
@@ -176,8 +176,8 @@ namespace alpaka::onAcc
             auto const& neutralElement,
             auto&& reduceFunc,
             auto&& transformFunc,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             return transformReduce(
                 acc,
@@ -198,8 +198,8 @@ namespace alpaka::onAcc
             auto const& neutralElement,
             auto&& reduceFunc,
             auto&& transformFunc,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
             return transformReduce<
@@ -245,8 +245,8 @@ namespace alpaka::onAcc
             auto const& neutralElement,
             auto&& reduceFunc,
             auto&& transformFunc,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             return transformReduce<T_maxConcurrencyInByte, T_MemAlignment>(
                 acc,
@@ -268,8 +268,8 @@ namespace alpaka::onAcc
             auto const& neutralElement,
             auto&& reduceFunc,
             auto&& transformFunc,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             return ReduceAlgo::template transformReduce<T_maxConcurrencyInByte, T_MemAlignment>(
                 acc,

--- a/include/alpaka/onAcc/internal/SimdConcurrent.hpp
+++ b/include/alpaka/onAcc/internal/SimdConcurrent.hpp
@@ -10,6 +10,7 @@
 #include "alpaka/api/trait.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/mem/concepts.hpp"
+#include "alpaka/mem/concepts/IGeneratorOrMdSpan.hpp"
 #include "alpaka/onAcc/interface.hpp"
 
 #include <cstdint>
@@ -29,8 +30,8 @@ namespace alpaka::onAcc::internal
             auto const& acc,
             alpaka::concepts::Vector auto extents,
             auto&& func,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             auto numElements = typename ALPAKA_TYPEOF(extents)::UniVec{extents};
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
@@ -82,7 +83,7 @@ namespace alpaka::onAcc::internal
             auto const& acc,
             auto const& dataIdx,
             auto&& func,
-            alpaka::concepts::MdSpan auto&&... data)
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... data)
         {
             func(acc, SimdPtr{ALPAKA_FORWARD(data), dataIdx, T_MemAlignment{}, CVec<uint32_t, T_width>{}}...);
         }
@@ -100,7 +101,7 @@ namespace alpaka::onAcc::internal
             auto& iter,
             std::integer_sequence<uint32_t, T_repeat...>,
             auto&& func,
-            alpaka::concepts::MdSpan auto&&... data)
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... data)
         {
             /* We do not check if the iterator points to a valid element, the caller must ensure that we can safely
              * increase the iterator without jumping over iter.end().
@@ -122,8 +123,8 @@ namespace alpaka::onAcc::internal
             auto const& acc,
             alpaka::concepts::Vector auto numElements,
             auto&& func,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
             constexpr uint32_t simdWidthInByte = T_simdWidth * sizeof(ValueType);

--- a/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
+++ b/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/core/common.hpp"
 #include "alpaka/functor.hpp"
 #include "alpaka/mem/concepts.hpp"
+#include "alpaka/mem/concepts/IGeneratorOrMdSpan.hpp"
 #include "alpaka/onAcc/Acc.hpp"
 #include "alpaka/onAcc/interface.hpp"
 
@@ -34,8 +35,8 @@ namespace alpaka::onAcc::internal
             auto const& neutralElement,
             auto&& reduceFunc,
             auto&& func,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             auto numElements = typename ALPAKA_TYPEOF(extents)::UniVec{extents};
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
@@ -94,7 +95,7 @@ namespace alpaka::onAcc::internal
             auto const& acc,
             auto const& dataIdx,
             auto&& func,
-            alpaka::concepts::MdSpan auto&&... data)
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... data)
         {
             return func(acc, SimdPtr{ALPAKA_FORWARD(data), dataIdx, T_MemAlignment{}, CVec<uint32_t, T_width>{}}...);
         }
@@ -113,7 +114,7 @@ namespace alpaka::onAcc::internal
             std::integer_sequence<uint32_t, T_repeat...>,
             auto&& reduceFunc,
             auto&& func,
-            alpaka::concepts::MdSpan auto&&... data)
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... data)
         {
             /* We do not check if the iterator points to a valid element, the caller must ensure that we can safely
              * increase the iterator without jumping over iter.end().
@@ -220,8 +221,8 @@ namespace alpaka::onAcc::internal
             auto const& neutralElement,
             auto&& userReduceFunc,
             auto&& func,
-            alpaka::concepts::MdSpan auto&& data0,
-            alpaka::concepts::MdSpan auto&&... dataN) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&& data0,
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... dataN) const
         {
             auto reduceFunc = getReducer(acc, userReduceFunc);
 

--- a/include/alpaka/onHost/algo/concurrent.hpp
+++ b/include/alpaka/onHost/algo/concurrent.hpp
@@ -47,7 +47,7 @@ namespace alpaka::onHost
         alpaka::concepts::Executor auto const exec,
         alpaka::concepts::VectorOrScalar auto const& extents,
         auto&& fn,
-        auto&&... inOut)
+        alpaka::concepts::IGeneratorOrMdSpan auto&&... inOut)
     {
         internal::concurrent<T_DataType>(queue, exec, extents, ALPAKA_FORWARD(fn), ALPAKA_FORWARD(inOut)...);
     }
@@ -61,7 +61,7 @@ namespace alpaka::onHost
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents,
         auto&& fn,
-        auto&&... inOut)
+        alpaka::concepts::IGeneratorOrMdSpan auto&&... inOut)
     {
         auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         internal::concurrent<T_DataType>(

--- a/include/alpaka/onHost/algo/internal/concurrent.hpp
+++ b/include/alpaka/onHost/algo/internal/concurrent.hpp
@@ -4,12 +4,9 @@
 
 #pragma once
 
-
-#include "alpaka/Simd.hpp"
 #include "alpaka/Vec.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/functor.hpp"
-#include "alpaka/mem/MdSpan.hpp"
 #include "alpaka/onAcc/Acc.hpp"
 #include "alpaka/onAcc/SimdAlgo.hpp"
 #include "alpaka/onHost/interface.hpp"
@@ -24,7 +21,7 @@ namespace alpaka::onHost::internal
             onAcc::concepts::Acc auto const& acc,
             alpaka::concepts::VectorOrScalar auto const& extents,
             auto const& func,
-            alpaka::concepts::MdSpan auto&&... inputs) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... inputs) const
         {
             Vec const extentMd = extents;
             auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
@@ -49,7 +46,7 @@ namespace alpaka::onHost::internal
         alpaka::concepts::Executor auto const exec,
         alpaka::concepts::VectorOrScalar auto const& extents,
         auto&& fn,
-        auto&&... in)
+        alpaka::concepts::IGeneratorOrMdSpan auto&&... in)
     {
         Vec const extentMd = extents;
         auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), extentMd);

--- a/include/alpaka/onHost/algo/internal/iota.hpp
+++ b/include/alpaka/onHost/algo/internal/iota.hpp
@@ -8,8 +8,6 @@
 #include "alpaka/SimdPtr.hpp"
 #include "alpaka/Vec.hpp"
 #include "alpaka/core/common.hpp"
-#include "alpaka/functor.hpp"
-#include "alpaka/mem/MdSpan.hpp"
 #include "alpaka/onAcc/Acc.hpp"
 #include "alpaka/onAcc/SimdAlgo.hpp"
 #include "alpaka/onHost/interface.hpp"
@@ -25,7 +23,7 @@ namespace alpaka::onHost::internal
             onAcc::concepts::Acc auto const& acc,
             alpaka::concepts::Vector auto extents,
             T_DataType const& initValue,
-            alpaka::concepts::MdSpan auto&&... inputs) const
+            alpaka::concepts::IMdSpan auto&&... inputs) const
         {
             auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
 
@@ -55,7 +53,7 @@ namespace alpaka::onHost::internal
         alpaka::concepts::Executor auto const exec,
         alpaka::concepts::Vector auto const& extents,
         T_DataType const& initValue,
-        alpaka::concepts::MdSpan auto&&... inputs)
+        alpaka::concepts::IMdSpan auto&&... inputs)
     {
         Vec const extentMd = extents;
         auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), extentMd);

--- a/include/alpaka/onHost/algo/internal/transform.hpp
+++ b/include/alpaka/onHost/algo/internal/transform.hpp
@@ -22,9 +22,9 @@ namespace alpaka::onHost::internal
     {
         ALPAKA_FN_ACC void operator()(
             onAcc::concepts::Acc auto const& acc,
-            alpaka::concepts::MdSpan auto&& output,
+            alpaka::concepts::IMdSpan auto&& output,
             auto const& func,
-            alpaka::concepts::MdSpan auto&&... inputs) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... inputs) const
         {
             auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
             if constexpr(isSpecializationOf_v<ALPAKA_TYPEOF(func), StencilFunc>)
@@ -83,9 +83,9 @@ namespace alpaka::onHost::internal
     inline void transform(
         auto const& queue,
         alpaka::concepts::Executor auto const exec,
-        auto&& out,
+        alpaka::concepts::IMdSpan auto&& out,
         auto&& fn,
-        auto&&... in)
+        alpaka::concepts::IGeneratorOrMdSpan auto&&... in)
     {
         auto extentMd = onHost::getExtents(out);
         using DataType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>;

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/core/common.hpp"
 #include "alpaka/functor.hpp"
 #include "alpaka/mem/MdSpan.hpp"
+#include "alpaka/mem/concepts/IGeneratorOrMdSpan.hpp"
 #include "alpaka/onAcc/Acc.hpp"
 #include "alpaka/onAcc/SimdAlgo.hpp"
 #include "alpaka/onAcc/atomic.hpp"
@@ -29,10 +30,10 @@ namespace alpaka::onHost::internal
             onAcc::concepts::Acc auto const& acc,
             alpaka::concepts::Vector auto const& extentMd,
             T_DataType const& neutralElement,
-            alpaka::concepts::MdSpan auto output,
+            alpaka::concepts::IMdSpan auto output,
             auto const& reduceFunc,
             auto const& transformFunc,
-            alpaka::concepts::MdSpan auto&&... inputs) const
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... inputs) const
         {
             static_assert(
                 std::is_same_v<ALPAKA_TYPEOF(neutralElement), alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(output)>>,
@@ -149,8 +150,7 @@ namespace alpaka::onHost::internal
             auto& result,
             auto&& reduceFunc,
             auto&& transformFunc,
-            alpaka::concepts::MdSpan auto&&... inputs)
-
+            alpaka::concepts::IGeneratorOrMdSpan auto&&... inputs)
         {
             // Use the generic transformFunc and the variant reduceFunc
             if constexpr(isSpecializationOf_v<ALPAKA_TYPEOF(transformFunc), StencilFunc>)
@@ -211,11 +211,11 @@ namespace alpaka::onHost::internal
         auto const& queue,
         alpaka::concepts::Executor auto const exec,
         T_DataType const& neutralElement,
-        alpaka::concepts::MdSpan auto out,
+        alpaka::concepts::IMdSpan auto out,
         auto&& reduceFn,
         auto&& transformFn,
         auto&& in0,
-        auto&&... in)
+        alpaka::concepts::IGeneratorOrMdSpan auto&&... in)
     {
         auto extentMd = onHost::getExtents(in0);
         using IndexType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(extentMd)>;

--- a/include/alpaka/onHost/algo/iota.hpp
+++ b/include/alpaka/onHost/algo/iota.hpp
@@ -32,8 +32,8 @@ namespace alpaka::onHost
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::Executor auto const exec,
         T_DataType const& initValue,
-        auto&& out0,
-        auto&&... outOther)
+        alpaka::concepts::IMdSpan auto&& out0,
+        alpaka::concepts::IMdSpan auto&&... outOther)
         requires(
             std::is_convertible_v<T_DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out0)>>
             && std::conjunction_v<
@@ -57,8 +57,8 @@ namespace alpaka::onHost
     inline void iota(
         Queue<T_Device, T_QueueKind> const& queue,
         T_DataType const& initValue,
-        auto&& out0,
-        auto&&... outOther)
+        alpaka::concepts::IMdSpan auto&& out0,
+        alpaka::concepts::IMdSpan auto&&... outOther)
         requires(
             std::is_convertible_v<T_DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out0)>>
             && std::conjunction_v<

--- a/include/alpaka/onHost/algo/reduce.hpp
+++ b/include/alpaka/onHost/algo/reduce.hpp
@@ -31,7 +31,7 @@ namespace alpaka::onHost
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::Executor auto const exec,
         DataType const& neutralElement,
-        alpaka::concepts::MdSpan auto out,
+        alpaka::concepts::IMdSpan auto out,
         auto&& binaryReduceFn,
         auto&& in) requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
     {
@@ -53,9 +53,10 @@ namespace alpaka::onHost
     inline void reduce(
         Queue<T_Device, T_QueueKind> const& queue,
         DataType const& neutralElement,
-        alpaka::concepts::MdSpan auto out,
+        alpaka::concepts::IMdSpan auto out,
         auto&& binaryReduceFn,
-        auto&& in) requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
+        alpaka::concepts::IGeneratorOrMdSpan auto&& in)
+        requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
     {
         auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         reduce(queue, std::get<0>(executor), neutralElement, out, ALPAKA_FORWARD(binaryReduceFn), ALPAKA_FORWARD(in));

--- a/include/alpaka/onHost/algo/transform.hpp
+++ b/include/alpaka/onHost/algo/transform.hpp
@@ -52,7 +52,7 @@ namespace alpaka::onHost
         alpaka::concepts::Executor auto const exec,
         alpaka::concepts::IMdSpan auto&& out,
         auto&& fn,
-        auto&&... in)
+        alpaka::concepts::IGeneratorOrMdSpan auto&&... in)
     {
         internal::transform(queue, exec, ALPAKA_FORWARD(out), ALPAKA_FORWARD(fn), ALPAKA_FORWARD(in)...);
     }
@@ -62,7 +62,11 @@ namespace alpaka::onHost
      * parallelism/performance.
      */
     template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
-    inline void transform(Queue<T_Device, T_QueueKind> const& queue, auto&& out, auto&& fn, auto&&... in)
+    inline void transform(
+        Queue<T_Device, T_QueueKind> const& queue,
+        alpaka::concepts::IMdSpan auto&& out,
+        auto&& fn,
+        alpaka::concepts::IGeneratorOrMdSpan auto&&... in)
     {
         auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         transform(queue, std::get<0>(executor), ALPAKA_FORWARD(out), ALPAKA_FORWARD(fn), ALPAKA_FORWARD(in)...);

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -61,10 +61,11 @@ namespace alpaka::onHost
         Queue<T_Device, T_QueueKind> const& queue,
         alpaka::concepts::Executor auto const exec,
         DataType const& neutralElement,
-        alpaka::concepts::MdSpan auto out,
+        alpaka::concepts::IMdSpan auto out,
         auto&& binaryReduceFn,
         auto&& transformFn,
-        auto&&... in) requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
+        alpaka::concepts::IGeneratorOrMdSpan auto&&... in)
+        requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
     {
         internal::transformReduce(
             queue,
@@ -84,10 +85,11 @@ namespace alpaka::onHost
     inline void transformReduce(
         Queue<T_Device, T_QueueKind> const& queue,
         DataType const& neutralElement,
-        alpaka::concepts::MdSpan auto out,
+        alpaka::concepts::IMdSpan auto out,
         auto&& binaryReduceFn,
         auto&& transformFn,
-        auto&&... in) requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
+        alpaka::concepts::IGeneratorOrMdSpan auto&&... in)
+        requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
     {
         auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         transformReduce(

--- a/tests/unit/algorithm/concurrent.cpp
+++ b/tests/unit/algorithm/concurrent.cpp
@@ -51,62 +51,71 @@ struct StencilAddMin
     }
 };
 
-/**
- * @param functorPair all functors should write the results to the first argument
- */
-template<typename T_DataType>
-void executeTest(
-    concepts::Executor auto exec,
-    auto const& computeQueue,
-    auto const functorPair,
-    concepts::Vector auto extentMd)
+struct TestWithMdSpan
 {
-    std::cout << "run func : " << onHost::demangledName(functorPair.second) << std::endl;
-
-    auto computeDev = computeQueue.getDevice();
-    using DataType = T_DataType;
-    onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::SharedBuffer computeBufferIn1 = onHost::allocLike(computeDev, computeBufferIn0);
-    onHost::SharedBuffer hostBufferIota = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
-    onHost::SharedBuffer hostBufferOut = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
-
-    // initialize with the linearized index
-    DataType iotaCounter = 0;
-    for(auto& value : hostBufferIota)
+    /**
+     * @param setup all functors should write the results to the first argument
+     */
+    template<typename T_DataType>
+    static void executeTest(
+        concepts::Executor auto exec,
+        auto const& computeQueue,
+        auto const setup,
+        concepts::Vector auto extentMd)
     {
-        value = iotaCounter;
-        ++iotaCounter;
-    }
+        std::cout << "run func : " << onHost::demangledName(std::get<1>(setup)) << std::endl;
 
-    onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
-    onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
+        auto computeDev = computeQueue.getDevice();
+        using DataType = T_DataType;
+        onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+        onHost::SharedBuffer computeBufferIn1 = onHost::allocLike(computeDev, computeBufferIn0);
+        onHost::SharedBuffer hostBufferIota = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
+        onHost::SharedBuffer hostBufferOut = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
 
-    onHost::wait(computeQueue);
-    auto const beginT = std::chrono::high_resolution_clock::now();
-
-    onHost::concurrent<DataType>(computeQueue, exec, extentMd, functorPair.first, computeBufferIn0, computeBufferIn1);
-
-    onHost::wait(computeQueue);
-    auto const endT = std::chrono::high_resolution_clock::now();
-    std::cout << "Time for concurrent: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-              << " data size: " << extentMd << std::endl;
-
-    onHost::memcpy(computeQueue, hostBufferOut, computeBufferIn0);
-    onHost::wait(computeQueue);
-
-    // validate without using the forward iterator
-    DataType refIotaCounter = 0;
-    meta::ndLoopIncIdx(
-        extentMd,
-        [&](auto idx)
+        // initialize with the linearized index
+        DataType iotaCounter = 0;
+        for(auto& value : hostBufferIota)
         {
-            CHECK(hostBufferOut[idx] == functorPair.second(refIotaCounter, refIotaCounter));
-            ++refIotaCounter;
-        });
+            value = iotaCounter;
+            ++iotaCounter;
+        }
+
+        onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+        onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
+
+        onHost::wait(computeQueue);
+        auto const beginT = std::chrono::high_resolution_clock::now();
+
+        onHost::concurrent<DataType>(
+            computeQueue,
+            exec,
+            extentMd,
+            std::get<0>(setup),
+            computeBufferIn0,
+            computeBufferIn1);
+
+        onHost::wait(computeQueue);
+        auto const endT = std::chrono::high_resolution_clock::now();
+        std::cout << "Time for concurrent: " << std::chrono::duration<double>(endT - beginT).count() << 's'
+                  << " data size: " << extentMd << std::endl;
+
+        onHost::memcpy(computeQueue, hostBufferOut, computeBufferIn0);
+        onHost::wait(computeQueue);
+
+        // validate without using the forward iterator
+        DataType refIotaCounter = 0;
+        meta::ndLoopIncIdx(
+            extentMd,
+            [&](auto idx)
+            {
+                CHECK(hostBufferOut[idx] == std::get<1>(setup)(refIotaCounter, refIotaCounter));
+                ++refIotaCounter;
+            });
+    };
 };
 
 template<typename T_DataType>
-void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTuples)
+void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
 
@@ -130,8 +139,9 @@ void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTu
 
     // execute for each functor
     std::apply(
-        [&](auto const&... functorPair) { (executeTest<DataType>(exec, computeQueue, functorPair, extentMd), ...); },
-        functorTuples);
+        [&](auto const&... setup)
+        { (std::get<2>(setup).template executeTest<DataType>(exec, computeQueue, setup, extentMd), ...); },
+        setupTuple);
 }
 
 TEMPLATE_LIST_TEST_CASE("concurrent", "", TestBackends)
@@ -141,13 +151,94 @@ TEMPLATE_LIST_TEST_CASE("concurrent", "", TestBackends)
     using DataType = int;
 
     // This list is not directly defined within the function `prepareTest()` due to nvcc compile issues.
-    auto functorList = std::make_tuple(
-        std::make_pair(StencilAddWithAcc{}, std::plus{}),
-        std::make_pair(StencilAddMin{}, [](DataType const& a, DataType const& b) { return a + math::min(a, b); }));
+    auto setups = std::make_tuple(
+        std::make_tuple(StencilAddWithAcc{}, std::plus{}, TestWithMdSpan{}),
+        std::make_tuple(
+            StencilAddMin{},
+            [](DataType const& a, DataType const& b) { return a + math::min(a, b); },
+            TestWithMdSpan{}));
 
     // different extents for testing
     auto extentMdList
         = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
 
-    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, functorList), ...); }, extentMdList);
+    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, setups), ...); }, extentMdList);
+}
+
+struct TestWithGenerator
+{
+    /**
+     * @param setup all functors should write the results to the first argument
+     */
+    template<typename T_DataType>
+    static void executeTest(
+        concepts::Executor auto exec,
+        auto const& computeQueue,
+        auto const setup,
+        concepts::Vector auto extentMd)
+    {
+        std::cout << "run func : " << onHost::demangledName(std::get<1>(setup)) << std::endl;
+
+        auto computeDev = computeQueue.getDevice();
+        using DataType = T_DataType;
+        onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+        onHost::SharedBuffer hostBufferIota = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
+        onHost::SharedBuffer hostBufferOut = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
+
+        auto generator = LinearizedIdxGenerator{extentMd};
+
+        // initialize with the linearized index
+        DataType iotaCounter = 0;
+        for(auto& value : hostBufferIota)
+        {
+            value = iotaCounter;
+            ++iotaCounter;
+        }
+
+        onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+
+        onHost::wait(computeQueue);
+        auto const beginT = std::chrono::high_resolution_clock::now();
+
+        onHost::concurrent<DataType>(computeQueue, exec, extentMd, std::get<0>(setup), computeBufferIn0, generator);
+
+        onHost::wait(computeQueue);
+        auto const endT = std::chrono::high_resolution_clock::now();
+        std::cout << "Time for concurrent: " << std::chrono::duration<double>(endT - beginT).count() << 's'
+                  << " data size: " << extentMd << std::endl;
+
+        onHost::memcpy(computeQueue, hostBufferOut, computeBufferIn0);
+        onHost::wait(computeQueue);
+
+        // validate without using the forward iterator
+        DataType refIotaCounter = 0;
+        meta::ndLoopIncIdx(
+            extentMd,
+            [&](auto idx)
+            {
+                CHECK(hostBufferOut[idx] == std::get<1>(setup)(refIotaCounter, generator[idx]));
+                ++refIotaCounter;
+            });
+    };
+};
+
+TEMPLATE_LIST_TEST_CASE("concurrent generator", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    using DataType = int;
+
+    // This list is not directly defined within the function `prepareTest()` due to nvcc compile issues.
+    auto setups = std::make_tuple(
+        std::make_tuple(StencilAddWithAcc{}, std::plus{}, TestWithGenerator{}),
+        std::make_tuple(
+            StencilAddMin{},
+            [](DataType const& a, DataType const& b) { return a + math::min(a, b); },
+            TestWithGenerator{}));
+
+    // different extents for testing
+    auto extentMdList
+        = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
+
+    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, setups), ...); }, extentMdList);
 }

--- a/tests/unit/algorithm/reduce.cpp
+++ b/tests/unit/algorithm/reduce.cpp
@@ -50,68 +50,65 @@ struct alpaka::onAcc::trait::FunctorToAtomicOp<MaxValue>
     using type = alpaka::onAcc::AtomicMax;
 };
 
-template<typename T_DataType>
-void executeTest(
-    concepts::Executor auto exec,
-    auto const& computeQueue,
-    auto const functorPair,
-    concepts::Vector auto extentMd)
+struct TestWithMdSpan
 {
-    std::cout << "run func : " << onHost::demangledName(std::get<2>(functorPair)) << std::endl;
-
-    auto computeDev = computeQueue.getDevice();
-    using DataType = T_DataType;
-    using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
-    onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd.all(1));
-    onHost::SharedBuffer computeBufferIn = onHost::allocDeferred<DataType>(computeQueue, extentMd);
-    onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn);
-    onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);
-
-    // initialize with the linearized index
-    DataType iotaCounter = 0;
-    for(auto& value : hostBufferIota)
+    template<typename T_DataType>
+    static void executeTest(
+        concepts::Executor auto exec,
+        auto const& computeQueue,
+        auto const setup,
+        concepts::Vector auto extentMd)
     {
-        value = iotaCounter;
-        ++iotaCounter;
-    }
+        std::cout << "run func : " << onHost::demangledName(std::get<2>(setup)) << std::endl;
 
-    onHost::memcpy(computeQueue, computeBufferIn, hostBufferIota);
+        auto computeDev = computeQueue.getDevice();
+        using DataType = T_DataType;
+        using OutDataType = ALPAKA_TYPEOF(std::get<0>(setup));
+        onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd.all(1));
+        onHost::SharedBuffer computeBufferIn = onHost::allocDeferred<DataType>(computeQueue, extentMd);
+        onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn);
+        onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);
 
-    onHost::wait(computeQueue);
-    auto const beginT = std::chrono::high_resolution_clock::now();
-
-    onHost::reduce(
-        computeQueue,
-        exec,
-        std::get<0>(functorPair),
-        computeBufferOut,
-        std::get<1>(functorPair),
-        computeBufferIn);
-
-    onHost::wait(computeQueue);
-    auto const endT = std::chrono::high_resolution_clock::now();
-    std::cout << "Time for reduction: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-              << " data size: " << hostBufferIota.getExtents() << std::endl;
-
-    onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
-    onHost::wait(computeQueue);
-
-    // validate without using the forward iterator
-    DataType refIotaCounter = 0;
-    auto result = std::get<0>(functorPair);
-    meta::ndLoopIncIdx(
-        extentMd,
-        [&](auto idx)
+        // initialize with the linearized index
+        DataType iotaCounter = 0;
+        for(auto& value : hostBufferIota)
         {
-            result = std::get<2>(functorPair)(result, refIotaCounter);
-            ++refIotaCounter;
-        });
+            value = iotaCounter;
+            ++iotaCounter;
+        }
 
-    CHECK(*hostBufferOut.data() == result);
+        onHost::memcpy(computeQueue, computeBufferIn, hostBufferIota);
+
+        onHost::wait(computeQueue);
+        auto const beginT = std::chrono::high_resolution_clock::now();
+
+        onHost::reduce(computeQueue, exec, std::get<0>(setup), computeBufferOut, std::get<1>(setup), computeBufferIn);
+
+        onHost::wait(computeQueue);
+        auto const endT = std::chrono::high_resolution_clock::now();
+        std::cout << "Time for reduction: " << std::chrono::duration<double>(endT - beginT).count() << 's'
+                  << " data size: " << hostBufferIota.getExtents() << std::endl;
+
+        onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
+        onHost::wait(computeQueue);
+
+        // validate without using the forward iterator
+        DataType refIotaCounter = 0;
+        auto result = std::get<0>(setup);
+        meta::ndLoopIncIdx(
+            extentMd,
+            [&](auto idx)
+            {
+                result = std::get<2>(setup)(result, refIotaCounter);
+                ++refIotaCounter;
+            });
+
+        CHECK(*hostBufferOut.data() == result);
+    };
 };
 
 template<typename T_DataType>
-void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTuples)
+void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
 
@@ -135,8 +132,9 @@ void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTu
 
     // execute for each functor
     std::apply(
-        [&](auto const&... functorPair) { (executeTest<DataType>(exec, computeQueue, functorPair, extentMd), ...); },
-        functorTuples);
+        [&](auto const&... setup)
+        { (std::get<3>(setup).template executeTest<DataType>(exec, computeQueue, setup, extentMd), ...); },
+        setupTuple);
 }
 
 TEMPLATE_LIST_TEST_CASE("reduce", "", TestBackends)
@@ -145,15 +143,82 @@ TEMPLATE_LIST_TEST_CASE("reduce", "", TestBackends)
 
     using DataType = int;
 
-    // This list is not directly defined within the function `prepareTest()` due to nvcc compile issues.
-    auto functorList = std::make_tuple(
-        std::make_tuple(DataType{0}, std::plus{}, std::plus{}),
-        std::make_tuple(std::numeric_limits<DataType>::max(), ScalarFunc{MinValue{}}, MinValue{}),
-        std::make_tuple(std::numeric_limits<DataType>::min(), ScalarFunc{MaxValue{}}, MaxValue{}));
+    // This list is not directly defined within the function TestWithMdSpan due to nvcc compile issues.
+    auto setups = std::make_tuple(
+        std::make_tuple(DataType{0}, std::plus{}, std::plus{}, TestWithMdSpan{}),
+        std::make_tuple(std::numeric_limits<DataType>::max(), ScalarFunc{MinValue{}}, MinValue{}, TestWithMdSpan{}),
+        std::make_tuple(std::numeric_limits<DataType>::min(), ScalarFunc{MaxValue{}}, MaxValue{}, TestWithMdSpan{}));
 
     // different extents for testing
     auto extentMdList
         = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
 
-    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, functorList), ...); }, extentMdList);
+    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, setups), ...); }, extentMdList);
+}
+
+struct TestWithGenerator
+{
+    template<typename T_DataType>
+    static void executeTest(
+        concepts::Executor auto exec,
+        auto const& computeQueue,
+        auto const functorPair,
+        concepts::Vector auto extentMd)
+    {
+        std::cout << "run func : " << onHost::demangledName(std::get<2>(functorPair)) << std::endl;
+
+        auto computeDev = computeQueue.getDevice();
+        using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
+        onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd.all(1));
+        auto generator = LinearizedIdxGenerator{extentMd};
+
+        onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);
+
+        onHost::wait(computeQueue);
+        auto const beginT = std::chrono::high_resolution_clock::now();
+
+        onHost::reduce(
+            computeQueue,
+            exec,
+            std::get<0>(functorPair),
+            computeBufferOut,
+            std::get<1>(functorPair),
+            generator);
+
+        onHost::wait(computeQueue);
+        auto const endT = std::chrono::high_resolution_clock::now();
+        std::cout << "Time for reduction: " << std::chrono::duration<double>(endT - beginT).count() << 's'
+                  << " data size: " << generator.getExtents() << std::endl;
+
+        onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
+        onHost::wait(computeQueue);
+
+        auto result = std::get<0>(functorPair);
+        meta::ndLoopIncIdx(extentMd, [&](auto idx) { result = std::get<2>(functorPair)(result, generator[idx]); });
+
+        CHECK(*hostBufferOut.data() == result);
+    };
+};
+
+TEMPLATE_LIST_TEST_CASE("reduce generator", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    using DataType = int;
+
+    // This list is not directly defined within the function TestWithGenerator due to nvcc compile issues.
+    auto setup = std::make_tuple(
+        std::make_tuple(DataType{0}, std::plus{}, std::plus{}, TestWithGenerator{}),
+        std::make_tuple(std::numeric_limits<DataType>::max(), ScalarFunc{MinValue{}}, MinValue{}, TestWithGenerator{}),
+        std::make_tuple(
+            std::numeric_limits<DataType>::min(),
+            ScalarFunc{MaxValue{}},
+            MaxValue{},
+            TestWithGenerator{}));
+
+    // different extents for testing
+    auto extentMdList
+        = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
+
+    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, setup), ...); }, extentMdList);
 }

--- a/tests/unit/algorithm/transform.cpp
+++ b/tests/unit/algorithm/transform.cpp
@@ -65,61 +65,70 @@ struct ScalarOpWithAcc
     }
 };
 
-template<typename T_DataType>
-void executeTest(
-    concepts::Executor auto exec,
-    auto const& computeQueue,
-    auto const functorPair,
-    concepts::Vector auto extentMd)
+struct TestWithMdSpan
 {
-    std::cout << "run func : " << onHost::demangledName(functorPair.second) << std::endl;
-
-    auto computeDev = computeQueue.getDevice();
-    using DataType = T_DataType;
-    using OutDataType = decltype(functorPair.second(std::declval<DataType>(), std::declval<DataType>()));
-    onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd);
-    onHost::SharedBuffer computeBufferIn0 = onHost::allocDeferred<DataType>(computeQueue, extentMd);
-    onHost::SharedBuffer computeBufferIn1 = onHost::allocLikeAsync(computeQueue, computeBufferIn0);
-    onHost::SharedBuffer hostBufferIota = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
-    onHost::SharedBuffer hostBufferOut = onHost::allocLike(onHost::makeHostDevice(), computeBufferOut);
-
-    // initialize with the linearized index
-    DataType iotaCounter = 0;
-    for(auto& value : hostBufferIota)
+    template<typename T_DataType>
+    static void executeTest(
+        concepts::Executor auto exec,
+        auto const& computeQueue,
+        auto const setup,
+        concepts::Vector auto extentMd)
     {
-        value = iotaCounter;
-        ++iotaCounter;
-    }
+        std::cout << "run func : " << onHost::demangledName(std::get<1>(setup)) << std::endl;
 
-    onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
-    onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
+        auto computeDev = computeQueue.getDevice();
+        using DataType = T_DataType;
+        using OutDataType = decltype(std::get<1>(setup)(std::declval<DataType>(), std::declval<DataType>()));
+        onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd);
+        onHost::SharedBuffer computeBufferIn0 = onHost::allocDeferred<DataType>(computeQueue, extentMd);
+        onHost::SharedBuffer computeBufferIn1 = onHost::allocLikeAsync(computeQueue, computeBufferIn0);
+        onHost::SharedBuffer hostBufferIota = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
+        onHost::SharedBuffer hostBufferOut = onHost::allocLike(onHost::makeHostDevice(), computeBufferOut);
 
-    onHost::wait(computeQueue);
-    auto const beginT = std::chrono::high_resolution_clock::now();
-
-    onHost::transform(computeQueue, exec, computeBufferOut, functorPair.first, computeBufferIn0, computeBufferIn1);
-
-    onHost::wait(computeQueue);
-    auto const endT = std::chrono::high_resolution_clock::now();
-    std::cout << "Time for transform: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-              << " data size: " << computeBufferOut.getExtents() << std::endl;
-
-    onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
-    onHost::wait(computeQueue);
-
-    // validate without using the forward iterator
-    DataType refIotaCounter = 0;
-    meta::ndLoopIncIdx(
-        extentMd,
-        [&](auto idx)
+        // initialize with the linearized index
+        DataType iotaCounter = 0;
+        for(auto& value : hostBufferIota)
         {
-            CHECK(hostBufferOut[idx] == functorPair.second(refIotaCounter, refIotaCounter));
-            ++refIotaCounter;
-        });
+            value = iotaCounter;
+            ++iotaCounter;
+        }
+
+        onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+        onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
+
+        onHost::wait(computeQueue);
+        auto const beginT = std::chrono::high_resolution_clock::now();
+
+        onHost::transform(
+            computeQueue,
+            exec,
+            computeBufferOut,
+            std::get<0>(setup),
+            computeBufferIn0,
+            computeBufferIn1);
+
+        onHost::wait(computeQueue);
+        auto const endT = std::chrono::high_resolution_clock::now();
+        std::cout << "Time for transform: " << std::chrono::duration<double>(endT - beginT).count() << 's'
+                  << " data size: " << computeBufferOut.getExtents() << std::endl;
+
+        onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
+        onHost::wait(computeQueue);
+
+        // validate without using the forward iterator
+        DataType refIotaCounter = 0;
+        meta::ndLoopIncIdx(
+            extentMd,
+            [&](auto idx)
+            {
+                CHECK(hostBufferOut[idx] == std::get<1>(setup)(refIotaCounter, refIotaCounter));
+                ++refIotaCounter;
+            });
+    };
 };
 
 template<typename T_DataType>
-void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTuples)
+void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
 
@@ -143,8 +152,9 @@ void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTu
 
     // execute for each functor
     std::apply(
-        [&](auto const&... functorPair) { (executeTest<DataType>(exec, computeQueue, functorPair, extentMd), ...); },
-        functorTuples);
+        [&](auto const&... setup)
+        { (std::get<2>(setup).template executeTest<DataType>(exec, computeQueue, setup, extentMd), ...); },
+        setupTuple);
 }
 
 TEMPLATE_LIST_TEST_CASE("transform", "", TestBackends)
@@ -155,28 +165,127 @@ TEMPLATE_LIST_TEST_CASE("transform", "", TestBackends)
 
     // This list is not directly defined within the function `prepareTest()` due to nvcc compile issues.
     auto functorList = std::make_tuple(
-        std::make_pair(std::minus{}, std::minus{}),
-        std::make_pair(std::plus{}, std::plus{}),
+        std::make_tuple(std::minus{}, std::minus{}, TestWithMdSpan{}),
+        std::make_tuple(std::plus{}, std::plus{}, TestWithMdSpan{}),
         // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
-        std::make_pair(StencilFunc{StencilAdd{}}, std::plus{}),
-        std::make_pair(StencilFunc{StencilAddWithAcc{}}, std::plus{}),
+        std::make_tuple(StencilFunc{StencilAdd{}}, std::plus{}, TestWithMdSpan{}),
+        std::make_tuple(StencilFunc{StencilAddWithAcc{}}, std::plus{}, TestWithMdSpan{}),
         /* We can use a lambda function because the types are explicitly defined.
          * Generic lambdas would not be supported for CUDA/HIP
          * Wrapp the functor as ScalarFunc because math::min() cannot be executed on a Simd pack.
          * This enforces that the functor is evaluated on scalar values and not SIMD packs.
          * Memory loads and stores will be vectorized.
          */
-        std::make_pair(
+        std::make_tuple(
             ScalarFunc{[] ALPAKA_FN_ACC(DataType const& a, DataType const& b)
                        { return math::min(a + DataType{1}, b); }},
-            [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); }),
-        std::make_pair(
+            [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); },
+            TestWithMdSpan{}),
+        std::make_tuple(
             ScalarFunc{ScalarOpWithAcc{}},
-            [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); }),
+            [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); },
+            TestWithMdSpan{}),
         // different output type
-        std::make_pair(
+        std::make_tuple(
             AddUpCastWithAcc{},
-            [](DataType const& a, DataType const& b) { return static_cast<size_t>(a + b); }));
+            [](DataType const& a, DataType const& b) { return static_cast<size_t>(a + b); },
+            TestWithMdSpan{}));
+
+    // different extents for testing
+    auto extentMdList
+        = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
+
+    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, functorList), ...); }, extentMdList);
+}
+
+struct TestWithGenerator
+{
+    template<typename T_DataType>
+    static void executeTest(
+        concepts::Executor auto exec,
+        auto const& computeQueue,
+        auto const setup,
+        concepts::Vector auto extentMd)
+    {
+        std::cout << "run func : " << onHost::demangledName(std::get<1>(setup)) << std::endl;
+
+        auto computeDev = computeQueue.getDevice();
+        using DataType = T_DataType;
+        using OutDataType = decltype(std::get<1>(setup)(std::declval<DataType>(), std::declval<DataType>()));
+        onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd);
+        onHost::SharedBuffer computeBufferIn0 = onHost::allocDeferred<DataType>(computeQueue, extentMd);
+        auto generator = LinearizedIdxGenerator{extentMd};
+        onHost::SharedBuffer hostBufferIota = onHost::allocLike(onHost::makeHostDevice(), computeBufferIn0);
+        onHost::SharedBuffer hostBufferOut = onHost::allocLike(onHost::makeHostDevice(), computeBufferOut);
+
+        // initialize with the linearized index
+        DataType iotaCounter = 0;
+        for(auto& value : hostBufferIota)
+        {
+            value = iotaCounter;
+            ++iotaCounter;
+        }
+
+        onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+
+        onHost::wait(computeQueue);
+        auto const beginT = std::chrono::high_resolution_clock::now();
+
+        onHost::transform(computeQueue, exec, computeBufferOut, std::get<0>(setup), computeBufferIn0, generator);
+
+        onHost::wait(computeQueue);
+        auto const endT = std::chrono::high_resolution_clock::now();
+        std::cout << "Time for transform: " << std::chrono::duration<double>(endT - beginT).count() << 's'
+                  << " data size: " << computeBufferOut.getExtents() << std::endl;
+
+        onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
+        onHost::wait(computeQueue);
+
+        // validate without using the forward iterator
+        DataType refIotaCounter = 0;
+        meta::ndLoopIncIdx(
+            extentMd,
+            [&](auto idx)
+            {
+                CHECK(hostBufferOut[idx] == std::get<1>(setup)(refIotaCounter, generator[idx]));
+                ++refIotaCounter;
+            });
+    };
+};
+
+TEMPLATE_LIST_TEST_CASE("transform generator", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    using DataType = int;
+
+    // This list is not directly defined within the function `prepareTest()` due to nvcc compile issues.
+    auto functorList = std::make_tuple(
+        std::make_tuple(std::minus{}, std::minus{}, TestWithGenerator{}),
+        std::make_tuple(std::plus{}, std::plus{}, TestWithGenerator{}),
+        // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
+        std::make_tuple(StencilFunc{StencilAdd{}}, std::plus{}, TestWithGenerator{}),
+        std::make_tuple(StencilFunc{StencilAddWithAcc{}}, std::plus{}, TestWithGenerator{}),
+        /* We can use a lambda function because the types are explicitly defined.
+         * Generic lambdas would not be supported for CUDA/HIP
+         * Wrapp the functor as ScalarFunc because math::min() cannot be executed on a Simd pack.
+         * This enforces that the functor is evaluated on scalar values and not SIMD packs.
+         * Memory loads and stores will be vectorized.
+         */
+        std::make_tuple(
+            ScalarFunc{[] ALPAKA_FN_ACC(DataType const& a, DataType const& b)
+                       { return math::min(a + DataType{1}, b); }},
+            [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); },
+            TestWithGenerator{}),
+        std::make_tuple(
+            ScalarFunc{ScalarOpWithAcc{}},
+            [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); },
+            TestWithGenerator{}),
+        // different output type
+        std::make_tuple(
+            AddUpCastWithAcc{},
+            [](DataType const& a, DataType const& b) { return static_cast<size_t>(a + b); },
+            TestWithGenerator{}));
 
     // different extents for testing
     auto extentMdList

--- a/tests/unit/algorithm/transformReduce.cpp
+++ b/tests/unit/algorithm/transformReduce.cpp
@@ -80,73 +80,75 @@ struct alpaka::onAcc::trait::FunctorToAtomicOp<MinValue>
     using type = alpaka::onAcc::AtomicMin;
 };
 
-template<typename T_DataType>
-void executeTest(
-    concepts::Executor auto exec,
-    auto const& computeQueue,
-    auto const functorPair,
-    concepts::Vector auto extentMd)
+struct TestWithMdSpan
 {
-    std::cout << "run reduce(func) : " << onHost::demangledName(std::get<1>(functorPair).second) << "("
-              << onHost::demangledName(std::get<2>(functorPair).second) << ")" << std::endl;
-
-    auto computeDev = computeQueue.getDevice();
-    using DataType = T_DataType;
-    using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
-    onHost::SharedBuffer computeBufferOut = onHost::alloc<OutDataType>(computeDev, extentMd.all(1));
-    onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
-    onHost::SharedBuffer computeBufferIn1 = onHost::allocLike(computeDev, computeBufferIn0);
-    onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn0);
-    onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);
-
-    // initialize with the linearized index
-    DataType iotaCounter = 0;
-    for(auto& value : hostBufferIota)
+    template<typename T_DataType>
+    static void executeTest(
+        concepts::Executor auto exec,
+        auto const& computeQueue,
+        auto const setup,
+        concepts::Vector auto extentMd)
     {
-        value = iotaCounter;
-        ++iotaCounter;
-    }
+        std::cout << "run reduce(func) : " << onHost::demangledName(std::get<1>(setup).second) << "("
+                  << onHost::demangledName(std::get<2>(setup).second) << ")" << std::endl;
 
-    onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
-    onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
+        auto computeDev = computeQueue.getDevice();
+        using DataType = T_DataType;
+        using OutDataType = ALPAKA_TYPEOF(std::get<0>(setup));
+        onHost::SharedBuffer computeBufferOut = onHost::alloc<OutDataType>(computeDev, extentMd.all(1));
+        onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+        onHost::SharedBuffer computeBufferIn1 = onHost::allocLike(computeDev, computeBufferIn0);
+        onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn0);
+        onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);
 
-    onHost::wait(computeQueue);
-    auto const beginT = std::chrono::high_resolution_clock::now();
-
-    onHost::transformReduce(
-        computeQueue,
-        exec,
-        std::get<0>(functorPair),
-        computeBufferOut,
-        std::get<1>(functorPair).first,
-        std::get<2>(functorPair).first,
-        computeBufferIn0,
-        computeBufferIn1);
-
-    onHost::wait(computeQueue);
-    auto const endT = std::chrono::high_resolution_clock::now();
-    std::cout << "Time for transform reduce: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-              << " data size: " << hostBufferIota.getExtents() << std::endl;
-
-    onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
-    onHost::wait(computeQueue);
-
-    // validate without using the forward iterator
-    DataType refIotaCounter = 0;
-    auto result = std::get<0>(functorPair);
-    meta::ndLoopIncIdx(
-        extentMd,
-        [&](auto idx)
+        // initialize with the linearized index
+        DataType iotaCounter = 0;
+        for(auto& value : hostBufferIota)
         {
-            result = std::get<1>(functorPair)
-                         .second(result, std::get<2>(functorPair).second(refIotaCounter, refIotaCounter));
-            ++refIotaCounter;
-        });
-    CHECK(*hostBufferOut.data() == result);
+            value = iotaCounter;
+            ++iotaCounter;
+        }
+
+        onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+        onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
+
+        onHost::wait(computeQueue);
+        auto const beginT = std::chrono::high_resolution_clock::now();
+
+        onHost::transformReduce(
+            computeQueue,
+            exec,
+            std::get<0>(setup),
+            computeBufferOut,
+            std::get<1>(setup).first,
+            std::get<2>(setup).first,
+            computeBufferIn0,
+            computeBufferIn1);
+
+        onHost::wait(computeQueue);
+        auto const endT = std::chrono::high_resolution_clock::now();
+        std::cout << "Time for transform reduce: " << std::chrono::duration<double>(endT - beginT).count() << 's'
+                  << " data size: " << hostBufferIota.getExtents() << std::endl;
+
+        onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
+        onHost::wait(computeQueue);
+
+        // validate without using the forward iterator
+        DataType refIotaCounter = 0;
+        auto result = std::get<0>(setup);
+        meta::ndLoopIncIdx(
+            extentMd,
+            [&](auto idx)
+            {
+                result = std::get<1>(setup).second(result, std::get<2>(setup).second(refIotaCounter, refIotaCounter));
+                ++refIotaCounter;
+            });
+        CHECK(*hostBufferOut.data() == result);
+    };
 };
 
 template<typename T_DataType>
-void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTuples)
+void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
 
@@ -170,8 +172,9 @@ void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& functorTu
 
     // execute for each functor
     std::apply(
-        [&](auto const&... functorPair) { (executeTest<DataType>(exec, computeQueue, functorPair, extentMd), ...); },
-        functorTuples);
+        [&](auto const&... setup)
+        { (std::get<3>(setup).template executeTest<DataType>(exec, computeQueue, setup, extentMd), ...); },
+        setupTuple);
 }
 
 TEMPLATE_LIST_TEST_CASE("transformReduce", "", TestBackends)
@@ -181,27 +184,31 @@ TEMPLATE_LIST_TEST_CASE("transformReduce", "", TestBackends)
     using DataType = int;
 
     // This list is not directly defined within the function `prepareTest()` due to nvcc compile issues.
-    auto functorList = std::make_tuple(
+    auto setups = std::make_tuple(
         std::make_tuple(
             DataType{0},
             std::make_pair(std::plus{}, std::plus{}),
-            std::make_pair(std::plus{}, std::plus{})),
-        std::make_tuple(
-            DataType{0},
             std::make_pair(std::plus{}, std::plus{}),
-            // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
-            std::make_pair(StencilFunc{StencilAdd{}}, std::plus{})),
+            TestWithMdSpan{}),
         std::make_tuple(
             DataType{0},
             std::make_pair(std::plus{}, std::plus{}),
             // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
-            std::make_pair(StencilFunc{StencilAddWithAcc{}}, std::plus{})),
+            std::make_pair(StencilFunc{StencilAdd{}}, std::plus{}),
+            TestWithMdSpan{}),
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
+            std::make_pair(StencilFunc{StencilAddWithAcc{}}, std::plus{}),
+            TestWithMdSpan{}),
         std::make_tuple(
             size_t{0},
             std::make_pair(std::plus{}, std::plus{}),
             std::make_pair(
                 AddUpCastWithAcc{},
-                [](DataType const& a, DataType const& b) { return static_cast<size_t>(a + b); })),
+                [](DataType const& a, DataType const& b) { return static_cast<size_t>(a + b); }),
+            TestWithMdSpan{}),
         /* We can use a lambda function because the types are explicitly defined.
          * Generic lambdas would not be supported for CUDA/HIP
          * Wrapp the functor as ScalarFunc because math::min() cannot be executed on a Simd pack.
@@ -214,16 +221,144 @@ TEMPLATE_LIST_TEST_CASE("transformReduce", "", TestBackends)
             std::make_pair(
                 ScalarFunc{[] ALPAKA_FN_ACC(DataType const& a, DataType const& b)
                            { return math::min(a + DataType{1}, b); }},
-                [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); })),
+                [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); }),
+            TestWithMdSpan{}),
         std::make_tuple(
             std::numeric_limits<DataType>::max(),
             std::make_pair(ScalarFunc{MinValue{}}, MinValue{}),
             // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
-            std::make_pair(std::plus{}, std::plus{})));
+            std::make_pair(std::plus{}, std::plus{}),
+            TestWithMdSpan{}));
 
     // different extents for testing
     auto extentMdList
         = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
 
-    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, functorList), ...); }, extentMdList);
+    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, setups), ...); }, extentMdList);
+}
+
+struct TestWithGenerator
+{
+    template<typename T_DataType>
+    static void executeTest(
+        concepts::Executor auto exec,
+        auto const& computeQueue,
+        auto const setup,
+        concepts::Vector auto extentMd)
+    {
+        std::cout << "run reduce(func) : " << onHost::demangledName(std::get<1>(setup).second) << "("
+                  << onHost::demangledName(std::get<2>(setup).second) << ")" << std::endl;
+
+        auto computeDev = computeQueue.getDevice();
+        using DataType = T_DataType;
+        using OutDataType = ALPAKA_TYPEOF(std::get<0>(setup));
+        onHost::SharedBuffer computeBufferOut = onHost::alloc<OutDataType>(computeDev, extentMd.all(1));
+        onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+        auto generator = LinearizedIdxGenerator{extentMd};
+        onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn0);
+        onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);
+
+        // initialize with the linearized index
+        DataType iotaCounter = 0;
+        for(auto& value : hostBufferIota)
+        {
+            value = iotaCounter;
+            ++iotaCounter;
+        }
+
+        onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+
+        onHost::wait(computeQueue);
+        auto const beginT = std::chrono::high_resolution_clock::now();
+
+        onHost::transformReduce(
+            computeQueue,
+            exec,
+            std::get<0>(setup),
+            computeBufferOut,
+            std::get<1>(setup).first,
+            std::get<2>(setup).first,
+            computeBufferIn0,
+            generator);
+
+        onHost::wait(computeQueue);
+        auto const endT = std::chrono::high_resolution_clock::now();
+        std::cout << "Time for transform reduce: " << std::chrono::duration<double>(endT - beginT).count() << 's'
+                  << " data size: " << hostBufferIota.getExtents() << std::endl;
+
+        onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
+        onHost::wait(computeQueue);
+
+        // validate without using the forward iterator
+        DataType refIotaCounter = 0;
+        auto result = std::get<0>(setup);
+        meta::ndLoopIncIdx(
+            extentMd,
+            [&](auto idx)
+            {
+                result = std::get<1>(setup).second(result, std::get<2>(setup).second(refIotaCounter, generator[idx]));
+                ++refIotaCounter;
+            });
+        CHECK(*hostBufferOut.data() == result);
+    };
+};
+
+TEMPLATE_LIST_TEST_CASE("transformReduce generator", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    using DataType = int;
+
+    // This list is not directly defined within the function `prepareTest()` due to nvcc compile issues.
+    auto setups = std::make_tuple(
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(std::plus{}, std::plus{}),
+            TestWithGenerator{}),
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
+            std::make_pair(StencilFunc{StencilAdd{}}, std::plus{}),
+            TestWithGenerator{}),
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
+            std::make_pair(StencilFunc{StencilAddWithAcc{}}, std::plus{}),
+            TestWithGenerator{}),
+        std::make_tuple(
+            size_t{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(
+                AddUpCastWithAcc{},
+                [](DataType const& a, DataType const& b) { return static_cast<size_t>(a + b); }),
+            TestWithGenerator{}),
+        /* We can use a lambda function because the types are explicitly defined.
+         * Generic lambdas would not be supported for CUDA/HIP
+         * Wrapp the functor as ScalarFunc because math::min() cannot be executed on a Simd pack.
+         * This enforces that the functor is evaluated on scalar values and not SIMD packs.
+         * Memory loads and stores will be vectorized.
+         */
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(
+                ScalarFunc{[] ALPAKA_FN_ACC(DataType const& a, DataType const& b)
+                           { return math::min(a + DataType{1}, b); }},
+                [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); }),
+            TestWithGenerator{}),
+        std::make_tuple(
+            std::numeric_limits<DataType>::max(),
+            std::make_pair(ScalarFunc{MinValue{}}, MinValue{}),
+            // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
+            std::make_pair(std::plus{}, std::plus{}),
+            TestWithGenerator{}));
+
+    // different extents for testing
+    auto extentMdList
+        = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
+
+    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, setups), ...); }, extentMdList);
 }


### PR DESCRIPTION
- introduce `internal::LoadAsSimd` load trait to avoid assuming SIMD load from a pointer only
- add generator `alpaka::LinearizedIdxGenerator`
- test using generators in all onHost algorithms
- add concepts `alpaka::concepts::IGenerator`
  - @SimeonEhrig It is currently an independent concept. We need to discuss a few points about it, but changes can be made in follow-up PRs.

This PR is required for the upcoming webinar.

note: Test cases partly copied and pasted from the same test without containers but IMO this is better to read compared to highly abstracted helpers. Never the there is room for improvements which should go into a separate PR.