### PR TITLE
fix MdSpanArray

### DIFF
--- a/include/alpaka/mem/MdSpanArray.hpp
+++ b/include/alpaka/mem/MdSpanArray.hpp
@@ -88,23 +88,23 @@ namespace alpaka
          */
         constexpr const_reference operator*() const
         {
-            return *this->m_ptr;
+            return *this->data();
         }
 
         constexpr reference operator*()
         {
-            return *this->m_ptr;
+            return *this->data();
         }
 
         /** get origin pointer */
         constexpr const_pointer data() const
         {
-            return this->m_ptr;
+            return reinterpret_cast<const_pointer>(this->m_ptr);
         }
 
         constexpr pointer data()
         {
-            return this->m_ptr;
+            return reinterpret_cast<pointer>(this->m_ptr);
         }
 
         constexpr auto begin() const


### PR DESCRIPTION
- calling `data()` was not possible because of implicit cast issues
- dereverencing the current position of the MdSpanArray was broken because a CArray can not simply be dereferenced