### PR TITLE
fix nvcc compile for pure C++ only

### DIFF
--- a/include/alpaka/trait.hpp
+++ b/include/alpaka/trait.hpp
@@ -101,7 +101,7 @@ namespace alpaka
          */
         template<typename T, typename = void>
         struct IsKernelTriviallyCopyable
-#if ALPAKA_COMP_NVCC
+#if ALPAKA_LANG_CUDA && ALPAKA_COMP_NVCC
             : std::bool_constant<
                   std::is_trivially_copyable_v<T> || __nv_is_extended_device_lambda_closure_type(T)
                   || __nv_is_extended_host_device_lambda_closure_type(T)>


### PR DESCRIPTION
If nvcc is used to compile alpaka without `-x cu` than all code is forwarded to the host compiler in that case
`__nv_is_extended_device_lambda_closure_type()` is not allowed to be called.

Found it by compiling with nvcc only as C++ `nvcc -std=c++20 --expt-relaxed-constexpr --extended-lambda -I ../alpaka3/include/ ../alpaka3/example/vectorAdd/src/vectorAdd.cpp` 