### PR TITLE
SIMD fix SVE/NEON vector size detection

### DIFF
--- a/include/alpaka/api/host/cpuArchSize.hpp
+++ b/include/alpaka/api/host/cpuArchSize.hpp
@@ -21,14 +21,23 @@ namespace alpaka::onHost::internal
 #elif defined(__riscv)
             // do not use vectors if the vector extension is not set
             sizeof(T_Type);
-        // ARM e.g. nvidia grace hopper
-#elif defined(__ARM_FEATURE_SVE) || defined(__ARM_FEATURE_SVE2_AES) || defined(__ARM_FEATURE_DOTPROD)
-            64u;
 #elif defined(__AVX2__)
             32u;
 #elif defined(__SSE__) || defined(__SSE2__) || defined(__SSE4_1__) || defined(__SSE4_2__)
             16u;
-#elif defined(__ARM_NEON__)
+// Macro to be define by the user to enable SVE backend and specify SVE size
+#elif defined(SVE_VECTOR_BITS)
+            SVE_VECTOR_BITS / 8;
+// If user has specified SVE vector lenght using the flag -msve-vector-bits
+#elif defined(__ARM_FEATURE_SVE_BITS)
+            __ARM_FEATURE_SVE_BITS / 8;
+// ARM e.g. nvidia grace hopper
+#elif defined(__ARM_FEATURE_SVE2_AES)
+            16u;
+// ARM e.g AWS Graviton 3
+#elif defined(__ARM_FEATURE_SVE)
+            32u;
+#elif defined(__ARM_NEON)
             16u;
 #elif defined(__ALTIVEC__)
             16u;


### PR DESCRIPTION
For NEON, the macro use was change to the correct one

Vector lenght for SVE was set to 512 bits, which is true only for the Fujitsu A64FX. CPU manufacturer can choose any size from 128 to 2048 bits for SVE vector.
For the moment, no way of getting the SVE size in the compiler preprocessor has been found other than (in priority order):
- User can define SVE_VECTOR_BIT to the value (in bit) to use
- If flag -msve-vector-bits=<value> was use, use this size. This flags is supported by most compilers
- If SVE2 is enable (by using -march or -mcpu flags) set size to 128 bits (for the moment, Neoverse-v2/3 machines use 128 bits SVE vector)
- If SVE is enable (by using -march or -mcpu flags) but not SVE2, you are likely on a Neoverse-v1 machine wich use 256 bits SVE. One issue is that we cannot differentiate if the user is using Neoverse-v1 (256 bits) or A64FX (512 bits)
- Else fallback on NEON if enable (supported by mosr ARM machines)