### PR TITLE
fix fetch content example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,6 @@ install(FILES "${_alpaka_FEATURE_TESTS_DIR}/StdAtomicRef.cpp" DESTINATION ${CMAK
 #
 # This macro must be called after FetchContent_MakeAvailable() used to load alpaka.
 # The reason is that this is the only way in CMake allowing alpaka to load the required languages.
-macro(alpaka_FetchContent_Finalize)
+macro(alpaka_fetchcontent_finalize)
     include("${alpaka_SOURCE_DIR}/cmake/alpakaFetchContentFinalize.cmake")
 endmacro()

--- a/docs/snippets/fetchContent/CMakeLists.txt
+++ b/docs/snippets/fetchContent/CMakeLists.txt
@@ -17,10 +17,8 @@ FetchContent_Declare(alpaka3 GIT_REPOSITORY https://github.com/alpaka-group/alpa
 # Make alpaka3 available for use in this project
 # This downloads, configures, and makes the library targets available
 FetchContent_MakeAvailable(alpaka3)
-# Finalize the alpaka FetchContent setup
-# this call is currently disabled because it the dev branch first needs the definition alpaka_FetchContent_Finalize()
-# this call will be enabled after the current PR is merged.
-#alpaka_FetchContent_Finalize()
+# Finalize the alpaka FetchContent setup and activate the required CMake languages
+alpaka_fetchcontent_finalize()
 
 # Define the device specification for your application
 # Format: "api:deviceKind" where:


### PR DESCRIPTION
- activate `alpaka_fetchcontent_finalize()`

Since pre-commit is changing our call `alpaka_fetchcontent_finalize()` to lower case letters I renamed the macro to.
CMake macros are not case sensitive, therefore all will work before the renamed macro is in the dev branch.