### PR TITLE
fix missing include to #include `onHost::executeForEach`

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -41,6 +41,7 @@
 #include "alpaka/onHost/algo/transform.hpp"
 #include "alpaka/onHost/algo/transformReduce.hpp"
 #include "alpaka/onHost/demangledName.hpp"
+#include "alpaka/onHost/executeForEach.hpp"
 #include "alpaka/onHost/interface.hpp"
 #include "alpaka/onHost/logger/logger.hpp"
 #include "alpaka/onHost/mem/stdContainer.hpp"


### PR DESCRIPTION
The function is part of `onHost` but was only available if the corresponding file was included directly.