### PR TITLE
fix using alpaka via CMake FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ install(
 )
 
 configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/alpakaConfig.cmake.in
+    ${_alpaka_ROOT_DIR}/cmake/alpakaConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/alpakaConfig.cmake
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/alpaka
 )
@@ -90,3 +90,11 @@ install(DIRECTORY ${_alpaka_TESTING_DIR} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR
 
 # File is required to validate the C++20 feature std::atomic_ref
 install(FILES "${_alpaka_FEATURE_TESTS_DIR}/StdAtomicRef.cpp" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/alpaka/tests)
+
+# Load alpaka's languages after FetchContent_MakeAvailable()
+#
+# This macro must be called after FetchContent_MakeAvailable() used to load alpaka.
+# The reason is that this is the only way in CMake allowing alpaka to load the required languages.
+macro(alpaka_FetchContent_Finalize)
+    include("${alpaka_SOURCE_DIR}/cmake/alpakaFetchContentFinalize.cmake")
+endmacro()

--- a/cmake/alpakaFetchContentFinalize.cmake
+++ b/cmake/alpakaFetchContentFinalize.cmake
@@ -1,0 +1,21 @@
+#
+# Copyright 2025 René Widera
+# SPDX-License-Identifier: MPL-2.0
+#
+
+# @file This file simply load alpakaCommon.cmake after alpaka is installed with FetchContent.
+# The reason is that languages bust be set in the configure setup of CMake.
+# Calling FetchContent_MakeAvailable() is not enough therefore this file must be loaded.
+# alpaka's CMakeLists.txt is providing a helper alpaka_FetchContent_Finalize() to load this cmake files.
+
+# alpaka root directory provided after FetchContent_MakeAvailable() was called.
+set(_alpaka_ROOT_DIR "${alpaka_SOURCE_DIR}")
+
+# Compiler feature tests.
+set(_alpaka_FEATURE_TESTS_DIR "${_alpaka_ROOT_DIR}/cmake/tests")
+set(_alpaka_CMAKE_DIR "${_alpaka_ROOT_DIR}/cmake")
+set(_alpaka_TESTING_DIR "${_alpaka_ROOT_DIR}/tests")
+# Set include directories
+set(_alpaka_INCLUDE_DIRECTORY "${_alpaka_ROOT_DIR}/include")
+
+include("${_alpaka_CMAKE_DIR}/alpakaCommon.cmake")

--- a/docs/snippets/fetchContent/CMakeLists.txt
+++ b/docs/snippets/fetchContent/CMakeLists.txt
@@ -17,6 +17,10 @@ FetchContent_Declare(alpaka3 GIT_REPOSITORY https://github.com/alpaka-group/alpa
 # Make alpaka3 available for use in this project
 # This downloads, configures, and makes the library targets available
 FetchContent_MakeAvailable(alpaka3)
+# Finalize the alpaka FetchContent setup
+# this call is currently disabled because it the dev branch first needs the definition alpaka_FetchContent_Finalize()
+# this call will be enabled after the current PR is merged.
+#alpaka_FetchContent_Finalize()
 
 # Define the device specification for your application
 # Format: "api:deviceKind" where:


### PR DESCRIPTION
When FetchContent is used, it is not possible to set the languages within the target. The reason is that the language must be set in the top-level domain during the CMake configure time.

To add support for using alpaka with FetchContent, a helper macro is required.

Note: I have not found anything via Google that describes how you can enable languages within a library when using CMake FetchContent; therefore, I came up with my own solution. 
I was not able to integrate this into `alpaka_finalize()` or push this to `FetchContent`, therefore the user is required to perform an additional call.