### PR TITLE
fix void casts

### DIFF
--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -334,8 +334,8 @@ namespace alpaka::onHost
                 /* Get all required properties outside the lambda function to not extend the life-time of the data.
                  * The life-time is not extended to have some life-time behaviours with all backends.
                  */
-                auto* destPtr = toVoidPtr(alpaka::onHost::data(ALPAKA_FORWARD(dest)));
-                auto const* srcPtr = toVoidPtr(alpaka::onHost::data(source));
+                void* destPtr = toVoidPtr(alpaka::onHost::data(ALPAKA_FORWARD(dest)));
+                void const* srcPtr = toVoidPtr(alpaka::onHost::data(source));
 
                 if constexpr(dim == 1u)
                 {

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -455,8 +455,8 @@ namespace alpaka::onHost
                     ApiInterface,
                     ApiInterface::setDevice(onHost::getNativeHandle(queue.m_device)));
 
-                auto* destPtr = (void*) onHost::data(dest);
-                auto* const srcPtr = (void*) onHost::data(source);
+                void* destPtr = toVoidPtr(onHost::data(dest));
+                void const* srcPtr = toVoidPtr(onHost::data(source));
 
                 auto copyKind = unifiedCudaHip::MemcpyKind<
                     ApiInterface,
@@ -497,7 +497,8 @@ namespace alpaka::onHost
                     typename ApiInterface::Memcpy3DParms_t memCpy3DParms{};
 
                     memCpy3DParms.srcPtr = ApiInterface::makePitchedPtr(
-                        srcPtr,
+                        // CUDA/HIP does not support const for pitched pointer
+                        const_cast<void*>(srcPtr),
                         source.getPitches().y(),
                         source.getExtents().x(),
                         source.getExtents().y());
@@ -541,7 +542,7 @@ namespace alpaka::onHost
                     ApiInterface,
                     ApiInterface::setDevice(onHost::getNativeHandle(queue.m_device)));
 
-                auto* destPtr = (void*) onHost::data(dest);
+                void* destPtr = toVoidPtr(onHost::data(dest));
 
                 constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
                 if constexpr(dim == 1u)


### PR DESCRIPTION
Use `toVoidPtr()` to cast to `void*` to handle volatile and constness correctly.