### PR TITLE
fix loop counter being incremented twice

### DIFF
--- a/example/grayScale/src/grayScale.cpp
+++ b/example/grayScale/src/grayScale.cpp
@@ -239,8 +239,6 @@ auto example(T_Cfg const& cfg, size_t numElements, size_t numberOfRuns, bool ena
             if(result != EXIT_SUCCESS)
                 return result;
         }
-
-        ++completedRuns;
     }
 
     if(completedRuns > 0u)


### PR DESCRIPTION
The grayscale example can be configured to run multiple times, but the loop counter was incremented twice in every loop.
This PR fixes this. Counter is now only incremented in the for loop statement
