### PR TITLE
fix wrong include breakets

### DIFF
--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <alpaka/core/config.hpp>
+#include "alpaka/core/config.hpp"
 
 #if ALPAKA_LANG_CUDA
 #    include <cuda_runtime_api.h>

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <alpaka/core/config.hpp>
+#include "alpaka/core/config.hpp"
 
 #if ALPAKA_LANG_HIP
 


### PR DESCRIPTION
Using `#include <...>` is making issues for the single header generator and creates issues in godbolt.