### PR TITLE
warp operations

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 René Widera
+/* Copyright 2024 René Widera, Mehmet Yusufoglu
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -10,7 +10,11 @@
 #include "alpaka/Vec.hpp"
 #include "alpaka/api/api.hpp"
 #include "alpaka/api/cpu.hpp"
+#include "alpaka/api/cuda/warp.hpp"
+#include "alpaka/api/hip/warp.hpp"
+#include "alpaka/api/host/warp.hpp"
 #include "alpaka/api/oneApi.hpp"
+#include "alpaka/api/oneApi/warp.hpp"
 #include "alpaka/api/unifiedCudaHip.hpp"
 #include "alpaka/apply.hpp"
 #include "alpaka/core/Dict.hpp"
@@ -33,6 +37,7 @@
 #include "alpaka/onAcc/interface.hpp"
 #include "alpaka/onAcc/memFence.hpp"
 #include "alpaka/onAcc/tag.hpp"
+#include "alpaka/onAcc/warp.hpp"
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/onHost/DeviceSelector.hpp"
 #include "alpaka/onHost/Queue.hpp"

--- a/include/alpaka/api/cuda/warp.hpp
+++ b/include/alpaka/api/cuda/warp.hpp
@@ -1,0 +1,107 @@
+/* Copyright 2025 Mehmet Yusufoglu, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/cuda/Api.hpp"
+#include "alpaka/core/CudaHipCommon.hpp"
+#include "alpaka/core/common.hpp"
+#include "alpaka/core/config.hpp"
+#include "alpaka/onAcc/internal/warp.hpp"
+
+#include <cstdint>
+#include <type_traits>
+
+#if ALPAKA_LANG_CUDA
+namespace alpaka::onAcc::warp::internal
+{
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Activemask::Op<T_Acc, api::Cuda>
+    {
+        constexpr __device__ auto operator()(T_Acc const& acc, api::Cuda) const
+        {
+            return __activemask();
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct GetLanIdx::Op<T_Acc, api::Cuda>
+    {
+        constexpr __device__ auto operator()(T_Acc const& acc, api::Cuda) const
+        {
+            constexpr uint32_t warpExtent = onAcc::warp::internal::getSize<ALPAKA_TYPEOF(acc)>();
+            unsigned lIdx;
+            asm volatile("mov.u32 %0, %laneid;" : "=r"(lIdx));
+            return lIdx % warpExtent;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct All::Op<T_Acc, api::Cuda>
+    {
+        constexpr __device__ bool operator()(T_Acc const& acc, api::Cuda, int32_t predicate) const
+        {
+            return __all_sync(__activemask(), static_cast<int>(predicate)) != 0;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Any::Op<T_Acc, api::Cuda>
+    {
+        constexpr __device__ bool operator()(T_Acc const& acc, api::Cuda, int32_t predicate) const
+        {
+            return __any_sync(__activemask(), static_cast<int>(predicate)) != 0;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Ballot::Op<T_Acc, api::Cuda>
+    {
+        constexpr __device__ auto operator()(T_Acc const& acc, api::Cuda, int32_t predicate) const
+        {
+            return __ballot_sync(__activemask(), static_cast<int>(predicate));
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct Shfl::Op<T_Acc, api::Cuda, T>
+    {
+        constexpr __device__ T
+        operator()(T_Acc const& acc, api::Cuda, T const& value, uint32_t srcLane, uint32_t width) const
+        {
+            return __shfl_sync(__activemask(), value, static_cast<int>(srcLane), static_cast<int>(width));
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflDown::Op<T_Acc, api::Cuda, T>
+    {
+        constexpr __device__ T
+        operator()(T_Acc const& acc, api::Cuda, T const& value, uint32_t delta, uint32_t width) const
+        {
+            return __shfl_down_sync(__activemask(), value, static_cast<int>(delta), static_cast<int>(width));
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflUp::Op<T_Acc, api::Cuda, T>
+    {
+        constexpr __device__ T
+        operator()(T_Acc const& acc, api::Cuda, T const& value, uint32_t delta, uint32_t width) const
+        {
+            return __shfl_up_sync(__activemask(), value, static_cast<int>(delta), static_cast<int>(width));
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflXor::Op<T_Acc, api::Cuda, T>
+    {
+        constexpr __device__ T
+        operator()(T_Acc const& acc, api::Cuda, T const& value, uint32_t laneMask, uint32_t width) const
+        {
+            return __shfl_xor_sync(__activemask(), value, static_cast<int>(laneMask), static_cast<int>(width));
+        }
+    };
+} // namespace alpaka::onAcc::warp::internal
+#endif

--- a/include/alpaka/api/hip/warp.hpp
+++ b/include/alpaka/api/hip/warp.hpp
@@ -1,0 +1,110 @@
+/* Copyright 2025 Mehmet Yusufoglu, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/hip/Api.hpp"
+#include "alpaka/core/CudaHipCommon.hpp"
+#include "alpaka/core/common.hpp"
+#include "alpaka/core/config.hpp"
+#include "alpaka/onAcc/internal/warp.hpp"
+
+#include <cstdint>
+#include <type_traits>
+
+#if ALPAKA_LANG_HIP
+namespace alpaka::onAcc::warp::internal
+{
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Activemask::Op<T_Acc, api::Hip>
+    {
+        constexpr __device__ auto operator()(T_Acc const& acc, api::Hip) const
+        {
+            return __ballot(1u);
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct GetLanIdx::Op<T_Acc, api::Hip>
+    {
+        constexpr __device__ auto operator()(T_Acc const& acc, api::Hip) const
+        {
+#    if defined(__HIP_DEVICE_COMPILE__)
+            constexpr uint32_t warpExtent = onAcc::warp::internal::getSize<ALPAKA_TYPEOF(acc)>();
+            return __lane_id() % warpExtent;
+#    else
+            // only for the host side deduction path, result is wrong but this is fine
+            return __lane_id();
+#    endif
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct All::Op<T_Acc, api::Hip>
+    {
+        constexpr __device__ bool operator()(T_Acc const& acc, api::Hip, int32_t predicate) const
+        {
+            return __all(static_cast<int>(predicate)) != 0u;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Any::Op<T_Acc, api::Hip>
+    {
+        constexpr __device__ bool operator()(T_Acc const& acc, api::Hip, int32_t predicate) const
+        {
+            return __any(static_cast<int>(predicate)) != 0;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Ballot::Op<T_Acc, api::Hip>
+    {
+        constexpr __device__ auto operator()(T_Acc const& acc, api::Hip, int32_t predicate) const
+        {
+            return __ballot(static_cast<int>(predicate));
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct Shfl::Op<T_Acc, api::Hip, T>
+    {
+        constexpr __device__ T
+        operator()(T_Acc const& acc, api::Hip, T const& value, uint32_t srcLane, uint32_t width) const
+        {
+            return __shfl(value, static_cast<int>(srcLane), static_cast<int>(width));
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflDown::Op<T_Acc, api::Hip, T>
+    {
+        constexpr __device__ T
+        operator()(T_Acc const& acc, api::Hip, T const& value, uint32_t delta, uint32_t width) const
+        {
+            return __shfl_down(value, static_cast<int>(delta), static_cast<int>(width));
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflUp::Op<T_Acc, api::Hip, T>
+    {
+        constexpr __device__ T
+        operator()(T_Acc const& acc, api::Hip, T const& value, uint32_t delta, uint32_t width) const
+        {
+            return __shfl_up(value, static_cast<int>(delta), static_cast<int>(width));
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflXor::Op<T_Acc, api::Hip, T>
+    {
+        constexpr __device__ T
+        operator()(T_Acc const& acc, api::Hip, T const& value, uint32_t laneMask, uint32_t width) const
+        {
+            return __shfl_xor(value, static_cast<int>(laneMask), static_cast<int>(width));
+        }
+    };
+} // namespace alpaka::onAcc::warp::internal
+#endif

--- a/include/alpaka/api/host/warp.hpp
+++ b/include/alpaka/api/host/warp.hpp
@@ -1,0 +1,97 @@
+/* Copyright 2025 Mehmet Yusufoglu, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * Provides warp trait fallbacks for scalar host execution.
+ */
+
+#pragma once
+
+#include "alpaka/api/host/Api.hpp"
+#include "alpaka/core/common.hpp"
+#include "alpaka/onAcc/internal/warp.hpp"
+
+#include <cstdint>
+
+namespace alpaka::onAcc::warp::internal
+{
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Activemask::Op<T_Acc, api::Host>
+    {
+        constexpr auto operator()(T_Acc const& acc, api::Host) const
+        {
+            return uint32_t{1u};
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct GetLanIdx::Op<T_Acc, api::Host>
+    {
+        constexpr auto operator()(T_Acc const& acc, api::Host) const
+        {
+            return uint32_t{0u};
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct All::Op<T_Acc, api::Host>
+    {
+        constexpr bool operator()(T_Acc const& acc, api::Host, int32_t predicate) const
+        {
+            return predicate != 0;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Any::Op<T_Acc, api::Host>
+    {
+        constexpr bool operator()(T_Acc const& acc, api::Host, int32_t predicate) const
+        {
+            return predicate != 0;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Ballot::Op<T_Acc, api::Host>
+    {
+        constexpr auto operator()(T_Acc const& acc, api::Host, int32_t predicate) const
+        {
+            return predicate != 0 ? 1u : 0u;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct Shfl::Op<T_Acc, api::Host, T>
+    {
+        constexpr T operator()(T_Acc const& acc, api::Host, T const& value, uint32_t srcLane, uint32_t width) const
+        {
+            return value;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflDown::Op<T_Acc, api::Host, T>
+    {
+        constexpr T operator()(T_Acc const& acc, api::Host, T const& value, uint32_t delta, uint32_t width) const
+        {
+            return value;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflUp::Op<T_Acc, api::Host, T>
+    {
+        constexpr T operator()(T_Acc const& acc, api::Host, T const& value, uint32_t delta, uint32_t width) const
+        {
+            return value;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflXor::Op<T_Acc, api::Host, T>
+    {
+        constexpr T operator()(T_Acc const& acc, api::Host, T const& value, uint32_t laneMask, uint32_t width) const
+        {
+            return value;
+        }
+    };
+} // namespace alpaka::onAcc::warp::internal

--- a/include/alpaka/api/oneApi/warp.hpp
+++ b/include/alpaka/api/oneApi/warp.hpp
@@ -1,0 +1,192 @@
+/* Copyright 2025 Mehmet Yusufoglu, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/oneApi/Api.hpp"
+#include "alpaka/concepts.hpp"
+#include "alpaka/core/common.hpp"
+#include "alpaka/onAcc/internal/warp.hpp"
+
+#include <algorithm>
+#include <cstdint>
+
+#if ALPAKA_LANG_ONEAPI
+#    include <sycl/sycl.hpp>
+
+namespace alpaka::onAcc::warp::internal
+{
+    // GPU back-ends use native SYCL subgroup operations.
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Activemask::Op<T_Acc, api::OneApi>
+    {
+        auto operator()(T_Acc const& acc, api::OneApi) const
+        {
+            sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+
+            return getMask(sg);
+        }
+
+        static auto getMask(auto const subGroup)
+        {
+            auto sgMask = sycl::ext::oneapi::group_ballot(subGroup, true);
+
+            constexpr auto const warpSize = T_Acc::getWarpSize();
+            using ReturnType = std::conditional_t<warpSize <= 32, uint32_t, uint64_t>;
+            ReturnType mask;
+            sgMask.extract_bits(mask, 0u);
+            return mask;
+        };
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct GetLanIdx::Op<T_Acc, api::OneApi>
+    {
+        constexpr auto operator()(T_Acc const& acc, api::OneApi) const
+        {
+            sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+            // lane id within the warp subgroup
+            return sg.get_local_id()[0];
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct All::Op<T_Acc, api::OneApi>
+    {
+        bool operator()(T_Acc const& acc, api::OneApi, int32_t predicate) const
+        {
+            using DeviceKind = ALPAKA_TYPEOF(acc[object::deviceKind]);
+            if constexpr(DeviceKind{} == alpaka::deviceKind::amdGpu)
+            {
+                /* Workaround for AMD GPUs: Sycl is taking the results of the non active threads into account
+                 * and therefore even if all participating threads have a true predicate the result will be false.
+                 * We vote with ballot and mask the result with the active thread mask.
+                 */
+                sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+                auto activeMask = Activemask::Op<T_Acc, api::OneApi>::getMask(sg);
+                auto sgMask = sycl::ext::oneapi::group_ballot(sg, predicate != 0);
+
+                constexpr auto const warpSize = T_Acc::getWarpSize();
+                using ReturnType = std::conditional_t<warpSize <= 32, uint32_t, uint64_t>;
+                ReturnType predicateMask;
+                sgMask.extract_bits(predicateMask, 0u);
+                return activeMask & predicateMask == activeMask;
+            }
+            else
+            {
+                sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+                return sycl::all_of_group(sg, predicate != 0);
+            }
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Any::Op<T_Acc, api::OneApi>
+    {
+        bool operator()(T_Acc const& acc, api::OneApi, int32_t predicate) const
+        {
+            using DeviceKind = ALPAKA_TYPEOF(acc[object::deviceKind]);
+            if constexpr(DeviceKind{} == alpaka::deviceKind::amdGpu)
+            {
+                /* Workaround for AMD GPUs: Sycl is taking the results of non active threads into account
+                 * and therefore even if all participating threads have a false predicate the result will be true.
+                 * We vote with ballot and mask the result with the active thread mask.
+                 */
+                sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+                auto activeMask = Activemask::Op<T_Acc, api::OneApi>::getMask(sg);
+                auto sgMask = sycl::ext::oneapi::group_ballot(sg, predicate != 0);
+
+                constexpr auto const warpSize = T_Acc::getWarpSize();
+                using ReturnType = std::conditional_t<warpSize <= 32, uint32_t, uint64_t>;
+                ReturnType predicateMask;
+                sgMask.extract_bits(predicateMask, 0u);
+                return activeMask & predicateMask;
+            }
+            else
+            {
+                sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+                return sycl::any_of_group(sg, predicate != 0);
+            }
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct Ballot::Op<T_Acc, api::OneApi>
+    {
+        auto operator()(T_Acc const& acc, api::OneApi, int32_t predicate) const
+        {
+            sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+            auto sgMask = sycl::ext::oneapi::group_ballot(sg, predicate != 0);
+
+            constexpr auto const warpSize = T_Acc::getWarpSize();
+            using ReturnType = std::conditional_t<warpSize <= 32, uint32_t, uint64_t>;
+            ReturnType mask;
+            sgMask.extract_bits(mask, 0u);
+            return mask;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct Shfl::Op<T_Acc, api::OneApi, T>
+    {
+        constexpr T operator()(T_Acc const& acc, api::OneApi, T const& value, uint32_t srcLane, uint32_t width) const
+        {
+            sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+            uint32_t laneIdxInWarp = sg.get_local_id()[0];
+            uint32_t partitionOffset = (laneIdxInWarp / width) * width;
+            uint32_t srcInPartitionLaneIdx = partitionOffset + (srcLane % width);
+
+            return sycl::select_from_group(sg, value, srcInPartitionLaneIdx);
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflDown::Op<T_Acc, api::OneApi, T>
+    {
+        constexpr T operator()(T_Acc const& acc, api::OneApi, T const& value, uint32_t delta, uint32_t width) const
+        {
+            sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+
+            uint32_t laneIdxInWarp = sg.get_local_id()[0];
+            uint32_t groupEndIdx = (laneIdxInWarp / width + 1) * width;
+
+            T result = sycl::shift_group_left(sg, value, delta);
+            if(laneIdxInWarp + delta >= groupEndIdx)
+                result = value;
+            return result;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflUp::Op<T_Acc, api::OneApi, T>
+    {
+        constexpr T operator()(T_Acc const& acc, api::OneApi, T const& value, uint32_t delta, uint32_t width) const
+        {
+            sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+
+            uint32_t laneIdxInWarp = sg.get_local_id()[0];
+            uint32_t groupStartIdx = (laneIdxInWarp / width) * width;
+
+            T result = sycl::shift_group_right(sg, value, delta);
+            if(laneIdxInWarp - groupStartIdx < delta)
+                result = value;
+            return result;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc, typename T>
+    struct ShflXor::Op<T_Acc, api::OneApi, T>
+    {
+        constexpr T operator()(T_Acc const& acc, api::OneApi, T const& value, uint32_t laneMask, uint32_t width) const
+        {
+            sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+            uint32_t laneIdxInWarp = sg.get_local_id()[0];
+            uint32_t groupStartIdx = (laneIdxInWarp / width) * width;
+            uint32_t const relativeIdx = laneIdxInWarp - groupStartIdx;
+            uint32_t const sourceLane = (relativeIdx % width) ^ laneMask;
+            return sycl::select_from_group(sg, value, sourceLane < width ? groupStartIdx + sourceLane : laneIdxInWarp);
+        }
+    };
+} // namespace alpaka::onAcc::warp::internal
+#endif

--- a/include/alpaka/onAcc/Acc.hpp
+++ b/include/alpaka/onAcc/Acc.hpp
@@ -70,7 +70,7 @@ namespace alpaka::onAcc
          *
          * To be able to use the warp size as constexpr value you must call the static function via the type
          * `Acc_t::getWarpSize()` else the warp size can only be used as runtime value.
-         * Alternative you can use the free function onAcc::getWarpSize<Acc_t>();
+         * Alternative you can use the free function onAcc::warp::getSize<Acc_t>();
          */
         static constexpr uint32_t getWarpSize()
         {
@@ -167,12 +167,6 @@ namespace alpaka::onAcc
     constexpr auto getDynSharedMem(concepts::Acc auto const& acc) -> T*
     {
         return internalCompute::declareDynamicSharedMem<T>(acc);
-    }
-
-    template<concepts::Acc T_Acc>
-    constexpr uint32_t getWarpSize()
-    {
-        return T_Acc::getWarpSize();
     }
 
 } // namespace alpaka::onAcc

--- a/include/alpaka/onAcc/internal/warp.hpp
+++ b/include/alpaka/onAcc/internal/warp.hpp
@@ -1,0 +1,149 @@
+/* Copyright 2025 Mehmet Yusufoglu, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * Defines the Alpaka3 warp traits for kernel calls for votes and shuffles.
+ * Central helpers (all, any, ballot, shfl…) forward to trait::Op specializations.
+ *
+ * Dispatch now depends on api::X and deviceKind::Y tags, keeping the layer backend free.
+ * Provides a single entry point that works for host and GPU backends alike.
+ *
+ * Legacy Alpaka preferred the dispatch through ConceptWarp implementations per accelerator and used
+ * interface::ImplementationBase indirection to select the correct implementation.
+ */
+
+#pragma once
+
+#include "alpaka/api/concepts/api.hpp"
+#include "alpaka/api/trait.hpp"
+#include "alpaka/core/common.hpp"
+#include "alpaka/onAcc/Acc.hpp"
+#include "alpaka/tag.hpp"
+
+#include <cstdint>
+
+namespace alpaka::onAcc::warp::internal
+{
+    template<concepts::Acc T_Acc>
+    constexpr uint32_t getSize()
+    {
+        return T_Acc::getWarpSize();
+    }
+
+    /** Retrieve a bit-mask describing which warp lanes are active. */
+    struct Activemask
+    {
+        template<alpaka::onAcc::concepts::Acc T_Acc, alpaka::concepts::Api T_Api>
+        struct Op
+        {
+            constexpr auto operator()(T_Acc const&, T_Api api) const
+            {
+                static_assert(sizeof(T_Acc) && false, "Missing warp Activemask implementation for the accelerator.");
+                return 0u;
+            }
+        };
+    };
+
+    struct GetLanIdx
+    {
+        template<alpaka::onAcc::concepts::Acc T_Acc, alpaka::concepts::Api T_Api>
+        struct Op
+        {
+            constexpr auto operator()(T_Acc const&, T_Api api) const
+            {
+                static_assert(sizeof(T_Acc) && false, "Missing warp GetLanIdx implementation for the accelerator.");
+                return 0u;
+            }
+        };
+    };
+
+    struct All
+    {
+        template<alpaka::onAcc::concepts::Acc T_Acc, alpaka::concepts::Api T_Api>
+        struct Op
+        {
+            constexpr bool operator()(T_Acc const&, T_Api api, int32_t predicate) const
+            {
+                static_assert(sizeof(T_Acc) && false, "Missing warp All implementation for the accelerator.");
+                return false;
+            }
+        };
+    };
+
+    struct Any
+    {
+        template<alpaka::onAcc::concepts::Acc T_Acc, alpaka::concepts::Api T_Api>
+        struct Op
+        {
+            constexpr bool operator()(T_Acc const&, T_Api api, int32_t predicate) const
+            {
+                static_assert(sizeof(T_Acc) && false, "Missing warp Any implementation for the accelerator.");
+                return false;
+            }
+        };
+    };
+
+    struct Ballot
+    {
+        template<alpaka::onAcc::concepts::Acc T_Acc, alpaka::concepts::Api T_Api>
+        struct Op
+        {
+            constexpr auto operator()(T_Acc const&, T_Api api, int32_t predicate) const
+            {
+                static_assert(sizeof(T_Acc) && false, "Missing warp Ballot implementation for the accelerator.");
+                return 0;
+            }
+        };
+    };
+
+    struct Shfl
+    {
+        template<alpaka::onAcc::concepts::Acc T_Acc, alpaka::concepts::Api T_Api, typename T>
+        struct Op
+        {
+            constexpr T operator()(T_Acc const&, T_Api api, T const& value, uint32_t srcLane, uint32_t width) const
+            {
+                static_assert(sizeof(T_Acc) && false, "Missing warp Shfl implementation for the accelerator.");
+                return T{};
+            }
+        };
+    };
+
+    struct ShflDown
+    {
+        template<alpaka::onAcc::concepts::Acc T_Acc, alpaka::concepts::Api T_Api, typename T>
+        struct Op
+        {
+            constexpr T operator()(T_Acc const&, T_Api api, T const& value, uint32_t delta, uint32_t width) const
+            {
+                static_assert(sizeof(T_Acc) && false, "Missing warp ShflDown implementation for the accelerator.");
+                return T{};
+            }
+        };
+    };
+
+    struct ShflUp
+    {
+        template<alpaka::onAcc::concepts::Acc T_Acc, alpaka::concepts::Api T_Api, typename T>
+        struct Op
+        {
+            constexpr T operator()(T_Acc const&, T_Api api, T const& value, uint32_t delta, uint32_t width) const
+            {
+                static_assert(sizeof(T_Acc) && false, "Missing warp ShflUp implementation for the accelerator.");
+                return T{};
+            }
+        };
+    };
+
+    struct ShflXor
+    {
+        template<alpaka::onAcc::concepts::Acc T_Acc, alpaka::concepts::Api T_Api, typename T>
+        struct Op
+        {
+            constexpr T operator()(T_Acc const&, T_Api api, T const& value, uint32_t laneMask, uint32_t width) const
+            {
+                static_assert(sizeof(T_Acc) && false, "Missing warp ShflXor implementation for the accelerator.");
+                return T{};
+            }
+        };
+    };
+} // namespace alpaka::onAcc::warp::internal

--- a/include/alpaka/onAcc/warp.hpp
+++ b/include/alpaka/onAcc/warp.hpp
@@ -1,0 +1,273 @@
+/* Copyright 2025 Sergei Bastrakov, David M. Rogers, Bernhard Manfred Gruber, Aurora Perego, Mehmet Yusufoglu, René
+ * Widera SPDX-License-Identifier: MPL-2.0
+ *
+ * Bridges runtime accelerator instances to the trait-based warp intrinsics so kernels can call them without tags.
+ * Exposes device-safe `alpaka::onAcc::warp::*` wrappers for ballots, shuffles, and lane queries.
+ * Reuses the compile-time warp trait specialisations instead of duplicating backend-specific logic in kernels.
+ * Supplies a uniform warp API across CUDA, HIP, SYCL, and host-emulation accelerators.
+ *
+ * Some example usages:
+ * - consteval `alpaka::getWarpSize(api::Cuda{}, deviceKind::NvidiaGpu{})` for tag-driven compile-time logic.
+ * - device-side `alpaka::onAcc::warp::getSize(acc)` to query the active warp inside a kernel.
+ * - device-side `alpaka::onAcc::warp::shfl(acc, 42, 0u) == 42`
+ */
+
+#pragma once
+
+#include "alpaka/Vec.hpp"
+#include "alpaka/interface.hpp"
+#include "alpaka/onAcc/Acc.hpp"
+#include "alpaka/onAcc/internal/warp.hpp"
+#include "alpaka/tag.hpp"
+
+#include <cstdint>
+
+namespace alpaka::onAcc::warp
+{
+    /** Return the bit-mask of active lanes for the warp associated with the accelerator.
+     *
+     * @return bit mask where the Nth bit is set to 1 if the corresponding thread is participating the call. The return
+     * type can be 64bit or 32bit depending on the API.
+     */
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    constexpr auto activemask(T_Acc const& acc) -> std::conditional_t<T_Acc::getWarpSize() <= 32u, uint32_t, uint64_t>
+    {
+        using Acc = ALPAKA_TYPEOF(acc);
+        using Api = ALPAKA_TYPEOF(acc[object::api]);
+        return internal::Activemask::Op<Acc, Api>{}(acc, Api{});
+    }
+
+    /** Return the lane index of the current thread within its warp. */
+    constexpr uint32_t getLaneIdx(alpaka::onAcc::concepts::Acc auto const& acc)
+    {
+        using Acc = ALPAKA_TYPEOF(acc);
+        using Api = ALPAKA_TYPEOF(acc[object::api]);
+        return internal::GetLanIdx::Op<Acc, Api>{}(acc, Api{});
+    }
+
+    /** Evaluates predicate for all active threads of the warp
+     *
+     * It follows the logic of __all_sync(__activemask(), predicate) in CUDA but returns a boolean.
+     *
+     * Note:
+     * * The programmer must ensure that all threads calling this function are executing
+     *   the same line of code. In particular, it is not portable to write
+     *   if(a) {all} else {all}.
+     *
+     * @param predicate The predicate value for current thread.
+     * @return true if all threads predicate non zero, else false
+     */
+    constexpr bool all(alpaka::onAcc::concepts::Acc auto const& acc, int32_t predicate)
+    {
+        using Acc = ALPAKA_TYPEOF(acc);
+        using Api = ALPAKA_TYPEOF(acc[object::api]);
+        return internal::All::Op<Acc, Api>{}(acc, Api{}, predicate);
+    }
+
+    /** Evaluates predicate for all active threads of the warp.
+     *
+     * It follows the logic of __any_sync(__activemask(), predicate) in CUDA but returns a boolean.
+     *
+     * Note:
+     * * The programmer must ensure that all threads calling this function are executing
+     *   the same line of code. In particular, it is not portable to write
+     *   if(a) {any} else {any}.
+     *
+     * @param predicate The predicate value for current thread.
+     * @return true if at least one threads predicate is non zero, else false
+     */
+    constexpr bool any(alpaka::onAcc::concepts::Acc auto const& acc, int32_t predicate)
+    {
+        using Acc = ALPAKA_TYPEOF(acc);
+        using Api = ALPAKA_TYPEOF(acc[object::api]);
+        return internal::Any::Op<Acc, Api>{}(acc, Api{}, predicate);
+    }
+
+    /** Evaluates predicate for all non-exited threads in a warp and returns
+     * a 32- or 64-bit unsigned integer (depending on the accelerator)
+     * whose Nth bit is set if and only if predicate evaluates to non-zero
+     * for the Nth thread of the warp and the Nth thread is active.
+     *
+     * It follows the logic of __ballot_sync(__activemask(), predicate) in CUDA.
+     *
+     * Note:
+     * * The programmer must ensure that all threads calling this function are executing
+     *   the same line of code. In particular, it is not portable to write
+     *   if(a) {ballot} else {ballot}.
+     *
+     * @param predicate The predicate value for current thread.
+     * @return bit mask where the Nth bit is set to 1 if the corresponding threads predicate was non zero. The return
+     * type can be 64bit or 32bit depending on the API.
+     */
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    constexpr auto ballot(T_Acc const& acc, int32_t predicate)
+        -> std::conditional_t<T_Acc::getWarpSize() <= 32u, uint32_t, uint64_t>
+    {
+        using Acc = ALPAKA_TYPEOF(acc);
+        using Api = ALPAKA_TYPEOF(acc[object::api]);
+        return internal::Ballot::Op<Acc, Api>{}(acc, Api{}, predicate);
+    }
+
+    /** Return the warp size.
+     *
+     * A warp is a collection of threads which work in lock step (executing the same command).
+     * The warp size can be larger than the number of threads executed in the kernel/ thread block.
+     * @{
+     */
+    template<concepts::Acc T_Acc>
+    constexpr uint32_t getSize()
+    {
+        return internal::getSize<T_Acc>();
+    }
+
+    template<concepts::Acc T_Acc>
+    constexpr uint32_t getSize(T_Acc const& acc)
+    {
+        return T_Acc::getWarpSize();
+    }
+
+    /** @} */
+
+    /** Exchange data between threads within a warp.
+     *
+     * Effectively executes:
+     *
+     *     __shared__ int32_t values[warpsize];
+     *     values[threadIdx.x] = value;
+     *     __syncthreads();
+     *     return values[width*(threadIdx.x/width) + srcLane%width];
+     *
+     * However, it does not use shared memory.
+     *
+     *  Commonly used with width = warpsize (the default), (returns values[srcLane])
+     *
+     * This method supports to be called in diverging control flow branches if you only query values from threads
+     * within the same branch path.
+     *
+     * @param value value to broadcast, only used if other thread is addressing the lane of this thread.
+     * @param srcLane source lane index within the group range [0; width).
+     * @param width number of threads receiving a single value, must be a power of 2.
+     * @return val from the thread index srcLane.
+     */
+    template<typename T, alpaka::onAcc::concepts::Acc T_Acc>
+    requires(std::is_trivially_copyable_v<T>)
+    constexpr T shfl(T_Acc const& acc, T const& value, uint32_t srcLane, uint32_t width = getSize<T_Acc>())
+    {
+        using Acc = ALPAKA_TYPEOF(acc);
+        using Api = ALPAKA_TYPEOF(acc[object::api]);
+        return internal::Shfl::Op<Acc, Api, T>{}(acc, Api{}, value, srcLane, width != 0u ? width : getSize<T_Acc>());
+    }
+
+    /** Read data from threads with higher lane index within a warp.
+     *
+     * It copies from a lane with higher ID relative to caller.
+     * The lane ID is calculated by adding delta to the caller’s lane ID.
+     *
+     * Effectively executes:
+     *
+     *     __shared__ int32_t values[warpsize];
+     *     values[threadIdx.x] = value;
+     *     __syncthreads();
+     *     return (threadIdx.x % width + delta < width) ? values[threadIdx.x + delta] : values[threadIdx.x];
+     *
+     * However, it does not use shared memory.
+     *
+     * Notes:
+     * * The programmer must ensure that all threads calling this
+     *   function (and the srcLane) are executing the same line of code.
+     *   In particular it is not portable to write if(a) {shfl} else {shfl}.
+     *
+     * * Commonly used with width = warpsize (the default), (returns values[threadIdx.x+delta] if threadIdx.x+delta <
+     * warpsize)
+     *
+     * @param value value to broadcast
+     * @param delta corresponds to the delta used to compute the lane ID
+     * @param width size of the group participating in the shuffle operation, must be a power of 2.
+     * @return the value from the thread index lane ID + delta within the group build by width, else value.
+     */
+    template<typename T, alpaka::onAcc::concepts::Acc T_Acc>
+    requires(std::is_trivially_copyable_v<T>)
+    constexpr T shflDown(T_Acc const& acc, T const& value, uint32_t delta, uint32_t width = getSize<T_Acc>())
+    {
+        using Acc = ALPAKA_TYPEOF(acc);
+        using Api = ALPAKA_TYPEOF(acc[object::api]);
+        return internal::ShflDown::Op<Acc, Api, T>{}(acc, Api{}, value, delta, width != 0u ? width : getSize<T_Acc>());
+    }
+
+    /** Read data from threads with lower lane index within a warp.
+     *
+     * It copies from a lane with lower ID relative to caller.
+     * The lane ID is calculated by subtracting delta from the caller’s lane ID.
+     *
+     * Effectively executes:
+     *
+     *     __shared__ int32_t values[warpsize];
+     *     values[threadIdx.x] = value;
+     *     __syncthreads();
+     *     return (threadIdx.x % width >= delta) ? values[threadIdx.x - delta] : values[threadIdx.x];
+     *
+     * However, it does not use shared memory.
+     *
+     * Notes:
+     * * The programmer must ensure that all threads calling this
+     *   function (and the srcLane) are executing the same line of code.
+     *   In particular it is not portable to write if(a) {shfl} else {shfl}.
+     *
+     * Commonly used with width = warpsize (the default), (returns values[threadIdx.x - delta] if threadIdx.x >= delta)
+     *
+     * @param value value to broadcast
+     * @param delta corresponds to the delta used to compute the lane ID
+     * @param width size of the group participating in the shuffle operation, must be a power of 2.
+     * @return the value from the thread index lane ID + delta within the group build by width, else value.
+     */
+    template<typename T, alpaka::onAcc::concepts::Acc T_Acc>
+    requires(std::is_trivially_copyable_v<T>)
+    constexpr T shflUp(T_Acc const& acc, T const& value, uint32_t delta, uint32_t width = getSize<T_Acc>())
+    {
+        using Acc = ALPAKA_TYPEOF(acc);
+        using Api = ALPAKA_TYPEOF(acc[object::api]);
+        return internal::ShflUp::Op<Acc, Api, T>{}(acc, Api{}, value, delta, width != 0u ? width : getSize<T_Acc>());
+    }
+
+    /** Exchange data between threads within a warp.
+     *
+     * It copies from a lane based on bitwise XOR of own lane ID.
+     * The lane ID is calculated by performing a bitwise XOR of the caller’s lane ID with laneMask
+     *
+     * Effectively executes:
+     *
+     *     __shared__ int32_t values[warpsize];
+     *     values[threadIdx.x] = value;
+     *     __syncthreads();
+     *     int lane = threadIdx.x ^ laneMask;
+     *     return values[lane / width > threadIdx.x / width ? threadIdx.x : lane];
+     *
+     * However, it does not use shared memory.
+     *
+     * Notes:
+     * * The programmer must ensure that all threads calling this
+     *   function (and the srcLane) are executing the same line of code.
+     *   In particular it is not portable to write if(a) {shfl} else {shfl}.
+     *
+     * * Commonly used with width = warpsize (the default), (returns values[threadIdx.x^laneMask])
+     *
+     * * Width must be a power of 2.
+     * @param value value to broadcast
+     * @param laneMask mask applied to the thread lane index within the subgroup created by width.
+     * @param width size of the group participating in the shuffle operation, must be a power of 2.
+     * @return the value from the thread index lane ID
+     */
+    template<typename T, alpaka::onAcc::concepts::Acc T_Acc>
+    requires(std::is_trivially_copyable_v<T>)
+    constexpr T shflXor(T_Acc const& acc, T const& value, uint32_t laneMask, uint32_t width = getSize<T_Acc>())
+    {
+        using Acc = ALPAKA_TYPEOF(acc);
+        using Api = ALPAKA_TYPEOF(acc[object::api]);
+        return internal::ShflXor::Op<Acc, Api, T>{}(
+            acc,
+            Api{},
+            value,
+            laneMask,
+            width != 0u ? width : getSize<T_Acc>());
+    }
+} // namespace alpaka::onAcc::warp

--- a/tests/unit/cvecKernelCall/cvecKernelCall.cpp
+++ b/tests/unit/cvecKernelCall/cvecKernelCall.cpp
@@ -39,7 +39,7 @@ struct KernelCVecFrameExtents
 
         // warp size must be accessible at compile time, this is only possible if we us ethe accelerator type
         constexpr uint32_t warpSize = ALPAKA_TYPEOF(acc)::getWarpSize();
-        constexpr uint32_t warpSizeFn = onAcc::getWarpSize<T_Acc>();
+        constexpr uint32_t warpSizeFn = onAcc::warp::getSize<T_Acc>();
 
         static_assert(warpSize == warpSizeFn);
     }
@@ -93,7 +93,7 @@ struct KernelCVecThreadExtents
 
         // warp size must be accessible at compile time, this is only possible if we us ethe accelerator type
         constexpr uint32_t warpSize = ALPAKA_TYPEOF(acc)::getWarpSize();
-        constexpr uint32_t warpSizeFn = onAcc::getWarpSize<T_Acc>();
+        constexpr uint32_t warpSizeFn = onAcc::warp::getSize<T_Acc>();
 
         static_assert(warpSize == warpSizeFn);
     }

--- a/tests/unit/warp/activemask.cpp
+++ b/tests/unit/warp/activemask.cpp
@@ -1,0 +1,98 @@
+/* Copyright 2025 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci, Aurora Perego, Mehmet
+ * Yusufoglu, René Widera SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file Tests that the warp activemask helper reports exactly the lanes participating in execution.
+ * Warp operations are SIMT collectives that act on the threads executing in lockstep on a GPU warp.
+ */
+
+#include "utils.hpp"
+
+#include <alpaka/onAcc/warp.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+
+using namespace alpaka;
+using alpaka::test::warp::fullMask;
+using alpaka::test::warp::singleBit;
+using alpaka::test::warp::warpCheck;
+using alpaka::test::warp::WarpTestBackends;
+
+namespace
+{
+    struct ActivemaskMultiThreadKernel
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(TAcc const& acc, concepts::MdSpan<bool> auto success, std::uint32_t inactiveLane)
+            const
+        {
+            // test if the warp size can be constexpr
+            constexpr uint32_t warpExtent = onAcc::warp::getSize<ALPAKA_TYPEOF(acc)>();
+            /* We can not use a static_assert for testing because the compiler will evaluate the warp size during the
+             * host parsing to what will result in false negatives */
+            warpCheck(success, warpExtent >= 1u);
+
+            /* We start on the host side a frame specification with a frame extent of the warp size.
+             * alpaka should not reduce the number of threads to a value smaller than the warp size if the user is not
+             * applying for it.
+             */
+            auto const threadsPerBlock = static_cast<std::uint32_t>(acc[alpaka::layer::thread].count().product());
+            // number of threads should be a multiple of the warp size
+            warpCheck(success, threadsPerBlock % warpExtent == 0);
+
+            auto const lane = onAcc::warp::getLaneIdx(acc);
+
+            if(lane == inactiveLane)
+            {
+                // Early exit: mark this lane inactive without touching the mask.
+                return;
+            }
+
+            auto const mask = onAcc::warp::activemask(acc);
+
+            auto const expected = fullMask(warpExtent) & ~singleBit(inactiveLane);
+            warpCheck(success, mask == expected);
+        }
+    };
+} // namespace
+
+TEMPLATE_LIST_TEST_CASE("warp activemask reflects participating lanes", "[warp][activemask]", WarpTestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    if(!selector.isAvailable())
+    {
+        INFO("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    auto deviceProperties = selector.getDeviceProperties(0);
+    auto const warpExtent = deviceProperties.m_warpSize;
+
+    auto device = selector.makeDevice(0);
+    auto queue = device.makeQueue(queueKind::blocking);
+
+    auto successHost = onHost::allocHost<bool>(1u);
+    auto successDev = onHost::allocLike(device, successHost);
+
+    auto const blocks = Vec<std::uint32_t, 1u>{5u};
+    auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
+    auto const frame = onHost::FrameSpec{blocks, threads};
+
+    for(std::uint32_t inactiveLane = 0u; inactiveLane < warpExtent; ++inactiveLane)
+    {
+        // Sweep every lane once to confirm the mask drops exactly that participant.
+        onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
+        queue.enqueue(exec, frame, KernelBundle{ActivemaskMultiThreadKernel{}, successDev, inactiveLane});
+        onHost::memcpy(queue, successHost, successDev);
+        onHost::wait(queue);
+        INFO("backend=" << deviceSpec.getName() << " inactiveLane=" << inactiveLane);
+        CHECK(successHost[0]);
+    }
+}

--- a/tests/unit/warp/all.cpp
+++ b/tests/unit/warp/all.cpp
@@ -1,0 +1,106 @@
+/* Copyright 2025 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci, Aurora Perego, Mehmet
+ * Yusufoglu, René Widera SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file Tests the warp "all" operation which checks if all lanes in the warp satisfy a predicate.
+ * The "all" warp operation returns true only when every participating thread evaluates the condition as true.
+ * It's a collective operation that requires unanimous agreement across all active threads in the warp.
+ */
+
+#include "utils.hpp"
+
+#include <alpaka/onAcc/warp.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+
+using namespace alpaka;
+using alpaka::test::warp::warpCheck;
+using alpaka::test::warp::WarpTestBackends;
+
+namespace
+{
+    struct AllMultiThreadKernel
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(TAcc const& acc, concepts::MdSpan<bool> auto success, std::uint32_t idx) const
+        {
+            constexpr uint32_t warpExtent = onAcc::warp::getSize<ALPAKA_TYPEOF(acc)>();
+
+            auto const threadsPerBlock = static_cast<std::int32_t>(acc[alpaka::layer::thread].count().product());
+            // number of threads should be a multiple of the warp size
+            warpCheck(success, threadsPerBlock % warpExtent == 0);
+
+            auto const lane = static_cast<std::int32_t>(onAcc::warp::getLaneIdx(acc));
+            if(lane % 3 != 0)
+            {
+                // Only every third lane participates in the collective vote.
+                // Other lanes exit silently below.
+                return;
+            }
+
+            // All participating lanes vote false hence the inverse must be true.
+            warpCheck(success, !onAcc::warp::all(acc, 0));
+
+            // assumes non-zero values evaluate as true
+            // All participating lanes vote true hence the result must be true.
+            warpCheck(success, onAcc::warp::all(acc, 42));
+
+
+            auto const castIdx = static_cast<std::int32_t>(idx);
+
+            // requires at least two threads
+            if constexpr(warpExtent >= 2)
+            {
+                // Example: active lanes {0,3,6}; choosing idx=3 yields predicates {0,1,0}, so unanimity fails.
+                warpCheck(success, !onAcc::warp::all(acc, lane == castIdx ? 1 : 0));
+            }
+
+            auto const expected = (idx % 3u != 0u);
+            // Every active lane except the triggering one votes true; the result is true only if that lane is
+            // inactive. Example: idx=4 (masked lane) leaves predicates {1,1,1} and the vote succeeds, whereas idx=3
+            // produces {1,0,1} and fails.
+            warpCheck(success, onAcc::warp::all(acc, lane == castIdx ? 0 : 1) == expected);
+        }
+    };
+} // namespace
+
+TEMPLATE_LIST_TEST_CASE("warp all vote honours only active lanes", "[warp][all]", WarpTestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    if(!selector.isAvailable())
+    {
+        INFO("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    auto deviceProperties = selector.getDeviceProperties(0);
+    auto const warpExtent = deviceProperties.m_warpSize;
+
+    auto device = selector.makeDevice(0);
+    auto queue = device.makeQueue(queueKind::blocking);
+
+    auto successHost = onHost::allocHost<bool>(1u);
+    auto successDev = onHost::allocLike(device, successHost);
+
+    auto const blocks = Vec<std::uint32_t, 1u>{5u};
+    auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
+    auto const frame = onHost::FrameSpec{blocks, threads};
+
+    for(std::uint32_t idx = 0u; idx < warpExtent; ++idx)
+    {
+        // Iterate over each potential trigger lane to verify masked votes.
+        onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
+        queue.enqueue(exec, frame, KernelBundle{AllMultiThreadKernel{}, successDev, idx});
+        onHost::memcpy(queue, successHost, successDev);
+        onHost::wait(queue);
+        INFO("backend=" << deviceSpec.getName() << " idx=" << idx);
+        CHECK(successHost[0]);
+    }
+}

--- a/tests/unit/warp/any.cpp
+++ b/tests/unit/warp/any.cpp
@@ -1,0 +1,106 @@
+/* Copyright 2025 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci, Aurora Perego, Mehmet
+ * Yusufoglu, René Widera SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file Tests the warp "any" operation which checks if at least one lane in the warp satisfies a predicate.
+ * The "any" warp operation returns true if any thread in the warp evaluates the condition as true.
+ * It's a collective operation that gathers votes across all participating threads executing in lockstep.
+ */
+
+#include "utils.hpp"
+
+#include <alpaka/onAcc/warp.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+
+using namespace alpaka;
+using alpaka::test::warp::warpCheck;
+using alpaka::test::warp::WarpTestBackends;
+
+namespace
+{
+    struct AnyMultiThreadKernel
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(TAcc const& acc, concepts::MdSpan<bool> auto success, std::uint32_t idx) const
+        {
+            // test if the warp size can be constexpr
+            constexpr uint32_t warpExtent = onAcc::warp::getSize<ALPAKA_TYPEOF(acc)>();
+            /* We can not use a static_assert for testing because the compiler will evaluate the warp size during the
+             * host parsing to what will result in false negatives */
+            warpCheck(success, warpExtent >= 1u);
+
+            auto const threadsPerBlock = static_cast<std::int32_t>(acc[alpaka::layer::thread].count().product());
+            // number of threads should be a multiple of the warp size
+            warpCheck(success, threadsPerBlock % warpExtent == 0);
+
+            auto const lane = static_cast<std::int32_t>(onAcc::warp::getLaneIdx(acc));
+            if(lane % 2 != 0)
+            {
+                // Only even lanes participate; others exit silently.
+                return;
+            }
+
+            // No participating lane votes true, so the result must stay false.
+            warpCheck(success, !onAcc::warp::any(acc, 0));
+            // At least one active lane votes true, toggling the aggregate to true.
+            warpCheck(success, onAcc::warp::any(acc, 42));
+
+            auto const castIdx = static_cast<std::int32_t>(idx);
+
+            if constexpr(warpExtent >= 2)
+            {
+                // Only the non-targeted even lanes vote true here; the chosen lane contributes false, so the
+                // collective stays true. Example: active lanes {0,2,4,6}; choosing idx=2 yields predicates {1,0,1,1}.
+                warpCheck(success, onAcc::warp::any(acc, lane == castIdx ? 0 : 1));
+            }
+
+            auto const expected = (idx % 2u == 0u);
+            // The inverse predicate now gives the selected lane the only true vote; the result is true only if that
+            // lane is active. Example: active lanes {0,2,4,6}; choosing idx=2 yields predicates {0,1,0,0}, so the vote
+            // is true.
+            warpCheck(success, onAcc::warp::any(acc, lane == castIdx ? 1 : 0) == expected);
+        }
+    };
+} // namespace
+
+TEMPLATE_LIST_TEST_CASE("warp any vote observes active lanes", "[warp][any]", WarpTestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    if(!selector.isAvailable())
+    {
+        INFO("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    auto deviceProperties = selector.getDeviceProperties(0);
+    auto const warpExtent = deviceProperties.m_warpSize;
+
+    auto device = selector.makeDevice(0);
+    auto queue = device.makeQueue(queueKind::blocking);
+
+    auto successHost = onHost::allocHost<bool>(1u);
+    auto successDev = onHost::allocLike(device, successHost);
+
+    auto const blocks = Vec<std::uint32_t, 1u>{5u};
+    auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
+    auto const frame = onHost::FrameSpec{blocks, threads};
+
+    for(std::uint32_t idx = 0u; idx < warpExtent; ++idx)
+    {
+        // Rotate through each candidate lane to ensure mask-gated votes succeed.
+        onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
+        queue.enqueue(exec, frame, KernelBundle{AnyMultiThreadKernel{}, successDev, idx});
+        onHost::memcpy(queue, successHost, successDev);
+        onHost::wait(queue);
+        INFO("backend=" << deviceSpec.getName() << " idx=" << idx);
+        CHECK(successHost[0]);
+    }
+}

--- a/tests/unit/warp/ballot.cpp
+++ b/tests/unit/warp/ballot.cpp
@@ -1,0 +1,111 @@
+/* Copyright 2025 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci, Aurora Perego, Mehmet
+ * Yusufoglu, René Widera SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file Tests the warp "ballot" operation which collects votes from all lanes into a bitmask.
+ * The "ballot" warp operation returns a bitmask where each bit represents whether that lane's predicate was true.
+ * It's a collective operation that gathers boolean values from all participating threads into a single integer.
+ */
+
+#include "utils.hpp"
+
+#include <alpaka/onAcc/warp.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <climits>
+#include <cstdint>
+
+using namespace alpaka;
+using alpaka::test::warp::warpCheck;
+using alpaka::test::warp::WarpTestBackends;
+
+namespace
+{
+    struct BallotMultiThreadKernel
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(TAcc const& acc, concepts::MdSpan<bool> auto success) const
+        {
+            // use runtime warp size to avoid compiler warning later
+            uint32_t warpExtent = onAcc::warp::getSize<ALPAKA_TYPEOF(acc)>();
+            /* We can not use a static_assert for testing because the compiler will evaluate the warp size during the
+             * host parsing to what will result in false negatives */
+            warpCheck(success, warpExtent >= 1u);
+
+            auto const threadsPerBlock = static_cast<std::uint32_t>(acc[alpaka::layer::thread].count().product());
+            // number of threads should be a multiple of the warp size
+            warpCheck(success, threadsPerBlock % warpExtent == 0);
+
+            using ResultType = decltype(onAcc::warp::ballot(acc, 42));
+            // Limit the comparison mask to the bits the backend can physically store.
+            auto const maxBits = static_cast<std::uint32_t>(sizeof(ResultType) * CHAR_BIT);
+            auto const totalBits = std::min(warpExtent, maxBits);
+            auto const allActive
+                = totalBits == maxBits ? ~ResultType{0u} : (ResultType{1} << totalBits) - ResultType{1};
+
+            // When every lane votes true, the ballot should mark all active bits.
+            warpCheck(success, onAcc::warp::ballot(acc, 42) == allActive);
+            // When every lane votes false, the ballot mask should be empty.
+            warpCheck(success, onAcc::warp::ballot(acc, 0) == 0u);
+
+            auto const lane = static_cast<std::uint32_t>(onAcc::warp::getLaneIdx(acc));
+            if(lane >= warpExtent / 2u)
+            {
+                // Upper half of the warp stays inactive to validate masked ballots.
+                return;
+            }
+
+            auto const activeLaneCount = static_cast<std::uint32_t>(warpExtent / 2u);
+            for(std::uint32_t idx = 0u; idx < activeLaneCount; ++idx)
+            {
+                // Each active lane should toggle exactly its bit when voting true.
+                auto const bitMask = static_cast<ResultType>(ResultType{1} << idx);
+                // Exactly one lane voting true elevates its corresponding bit.
+                // Example: active lanes {0,1,2,3}; choosing idx=2 makes lane 2 vote true while others vote false,
+                // yielding 0b0100.
+                warpCheck(success, onAcc::warp::ballot(acc, lane == idx ? 1 : 0) == bitMask);
+
+                auto const expected = ((ResultType{1} << activeLaneCount) - ResultType{1}) & ~bitMask;
+                // Everyone except the toggled lane voting true should set all other bits.
+                // Example: active lanes {0,1,2,3}; choosing idx=2 makes predicates {1,1,0,1}, yielding 0b1011.
+                warpCheck(success, onAcc::warp::ballot(acc, lane == idx ? 0 : 1) == expected);
+            }
+        }
+    };
+} // namespace
+
+TEMPLATE_LIST_TEST_CASE("warp ballot captures predicate lanes", "[warp][ballot]", WarpTestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    if(!selector.isAvailable())
+    {
+        INFO("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    auto deviceProperties = selector.getDeviceProperties(0);
+    auto const warpExtent = deviceProperties.m_warpSize;
+
+    auto device = selector.makeDevice(0);
+    auto queue = device.makeQueue(queueKind::blocking);
+
+    auto successHost = onHost::allocHost<bool>(1u);
+    auto successDev = onHost::allocLike(device, successHost);
+
+    auto const blocks = Vec<std::uint32_t, 1u>{5u};
+    auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
+
+    onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
+    queue.enqueue(exec, onHost::FrameSpec{blocks, threads}, KernelBundle{BallotMultiThreadKernel{}, successDev});
+    onHost::memcpy(queue, successHost, successDev);
+    onHost::wait(queue);
+    INFO("backend=" << deviceSpec.getName());
+    CHECK(successHost[0]);
+}

--- a/tests/unit/warp/getSize.cpp
+++ b/tests/unit/warp/getSize.cpp
@@ -1,0 +1,83 @@
+/* Copyright 2025 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci, Aurora Perego, Mehmet
+ * Yusufoglu, René Widera SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file
+ * Tests the warp "getSize" operation which queries the number of threads in a warp.
+ * The "getSize" warp operation returns the warp width (e.g., 32 for NVIDIA GPUs, 64 for AMD).
+ * It's a query operation that reports the hardware-defined number of threads executing in lockstep.
+ */
+
+#include "utils.hpp"
+
+#include <alpaka/onAcc/warp.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+
+using namespace alpaka;
+using alpaka::test::warp::warpCheck;
+using alpaka::test::warp::WarpTestBackends;
+
+namespace
+{
+    struct GetSizeKernel
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+            TAcc const& acc,
+            concepts::MdSpan<bool> auto success,
+            std::uint32_t expectedWarpSize) const
+        {
+            // Compare device-reported warp extent against the precomputed traits.
+            auto const runtimeSize = onAcc::warp::getSize(acc);
+            warpCheck(success, runtimeSize != 0u);
+            warpCheck(success, runtimeSize == expectedWarpSize);
+
+            // test if the warp size can be constexpr
+            constexpr uint32_t warpExtent = onAcc::warp::getSize<ALPAKA_TYPEOF(acc)>();
+            warpCheck(success, warpExtent == expectedWarpSize);
+            // laneIdx should be in range [0;warpSize)
+            auto const laneIdx = static_cast<std::int32_t>(onAcc::warp::getLaneIdx(acc));
+            warpCheck(success, laneIdx < warpExtent);
+        }
+    };
+} // namespace
+
+TEMPLATE_LIST_TEST_CASE("warp size trait matches runtime size", "[warp][getSize]", WarpTestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    if(!selector.isAvailable())
+    {
+        INFO("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    auto deviceProperties = selector.getDeviceProperties(0);
+    auto const warpExtent = deviceProperties.m_warpSize;
+
+    auto device = selector.makeDevice(0);
+    auto queue = device.makeQueue(queueKind::blocking);
+
+    auto successHost = onHost::allocHost<bool>(1u);
+    auto successDev = onHost::allocLike(device, successHost);
+    auto const blocks = Vec<std::uint32_t, 1u>{5u};
+    auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
+
+    onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
+    queue.enqueue(
+        exec,
+        onHost::FrameSpec{blocks, threads},
+        // Pass the host-side expectation down to the device for verification.
+        KernelBundle{GetSizeKernel{}, successDev, static_cast<std::uint32_t>(warpExtent)});
+    onHost::memcpy(queue, successHost, successDev);
+    onHost::wait(queue);
+    INFO("backend=" << deviceSpec.getName());
+    CHECK(successHost[0]);
+}

--- a/tests/unit/warp/shfl.cpp
+++ b/tests/unit/warp/shfl.cpp
@@ -1,0 +1,131 @@
+/* Copyright 2025 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci, Aurora Perego, Mehmet
+ * Yusufoglu, René Widera SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file Tests the warp "shfl" (shuffle) operation which broadcasts a value from one lane to all lanes.
+ * The "shfl" warp operation allows each thread to read a value from a specified source lane's register.
+ * It's a data exchange operation that enables direct thread-to-thread communication within a warp without shared
+ * memory.
+ */
+
+#include "utils.hpp"
+
+#include <alpaka/onAcc/warp.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <limits>
+
+using namespace alpaka;
+using alpaka::test::warp::warpCheck;
+using alpaka::test::warp::WarpTestBackends;
+
+namespace
+{
+    struct ShflMultiThreadKernel
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(TAcc const& acc, concepts::MdSpan<bool> auto success) const
+        {
+            constexpr uint32_t warpExtent = onAcc::warp::getSize<ALPAKA_TYPEOF(acc)>();
+
+            // number of threads should be a multiple of the warp size
+            warpCheck(success, warpExtent >= 1u);
+
+            // Lane ID drives the expected source values for each shuffle check.
+            uint32_t const lane = onAcc::warp::getLaneIdx(acc);
+
+            // Exercise trivial zero-offset and max-offset cases.
+            // Broadcasting from literal lane 0 must work regardless of the caller lane.
+            warpCheck(success, onAcc::warp::shfl(acc, 42, 0u) == 42);
+            // Using the current lane as the payload and requesting src=0 should always give back 0.
+            warpCheck(success, onAcc::warp::shfl(acc, lane, 0u) == 0);
+            if constexpr(warpExtent >= 2)
+            {
+                // Requesting src=1 broadcasts lane 1's value to every participant.
+                // test requires at least two threads in a warp
+                warpCheck(success, onAcc::warp::shfl(acc, lane, 1u) == 1);
+            }
+
+            // Large src index is clamped to the logical width; value must remain unchanged.
+            warpCheck(success, onAcc::warp::shfl(acc, 5, std::numeric_limits<uint32_t>::max()) == 5);
+
+            auto const epsilon = std::numeric_limits<float>::epsilon();
+            for(uint32_t width = 1; width < warpExtent; width *= 2)
+            {
+                // Check every logical partition width supported by the backend.
+                for(uint32_t idx = 0; idx < width; ++idx)
+                {
+                    auto const section = width * (lane / width);
+                    // Integer payloads should resolve to the subgroup-relative source index.
+                    auto const shuffle = onAcc::warp::shfl(acc, lane, idx, width);
+                    warpCheck(success, shuffle == idx + section);
+
+                    // Floating payloads exercise non-integral types under the same subgroup restriction.
+                    auto const ans = onAcc::warp::shfl(acc, 4.0f - static_cast<float>(lane), idx, width);
+                    auto const expect = 4.0f - static_cast<float>(idx + section);
+                    warpCheck(success, alpaka::math::abs(ans - expect) < epsilon);
+                }
+            }
+
+            if(static_cast<int>(lane) >= static_cast<int>(warpExtent / 2u))
+            {
+                warpCheck(success, onAcc::warp::shfl(acc, 42, warpExtent - 1u) == 42);
+                // Upper half should be fully masked from the final checks.
+                return;
+            }
+            else
+            {
+                // check that shfl can be called within branches of the same level
+                warpCheck(success, onAcc::warp::shfl(acc, 11, 0u) == 11);
+            }
+            // int is used to silence cast warning because warpExtent can be zero during the host path evaluation
+            for(int idxTmp = 0u; idxTmp < static_cast<int>(warpExtent) / 2; ++idxTmp)
+            {
+                uint32_t idx = static_cast<uint32_t>(idxTmp);
+                // Active sub-group must always read the value produced by the chosen lane.
+                // Within the lower half, shuffling with src=idx must reproduce the selected lane.
+                warpCheck(success, onAcc::warp::shfl(acc, lane, idx) == idx);
+                auto const ans = onAcc::warp::shfl(acc, 4.0f - static_cast<float>(lane), idx);
+                // Float payload confirms the same behaviour holds across types for the masked subgroup.
+                auto const expect = 4.0f - static_cast<float>(idx);
+                warpCheck(success, alpaka::math::abs(ans - expect) < epsilon);
+            }
+        }
+    };
+} // namespace
+
+TEMPLATE_LIST_TEST_CASE("warp shfl moves values between lanes", "[warp][shfl]", WarpTestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    if(!selector.isAvailable())
+    {
+        INFO("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    auto deviceProperties = selector.getDeviceProperties(0);
+    auto const warpExtent = deviceProperties.m_warpSize;
+
+    auto device = selector.makeDevice(0);
+    auto queue = device.makeQueue(queueKind::blocking);
+
+    auto successHost = onHost::allocHost<bool>(1u);
+    auto successDev = onHost::allocLike(device, successHost);
+
+    auto const blocks = Vec<std::uint32_t, 1u>{5u};
+    auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
+
+    onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
+    queue.enqueue(exec, onHost::FrameSpec{blocks, threads}, KernelBundle{ShflMultiThreadKernel{}, successDev});
+    onHost::memcpy(queue, successHost, successDev);
+    onHost::wait(queue);
+    INFO("backend=" << deviceSpec.getName());
+    CHECK(successHost[0]);
+}

--- a/tests/unit/warp/shfl_down.cpp
+++ b/tests/unit/warp/shfl_down.cpp
@@ -1,0 +1,141 @@
+/* Copyright 2025 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci, Aurora Perego, Mehmet
+ * Yusufoglu, René Widera SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file Tests the warp "shfl_down" (shuffle down) operation which shifts values toward higher-numbered lanes.
+ * The "shfl_down" warp operation allows each thread to read a value from a lane at a fixed offset below.
+ * It's a data exchange operation useful for prefix scans and reduction patterns within a warp.
+ */
+
+#include "utils.hpp"
+
+#include <alpaka/onAcc/warp.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <limits>
+
+using namespace alpaka;
+using alpaka::test::warp::warpCheck;
+using alpaka::test::warp::WarpTestBackends;
+
+namespace
+{
+    struct ShflDownMultiThreadKernel
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(TAcc const& acc, concepts::MdSpan<bool> auto success) const
+        {
+            auto const warpExtent = static_cast<std::int32_t>(onAcc::warp::getSize(acc));
+            warpCheck(success, warpExtent >= 1u);
+
+            auto const threadsPerBlock = static_cast<std::int32_t>(acc[alpaka::layer::thread].count().product());
+            warpCheck(success, threadsPerBlock % warpExtent == 0);
+
+            auto const lane = static_cast<std::int32_t>(onAcc::warp::getLaneIdx(acc));
+
+            // With zero offset, every lane should see the source literal unchanged.
+            warpCheck(success, onAcc::warp::shflDown(acc, 42, 0u) == 42);
+            // A zero-width shuffle leaves each lane's original value intact.
+            warpCheck(success, onAcc::warp::shflDown(acc, lane, 0u) == lane);
+            // Offset of one shifts values toward higher indices, clamping at the partition boundary.
+            // For example, lane 0 with offset 1 should see lane 1's value, lane 1 should see lane 2's value, and so
+            // on, with the last lane seeing its own value.
+            warpCheck(success, onAcc::warp::shflDown(acc, lane, 1u) == (lane + 1 < warpExtent ? lane + 1 : lane));
+
+            auto const epsilon = std::numeric_limits<float>::epsilon();
+            for(int width = 1; width < warpExtent; width *= 2)
+            {
+                // Validate every partition width the backend claims to support.
+                for(int idx = 0; idx < width; ++idx)
+                {
+                    auto const sectionStart = width * (lane / width);
+                    auto const sectionEnd = sectionStart + width;
+                    auto const shuffled = onAcc::warp::shflDown(
+                        acc,
+                        lane,
+                        static_cast<std::uint32_t>(idx),
+                        static_cast<std::uint32_t>(width));
+                    auto const expectedInt = (lane + idx < sectionEnd) ? lane + idx : lane;
+                    // Each lane should see the value from the lane at the offset below, or clamp to its own value if
+                    // out of range. For example, if lane 2 with offset 1 should see lane 3's value, but if lane 3 is
+                    // the last lane in the partition, it sees its own value.
+                    warpCheck(success, shuffled == expectedInt);
+
+                    auto const ans = onAcc::warp::shflDown(
+                        acc,
+                        4.0f - static_cast<float>(lane),
+                        static_cast<std::uint32_t>(idx),
+                        static_cast<std::uint32_t>(width));
+                    auto const expect = (lane + idx < sectionEnd) ? 4.0f - static_cast<float>(lane + idx)
+                                                                  : 4.0f - static_cast<float>(lane);
+                    warpCheck(success, alpaka::math::abs(ans - expect) < epsilon);
+                }
+            }
+
+            if(lane >= warpExtent / 2)
+            {
+                warpCheck(success, onAcc::warp::shflDown(acc, 42, 1u) == 42);
+                // Mask out the upper sub-group for the final spot checks.
+                return;
+            }
+            else
+            {
+                // warpCheck(success, onAcc::warp::shflDown(acc, 43, 1u) == 43);
+            }
+
+            for(int idx = 0; idx < warpExtent / 2; ++idx)
+            {
+                // Active lanes must march forward until the end of the logical sub-group.
+                auto const shuffled = onAcc::warp::shflDown(acc, lane, static_cast<std::uint32_t>(idx));
+                auto const ans
+                    = onAcc::warp::shflDown(acc, 4.0f - static_cast<float>(lane), static_cast<std::uint32_t>(idx));
+                auto const expectFloat = (lane + idx < warpExtent / 2) ? 4.0f - static_cast<float>(lane + idx) : 0.0f;
+
+                if(lane + idx < warpExtent / 2)
+                {
+                    // Each lane should see the value from the lane at the offset below within the active sub-group.
+                    // Example: lane 0 with offset 1 reads lane 1, lane 1 reads lane 2, etc., until the subgroup ends.
+                    warpCheck(success, shuffled == lane + idx);
+                    // Floating payload mirrors the integer expectation for the same in-range partner lane.
+                    warpCheck(success, alpaka::math::abs(ans - expectFloat) < epsilon);
+                }
+            }
+        }
+    };
+} // namespace
+
+TEMPLATE_LIST_TEST_CASE("warp shflDown shifts toward higher lanes", "[warp][shfl_down]", WarpTestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    if(!selector.isAvailable())
+    {
+        INFO("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    auto deviceProperties = selector.getDeviceProperties(0);
+    auto const warpExtent = deviceProperties.m_warpSize;
+
+    auto device = selector.makeDevice(0);
+    auto queue = device.makeQueue(queueKind::blocking);
+
+    auto successHost = onHost::allocHost<bool>(1u);
+    auto successDev = onHost::allocLike(device, successHost);
+
+    auto const blocks = Vec<std::uint32_t, 1u>{5u};
+    auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
+
+    onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
+    queue.enqueue(exec, onHost::FrameSpec{blocks, threads}, KernelBundle{ShflDownMultiThreadKernel{}, successDev});
+    onHost::memcpy(queue, successHost, successDev);
+    onHost::wait(queue);
+    INFO("backend=" << deviceSpec.getName());
+    CHECK(successHost[0]);
+}

--- a/tests/unit/warp/shfl_up.cpp
+++ b/tests/unit/warp/shfl_up.cpp
@@ -1,0 +1,131 @@
+/* Copyright 2025 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci, Aurora Perego, Mehmet
+ * Yusufoglu, René Widera SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file Tests the warp "shfl_up" (shuffle up) operation which shifts values toward lower-numbered lanes.
+ * The "shfl_up" warp operation allows each thread to read a value from a lane at a fixed offset above.
+ * It's a data exchange operation useful for suffix scans and reverse reduction patterns within a warp.
+ */
+
+#include "utils.hpp"
+
+#include <alpaka/onAcc/warp.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <limits>
+
+using namespace alpaka;
+using alpaka::test::warp::warpCheck;
+using alpaka::test::warp::WarpTestBackends;
+
+namespace
+{
+    struct ShflUpMultiThreadKernel
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(TAcc const& acc, concepts::MdSpan<bool> auto success) const
+        {
+            auto const warpExtent = static_cast<std::int32_t>(onAcc::warp::getSize(acc));
+            warpCheck(success, warpExtent >= 1);
+
+            auto const threadsPerBlock = static_cast<std::int32_t>(acc[alpaka::layer::thread].count().product());
+            warpCheck(success, threadsPerBlock % warpExtent == 0);
+
+            auto const lane = static_cast<std::int32_t>(onAcc::warp::getLaneIdx(acc));
+
+            // With zero offset, every lane should see the source literal unchanged.
+            warpCheck(success, onAcc::warp::shflUp(acc, 42, 0u) == 42);
+            // A zero-width shuffle leaves each lane's original value intact.
+            // For example, lane 2 with offset 0 should see lane 2's own value.
+            warpCheck(success, onAcc::warp::shflUp(acc, lane, 0u) == lane);
+            // Offset of one shifts values toward lower indices, clamping at the partition boundary.
+            // For example, lane 0 with offset 1 should see lane 0's own value, lane 1 should see lane 0's value, and
+            // so on.
+            warpCheck(success, onAcc::warp::shflUp(acc, lane, 1u) == (lane - 1 >= 0 ? lane - 1 : lane));
+
+            auto const epsilon = std::numeric_limits<float>::epsilon();
+            for(int width = 1; width < warpExtent; width *= 2)
+            {
+                // Exercise each logical partition width independently.
+                for(int idx = 0; idx < width; ++idx)
+                {
+                    auto const sectionStart = width * (lane / width);
+                    auto const shuffled = onAcc::warp::shflUp(
+                        acc,
+                        lane,
+                        static_cast<std::uint32_t>(idx),
+                        static_cast<std::uint32_t>(width));
+                    auto const expectedInt = (lane - idx >= sectionStart) ? lane - idx : lane;
+                    // Each lane should see the value from the lane at the offset above, or clamp to its own value if
+                    // out of range. For example, if lane 2 with offset 1 should see lane 1's value, but if lane 1 is
+                    // the first lane in the partition, it sees its own value
+                    warpCheck(success, shuffled == expectedInt);
+
+                    auto const ans = onAcc::warp::shflUp(
+                        acc,
+                        4.0f - static_cast<float>(lane),
+                        static_cast<std::uint32_t>(idx),
+                        static_cast<std::uint32_t>(width));
+                    auto const expect = (lane - idx >= sectionStart) ? 4.0f - static_cast<float>(lane - idx)
+                                                                     : 4.0f - static_cast<float>(lane);
+                    warpCheck(success, alpaka::math::abs(ans - expect) < epsilon);
+                }
+            }
+
+            if(lane >= warpExtent / 2)
+            {
+                // Suppress half the warp to emulate a masked collective.
+                return;
+            }
+
+            for(int idx = 0; idx < warpExtent / 2; ++idx)
+            {
+                // Remaining active lanes should shift values toward lower indices.
+                auto const shuffled = onAcc::warp::shflUp(acc, lane, static_cast<std::uint32_t>(idx));
+                auto const ans
+                    = onAcc::warp::shflUp(acc, 4.0f - static_cast<float>(lane), static_cast<std::uint32_t>(idx));
+                auto const expect
+                    = (lane - idx >= 0) ? 4.0f - static_cast<float>(lane - idx) : 4.0f - static_cast<float>(lane);
+                // Each lane should see the value from the lane at the offset above within the active sub-group.
+                warpCheck(success, shuffled == (lane - idx >= 0 ? lane - idx : lane));
+                warpCheck(success, alpaka::math::abs(ans - expect) < epsilon);
+            }
+        }
+    };
+} // namespace
+
+TEMPLATE_LIST_TEST_CASE("warp shflUp shifts toward lower lanes", "[warp][shfl_up]", WarpTestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    if(!selector.isAvailable())
+    {
+        INFO("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    auto deviceProperties = selector.getDeviceProperties(0);
+    auto const warpExtent = deviceProperties.m_warpSize;
+
+    auto device = selector.makeDevice(0);
+    auto queue = device.makeQueue(queueKind::blocking);
+
+    auto successHost = onHost::allocHost<bool>(1u);
+    auto successDev = onHost::allocLike(device, successHost);
+
+    auto const blocks = Vec<std::uint32_t, 1u>{5u};
+    auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
+
+    onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
+    queue.enqueue(exec, onHost::FrameSpec{blocks, threads}, KernelBundle{ShflUpMultiThreadKernel{}, successDev});
+    onHost::memcpy(queue, successHost, successDev);
+    onHost::wait(queue);
+    INFO("backend=" << deviceSpec.getName());
+    CHECK(successHost[0]);
+}

--- a/tests/unit/warp/shfl_xor.cpp
+++ b/tests/unit/warp/shfl_xor.cpp
@@ -1,0 +1,129 @@
+/* Copyright 2025 Mehmet Yusufoglu
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file Tests the warp "shfl_xor" (shuffle XOR) operation which exchanges values according to XOR-based lane pairing.
+ * The "shfl_xor" warp operation allows each thread to read from a lane whose ID is the XOR of its own ID with a mask.
+ * It's a data exchange operation commonly used in butterfly reduction and FFT-like parallel algorithms.
+ */
+
+#include "utils.hpp"
+
+#include <alpaka/onAcc/warp.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <limits>
+
+using namespace alpaka;
+using alpaka::test::warp::warpCheck;
+using alpaka::test::warp::WarpTestBackends;
+
+namespace
+{
+    struct ShflXorMultiThreadKernel
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(TAcc const& acc, concepts::MdSpan<bool> auto success) const
+        {
+            auto const warpExtent = static_cast<std::int32_t>(onAcc::warp::getSize(acc));
+            warpCheck(success, warpExtent >= 1);
+
+            auto const threadsPerBlock = static_cast<std::int32_t>(acc[alpaka::layer::thread].count().product());
+            warpCheck(success, threadsPerBlock % warpExtent == 0);
+
+            auto const lane = static_cast<std::int32_t>(onAcc::warp::getLaneIdx(acc));
+            // Exercise trivial zero-offset and max-offset cases.
+            // For zero offset, each lane should see its own value.
+            warpCheck(success, onAcc::warp::shflXor(acc, 42, 0u) == 42);
+            // For zero offset, each lane should see its own value.
+            warpCheck(success, onAcc::warp::shflXor(acc, lane, 0u) == lane);
+
+            // For offset one, each lane should xor with 1 to find its partner.
+            // For example, lane 0 with offset 1 should see lane 1's value, lane 1 should see lane 0's value, and so
+            // on.
+            auto shuffleOneMaskResult = onAcc::warp::shflXor(acc, lane, 1u);
+            warpCheck(
+                success,
+                shuffleOneMaskResult == (lane ^ 1) || (warpExtent == 1 && shuffleOneMaskResult == lane));
+
+            // Max offset should behave like zero offset since no lanes exist beyond the warp size.
+            // For example, lane 2 with max offset should see lane 2's own value.
+            warpCheck(success, onAcc::warp::shflXor(acc, 5, std::numeric_limits<std::uint32_t>::max()) == 5);
+
+            auto const epsilon = std::numeric_limits<float>::epsilon();
+            for(int width = 1; width < warpExtent; width *= 2)
+            {
+                // Test every xor distance inside the advertised subgroup width.
+                for(int idx = 0; idx < width; ++idx)
+                {
+                    auto const shuffled = onAcc::warp::shflXor(
+                        acc,
+                        lane,
+                        static_cast<std::uint32_t>(idx),
+                        static_cast<std::uint32_t>(width));
+                    warpCheck(success, shuffled == (lane ^ idx));
+
+                    auto const ans = onAcc::warp::shflXor(
+                        acc,
+                        4.0f - static_cast<float>(lane),
+                        static_cast<std::uint32_t>(idx),
+                        static_cast<std::uint32_t>(width));
+                    auto const expect = 4.0f - static_cast<float>(lane ^ idx);
+                    warpCheck(success, alpaka::math::abs(ans - expect) < epsilon);
+                }
+            }
+
+            if(lane >= warpExtent / 2)
+            {
+                // Deactivate the upper half to probe masked partners.
+                return;
+            }
+
+            for(int idx = 0; idx < warpExtent / 2; ++idx)
+            {
+                // Remaining lanes must xor-pair with the expected partner.
+                warpCheck(success, onAcc::warp::shflXor(acc, lane, static_cast<std::uint32_t>(idx)) == (lane ^ idx));
+                auto const ans
+                    = onAcc::warp::shflXor(acc, 4.0f - static_cast<float>(lane), static_cast<std::uint32_t>(idx));
+                auto const expect = 4.0f - static_cast<float>(lane ^ idx);
+                warpCheck(success, alpaka::math::abs(ans - expect) < epsilon);
+            }
+        }
+    };
+} // namespace
+
+TEMPLATE_LIST_TEST_CASE("warp shflXor exchanges partner lanes", "[warp][shfl_xor]", WarpTestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    if(!selector.isAvailable())
+    {
+        INFO("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    auto deviceProperties = selector.getDeviceProperties(0);
+    auto const warpExtent = deviceProperties.m_warpSize;
+
+    auto device = selector.makeDevice(0);
+    auto queue = device.makeQueue(queueKind::blocking);
+
+    auto successHost = onHost::allocHost<bool>(1u);
+    auto successDev = onHost::allocLike(device, successHost);
+
+    auto const blocks = Vec<std::uint32_t, 1u>{5u};
+    auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
+
+    onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
+    queue.enqueue(exec, onHost::FrameSpec{blocks, threads}, KernelBundle{ShflXorMultiThreadKernel{}, successDev});
+    onHost::memcpy(queue, successHost, successDev);
+    onHost::wait(queue);
+    INFO("backend=" << deviceSpec.getName());
+    CHECK(successHost[0]);
+}

--- a/tests/unit/warp/utils.hpp
+++ b/tests/unit/warp/utils.hpp
@@ -1,0 +1,66 @@
+/* Copyright 2025 Mehmet Yusufoglu
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/onHost/example/executors.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+namespace alpaka::test::warp
+{
+    using WarpTestBackends
+        = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+
+    template<typename SuccessView>
+    // Marks the shared success flag false when a lane detects a failure without aborting execution.
+    constexpr void warpCheck(SuccessView success, bool condition)
+    {
+        if(!condition)
+        {
+            // Trip the shared success flag without aborting the kernel.
+            success[0u] = false;
+        }
+    }
+
+    // Builds a mask with all lanes active for the provided warp size.
+    constexpr std::uint64_t fullMask(std::uint32_t warpSize)
+    {
+        if(warpSize == 0u)
+        {
+            return 0u;
+        }
+        if(warpSize >= 64u)
+        {
+            return std::numeric_limits<std::uint64_t>::max();
+        }
+        return (std::uint64_t{1} << warpSize) - 1u;
+    }
+
+    // Produces a mask that enables every even-numbered lane up to the warp size.
+    constexpr std::uint64_t evenMask(std::uint32_t warpSize)
+    {
+        auto const limit = warpSize < 64u ? warpSize : 64u;
+        std::uint64_t mask = 0u;
+        for(std::uint32_t lane = 0u; lane < limit; lane += 2u)
+        {
+            // Populate only even-numbered lanes to model a checkerboard mask.
+            mask |= (std::uint64_t{1} << lane);
+        }
+        return mask;
+    }
+
+    // Returns a mask with only the requested lane bit set if it fits within 64 lanes.
+    constexpr std::uint64_t singleBit(std::uint32_t lane)
+    {
+        if(lane >= 64u)
+        {
+            return 0u;
+        }
+        return std::uint64_t{1} << lane;
+    }
+} // namespace alpaka::test::warp


### PR DESCRIPTION
- provide warp function for all backends
- add tests
- add doxygen documentation

Compared to mainline alpaka voting function  like `any`, `all` returning `bool`.
The warp size and lane index is a unisgned 32bit integral value.

This PR based on #339, it removed special handling of executors using a single thread per block and applied many cleanups to keep the PR small.

All implementations are tested with CUDA 12.5, HIP 6.2 and OneApi 2025.2 (CUDA 12.6, HIP 6.3.4 - for Intel GPU, CPU, AMD GPU/gfx1100 and NVIDIA A40)