### PR TITLE
support for copy from and to global device memory.

### DIFF
--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -16,6 +16,7 @@
 #include "alpaka/interface.hpp"
 #include "alpaka/internal/interface.hpp"
 #include "alpaka/meta/NdLoop.hpp"
+#include "alpaka/onAcc/internal/globalMem.hpp"
 #include "alpaka/onHost/FrameSpec.hpp"
 #include "alpaka/onHost/Handle.hpp"
 #include "alpaka/onHost/interface.hpp"
@@ -215,6 +216,7 @@ namespace alpaka::onHost
             friend struct internal::Wait;
             friend struct internal::WaitFor;
             friend struct internal::Memcpy;
+            friend struct internal::MemcpyDeviceGlobal;
             friend struct internal::Memset;
             friend struct alpaka::internal::GetApi;
             friend struct internal::AllocDeferred;
@@ -372,6 +374,48 @@ namespace alpaka::onHost
                             }
                         });
                 }
+            }
+        };
+
+        // copy to device global memory
+        template<typename T_Device, typename T_Source, typename T_Storage, typename T>
+        struct internal::MemcpyDeviceGlobal::
+            Op<cpu::Queue<T_Device>, onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>, T_Source>
+        {
+            void operator()(
+                cpu::Queue<T_Device>& queue,
+                onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> dest,
+                auto&& source) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+                auto* destPtr = dest.getHandle(api::host).data();
+                void const* srcPtr{nullptr};
+                if constexpr(std::is_pointer_v<ALPAKA_TYPEOF(source)>)
+                    srcPtr = source;
+                else
+                    srcPtr = toVoidPtr(alpaka::onHost::data(ALPAKA_FORWARD(source)));
+                queue.submit([destPtr, srcPtr]() { std::memcpy(destPtr, srcPtr, sizeof(T)); });
+            }
+        };
+
+        // copy from device global memory
+        template<typename T_Device, typename T_Dest, typename T_Storage, typename T>
+        struct internal::MemcpyDeviceGlobal::
+            Op<cpu::Queue<T_Device>, T_Dest, onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>>
+        {
+            void operator()(
+                cpu::Queue<T_Device>& queue,
+                auto&& dest,
+                onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> source) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+                void* destPtr{nullptr};
+                if constexpr(std::is_pointer_v<ALPAKA_TYPEOF(dest)>)
+                    destPtr = dest;
+                else
+                    destPtr = toVoidPtr(alpaka::onHost::data(ALPAKA_FORWARD(dest)));
+                auto const* srcPtr = source.getHandle(api::host).data();
+                queue.submit([destPtr, srcPtr]() { std::memcpy(destPtr, srcPtr, sizeof(T)); });
             }
         };
 

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -12,6 +12,7 @@
 #    include "alpaka/api/oneApi/StaticSharedMemory.hpp"
 #    include "alpaka/api/syclGeneric/Queue.hpp"
 #    include "alpaka/api/syclGeneric/onAcc.hpp"
+#    include "alpaka/onAcc/internal/globalMem.hpp"
 #    include "alpaka/onHost/internal/interface.hpp"
 
 
@@ -111,6 +112,54 @@ namespace alpaka::onHost::internal
                     extentMd.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
                     dstExtentWithoutColumn.product());
             }
+
+            if(queue.isBlocking())
+                ev.wait_and_throw();
+        }
+    };
+
+    // copy to device global memory
+    template<typename T_Device, typename T_Source, typename T_Storage, typename T>
+    struct internal::MemcpyDeviceGlobal::
+        Op<syclGeneric::Queue<T_Device>, onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>, T_Source>
+    {
+        void operator()(
+            syclGeneric::Queue<T_Device>& queue,
+            onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> dest,
+            auto&& source) const
+        {
+            ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+            sycl::queue sycl_queue = queue.getNativeHandle();
+            void const* srcPtr{nullptr};
+            if constexpr(std::is_pointer_v<ALPAKA_TYPEOF(source)>)
+                srcPtr = source;
+            else
+                srcPtr = toVoidPtr(alpaka::onHost::data(source));
+            [[maybe_unused]] sycl::event ev = sycl_queue.memcpy(dest.getHandle(alpaka::api::oneApi), srcPtr);
+
+            if(queue.isBlocking())
+                ev.wait_and_throw();
+        }
+    };
+
+    // copy from device global memory
+    template<typename T_Device, typename T_Dest, typename T_Storage, typename T>
+    struct internal::MemcpyDeviceGlobal::
+        Op<syclGeneric::Queue<T_Device>, T_Dest, onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>>
+    {
+        void operator()(
+            syclGeneric::Queue<T_Device>& queue,
+            auto&& dest,
+            onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> source) const
+        {
+            ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+            sycl::queue sycl_queue = queue.getNativeHandle();
+            void* destPtr{nullptr};
+            if constexpr(std::is_pointer_v<ALPAKA_TYPEOF(dest)>)
+                destPtr = dest;
+            else
+                destPtr = toVoidPtr(alpaka::onHost::data(dest));
+            [[maybe_unused]] sycl::event ev = sycl_queue.memcpy(destPtr, source.getHandle(alpaka::api::oneApi));
 
             if(queue.isBlocking())
                 ev.wait_and_throw();

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -20,6 +20,7 @@
 #    include "alpaka/core/UniformCudaHip.hpp"
 #    include "alpaka/internal/interface.hpp"
 #    include "alpaka/onAcc/Acc.hpp"
+#    include "alpaka/onAcc/internal/globalMem.hpp"
 #    include "alpaka/onHost/FrameSpec.hpp"
 #    include "alpaka/onHost/Handle.hpp"
 #    include "alpaka/onHost/interface.hpp"
@@ -160,6 +161,7 @@ namespace alpaka::onHost
 
             friend struct alpaka::internal::GetApi;
             friend struct onHost::internal::Memcpy;
+            friend struct onHost::internal::MemcpyDeviceGlobal;
             friend struct onHost::internal::Memset;
             friend struct onHost::internal::AllocDeferred;
             friend struct CallKernel;
@@ -516,6 +518,79 @@ namespace alpaka::onHost
                         ApiInterface,
                         ApiInterface::memcpy3DAsync(&memCpy3DParms, internal::getNativeHandle(queue)));
                 }
+
+                queue.conditionalWait();
+            }
+        };
+
+        // copy to device global memory
+        template<typename T_Device, typename T_Source, typename T_Storage, typename T>
+        struct internal::MemcpyDeviceGlobal::
+            Op<unifiedCudaHip::Queue<T_Device>, onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>, T_Source>
+        {
+            void operator()(
+                unifiedCudaHip::Queue<T_Device>& queue,
+                onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> dest,
+                auto&& source) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+
+                using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
+                auto queueApi = alpaka::internal::getApi(queue);
+                auto copyKind = unifiedCudaHip::
+                    MemcpyKind<ApiInterface, ALPAKA_TYPEOF(queueApi), ALPAKA_TYPEOF(api::host)>::kind;
+
+                void* destPtr{nullptr};
+                void const* srcPtr{nullptr};
+                if constexpr(std::is_pointer_v<ALPAKA_TYPEOF(source)>)
+                    srcPtr = source;
+                else
+                    srcPtr = toVoidPtr(alpaka::onHost::data(ALPAKA_FORWARD(source)));
+
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::getSymbolAddress(reinterpret_cast<void**>(&destPtr), dest.getHandle(queueApi)));
+
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::memcpyAsync(destPtr, srcPtr, sizeof(T), copyKind, internal::getNativeHandle(queue)));
+
+                queue.conditionalWait();
+            }
+        };
+
+        // copy from device global memory
+        template<typename T_Device, typename T_Dest, typename T_Storage, typename T>
+        struct internal::MemcpyDeviceGlobal::
+            Op<unifiedCudaHip::Queue<T_Device>, T_Dest, onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>>
+        {
+            void operator()(
+                unifiedCudaHip::Queue<T_Device>& queue,
+                auto&& dest,
+                onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> source) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+
+                using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
+                auto queueApi = alpaka::internal::getApi(queue);
+                auto copyKind = unifiedCudaHip::
+                    MemcpyKind<ApiInterface, ALPAKA_TYPEOF(api::host), ALPAKA_TYPEOF(queueApi)>::kind;
+
+                void* destPtr{nullptr};
+                if constexpr(std::is_pointer_v<ALPAKA_TYPEOF(dest)>)
+                    destPtr = dest;
+                else
+                    destPtr = toVoidPtr(alpaka::onHost::data(ALPAKA_FORWARD(dest)));
+
+                void* srcPtr{nullptr};
+
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::getSymbolAddress(reinterpret_cast<void**>(&srcPtr), source.getHandle(queueApi)));
+
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::memcpyAsync(destPtr, srcPtr, sizeof(T), copyKind, internal::getNativeHandle(queue)));
 
                 queue.conditionalWait();
             }

--- a/include/alpaka/onAcc/globalMem.hpp
+++ b/include/alpaka/onAcc/globalMem.hpp
@@ -44,7 +44,14 @@
                                                                                                                       \
     struct ALPAKA_PP_CAT(AlpakaGlobalStorage, name)                                                                   \
     {                                                                                                                 \
-        ALPAKA_DEVICE_GLOBAL_GET_HOST(attributes, dataType, name, __VA_ARGS__)                                        \
+        constexpr auto& get(alpaka::api::Host) const                                                                  \
+        {                                                                                                             \
+            return alpaka_onHost::name.value;                                                                         \
+        }                                                                                                             \
+        constexpr auto& getHandle(alpaka::api::Host) const                                                            \
+        {                                                                                                             \
+            return alpaka_onHost::name;                                                                               \
+        }                                                                                                             \
         ALPAKA_DEVICE_GLOBAL_GET_CUDA_HIP(attributes, dataType, name, __VA_ARGS__)                                    \
         ALPAKA_DEVICE_GLOBAL_GET_ONEAPI(attributes, dataType, name, __VA_ARGS__)                                      \
     };                                                                                                                \

--- a/include/alpaka/onAcc/internal/globalMem.hpp
+++ b/include/alpaka/onAcc/internal/globalMem.hpp
@@ -8,7 +8,24 @@
 #include "alpaka/concepts/types.hpp"
 #include "alpaka/core/PP.hpp"
 #include "alpaka/core/config.hpp"
+#include "alpaka/mem/MdSpan.hpp"
 #include "alpaka/mem/MdSpanArray.hpp"
+
+/** @file global device memory implementation for all APIs
+ *
+ * We need many precompiler macros to handle the device global feature.
+ * The reason is that we would like to have the possibility to create a variable where the same name can be used on all
+ * devices. Each device will have it's own instance of memory and via a global instance GlobalDeviceMemoryWrapper we
+ * redirect queries to the corresponding instance of memory based on the alpaka API.
+ *
+ * OneAPI Sycl is the only API which does not allow querying the device pointer of a global variable from the host.
+ * That's why we have special implementations of onHost::memcpy() which using the device global object directly.
+ * That's also the reason why we can not use the global memory for onHost::fill() or onHost::memset().
+ */
+namespace alpaka::onHost::internal
+{
+    struct MemcpyDeviceGlobal;
+} // namespace alpaka::onHost::internal
 
 /** Create a device global variable for the API host */
 #define ALPAKA_DEVICE_GLOBAL_DATA_HOST(attributes, dataType, name, ...)                                               \
@@ -24,18 +41,6 @@
     {                                                                                                                 \
         extern attributes alpaka::onAcc::internal::GlobalDeviceMemoryDataWrapper<ALPAKA_PP_REMOVE_BRACKETS(dataType)> \
             name;                                                                                                     \
-    }
-
-/** Access operator for usage in AlpakaGlobalStorage for API host */
-#define ALPAKA_DEVICE_GLOBAL_GET_HOST(attributes, dataType, name, ...)                                                \
-    template<typename T_Api>                                                                                          \
-    requires(std::is_same_v<alpaka::api::Host, T_Api>)                                                                \
-    constexpr auto& get(T_Api) const                                                                                  \
-    {                                                                                                                 \
-        static_assert(                                                                                                \
-            std::is_same_v<alpaka::api::Host, ALPAKA_TYPEOF(thisApi())>,                                              \
-            "This call is only allowed from the host or a kernel running on CPU.");                                   \
-        return alpaka_onHost::name.data;                                                                              \
     }
 
 #if ALPAKA_LANG_CUDA || ALPAKA_LANG_HIP
@@ -54,13 +59,15 @@
         requires(std::is_same_v<alpaka::api::Cuda, T_Api> || std::is_same_v<alpaka::api::Hip, T_Api>)                 \
         constexpr auto& get(T_Api) const                                                                              \
         {                                                                                                             \
-            static_assert(                                                                                            \
-                sizeof(T_Api)                                                                                         \
-                    && (ALPAKA_LANG_CUDA != ALPAKA_VERSION_NUMBER_NOT_AVAILABLE                                       \
-                        || ALPAKA_LANG_HIP != ALPAKA_VERSION_NUMBER_NOT_AVAILABLE),                                   \
-                "This call requires a CUDA/HIP compiler.");                                                           \
-            return alpaka_onAccCudaHip::name.data;                                                                    \
+            return alpaka_onAccCudaHip::name.value;                                                                   \
+        }                                                                                                             \
+        template<typename T_Api>                                                                                      \
+        requires(std::is_same_v<alpaka::api::Cuda, T_Api> || std::is_same_v<alpaka::api::Hip, T_Api>)                 \
+        constexpr auto& getHandle(T_Api) const                                                                        \
+        {                                                                                                             \
+            return alpaka_onAccCudaHip::name.value;                                                                   \
         }
+
 #else
 #    define ALPAKA_DEVICE_GLOBAL_DATA_CUDA_HIP(attributes, dataType, name, ...)
 #    define ALPAKA_DEVICE_GLOBAL_GET_CUDA_HIP(attributes, dataType, name, ...)
@@ -114,10 +121,13 @@
         requires(std::is_same_v<alpaka::api::OneApi, T_Api>)                                                          \
         constexpr auto& get(T_Api) const                                                                              \
         {                                                                                                             \
-            static_assert(                                                                                            \
-                sizeof(T_Api) && ALPAKA_LANG_SYCL != ALPAKA_VERSION_NUMBER_NOT_AVAILABLE,                             \
-                "This call requires a SYCL compiler.");                                                               \
-            return alpaka_onAccOneAPI::name.get().data;                                                               \
+            return alpaka_onAccOneAPI::name.get().value;                                                              \
+        }                                                                                                             \
+        template<typename T_Api>                                                                                      \
+        requires(std::is_same_v<alpaka::api::OneApi, T_Api>)                                                          \
+        constexpr auto& getHandle(T_Api) const                                                                        \
+        {                                                                                                             \
+            return alpaka_onAccOneAPI::name;                                                                          \
         }
 #else
 #    define ALPAKA_DEVICE_GLOBAL_DATA_ONEAPI(attributes, dataType, name, ...)
@@ -135,11 +145,21 @@ namespace alpaka::onAcc::internal
     template<typename T>
     struct GlobalDeviceMemoryDataWrapper
     {
-        constexpr GlobalDeviceMemoryDataWrapper(auto const&... args) : data{ALPAKA_FORWARD(args)...}
+        constexpr GlobalDeviceMemoryDataWrapper(auto const&... args) : value{ALPAKA_FORWARD(args)...}
         {
         }
 
-        T data;
+        T value;
+
+        T* data()
+        {
+            return &value;
+        }
+
+        T const* data() const
+        {
+            return &value;
+        }
     };
 
     /** Specialization of GlobalDeviceMemoryDataWrapper for C static arrays.
@@ -150,13 +170,40 @@ namespace alpaka::onAcc::internal
     template<alpaka::concepts::CStaticArray T>
     struct GlobalDeviceMemoryDataWrapper<T>
     {
-        T data;
+        T value;
+        using value_type = std::remove_all_extents_t<T>;
+
+        value_type* data()
+        {
+            return reinterpret_cast<value_type*>(&value);
+        }
+
+        value_type const* data() const
+        {
+            return reinterpret_cast<value_type const*>(&value);
+        }
     };
 
     /** Helper class to provide access to device global memory variables */
     template<typename T_Storage, typename T_Type>
     struct GlobalDeviceMemoryWrapper : private T_Storage
     {
+    private:
+        friend struct onHost::internal::MemcpyDeviceGlobal;
+
+        /** Get the handle to call native API specific memcopy for global device memory operation
+         *
+         * @attention This method is for internal usage only.
+         *
+         * @return type depends on the native API e.g Cuda, OneApi, ...
+         */
+        template<alpaka::concepts::Api T_Api>
+        constexpr decltype(auto) getHandle(T_Api api) const
+        {
+            return T_Storage::getHandle(api);
+        }
+
+    public:
         using type = T_Type;
 
         constexpr decltype(auto) get() const

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -220,6 +220,42 @@ namespace alpaka::onHost
             std::decay_t<decltype(extentsVec)>>{}(*queue.get(), ALPAKA_FORWARD(dest), source, extentsVec);
     }
 
+    /** copy data byte wise from a container or host pointer to global device memory
+     *
+     * @param queue the copy will be executed after all previous work in this queue is finished
+     * @param[in,out] dest must be device global memory on the device of the queue the data should be written to
+     * @param[in] source can be a container/view or host accessible pointer from which the data will be copied
+     */
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, typename T_Storage, typename T>
+    inline void memcpy(
+        Queue<T_Device, T_QueueKind> const& queue,
+        onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> dest,
+        auto&& source)
+    {
+        internal::MemcpyDeviceGlobal::Op<
+            std::decay_t<decltype(*queue.get())>,
+            onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>,
+            std::decay_t<decltype(source)>>{}(*queue.get(), dest, ALPAKA_FORWARD(source));
+    }
+
+    /** copy data byte wise from global device memory to a container or host pointer
+     *
+     * @param queue the copy will be executed after all previous work in this queue is finished
+     * @param[in,out] dest can be a container/view or host accessible pointer the data should be written to
+     * @param[in] source must be device global memory on the device of the queue from which the data will be copied
+     */
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, typename T_Storage, typename T>
+    inline void memcpy(
+        Queue<T_Device, T_QueueKind> const& queue,
+        auto&& dest,
+        onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> source)
+    {
+        internal::MemcpyDeviceGlobal::Op<
+            std::decay_t<decltype(*queue.get())>,
+            std::decay_t<decltype(dest)>,
+            onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>>{}(*queue.get(), ALPAKA_FORWARD(dest), source);
+    }
+
     /** fill memory byte wise
      *
      * @param[in,out] dest can be a container/view where the data should be written to

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -13,6 +13,13 @@
 #include "alpaka/onHost/ThreadSpec.hpp"
 #include "alpaka/tag.hpp"
 
+namespace alpaka::onAcc::internal
+{
+    // forward declaration to avoid cyclic includes
+    template<typename T_Storage, typename T_Type>
+    struct GlobalDeviceMemoryWrapper;
+} // namespace alpaka::onAcc::internal
+
 namespace alpaka::onHost
 {
     namespace internal
@@ -346,6 +353,21 @@ namespace alpaka::onHost
             struct Op
             {
                 void operator()(T_Queue& queue, auto&&, T_Source const&, T_Extents const&) const;
+            };
+        };
+
+        struct MemcpyDeviceGlobal
+        {
+            template<typename T_Queue, typename T_Dest, typename T_Source>
+            struct Op
+            {
+                /** copy data from or to the device global memory
+                 *
+                 * It is only allowed to copy data from or to the host.
+                 * Copy from device global variable to device global variables is not supported.
+                 * The host data is allowed te be a host accessible pointer.
+                 */
+                void operator()(T_Queue& queue, T_Dest&&, T_Source&&) const;
             };
         };
 

--- a/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -86,13 +86,13 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     onHost::Device device = devSelector.makeDevice(0);
 
-    std::cout << device.getName() << std::endl;
+    std::cout << "device name: " << device.getName() << "\n";
+    std::cout << "executor   : " << exec.getName() << std::endl;
 
     Queue queue = device.makeQueue();
     constexpr Vec numBlocks = Vec{1u};
     constexpr Vec blockExtent = Vec{4u};
     constexpr Vec dataExtent = numBlocks * blockExtent;
-    std::cout << "block shared iota exec=" << onHost::demangledName(exec) << std::endl;
     auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -157,6 +157,120 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
         for(uint32_t i = 0u; i < dataExtent; ++i)
         {
             CHECK(45 == ptr[i]);
+        }
+    }
+}
+
+// The initial value will be overwritten
+ALPAKA_DEVICE_GLOBAL(, uint32_t, globalScalar, 42u);
+
+struct DeviceGlobalMemCpyScalarKernel
+{
+    template<typename T>
+    ALPAKA_FN_ACC void operator()(T const& acc, auto out) const
+    {
+        for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
+        {
+            out[idx] = globalScalar.get();
+        }
+    }
+};
+
+ALPAKA_DEVICE_GLOBAL(, uint32_t[2u][3u], global2DCArray, {{9u, 5u}, {6u, 11u, 45u}});
+
+struct DeviceGlobalMemCpyCArray2DKernel
+{
+    template<typename T>
+    ALPAKA_FN_ACC void operator()(T const& acc, auto out) const
+    {
+        for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
+        {
+            out[idx] = global2DCArray.get()[Vec{1u, 2u}];
+        }
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("device global mem copy", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    std::cout << deviceSpec.getApi().getName() << std::endl;
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    onHost::Device device = devSelector.makeDevice(0);
+
+    std::cout << device.getName() << std::endl;
+
+    Queue queue = device.makeQueue();
+    constexpr Vec numBlocks = Vec{1u};
+    constexpr Vec blockExtent = Vec{4u};
+    constexpr Vec dataExtent = 13u;
+    std::cout << "device name: " << device.getName() << "\n";
+    std::cout << "executor   : " << exec.getName() << std::endl;
+
+    auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
+    auto hBuff = onHost::allocHostLike(dBuff);
+    onHost::wait(queue);
+    {
+        /* Get the value from the host representation and increase it because if we run with multiple host executors we
+         * need to be sure we test unique values for each executor. */
+        uint32_t newValue = globalScalar.get() + 1u;
+        if(queue.getApi() != api::host)
+            globalScalar.get() = newValue - 2u;
+
+        uint32_t val = newValue;
+        // check that we can copy from host to device
+        onHost::memcpy(queue, globalScalar, &val);
+        // reset host value
+        queue.enqueue([&]() { val = 0u; });
+        // check that we can copy from device to host
+        onHost::memcpy(queue, &val, globalScalar);
+        queue.enqueue(exec, FrameSpec{numBlocks, blockExtent}, KernelBundle{DeviceGlobalMemCpyScalarKernel{}, dBuff});
+        onHost::memcpy(queue, hBuff, dBuff);
+        onHost::wait(queue);
+        // check that copy from device to host worked
+        CHECK(val == newValue);
+        for(uint32_t i = 0u; i < dataExtent; ++i)
+        {
+            CHECK(newValue == hBuff[i]);
+            if(queue.getApi() != api::host)
+            {
+                // the host and device representation must differ because they are manipulated independently
+                CHECK(globalScalar.get() != hBuff[i]);
+            }
+        }
+    }
+    {
+        /* Get the value from the host representation and increase it because if we run with multiple host executors we
+         * need to be sure we test unique values for each executor. */
+        uint32_t newValue = global2DCArray.get()[Vec{1u, 2u}] + 1u;
+        if(queue.getApi() != api::host)
+            global2DCArray.get()[Vec{1u, 2u}] = newValue - 2u;
+
+        uint32_t val[2u][3u] = {{9u, 5u}, {6u, 11u, 45u}};
+        val[1][2] = newValue;
+        onHost::memcpy(queue, global2DCArray, val);
+        // reset host value
+        queue.enqueue([&]() { val[1][2] = 0u; });
+        onHost::memcpy(queue, val, global2DCArray);
+        queue.enqueue(
+            exec,
+            FrameSpec{numBlocks, blockExtent},
+            KernelBundle{DeviceGlobalMemCpyCArray2DKernel{}, dBuff});
+        onHost::memcpy(queue, hBuff, dBuff);
+        onHost::wait(queue);
+        // check that copy from device to host worked
+        CHECK(val[1][2] == newValue);
+        for(uint32_t i = 0u; i < dataExtent; ++i)
+        {
+            CHECK(newValue == hBuff[i]);
+            if(queue.getApi() != api::host)
+            {
+                // the host and device representation must differ because they are manipulated independently
+                CHECK(global2DCArray.get()[Vec{1u, 2u}] != hBuff[i]);
+            }
         }
     }
 }


### PR DESCRIPTION
- add support to use `onHost::memcpy()` to change values in the global
  device memory

note: I realized that the object `MemcpyDeviceGlobal` should not in the `onAcc` namespace.
I will refactor this in a separate PR and move it to `onHost`. It should also be in the user namespace and not internal because it is used as argument in the user function `onHost::memcpy()`
There is also no documentation for global device variables available, this is a todo which will be handled in an separate PR too.