### PR TITLE
Added  IEEE isnan/isinf/isfinite helper and wire CUDA/HIP/SYCL to it.

### DIFF
--- a/include/alpaka/api/generic.hpp
+++ b/include/alpaka/api/generic.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 René Widera
+/* Copyright 2025 René Widera, Mehmet Yusufoglu
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "alpaka/internal/interface.hpp"
+#include "alpaka/math/internal/ieee754.hpp"
 #include "alpaka/onAcc/SimdAlgo.hpp"
 #include "alpaka/onAcc/interface.hpp"
 #include "alpaka/onHost/FrameSpec.hpp"
@@ -16,6 +17,27 @@
 
 namespace alpaka::internal::generic
 {
+    namespace math
+    {
+        template<typename T>
+        ALPAKA_FN_HOST_ACC constexpr bool isnan(T const& value)
+        {
+            return alpaka::math::internal::ieeeIsnan(value);
+        }
+
+        template<typename T>
+        ALPAKA_FN_HOST_ACC constexpr bool isinf(T const& value)
+        {
+            return alpaka::math::internal::ieeeIsinf(value);
+        }
+
+        template<typename T>
+        ALPAKA_FN_HOST_ACC constexpr bool isfinite(T const& value)
+        {
+            return alpaka::math::internal::ieeeIsfinite(value);
+        }
+    } // namespace math
+
     /** assign a value to each element of the destination
      *
      * @todo replace the kernel as soon as we have an algorithm forEach callable from host

--- a/include/alpaka/api/syclGeneric/math.hpp
+++ b/include/alpaka/api/syclGeneric/math.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2023 Axel Huebl, Benjamin Worpitz, Matthias Werner, Bert Wesarg, Valentin Gehrke, René Widera,
- * Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Jeffrey Kelling, Sergei Bastrakov
+ * Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Jeffrey Kelling, Sergei Bastrakov, Mehmet Yusufoglu
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -10,6 +10,7 @@
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/math/Complex.hpp"
+#include "alpaka/math/internal/ieee754.hpp"
 #include "alpaka/math/internal/math.hpp"
 
 #if ALPAKA_LANG_SYCL
@@ -319,12 +320,13 @@ namespace alpaka::math::internal
         }
     };
 
+    // Route SYCL predicates through shared helper to match host/CUDA semantics exactly.
     template<std::floating_point T_Arg>
     struct Isnan::Op<SyclMath, T_Arg>
     {
         constexpr auto operator()(SyclMath, T_Arg const& arg) const
         {
-            return static_cast<bool>(sycl::isnan(arg));
+            return ieeeIsnan(arg);
         }
     };
 
@@ -333,7 +335,7 @@ namespace alpaka::math::internal
     {
         constexpr auto operator()(SyclMath, T_Arg const& arg) const
         {
-            return static_cast<bool>(sycl::isinf(arg));
+            return ieeeIsinf(arg);
         }
     };
 
@@ -342,7 +344,7 @@ namespace alpaka::math::internal
     {
         constexpr auto operator()(SyclMath, T_Arg const& arg) const
         {
-            return static_cast<bool>(sycl::isfinite(arg));
+            return ieeeIsfinite(arg);
         }
     };
 

--- a/include/alpaka/api/unifiedCudaHip/math.hpp
+++ b/include/alpaka/api/unifiedCudaHip/math.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2023 Axel Huebl, Benjamin Worpitz, Matthias Werner, Bert Wesarg, Valentin Gehrke, René Widera,
- * Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Jeffrey Kelling, Sergei Bastrakov
+ * Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Jeffrey Kelling, Sergei Bastrakov, Mehmet Yusufoglu
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -11,6 +11,7 @@
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/decay.hpp"
 #include "alpaka/math/Complex.hpp"
+#include "alpaka/math/internal/ieee754.hpp"
 #include "alpaka/math/internal/math.hpp"
 
 #include <cmath>
@@ -502,19 +503,13 @@ namespace alpaka::math::internal
         }
     };
 
+    // Shared helper keeps CUDA/HIP IEEE predicates aligned with host behavior under fast-math.
     template<std::floating_point T_Arg>
     struct Isnan::Op<CudaHipMath, T_Arg>
     {
         constexpr auto operator()(CudaHipMath, T_Arg const& arg) const
         {
-            if constexpr(is_decayed_v<T_Arg, float> || is_decayed_v<T_Arg, double>)
-            {
-                return ::isnan(arg);
-            }
-            else
-                static_assert(!sizeof(T_Arg), "Unsupported data type");
-
-            ALPAKA_UNREACHABLE(T_Arg{});
+            return ieeeIsnan(arg);
         }
     };
 
@@ -523,7 +518,7 @@ namespace alpaka::math::internal
     {
         constexpr auto operator()(CudaHipMath, T_Arg const& arg) const
         {
-            return ::isinf(arg);
+            return ieeeIsinf(arg);
         }
     };
 
@@ -532,7 +527,7 @@ namespace alpaka::math::internal
     {
         constexpr auto operator()(CudaHipMath, T_Arg const& arg) const
         {
-            return ::isfinite(arg);
+            return ieeeIsfinite(arg);
         }
     };
 

--- a/include/alpaka/math/internal/ieee754.hpp
+++ b/include/alpaka/math/internal/ieee754.hpp
@@ -1,0 +1,91 @@
+/* Copyright 2025 Mehmet Yusufoglu, Andrea Bocci, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/Unreachable.hpp"
+
+#include <bit>
+#include <cstdint>
+#include <type_traits>
+
+namespace alpaka::math::internal
+{
+    namespace detail
+    {
+        template<typename T>
+        inline constexpr bool is_supported_ieee_v = std::is_same_v<T, float> || std::is_same_v<T, double>;
+
+        template<typename T>
+        ALPAKA_FN_HOST_ACC constexpr void assert_supported_type()
+        {
+            static_assert(is_supported_ieee_v<T>, "Unsupported floating-point type");
+        }
+    } // namespace detail
+
+    // Bit pattern checks keep isnan portable across host/device and fast-math builds.
+    template<typename T>
+    ALPAKA_FN_HOST_ACC constexpr bool ieeeIsnan(T const& arg)
+    {
+        detail::assert_supported_type<T>();
+        if constexpr(std::is_same_v<T, float>)
+        {
+            constexpr std::uint32_t expMask = 0x7F80'0000;
+            constexpr std::uint32_t fracMask = 0x007F'FFFF;
+            auto bits = std::bit_cast<std::uint32_t>(arg);
+            return ((bits & expMask) == expMask) && (bits & fracMask);
+        }
+        else if constexpr(std::is_same_v<T, double>)
+        {
+            constexpr std::uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
+            constexpr std::uint64_t fracMask = 0x000F'FFFF'FFFF'FFFFULL;
+            auto bits = std::bit_cast<std::uint64_t>(arg);
+            return ((bits & expMask) == expMask) && (bits & fracMask);
+        }
+
+        ALPAKA_UNREACHABLE(T{});
+    }
+
+    template<typename T>
+    ALPAKA_FN_HOST_ACC constexpr bool ieeeIsinf(T const& arg)
+    {
+        detail::assert_supported_type<T>();
+        if constexpr(std::is_same_v<T, float>)
+        {
+            constexpr std::uint32_t expMask = 0x7F80'0000;
+            constexpr std::uint32_t fracMask = 0x007F'FFFF;
+            auto bits = std::bit_cast<std::uint32_t>(arg);
+            return ((bits & expMask) == expMask) && !(bits & fracMask);
+        }
+        else if constexpr(std::is_same_v<T, double>)
+        {
+            constexpr std::uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
+            constexpr std::uint64_t fracMask = 0x000F'FFFF'FFFF'FFFFULL;
+            auto bits = std::bit_cast<std::uint64_t>(arg);
+            return ((bits & expMask) == expMask) && !(bits & fracMask);
+        }
+
+        ALPAKA_UNREACHABLE(T{});
+    }
+
+    template<typename T>
+    ALPAKA_FN_HOST_ACC constexpr bool ieeeIsfinite(T const& arg)
+    {
+        detail::assert_supported_type<T>();
+        if constexpr(std::is_same_v<T, float>)
+        {
+            constexpr std::uint32_t expMask = 0x7F80'0000;
+            auto bits = std::bit_cast<std::uint32_t>(arg);
+            return (bits & expMask) != expMask;
+        }
+        else if constexpr(std::is_same_v<T, double>)
+        {
+            constexpr std::uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
+            auto bits = std::bit_cast<std::uint64_t>(arg);
+            return (bits & expMask) != expMask;
+        }
+
+        ALPAKA_UNREACHABLE(T{});
+    }
+} // namespace alpaka::math::internal

--- a/include/alpaka/math/internal/ieee754.hpp
+++ b/include/alpaka/math/internal/ieee754.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/core/Unreachable.hpp"
+#include "alpaka/core/common.hpp"
 
 #include <bit>
 #include <cstdint>

--- a/include/alpaka/math/internal/ieee754.hpp
+++ b/include/alpaka/math/internal/ieee754.hpp
@@ -13,77 +13,69 @@
 
 namespace alpaka::math::internal
 {
-    namespace detail
+    namespace concepts
     {
+        /** Checks for single and double floating point precision */
         template<typename T>
-        inline constexpr bool is_supported_ieee_v = std::is_same_v<T, float> || std::is_same_v<T, double>;
-
-        template<typename T>
-        ALPAKA_FN_HOST_ACC constexpr void assert_supported_type()
-        {
-            static_assert(is_supported_ieee_v<T>, "Unsupported floating-point type");
-        }
-    } // namespace detail
+        concept FloatingPoint = std::is_same_v<T, float> || std::is_same_v<T, double>;
+    } // namespace concepts
 
     // Bit pattern checks keep isnan portable across host/device and fast-math builds.
-    template<typename T>
-    ALPAKA_FN_HOST_ACC constexpr bool ieeeIsnan(T const& arg)
+    template<concepts::FloatingPoint T>
+    constexpr bool ieeeIsnan(T const& arg)
     {
-        detail::assert_supported_type<T>();
         if constexpr(std::is_same_v<T, float>)
         {
-            constexpr std::uint32_t expMask = 0x7F80'0000;
-            constexpr std::uint32_t fracMask = 0x007F'FFFF;
-            auto bits = std::bit_cast<std::uint32_t>(arg);
+            constexpr uint32_t expMask = 0x7F80'0000;
+            constexpr uint32_t fracMask = 0x007F'FFFF;
+            auto bits = std::bit_cast<uint32_t>(arg);
             return ((bits & expMask) == expMask) && (bits & fracMask);
         }
         else if constexpr(std::is_same_v<T, double>)
         {
-            constexpr std::uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
-            constexpr std::uint64_t fracMask = 0x000F'FFFF'FFFF'FFFFULL;
-            auto bits = std::bit_cast<std::uint64_t>(arg);
+            constexpr uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
+            constexpr uint64_t fracMask = 0x000F'FFFF'FFFF'FFFFULL;
+            auto bits = std::bit_cast<uint64_t>(arg);
             return ((bits & expMask) == expMask) && (bits & fracMask);
         }
 
         ALPAKA_UNREACHABLE(T{});
     }
 
-    template<typename T>
-    ALPAKA_FN_HOST_ACC constexpr bool ieeeIsinf(T const& arg)
+    template<concepts::FloatingPoint T>
+    constexpr bool ieeeIsinf(T const& arg)
     {
-        detail::assert_supported_type<T>();
         if constexpr(std::is_same_v<T, float>)
         {
-            constexpr std::uint32_t expMask = 0x7F80'0000;
-            constexpr std::uint32_t fracMask = 0x007F'FFFF;
-            auto bits = std::bit_cast<std::uint32_t>(arg);
+            constexpr uint32_t expMask = 0x7F80'0000;
+            constexpr uint32_t fracMask = 0x007F'FFFF;
+            auto bits = std::bit_cast<uint32_t>(arg);
             return ((bits & expMask) == expMask) && !(bits & fracMask);
         }
         else if constexpr(std::is_same_v<T, double>)
         {
-            constexpr std::uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
-            constexpr std::uint64_t fracMask = 0x000F'FFFF'FFFF'FFFFULL;
-            auto bits = std::bit_cast<std::uint64_t>(arg);
+            constexpr uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
+            constexpr uint64_t fracMask = 0x000F'FFFF'FFFF'FFFFULL;
+            auto bits = std::bit_cast<uint64_t>(arg);
             return ((bits & expMask) == expMask) && !(bits & fracMask);
         }
 
         ALPAKA_UNREACHABLE(T{});
     }
 
-    template<typename T>
-    ALPAKA_FN_HOST_ACC constexpr bool ieeeIsfinite(T const& arg)
+    template<concepts::FloatingPoint T>
+    constexpr bool ieeeIsfinite(T const& arg)
     {
-        detail::assert_supported_type<T>();
         if constexpr(std::is_same_v<T, float>)
         {
-            constexpr std::uint32_t expMask = 0x7F80'0000;
-            auto bits = std::bit_cast<std::uint32_t>(arg);
+            constexpr uint32_t expMask = 0x7F80'0000;
+            auto bits = std::bit_cast<uint32_t>(arg);
             return (bits & expMask) != expMask;
         }
         else if constexpr(std::is_same_v<T, double>)
         {
-            constexpr std::uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
-            auto bits = std::bit_cast<std::uint64_t>(arg);
+            constexpr uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
+            auto bits = std::bit_cast<uint64_t>(arg);
             return (bits & expMask) != expMask;
         }
 

--- a/include/alpaka/math/internal/stlMathImpl.hpp
+++ b/include/alpaka/math/internal/stlMathImpl.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2023 Alexander Matthes, Axel Huebl, Benjamin Worpitz, Matthias Werner, Bernhard Manfred Gruber,
- * Jeffrey Kelling, Sergei Bastrakov, Andrea Bocci, René Widera
+ * Jeffrey Kelling, Sergei Bastrakov, Andrea Bocci, René Widera, Mehmet Yusufoglu
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -10,12 +10,11 @@
 
 #include "alpaka/core/Unreachable.hpp"
 #include "alpaka/core/decay.hpp"
+#include "alpaka/math/internal/ieee754.hpp"
 #include "alpaka/math/internal/math.hpp"
 #include "alpaka/math/internal/stlMath.hpp"
 
-#include <bit>
 #include <cmath>
-#include <cstdint>
 #include <type_traits>
 
 namespace alpaka::math::internal
@@ -77,27 +76,7 @@ namespace alpaka::math::internal
     {
         constexpr auto operator()(StlMath, T_Arg const& arg) const -> bool
         {
-            if constexpr(std::is_same_v<T_Arg, float>)
-            {
-                constexpr uint32_t expMask = 0x7F80'0000;
-                constexpr uint32_t fracMask = 0x007F'FFFF;
-                uint32_t bits = std::bit_cast<uint32_t>(arg);
-                bool result = ((bits & expMask) == expMask) && (bits & fracMask);
-                return result;
-            }
-            else if constexpr(std::is_same_v<T_Arg, double>)
-            {
-                constexpr uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
-                constexpr uint64_t fracMask = 0x000F'FFFF'FFFF'FFFFULL;
-                uint64_t bits = std::bit_cast<uint64_t>(arg);
-                bool result = ((bits & expMask) == expMask) && (bits & fracMask);
-                return result;
-            }
-            else
-            {
-                static_assert(!sizeof(T_Arg), "Unsupported floating-point type");
-                ALPAKA_UNREACHABLE(T_Arg{});
-            }
+            return ieeeIsnan(arg);
         }
     };
 
@@ -108,27 +87,7 @@ namespace alpaka::math::internal
     {
         constexpr auto operator()(StlMath, T_Arg const& arg) const -> bool
         {
-            if constexpr(std::is_same_v<T_Arg, float>)
-            {
-                constexpr uint32_t expMask = 0x7F80'0000;
-                constexpr uint32_t fracMask = 0x007F'FFFF;
-                uint32_t bits = std::bit_cast<uint32_t>(arg);
-                bool result = ((bits & expMask) == expMask) && !(bits & fracMask);
-                return result;
-            }
-            else if constexpr(std::is_same_v<T_Arg, double>)
-            {
-                constexpr uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
-                constexpr uint64_t fracMask = 0x000F'FFFF'FFFF'FFFFULL;
-                uint64_t bits = std::bit_cast<uint64_t>(arg);
-                bool result = ((bits & expMask) == expMask) && !(bits & fracMask);
-                return result;
-            }
-            else
-            {
-                static_assert(!sizeof(T_Arg), "Unsupported floating-point type");
-                ALPAKA_UNREACHABLE(T_Arg{});
-            }
+            return ieeeIsinf(arg);
         }
     };
 
@@ -139,25 +98,7 @@ namespace alpaka::math::internal
     {
         constexpr auto operator()(StlMath, T_Arg const& arg) const -> bool
         {
-            if constexpr(std::is_same_v<T_Arg, float>)
-            {
-                constexpr uint32_t expMask = 0x7F80'0000;
-                uint32_t bits = std::bit_cast<uint32_t>(arg);
-                bool result = (bits & expMask) != expMask;
-                return result;
-            }
-            else if constexpr(std::is_same_v<T_Arg, double>)
-            {
-                constexpr uint64_t expMask = 0x7FF0'0000'0000'0000ULL;
-                uint64_t bits = std::bit_cast<uint64_t>(arg);
-                bool result = (bits & expMask) != expMask;
-                return result;
-            }
-            else
-            {
-                static_assert(!sizeof(T_Arg), "Unsupported floating-point type");
-                ALPAKA_UNREACHABLE(T_Arg{});
-            }
+            return ieeeIsfinite(arg);
         }
     };
 

--- a/tests/unit/math/isSpecialIEEE.cpp
+++ b/tests/unit/math/isSpecialIEEE.cpp
@@ -1,0 +1,46 @@
+/* Copyright 2025 René Widera, Mehmet Yusufoglu, Andrea Bocci
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include "alpaka/api/generic.hpp"
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <limits>
+
+template<typename T>
+static void verifyIsSpecial()
+{
+    namespace generic_math = alpaka::internal::generic::math;
+
+    auto const quietNaN = std::numeric_limits<T>::quiet_NaN();
+    auto const posInf = std::numeric_limits<T>::infinity();
+    auto const negInf = -posInf;
+    auto const finiteVal = static_cast<T>(42.5);
+
+    CHECK(generic_math::isnan(quietNaN));
+    CHECK_FALSE(generic_math::isnan(finiteVal));
+
+    if constexpr(std::numeric_limits<T>::has_signaling_NaN)
+    {
+        auto const signalingNaN = std::numeric_limits<T>::signaling_NaN();
+        CHECK(generic_math::isnan(signalingNaN));
+    }
+
+    CHECK(generic_math::isinf(posInf));
+    CHECK(generic_math::isinf(negInf));
+    CHECK_FALSE(generic_math::isinf(finiteVal));
+
+    CHECK(generic_math::isfinite(finiteVal));
+    CHECK(generic_math::isfinite(static_cast<T>(0)));
+    CHECK_FALSE(generic_math::isfinite(posInf));
+    CHECK_FALSE(generic_math::isfinite(negInf));
+    CHECK_FALSE(generic_math::isfinite(quietNaN));
+}
+
+// Regression guard to ensure ieee helper stays stable for each floating type.
+TEMPLATE_TEST_CASE("generic ieee helpers detect special values", "[math][generic][ieee]", float, double)
+{
+    verifyIsSpecial<TestType>();
+}


### PR DESCRIPTION
A new file (include/alpaka/math/internal/ieee754.hpp) is added, since as far as i see the device-side headers do not include generic.hpp; because generic.hpp file includes in many host-only helpers (logging, FrameSpec, MdSpan infrastructure).  A small` ieee754.hpp` keeps the IEEE helpers safe to include everywhere while `generic.hpp` just re-exports them for host callers.

The old IEEE style isNan, isInf .. code was only in` stlMathImpl.hpp`, so CUDA/HIP and SYCL could not reuse it and each backend needed a separate copy. By moving that logic into ieee754.hpp, every backend now includes one shared helper, which keeps behavior consistent and easier to maintain.