### PR TITLE
compile time warp size in kernel

### DIFF
--- a/include/alpaka/api/cuda/computeApi.hpp
+++ b/include/alpaka/api/cuda/computeApi.hpp
@@ -1,0 +1,26 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/unifiedCudaHip/ComputeApi.hpp"
+#include "alpaka/core/config.hpp"
+
+#include <type_traits>
+
+#if ALPAKA_LANG_CUDA
+
+namespace alpaka::onAcc::unifiedCudaHip::internal
+{
+    template<>
+    struct WarpSize::Get<alpaka::deviceKind::NvidiaGpu>
+    {
+        constexpr auto operator()() const
+        {
+            return std::integral_constant<uint32_t, 32u>{};
+        }
+    };
+} // namespace alpaka::onAcc::unifiedCudaHip::internal
+
+#endif

--- a/include/alpaka/api/hip/computeApi.hpp
+++ b/include/alpaka/api/hip/computeApi.hpp
@@ -1,0 +1,47 @@
+/* Copyright 2025 Andrea Bocci, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/unifiedCudaHip/ComputeApi.hpp"
+#include "alpaka/core/config.hpp"
+
+#include <type_traits>
+
+#if ALPAKA_LANG_HIP
+
+namespace alpaka::onAcc::unifiedCudaHip::internal
+{
+    template<>
+    struct WarpSize::Get<alpaka::deviceKind::AmdGpu>
+    {
+        constexpr auto operator()() const
+        {
+#    if defined(__HIP_DEVICE_COMPILE__)
+            // HIP/ROCm may have a wavefront of 32 or 64 depending on the target device
+#        if defined(__GFX9__)
+            // GCN 5.0 and CDNA GPUs have a wavefront size of 64
+            return std::integral_constant<uint32_t, 64u>{};
+#        elif defined(__GFX10__) or defined(__GFX11__) or defined(__GFX12__)
+            // RDNA GPUs have a wavefront size of 32
+            return std::integral_constant<uint32_t, 32u>{};
+#        else
+            // Unknown AMD GPU architecture
+#            ifdef ALPAKA_DEFAULT_HIP_WAVEFRONT_SIZE
+            return std::integral_constant<uint32_t, ALPAKA_DEFAULT_HIP_WAVEFRONT_SIZE>{};
+#            else
+#                error The current AMD GPU architucture is not supported by this version of alpaka. You can define a default wavefront size setting the preprocessor macro ALPAKA_DEFAULT_HIP_WAVEFRONT_SIZE
+            // return 32 instead of zero to avoid errors due to possible devision by zero, the code will throw at this
+            // point anyway therefore we can return what we want
+            return std::integral_constant<uint32_t, 32u>{};
+#            endif
+#        endif
+#    else
+            return std::integral_constant<uint32_t, 0u>{};
+#    endif
+        }
+    };
+} // namespace alpaka::onAcc::unifiedCudaHip::internal
+
+#endif

--- a/include/alpaka/api/host/exec/OmpBlocks.hpp
+++ b/include/alpaka/api/host/exec/OmpBlocks.hpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <stdexcept>
 #include <tuple>
+#include <type_traits>
 
 #if ALPAKA_OMP
 
@@ -70,9 +71,10 @@ namespace alpaka::onHost
                     auto const threadLayerEntry = DictEntry{layer::thread, onAcc::cpu::OneLayer<NumThreadsVecType>{}};
                     auto const blockSharedMemEntry = DictEntry{layer::shared, std::ref(blockSharedMem)};
                     auto const blockSyncEntry = DictEntry{action::threadBlockSync, onAcc::cpu::NoOp{}};
+                    auto const warpSizeEntry = DictEntry{object::warpSize, std::integral_constant<uint32_t, 1u>{}};
 
                     auto acc = onAcc::Acc(joinDict(
-                        Dict{blockLayerEntry, threadLayerEntry, blockSharedMemEntry, blockSyncEntry},
+                        Dict{blockLayerEntry, threadLayerEntry, blockSharedMemEntry, blockSyncEntry, warpSizeEntry},
                         additionalDict));
 
                     using ThreadIdxType = typename NumThreadsVecType::type;

--- a/include/alpaka/api/host/exec/Serial.hpp
+++ b/include/alpaka/api/host/exec/Serial.hpp
@@ -15,6 +15,7 @@
 
 #include <cassert>
 #include <tuple>
+#include <type_traits>
 
 namespace alpaka::onHost
 {
@@ -60,8 +61,10 @@ namespace alpaka::onHost
                     dict,
                     Dict{blockDynSharedMemEntry, blockDynSharedMemBytesEntry});
 
+                auto const warpSizeEntry = DictEntry{object::warpSize, std::integral_constant<uint32_t, 1u>{}};
+
                 auto acc = onAcc::Acc(joinDict(
-                    Dict{blockLayerEntry, threadLayerEntry, blockSharedMemEntry, blockSyncEntry},
+                    Dict{blockLayerEntry, threadLayerEntry, blockSharedMemEntry, blockSyncEntry, warpSizeEntry},
                     additionalDict));
                 meta::ndLoopIncIdx(
                     blockIdx,

--- a/include/alpaka/api/host/exec/TbbBlocks.hpp
+++ b/include/alpaka/api/host/exec/TbbBlocks.hpp
@@ -15,6 +15,7 @@
 
 #include <cstddef>
 #include <stdexcept>
+#include <type_traits>
 
 #if ALPAKA_TBB
 #    include <oneapi/tbb/blocked_range.h>
@@ -85,8 +86,16 @@ namespace alpaka::onHost
                                     dict,
                                     Dict{blockDynSharedMemEntry, blockDynSharedMemBytesEntry});
 
+                                auto const warpSizeEntry
+                                    = DictEntry{object::warpSize, std::integral_constant<uint32_t, 1u>{}};
+
                                 auto acc = onAcc::Acc(joinDict(
-                                    Dict{blockLayerEntry, threadLayerEntry, blockSharedMemEntry, blockSyncEntry},
+                                    Dict{
+                                        blockLayerEntry,
+                                        threadLayerEntry,
+                                        blockSharedMemEntry,
+                                        blockSyncEntry,
+                                        warpSizeEntry},
                                     additionalDict));
 
                                 kernelBundle(acc);

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/api/syclGeneric/Queue.hpp"
 #include "alpaka/api/syclGeneric/onAcc.hpp"
 #include "alpaka/core/config.hpp"
+#include "alpaka/core/syclConfig.hpp"
 #include "alpaka/onAcc/internal/globalMem.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
 
@@ -248,6 +249,69 @@ namespace alpaka::onHost::internal
             auto optimizedThreadSpec = ThreadSpecType(threadSpec.m_numBlocks, threadSpec.m_numThreads);
             return std::make_pair(gridRange, optimizedThreadSpec);
         }
+
+        /** Generate the kernel with the given warp size.
+         *
+         * @tparam T_dim number of dimension of the kernel
+         * @tparam T_warpSize requested warp size
+         * @tparam T_isValid 0u means it is not valid, else it is valid and a kernel is generated
+         */
+        template<uint32_t T_dim, uint32_t T_warpSize, uint32_t T_isValid>
+        struct EnqueueKernelWithWarpSize
+        {
+            static void call(
+                sycl::handler& cgh,
+                auto gridRange,
+                auto const& kernelBundle,
+                auto const& st_shared_accessor,
+                auto const& dyn_shared_accessor,
+                auto const& optimizedThreadSpec,
+                auto... args)
+            {
+                cgh.parallel_for(
+                    gridRange,
+                    [kernelBundle, st_shared_accessor, dyn_shared_accessor, optimizedThreadSpec, args...](
+                        sycl::nd_item<T_dim> work_item) [[sycl::reqd_sub_group_size(T_warpSize)]]
+                    {
+                        onAcc::oneApi::StaticSharedMemory ssm(st_shared_accessor);
+                        onAcc::syclGeneric::DynamicSharedMemory dsm(dyn_shared_accessor);
+
+                        static_assert(T_dim > 0);
+                        static_assert(T_dim <= 3, "more the 3 dimensions are not supported");
+                        auto acc = onAcc::Acc{Dict{
+                            DictEntry(layer::block, onAcc::syclGeneric::BlockLayer{work_item, optimizedThreadSpec}),
+                            DictEntry(layer::thread, onAcc::syclGeneric::ThreadLayer{work_item, optimizedThreadSpec}),
+                            DictEntry(action::threadBlockSync, onAcc::syclGeneric::Sync{work_item}),
+                            DictEntry(layer::shared, std::ref(ssm)),
+                            DictEntry(layer::dynShared, std::ref(dsm)),
+                            DictEntry(object::dynSharedMemBytes, dsm.byte_size()),
+                            args...}};
+
+                        kernelBundle(acc);
+                    });
+            }
+        };
+
+        template<uint32_t T_dim, uint32_t T_warpSize>
+        struct EnqueueKernelWithWarpSize<T_dim, T_warpSize, 0u>
+        {
+            static void call(
+                sycl::handler& cgh,
+                auto gridRange,
+                auto const& kernelBundle,
+                auto const& st_shared_accessor,
+                auto const& dyn_shared_accessor,
+                auto const& optimizedThreadSpec,
+                auto... args)
+            {
+                printf(
+                    "Dynamic evaluated warp size on host does not match the compile time warp size ( macro "
+                    "SYCL_SUBGROUP_SIZE) evaluated in the "
+                    "kernel. Update the definition of SYCL_SUBGROUP_SIZE section and check the trait "
+                    "Warpsize::Dispatch<>.");
+                abort();
+            }
+        };
     } // namespace detail
 
     template<
@@ -272,48 +336,41 @@ namespace alpaka::onHost::internal
                 st_shared_mem_bytes + blockDynSharedMemBytes
                 <= queue.m_device->getNativeHandle().first.template get_info<sycl::info::device::local_mem_size>());
 
-            [[maybe_unused]] sycl::event ev = queue.m_queue.submit(
-                [threadBlocking, kernelBundle, blockDynSharedMemBytes](sycl::handler& cgh)
+            [[maybe_unused]] sycl::event ev = queue.dispatchWarpSize(
+                [&](auto warpSize) requires std::same_as<
+                    std::integral_constant<
+                        typename ALPAKA_TYPEOF(warpSize)::value_type,
+                        ALPAKA_TYPEOF(warpSize)::value>,
+                    ALPAKA_TYPEOF(warpSize)>
                 {
-                    using ApiType = decltype(getApi(queue));
-                    using DeviceKindType = ALPAKA_TYPEOF(getDeviceKind(queue));
-
-                    auto st_shared_accessor
-                        = sycl::local_accessor<std::byte>{sycl::range<1>{st_shared_mem_bytes}, cgh};
-
-                    auto dyn_shared_accessor
-                        = sycl::local_accessor<std::byte>{sycl::range<1>{blockDynSharedMemBytes}, cgh};
-
-                    auto workerDesc = detail::getWorkerDescription(threadBlocking);
-                    auto optimizedThreadSpec = workerDesc.second;
-                    constexpr uint32_t syclDim = workerDesc.first.dimensions;
-
-                    cgh.parallel_for(
-                        workerDesc.first,
-                        [optimizedThreadSpec, st_shared_accessor, dyn_shared_accessor, kernelBundle](
-                            sycl::nd_item<syclDim> work_item)
+                    return queue.m_queue.submit(
+                        [warpSize, threadBlocking, kernelBundle, blockDynSharedMemBytes](sycl::handler& cgh)
                         {
-                            onAcc::oneApi::StaticSharedMemory ssm(st_shared_accessor);
-                            onAcc::syclGeneric::DynamicSharedMemory dsm(dyn_shared_accessor);
+                            using ApiType = decltype(getApi(queue));
+                            using DeviceKindType = ALPAKA_TYPEOF(getDeviceKind(queue));
 
-                            static_assert(syclDim > 0);
-                            static_assert(syclDim <= 3, "more the 3 dimensions are not supported");
-                            auto acc = onAcc::Acc{Dict{
-                                DictEntry(
-                                    layer::block,
-                                    onAcc::syclGeneric::BlockLayer{work_item, optimizedThreadSpec}),
-                                DictEntry(
-                                    layer::thread,
-                                    onAcc::syclGeneric::ThreadLayer{work_item, optimizedThreadSpec}),
-                                DictEntry(layer::shared, std::ref(ssm)),
-                                DictEntry(layer::dynShared, std::ref(dsm)),
-                                DictEntry(object::dynSharedMemBytes, dsm.byte_size()),
-                                DictEntry(action::threadBlockSync, onAcc::syclGeneric::Sync{work_item}),
+                            auto st_shared_accessor
+                                = sycl::local_accessor<std::byte>{sycl::range<1>{st_shared_mem_bytes}, cgh};
+
+                            auto dyn_shared_accessor
+                                = sycl::local_accessor<std::byte>{sycl::range<1>{blockDynSharedMemBytes}, cgh};
+
+                            auto workerDesc = detail::getWorkerDescription(threadBlocking);
+                            auto optimizedThreadSpec = workerDesc.second;
+                            constexpr uint32_t syclDim = workerDesc.first.dimensions;
+
+                            constexpr uint32_t w = ALPAKA_TYPEOF(warpSize)::value;
+                            detail::EnqueueKernelWithWarpSize<syclDim, w, SYCL_SUBGROUP_SIZE & w>::call(
+                                cgh,
+                                workerDesc.first,
+                                kernelBundle,
+                                st_shared_accessor,
+                                dyn_shared_accessor,
+                                optimizedThreadSpec,
                                 DictEntry(object::api, ApiType{}),
                                 DictEntry(object::deviceKind, DeviceKindType{}),
-                                DictEntry(object::exec, T_Executor{})}};
-
-                            kernelBundle(acc);
+                                DictEntry(object::exec, T_Executor{}),
+                                DictEntry(object::warpSize, warpSize));
                         });
                 });
 
@@ -349,48 +406,42 @@ namespace alpaka::onHost::internal
                 st_shared_mem_bytes + blockDynSharedMemBytes
                 <= queue.m_device->getNativeHandle().first.template get_info<sycl::info::device::local_mem_size>());
 
-            [[maybe_unused]] sycl::event ev = queue.m_queue.submit(
-                [threadBlocking, frameSpec, kernelBundle, blockDynSharedMemBytes](sycl::handler& cgh)
+            sycl::event ev = queue.dispatchWarpSize(
+                [&](auto warpSize) requires std::same_as<
+                    std::integral_constant<
+                        typename ALPAKA_TYPEOF(warpSize)::value_type,
+                        ALPAKA_TYPEOF(warpSize)::value>,
+                    ALPAKA_TYPEOF(warpSize)>
                 {
-                    using ApiType = decltype(getApi(queue));
-                    using DeviceKindType = ALPAKA_TYPEOF(getDeviceKind(queue));
-                    auto st_shared_accessor
-                        = sycl::local_accessor<std::byte>{sycl::range<1>{st_shared_mem_bytes}, cgh};
-                    auto dyn_shared_accessor
-                        = sycl::local_accessor<std::byte>{sycl::range<1>{blockDynSharedMemBytes}, cgh};
-
-                    auto workerDesc = detail::getWorkerDescription(threadBlocking);
-                    auto optimizedThreadSpec = workerDesc.second;
-                    constexpr uint32_t syclDim = workerDesc.first.dimensions;
-
-                    cgh.parallel_for(
-                        workerDesc.first,
-                        [optimizedThreadSpec, frameSpec, st_shared_accessor, dyn_shared_accessor, kernelBundle](
-                            sycl::nd_item<syclDim> work_item)
+                    return queue.m_queue.submit(
+                        [warpSize, threadBlocking, frameSpec, kernelBundle, blockDynSharedMemBytes](sycl::handler& cgh)
                         {
-                            onAcc::oneApi::StaticSharedMemory ssm(st_shared_accessor);
-                            onAcc::syclGeneric::DynamicSharedMemory dsm(dyn_shared_accessor);
+                            using ApiType = decltype(getApi(queue));
+                            using DeviceKindType = ALPAKA_TYPEOF(getDeviceKind(queue));
+                            auto st_shared_accessor
+                                = sycl::local_accessor<std::byte>{sycl::range<1>{st_shared_mem_bytes}, cgh};
+                            auto dyn_shared_accessor
+                                = sycl::local_accessor<std::byte>{sycl::range<1>{blockDynSharedMemBytes}, cgh};
 
-                            static_assert(syclDim > 0);
-                            static_assert(syclDim <= 3, "more the 3 dimensions are not supported");
-                            auto acc = onAcc::Acc{Dict{
-                                DictEntry(
-                                    layer::block,
-                                    onAcc::syclGeneric::BlockLayer{work_item, optimizedThreadSpec}),
-                                DictEntry(
-                                    layer::thread,
-                                    onAcc::syclGeneric::ThreadLayer{work_item, optimizedThreadSpec}),
-                                DictEntry(layer::shared, std::ref(ssm)),
-                                DictEntry(layer::dynShared, std::ref(dsm)),
-                                DictEntry(object::dynSharedMemBytes, dsm.byte_size()),
-                                DictEntry(action::threadBlockSync, onAcc::syclGeneric::Sync{work_item}),
+                            auto workerDesc = detail::getWorkerDescription(threadBlocking);
+                            auto optimizedThreadSpec = workerDesc.second;
+                            constexpr uint32_t syclDim = workerDesc.first.dimensions;
+
+                            constexpr uint32_t w = ALPAKA_TYPEOF(warpSize)::value;
+
+                            detail::EnqueueKernelWithWarpSize<syclDim, w, SYCL_SUBGROUP_SIZE & w>::call(
+                                cgh,
+                                workerDesc.first,
+                                kernelBundle,
+                                st_shared_accessor,
+                                dyn_shared_accessor,
+                                optimizedThreadSpec,
                                 DictEntry(object::api, ApiType{}),
                                 DictEntry(object::deviceKind, DeviceKindType{}),
                                 DictEntry(object::exec, T_Executor{}),
                                 DictEntry(frame::count, frameSpec.m_numFrames),
-                                DictEntry(frame::extent, frameSpec.m_frameExtent)}};
-
-                            kernelBundle(acc);
+                                DictEntry(frame::extent, frameSpec.m_frameExtent),
+                                DictEntry(object::warpSize, warpSize));
                         });
                 });
             if(queue.isBlocking())

--- a/include/alpaka/api/syclGeneric/Platform.hpp
+++ b/include/alpaka/api/syclGeneric/Platform.hpp
@@ -239,7 +239,10 @@ namespace alpaka
                         {
                             // The CPU runtime supports a sub-group size of 64, but the SYCL implementation
                             // currently does not
-                            return std::max(a, b) <= 32 ? std::max(a, b) : 32;
+                            if constexpr(T_DeviceKind{} == deviceKind::cpu)
+                                return std::max(a, b) <= 32 ? std::max(a, b) : 32;
+                            else
+                                return std::max(a, b);
                         }));
                     prop.m_multiProcessorCount = dev.get_info<sycl::info::device::max_compute_units>();
 

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -17,18 +17,135 @@
 #include "alpaka/onHost/mem/SharedBuffer.hpp"
 #include "alpaka/onHost/trait.hpp"
 
+#include <algorithm>
+#include <future>
+#include <sstream>
+#include <type_traits>
+
 #if ALPAKA_LANG_SYCL
 
 #    include <sycl/sycl.hpp>
-
-#    include <algorithm>
-#    include <future>
-#    include <sstream>
 
 namespace alpaka::onHost
 {
     namespace syclGeneric
     {
+        /** Dispatch a compile time warp size to the kernel
+         *
+         * The runtime provided warp size of the device is transformed into a compile time warp size.
+         * During the kernel (lambda) call in cgh.parallel_for() the lambda must be annotated with
+         * `[[sycl::reqd_sub_group_size(WARP_SIZE)]]`. In cases where the warp size is not supported by device a
+         * compiler warning will be shown, therefore a second stage during the call of parallel_for() is required where
+         * we check if we know based on macro defines provided by the compiler which subgroup sizes (warp size) are
+         * supported for the device ther kernel is currently compiled. In cases, where the macro definition to detect
+         * the target device is not in the list (file: core/syclConfig.hpp) we allow all subgroup sizes generated from
+         * the runtime dispatcher in this trait. This is also the case if we not compile ahead of time for a device.
+         * @attention If a warning `-Wincorrect-sub-group-size` is shown this mean we generated a kernel with an
+         * unsupported warp size, triggered by the on host runtime dispatch in this trait.
+         *
+         * The reason why we do not want to execute the runtime dispatch within the parallel_for, equal to what
+         * mainline alpaka is doing, is that any kernel instance should have only one code patch to avoid possible
+         * register pressure due to a code path which will maybe never called but is generated in the kernel.
+         * This complicated approach gives us the guarantee that the runtime device warp size is used during the kernel
+         * generation.
+         */
+        struct Warpsize
+        {
+            template<alpaka::concepts::DeviceKind T_DeviceKind>
+            struct Dispatch
+            {
+                auto operator()(T_DeviceKind deviceKind, auto&& fn) const;
+            };
+        };
+
+        template<>
+        struct Warpsize::Dispatch<alpaka::deviceKind::Cpu>
+        {
+            auto operator()(alpaka::deviceKind::Cpu, auto&& fn, uint32_t warpSize) const
+            {
+                switch(warpSize)
+                {
+                case 1u:
+                    return fn(std::integral_constant<uint32_t, 1u>{});
+                case 2u:
+                    return fn(std::integral_constant<uint32_t, 2u>{});
+                case 4u:
+                    return fn(std::integral_constant<uint32_t, 4u>{});
+                case 8u:
+                    return fn(std::integral_constant<uint32_t, 8u>{});
+                case 16u:
+                    return fn(std::integral_constant<uint32_t, 16u>{});
+                case 32u:
+                    return fn(std::integral_constant<uint32_t, 32u>{});
+                default:
+                    throw std::runtime_error(
+                        std::string("Sycl warp size runtime dispatch, unsupported warpSize: ")
+                        + std::to_string(warpSize));
+                    return fn(std::integral_constant<uint32_t, 1u>{});
+                }
+            }
+        };
+
+        template<>
+        struct Warpsize::Dispatch<alpaka::deviceKind::IntelGpu>
+        {
+            auto operator()(alpaka::deviceKind::IntelGpu, auto&& fn, uint32_t warpSize) const
+            {
+                switch(warpSize)
+                {
+                case 8u:
+                    return fn(std::integral_constant<uint32_t, 8u>{});
+                case 16u:
+                    return fn(std::integral_constant<uint32_t, 16u>{});
+                case 32u:
+                    return fn(std::integral_constant<uint32_t, 32u>{});
+                default:
+                    throw std::runtime_error(
+                        std::string("Sycl warp size runtime dispatch, unsupported warpSize: ")
+                        + std::to_string(warpSize));
+                    return fn(std::integral_constant<uint32_t, 32u>{});
+                }
+            }
+        };
+
+        template<>
+        struct Warpsize::Dispatch<alpaka::deviceKind::AmdGpu>
+        {
+            auto operator()(alpaka::deviceKind::AmdGpu, auto&& fn, uint32_t warpSize) const
+            {
+                switch(warpSize)
+                {
+                case 32u:
+                    return fn(std::integral_constant<uint32_t, 32u>{});
+                case 64u:
+                    return fn(std::integral_constant<uint32_t, 64u>{});
+                default:
+                    throw std::runtime_error(
+                        std::string("Sycl warp size runtime dispatch, unsupported warpSize: ")
+                        + std::to_string(warpSize));
+                    return fn(std::integral_constant<uint32_t, 32u>{});
+                }
+            }
+        };
+
+        template<>
+        struct Warpsize::Dispatch<alpaka::deviceKind::NvidiaGpu>
+        {
+            auto operator()(alpaka::deviceKind::NvidiaGpu, auto&& fn, uint32_t warpSize) const
+            {
+                switch(warpSize)
+                {
+                case 32u:
+                    return fn(std::integral_constant<uint32_t, 32u>{});
+                default:
+                    throw std::runtime_error(
+                        std::string("Sycl warp size runtime dispatch, unsupported warpSize: ")
+                        + std::to_string(warpSize));
+                    return fn(std::integral_constant<uint32_t, 32u>{});
+                }
+            }
+        };
+
         template<typename T_Device>
         struct Queue : std::enable_shared_from_this<Queue<T_Device>>
         {
@@ -43,6 +160,18 @@ namespace alpaka::onHost
                 // TODO: check if this is the correct order
                 { return sycl::range<dim>(vec[I]...); }(std::make_index_sequence<dim>{});
             };
+
+            inline constexpr auto dispatchWarpSize(auto&& fn) const
+            {
+                auto warpSize
+                    = internal::GetDeviceProperties::Op<ALPAKA_TYPEOF(*m_device.get())>{}(*m_device.get()).m_warpSize;
+
+                return Warpsize::Dispatch<ALPAKA_TYPEOF(getDeviceKind())>{}(
+                    getDeviceKind(),
+                    ALPAKA_FORWARD(fn),
+                    warpSize);
+            }
+
 
         public:
             Queue(internal::concepts::DeviceHandle auto device, uint32_t const idx, bool isBlocking)
@@ -145,7 +274,6 @@ namespace alpaka::onHost
             core::CallbackThread m_callBackThread;
             bool m_isBlocking{false};
         };
-
 
     } // namespace syclGeneric
 
@@ -279,8 +407,8 @@ namespace alpaka::onHost
             auto deleter = [queueDep = std::move(queueDependency), ptr]()
             {
                 sycl::queue sycl_queue = queueDep->getNativeHandle();
-                /* Always enqueue into a queue, even if the queue is blocking, to track possible in queue dependencies.
-                 * sycl::free() is safe to be called within a hast_task
+                /* Always enqueue into a queue, even if the queue is blocking, to track possible in queue
+                 * dependencies. sycl::free() is safe to be called within a hast_task
                  */
                 [[maybe_unused]] sycl::event ev = sycl_queue.submit(
                     [&](sycl::handler& cgh) { cgh.host_task([=]() { sycl::free(toVoidPtr(ptr), sycl_queue); }); });

--- a/include/alpaka/api/unifiedCudaHip/ComputeApi.hpp
+++ b/include/alpaka/api/unifiedCudaHip/ComputeApi.hpp
@@ -26,6 +26,20 @@ namespace alpaka::onAcc
                 __syncthreads();
             }
         };
+
+        namespace internal
+        {
+            /** This trait is only for uniform CUDA and HIP warp size abstraction
+             *
+             * Use onAcc::internal::GetWarpSize to query the warp size independent of the API.
+             * The warp size must be a std::integral_constant<uint32_t,X>.
+             */
+            struct WarpSize
+            {
+                template<alpaka::concepts::DeviceKind T_DeviceKind>
+                struct Get;
+            };
+        } // namespace internal
     } // namespace unifiedCudaHip
 } // namespace alpaka::onAcc
 

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -5,8 +5,10 @@
 
 #include "alpaka/api/concepts/api.hpp"
 #include "alpaka/api/cuda/IdxLayer.hpp"
+#include "alpaka/api/cuda/computeApi.hpp"
 #include "alpaka/api/generic.hpp"
 #include "alpaka/api/hip/IdxLayer.hpp"
+#include "alpaka/api/hip/computeApi.hpp"
 #include "alpaka/api/unifiedCudaHip/ComputeApi.hpp"
 #include "alpaka/api/unifiedCudaHip/Event.hpp"
 #include "alpaka/api/unifiedCudaHip/MemcpyKind.hpp"
@@ -182,6 +184,7 @@ namespace alpaka::onHost
             T_NumFrames const numFrames,
             T_FrameSize const frameExtent)
         {
+            constexpr auto warpSizeValue = alpaka::onAcc::unifiedCudaHip::internal::WarpSize::Get<T_DeviceKind>{}();
             auto acc = onAcc::Acc{
                 Dict{
                     DictEntry(layer::block, onAcc::unifiedCudaHip::BlockLayer{optimizedThreadSpec}),
@@ -191,7 +194,8 @@ namespace alpaka::onHost
                     DictEntry(action::threadBlockSync, onAcc::unifiedCudaHip::Sync{}),
                     DictEntry(object::api, T_Api{}),
                     DictEntry(object::deviceKind, T_DeviceKind{}),
-                    DictEntry(object::exec, T_Executor{})},
+                    DictEntry(object::exec, T_Executor{}),
+                    DictEntry(object::warpSize, warpSizeValue)},
             };
             kernelBundle(acc);
         }
@@ -204,6 +208,7 @@ namespace alpaka::onHost
             typename T_OptimizedThreadSpec>
         __global__ void gpuKernel(TKernelBundle const kernelBundle, T_OptimizedThreadSpec const optimizedThreadSpec)
         {
+            constexpr auto warpSizeValue = alpaka::onAcc::unifiedCudaHip::internal::WarpSize::Get<T_DeviceKind>{}();
             auto acc = onAcc::Acc{
                 Dict{
                     DictEntry(layer::block, onAcc::unifiedCudaHip::BlockLayer{optimizedThreadSpec}),
@@ -211,7 +216,8 @@ namespace alpaka::onHost
                     DictEntry(action::threadBlockSync, onAcc::unifiedCudaHip::Sync{}),
                     DictEntry(object::api, T_Api{}),
                     DictEntry(object::deviceKind, T_DeviceKind{}),
-                    DictEntry(object::exec, T_Executor{})},
+                    DictEntry(object::exec, T_Executor{}),
+                    DictEntry(object::warpSize, warpSizeValue)},
             };
             kernelBundle(acc);
         }

--- a/include/alpaka/core/config.hpp
+++ b/include/alpaka/core/config.hpp
@@ -259,6 +259,8 @@
 // ONE API must be detected via the ICPX compiler see
 // https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2023-2/use-predefined-macros-to-specify-intel-compilers.html
 #        define ALPAKA_LANG_ONEAPI ALPAKA_COMP_ICPX
+#    else
+#        define ALPAKA_LANG_ONEAPI ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif
 #endif
 

--- a/include/alpaka/core/syclConfig.hpp
+++ b/include/alpaka/core/syclConfig.hpp
@@ -1,0 +1,147 @@
+/* Copyright 2023 Andrea Bocci, Aurora Perego, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include "alpaka/core/config.hpp"
+
+#if ALPAKA_LANG_SYCL
+
+#    if defined(__SYCL_DEVICE_ONLY__)
+
+// defines can be taken from
+// https://github.com/llvm/llvm-project/blob/3cfe6aa46e06a8caa3f07057838d31c6ce840076/clang/include/clang/Basic/OffloadArch.h#L18-L28
+
+/* Intel GPU and CPU subgroup size detection */
+#        if (/* Broadwell Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_BDW__)                               \
+            || (/* Skylake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_SKL__)                              \
+            || (/* Kaby Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_KBL__)                            \
+            || (/* Coffee Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_CFL__)                          \
+            || (/* Apollo Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_APL__)                          \
+            || (/* Gemini Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_GLK__)                          \
+            || (/* Whiskey Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_WHL__)                         \
+            || (/* Amber Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_AML__)                           \
+            || (/* Comet Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_CML__)                           \
+            || (/* Ice Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ICLLP__)                           \
+            || (/* Elkhart Lake or Jasper Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_EHL__)          \
+            || (/* Tiger Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_TGLLP__)                         \
+            || (/* Rocket Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_RKL__)                          \
+            || (/* Alder Lake S or Raptor Lake S Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ADL_S__)      \
+            || (/* Alder Lake P Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ADL_P__)                       \
+            || (/* Alder Lake N Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ADL_N__)                       \
+            || (/* DG1 Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_DG1__)                                  \
+            || (/* Alchemist G10 Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ACM_G10__)                    \
+            || (/* Alchemist G11 Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ACM_G11__)                    \
+            || (/* Alchemist G12 Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ACM_G12__)                    \
+            || (/* Meteor Lake U/S or Arrow Lake U/S Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_MTL_U__)  \
+            || (/* Meteor Lake H Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_MTL_H__)                      \
+            || (/* Arrow Lake H Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ARL_H__)                       \
+            || (/* Battlemage G21 Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_BMG_G21__)                   \
+            || (/* Lunar Lake M Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_LNL_M__)
+#            define SYCL_SUBGROUP_SIZE (8 | 16 | 32)
+
+#        elif (/* Ponte Vecchio Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_PVC__)                         \
+            || (/* Ponte Vecchio VG Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_PVC_VG__)
+#            define SYCL_SUBGROUP_SIZE (16 | 32)
+
+#        elif (/* x86_64 CPUs */ __SYCL_TARGET_INTEL_X86_64__)
+// @attention ony CPU side detachment of SYCL kernel we limit the CPU currently to max warp group size of 32, therefore
+// 64 is removed from this list
+#            define SYCL_SUBGROUP_SIZE (1 | 2 | 4 | 8 | 16 | 32)
+
+#        elif (/* NVIDIA Maxwell architecture (compute capability 5.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_50__)           \
+            || (/* NVIDIA Maxwell architecture (compute capability 5.2) */ __SYCL_TARGET_NVIDIA_GPU_SM_52__)          \
+            || (/* NVIDIA Jetson TX1 / Nano (compute capability 5.3) */ __SYCL_TARGET_NVIDIA_GPU_SM_53__)             \
+            || (/* NVIDIA Pascal architecture (compute capability 6.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_60__)           \
+            || (/* NVIDIA Pascal architecture (compute capability 6.1) */ __SYCL_TARGET_NVIDIA_GPU_SM_61__)           \
+            || (/* NVIDIA Jetson TX2 (compute capability 6.2) */ __SYCL_TARGET_NVIDIA_GPU_SM_62__)                    \
+            || (/* NVIDIA Volta architecture (compute capability 7.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_70__)            \
+            || (/* NVIDIA Jetson AGX Xavier (compute capability 7.2) */ __SYCL_TARGET_NVIDIA_GPU_SM_72__)             \
+            || (/* NVIDIA Turing architecture (compute capability 7.5) */ __SYCL_TARGET_NVIDIA_GPU_SM_75__)           \
+            || (/* NVIDIA Ampere architecture (compute capability 8.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_80__)           \
+            || (/* NVIDIA Ampere architecture (compute capability 8.6) */ __SYCL_TARGET_NVIDIA_GPU_SM_86__)           \
+            || (/* NVIDIA Jetson/Drive AGX Orin (compute capability 8.7) */ __SYCL_TARGET_NVIDIA_GPU_SM_87__)         \
+            || (/* NVIDIA Ada Lovelace architecture (compute capability 8.9) */ __SYCL_TARGET_NVIDIA_GPU_SM_89__)     \
+            || (/* NVIDIA Hopper architecture (compute capability 9.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_90__)           \
+            || (/* NVIDIA Hopper architecture variant (compute capability 9.0a) */ __SYCL_TARGET_NVIDIA_GPU_SM_90a__) \
+            || (/* NVIDIA Blackwell architecture (compute capability 10.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_100__)      \
+            || (/* NVIDIA Blackwell architecture variant (compute capability 10.0a) */                                \
+                __SYCL_TARGET_NVIDIA_GPU_SM_100a__)                                                                   \
+            || (/* NVIDIA Blackwell Next architecture (compute capability 10.1) */ __SYCL_TARGET_NVIDIA_GPU_SM_101__) \
+            || (/* NVIDIA Blackwell Next architecture variant (compute capability 10.1a) */                           \
+                __SYCL_TARGET_NVIDIA_GPU_SM_101a__)                                                                   \
+            || (/* NVIDIA Next-generation architecture (compute capability 10.3) */                                   \
+                __SYCL_TARGET_NVIDIA_GPU_SM_103__)                                                                    \
+            || (/* NVIDIA Next-generation architecture variant (compute capability 10.3a) */                          \
+                __SYCL_TARGET_NVIDIA_GPU_SM_103a__)                                                                   \
+            || (/* NVIDIA Future architecture (compute capability 12.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_120__)         \
+            || (/* NVIDIA Future architecture variant (compute capability 12.0a) */                                   \
+                __SYCL_TARGET_NVIDIA_GPU_SM_120a__)                                                                   \
+            || (/* NVIDIA Future architecture (compute capability 12.1) */ __SYCL_TARGET_NVIDIA_GPU_SM_121__)         \
+            || (/*NVIDIA Future architecture variant (compute capability 12.1a) */                                    \
+                __SYCL_TARGET_NVIDIA_GPU_SM_121a__)
+
+#            define SYCL_SUBGROUP_SIZE (32) /* CUDA supports warp size 32 */
+
+#        elif (/* AMD GCN 5.0 Vega architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX900__)                          \
+            || (/* AMD GCN 5.0 Vega architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX902__)                         \
+            || (/* AMD GCN 5.0 Vega architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX904__)                         \
+            || (/* AMD GCN 5.1 Vega II architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX906__)                      \
+            || (/* AMD CDNA 1.0 Arcturus architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX908__)                    \
+            || (/* AMD GCN 5.0 Raven 2 architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX909__)                      \
+            || (/* AMD CDNA 2.0 Aldebaran architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX90A__)                   \
+            || (/* AMD GCN 5.1 Renoir architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX90C__)                       \
+            || (/* AMD CDNA 3.x generic architecture (gfx 9.4) */ __SYCL_TARGET_AMD_GPU_GFX9_4_GENERIC__)             \
+            || (/* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */ __SYCL_TARGET_AMD_GPU_GFX940__)               \
+            || (/* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */ __SYCL_TARGET_AMD_GPU_GFX941__)               \
+            || (/* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */ __SYCL_TARGET_AMD_GPU_GFX942__)               \
+            || (/* AMD CDNA 3.5 derivative architecture (gfx 9.5) */ __SYCL_TARGET_AMD_GPU_GFX950__)                  \
+            || (/* AMD GCN 5.x generic architecture (gfx 9.x) */ __SYCL_TARGET_AMD_GPU_GFX9_GENERIC__)
+
+#            define SYCL_SUBGROUP_SIZE (64) /* up to gfx9, HIP supports wavefront size 64 */
+
+#        elif (/* AMD RDNA 1.0 Navi 10 architecture (gfx 10.1) */ __SYCL_TARGET_AMD_GPU_GFX1010__)                    \
+            || (/* AMD RDNA 1.0 Navi 12 architecture (gfx 10.1) */ __SYCL_TARGET_AMD_GPU_GFX1011__)                   \
+            || (/* AMD RDNA 1.0 Navi 14 architecture (gfx 10.1) */ __SYCL_TARGET_AMD_GPU_GFX1012__)                   \
+            || (/* AMD RDNA 2.0 Oberon architecture (gfx 10.1) */ __SYCL_TARGET_AMD_GPU_GFX1013__)                    \
+            || (/* AMD RDNA 1.x generic architecture (gfx 10.1) */ __SYCL_TARGET_AMD_GPU_GFX10_1_GENERIC__)           \
+            || (/* AMD RDNA 2.0 Navi 21 architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1030__)                   \
+            || (/* AMD RDNA 2.0 Navi 22 architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1031__)                   \
+            || (/* AMD RDNA 2.0 Navi 23 architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1032__)                   \
+            || (/* AMD RDNA 2.0 Van Gogh architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1033__)                  \
+            || (/* AMD RDNA 2.0 Navi 24 architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1034__)                   \
+            || (/* AMD RDNA 2.0 Rembrandt Mobile architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1035__)          \
+            || (/* AMD RDNA 2.0 Raphael architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1036__)                   \
+            || (/* AMD RDNA 2.x generic architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX10_3_GENERIC__)           \
+            || (/* AMD RDNA 3.0 Navi 31 architecture (gfx 11.0) */ __SYCL_TARGET_AMD_GPU_GFX1100__)                   \
+            || (/* AMD RDNA 3.0 Navi 32 architecture (gfx 11.0) */ __SYCL_TARGET_AMD_GPU_GFX1101__)                   \
+            || (/* AMD RDNA 3.0 Navi 33 architecture (gfx 11.0) */ __SYCL_TARGET_AMD_GPU_GFX1102__)                   \
+            || (/* AMD RDNA 3.0 Phoenix mobile architecture (gfx 11.0) */ __SYCL_TARGET_AMD_GPU_GFX1103__)            \
+            || (/* AMD RDNA 3.x generic architecture (gfx 11.x) */ __SYCL_TARGET_AMD_GPU_GFX11_GENERIC__)             \
+            || (/* AMD RDNA 3.5 Strix Point architecture (gfx 11.5) */ __SYCL_TARGET_AMD_GPU_GFX1150__)               \
+            || (/* AMD RDNA 3.5 Strix Halo architecture (gfx 11.5) */ __SYCL_TARGET_AMD_GPU_GFX1151__)                \
+            || (/* AMD RDNA 3.5 derivative architecture (gfx 11.5) */ __SYCL_TARGET_AMD_GPU_GFX1152__)                \
+            || (/* AMD RDNA 3.5 derivative architecture (gfx 11.5) */ __SYCL_TARGET_AMD_GPU_GFX1153__)                \
+            || (/* AMD RDNA 4.0 Navi 44 architecture (gfx 12.0) */ __SYCL_TARGET_AMD_GPU_GFX1200__)                   \
+            || (/* AMD RDNA 4.0 Navi 48 architecture (gfx 12.0) */ __SYCL_TARGET_AMD_GPU_GFX1201__)                   \
+            || (/* AMD RDNA 4.x generic architecture (gfx 12.x) */ __SYCL_TARGET_AMD_GPU_GFX12_GENERIC__)             \
+            || (/* AMD RDNA 4.5 derivative architecture (gfx 12.5) */ __SYCL_TARGET_AMD_GPU_GFX1250__)                \
+            || (/* AMD RDNA 4.5 derivative architecture (gfx 12.5) */ __SYCL_TARGET_AMD_GPU_GFX1251__)
+
+#            define SYCL_SUBGROUP_SIZE (32) /* starting from gfx10, HIP supports wavefront size 32 */
+
+#        else // __SYCL_TARGET_*
+
+// if we do not compile ahead of time for a device and use e.g. -fsycl-targets=spir64 we need to accept all possible
+// variants
+#            define SYCL_SUBGROUP_SIZE (0xFFFF'FFFF) /* unknown target */
+
+#        endif // __SYCL_TARGET_*
+
+#    else
+
+// ony the host side we need to allow all possible variants of a subgroup size else kernel will not be build
+#        define SYCL_SUBGROUP_SIZE (0xFFFF'FFFF) /* host compilation */
+
+#    endif // __SYCL_DEVICE_ONLY__
+
+#endif

--- a/include/alpaka/onAcc/Acc.hpp
+++ b/include/alpaka/onAcc/Acc.hpp
@@ -65,6 +65,18 @@ namespace alpaka::onAcc
         {
             return T_Storage::operator[](object::deviceKind);
         }
+
+        /** Get the warp size
+         *
+         * To be able to use the warp size as constexpr value you must call the static function via the type
+         * `Acc_t::getWarpSize()` else the warp size can only be used as runtime value.
+         * Alternative you can use the free function onAcc::getWarpSize<Acc_t>();
+         */
+        static constexpr uint32_t getWarpSize()
+        {
+            constexpr uint32_t w = ALPAKA_TYPEOF(std::declval<T_Storage>()[object::warpSize])::value;
+            return w;
+        }
     };
 
     namespace concepts
@@ -155,6 +167,12 @@ namespace alpaka::onAcc
     constexpr auto getDynSharedMem(concepts::Acc auto const& acc) -> T*
     {
         return internalCompute::declareDynamicSharedMem<T>(acc);
+    }
+
+    template<concepts::Acc T_Acc>
+    constexpr uint32_t getWarpSize()
+    {
+        return T_Acc::getWarpSize();
     }
 
 } // namespace alpaka::onAcc

--- a/include/alpaka/tag.hpp
+++ b/include/alpaka/tag.hpp
@@ -33,6 +33,12 @@ namespace alpaka
         ALPAKA_TAG(deviceSpec);
 
         ALPAKA_TAG(dynSharedMemBytes);
+
+        struct WarpSize
+        {
+        };
+
+        constexpr WarpSize warpSize;
     } // namespace object
 
     namespace queueKind

--- a/tests/unit/cvecKernelCall/cvecKernelCall.cpp
+++ b/tests/unit/cvecKernelCall/cvecKernelCall.cpp
@@ -25,8 +25,8 @@ using TestApis = std::decay_t<decltype(allBackends(enabledApis, onHost::example:
 
 struct KernelCVecFrameExtents
 {
-    template<typename T>
-    ALPAKA_FN_ACC void operator()(T const& acc, auto result) const
+    template<onAcc::concepts::Acc T_Acc>
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc, auto result) const
     {
         alpaka::concepts::CVector auto frameExtent = acc[alpaka::frame::extent];
         // compile will fail if the type is silently cast to non CVec type
@@ -36,6 +36,12 @@ struct KernelCVecFrameExtents
         static_assert(blockThreadCount2 == blockThreadCount);
         static_assert(frameExtent.x() == 43u);
         result[0] = frameExtent.x() == 43u;
+
+        // warp size must be accessible at compile time, this is only possible if we us ethe accelerator type
+        constexpr uint32_t warpSize = ALPAKA_TYPEOF(acc)::getWarpSize();
+        constexpr uint32_t warpSizeFn = onAcc::getWarpSize<T_Acc>();
+
+        static_assert(warpSize == warpSizeFn);
     }
 };
 
@@ -77,13 +83,19 @@ TEMPLATE_LIST_TEST_CASE("CVec frame extent kernel call", "", TestApis)
 
 struct KernelCVecThreadExtents
 {
-    template<typename T>
-    ALPAKA_FN_ACC void operator()(T const& acc, auto result) const
+    template<onAcc::concepts::Acc T_Acc>
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc, auto result) const
     {
         // compile will fail if the type is silently cast to non CVec type
         alpaka::concepts::CVector auto blockThreadCount = acc[alpaka::layer::thread].count();
         static_assert(blockThreadCount.x() == 1u);
         result[0] = blockThreadCount.x() == 1u;
+
+        // warp size must be accessible at compile time, this is only possible if we us ethe accelerator type
+        constexpr uint32_t warpSize = ALPAKA_TYPEOF(acc)::getWarpSize();
+        constexpr uint32_t warpSizeFn = onAcc::getWarpSize<T_Acc>();
+
+        static_assert(warpSize == warpSizeFn);
     }
 };
 


### PR DESCRIPTION
- provide a way to query the warp size at compile time in the kernel

note: We will always only support one warp size per device, and this is the warp size from the device properties.
Generating the warp size (subgroup size) in sycl is very complex and requires a two-stage approach.
I am not happy with this, but from my testing, it guarantees that the kernel `parallel_for()` in sycl is annotated correctly with the compile-time values, and it is not falling back to any other default.