### PR TITLE
fix atomic ref usage/detection

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -207,9 +207,9 @@ try_compile(
 )
 if(alpaka_HAS_STD_ATOMIC_REF AND (NOT alpaka_ACC_CPU_DISABLE_ATOMIC_REF))
     message(STATUS "std::atomic_ref<T> found")
-    target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_HAS_STD_ATOMIC_REF)
 else()
     message(STATUS "std::atomic_ref<T> NOT found")
+    target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_DISABLE_STD_ATOMIC_REF)
 endif()
 
 if(NOT alpaka_HAS_STD_ATOMIC_REF)
@@ -218,15 +218,8 @@ if(NOT alpaka_HAS_STD_ATOMIC_REF)
         target_link_libraries(alpaka_target_host INTERFACE Boost::atomic)
     else()
         message(STATUS "boost::atomic_ref<T> NOT found")
+        message(FATAL_ERROR "std::atomic_ref<T> OR boost::atomic_ref<T> is required")
     endif()
-endif()
-
-if((NOT alpaka_HAS_STD_ATOMIC_REF) AND (NOT Boost_ATOMIC_FOUND))
-    message(
-        STATUS
-        "atomic_ref<T> or boost::atomic_ref<T> was not found or manually disabled. Falling back to lock-based CPU atomics."
-    )
-    target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_DISABLE_ATOMIC_ATOMICREF)
 endif()
 
 # These options are used in the alpaka_finalize call

--- a/include/alpaka/api/host/atomic.hpp
+++ b/include/alpaka/api/host/atomic.hpp
@@ -14,22 +14,22 @@
 #include <atomic>
 #include <type_traits>
 
-#ifndef ALPAKA_DISABLE_ATOMIC_ATOMICREF
-#    ifndef ALPAKA_HAS_STD_ATOMIC_REF
-#        include <boost/atomic.hpp>
-#    endif
+
+#ifdef ALPAKA_DISABLE_STD_ATOMIC_REF
+#    include <boost/atomic.hpp>
+#endif
 
 namespace alpaka::onAcc
 {
     namespace detail
     {
-#    if defined(ALPAKA_HAS_STD_ATOMIC_REF)
-        template<typename T>
-        using atomic_ref = std::atomic_ref<T>;
-#    else
+#if defined(ALPAKA_DISABLE_STD_ATOMIC_REF)
         template<typename T>
         using atomic_ref = boost::atomic_ref<T>;
-#    endif
+#else
+        template<typename T>
+        using atomic_ref = std::atomic_ref<T>;
+#endif
     } // namespace detail
 
     //! The atomic ops based on atomic_ref for CPU accelerators.
@@ -222,19 +222,17 @@ namespace alpaka::onAcc
                 T result;
                 do
                 {
-#    if ALPAKA_COMP_GNUC || ALPAKA_COMP_CLANG
-#        pragma GCC diagnostic push
-#        pragma GCC diagnostic ignored "-Wfloat-equal"
-#    endif
+#if ALPAKA_COMP_GNUC || ALPAKA_COMP_CLANG
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
                     result = ((old == compare) ? value : old);
-#    if ALPAKA_COMP_GNUC || ALPAKA_COMP_CLANG
-#        pragma GCC diagnostic pop
-#    endif
+#if ALPAKA_COMP_GNUC || ALPAKA_COMP_CLANG
+#    pragma GCC diagnostic pop
+#endif
                 } while(!ref.compare_exchange_weak(old, result));
                 return old;
             }
         };
     } // namespace internalCompute
 } // namespace alpaka::onAcc
-
-#endif


### PR DESCRIPTION
In cases alpaka is used without CMake all features should be enabled based on feature detections e.g. with C++ macros.
We try not depend on defines set in CMake to enable features. We use only the logic to define macros from CMake to force disable features to support using the full alpaka feature set even without CMake e.g in compiler explorers.

The atomic detection was violating the design principles.