### PR TITLE
Allow execution of atomic functions as non-atomic within specialized …

### DIFF
--- a/include/alpaka/api/cuda/executor.hpp
+++ b/include/alpaka/api/cuda/executor.hpp
@@ -36,10 +36,10 @@ namespace alpaka
 
 namespace alpaka::onAcc::trait
 {
-    template<>
-    struct GetAtomicImpl::Op<alpaka::exec::GpuCuda>
+    template<typename T_AtomicScope>
+    struct GetAtomicImpl::Op<alpaka::exec::GpuCuda, T_AtomicScope>
     {
-        constexpr decltype(auto) operator()(alpaka::exec::GpuCuda const) const
+        constexpr decltype(auto) operator()(alpaka::exec::GpuCuda const, T_AtomicScope const) const
         {
             return internal::cudaHipAtomic;
         }

--- a/include/alpaka/api/hip/executor.hpp
+++ b/include/alpaka/api/hip/executor.hpp
@@ -36,10 +36,10 @@ namespace alpaka
 
 namespace alpaka::onAcc::trait
 {
-    template<>
-    struct GetAtomicImpl::Op<alpaka::exec::GpuHip>
+    template<typename T_AtomicScope>
+    struct GetAtomicImpl::Op<alpaka::exec::GpuHip, T_AtomicScope>
     {
-        constexpr decltype(auto) operator()(alpaka::exec::GpuHip const) const
+        constexpr decltype(auto) operator()(alpaka::exec::GpuHip const, T_AtomicScope const) const
         {
             return internal::cudaHipAtomic;
         }

--- a/include/alpaka/api/host/executor.hpp
+++ b/include/alpaka/api/host/executor.hpp
@@ -6,6 +6,8 @@
 
 #include "alpaka/api/host/tag.hpp"
 #include "alpaka/api/trait.hpp"
+#include "alpaka/onAcc/internal/atomic.hpp"
+#include "alpaka/onAcc/scope.hpp"
 #include "alpaka/tag.hpp"
 
 #include <string>
@@ -85,30 +87,57 @@ namespace alpaka
 
 namespace alpaka::onAcc::trait
 {
-    template<>
-    struct GetAtomicImpl::Op<alpaka::exec::CpuSerial>
+    template<typename T_AtomicScope>
+    struct GetAtomicImpl::Op<alpaka::exec::CpuSerial, T_AtomicScope>
     {
-        constexpr decltype(auto) operator()(alpaka::exec::CpuSerial const) const
+        constexpr decltype(auto) operator()(alpaka::exec::CpuSerial const, T_AtomicScope const) const
         {
             return alpaka::onAcc::internal::stlAtomic;
         }
     };
 
     template<>
-    struct GetAtomicImpl::Op<alpaka::exec::CpuOmpBlocks>
+    struct GetAtomicImpl::Op<alpaka::exec::CpuSerial, onAcc::scope::Block>
     {
-        constexpr decltype(auto) operator()(alpaka::exec::CpuOmpBlocks const) const
+        constexpr decltype(auto) operator()(alpaka::exec::CpuSerial const, onAcc::scope::Block const) const
+        {
+            return alpaka::onAcc::internal::nonAtomic;
+        }
+    };
+
+    template<typename T_AtomicScope>
+    struct GetAtomicImpl::Op<alpaka::exec::CpuOmpBlocks, T_AtomicScope>
+    {
+        constexpr decltype(auto) operator()(alpaka::exec::CpuOmpBlocks const, T_AtomicScope const) const
         {
             return alpaka::onAcc::internal::stlAtomic;
         }
     };
 
     template<>
-    struct GetAtomicImpl::Op<alpaka::exec::CpuTbbBlocks>
+    struct GetAtomicImpl::Op<alpaka::exec::CpuOmpBlocks, onAcc::scope::Block>
     {
-        constexpr decltype(auto) operator()(alpaka::exec::CpuTbbBlocks const) const
+        constexpr decltype(auto) operator()(alpaka::exec::CpuOmpBlocks const, onAcc::scope::Block const) const
+        {
+            return alpaka::onAcc::internal::nonAtomic;
+        }
+    };
+
+    template<typename T_AtomicScope>
+    struct GetAtomicImpl::Op<alpaka::exec::CpuTbbBlocks, T_AtomicScope>
+    {
+        constexpr decltype(auto) operator()(alpaka::exec::CpuTbbBlocks const, T_AtomicScope const) const
         {
             return alpaka::onAcc::internal::stlAtomic;
+        }
+    };
+
+    template<>
+    struct GetAtomicImpl::Op<alpaka::exec::CpuTbbBlocks, onAcc::scope::Block>
+    {
+        constexpr decltype(auto) operator()(alpaka::exec::CpuTbbBlocks const, onAcc::scope::Block const) const
+        {
+            return alpaka::onAcc::internal::nonAtomic;
         }
     };
 

--- a/include/alpaka/api/oneApi/executor.hpp
+++ b/include/alpaka/api/oneApi/executor.hpp
@@ -32,10 +32,10 @@ namespace alpaka
 
     namespace onAcc::trait
     {
-        template<>
-        struct GetAtomicImpl::Op<alpaka::exec::OneApi>
+        template<typename T_AtomicScope>
+        struct GetAtomicImpl::Op<alpaka::exec::OneApi, T_AtomicScope>
         {
-            constexpr decltype(auto) operator()(alpaka::exec::OneApi const) const
+            constexpr decltype(auto) operator()(alpaka::exec::OneApi const, T_AtomicScope const) const
             {
                 return alpaka::onAcc::internal::syclAtomic;
             }

--- a/include/alpaka/api/trait.hpp
+++ b/include/alpaka/api/trait.hpp
@@ -164,7 +164,7 @@ namespace alpaka
         /** Defines the implementation used for atomic operations toghether with the used executor */
         struct GetAtomicImpl
         {
-            template<alpaka::concepts::Executor T_Executor>
+            template<alpaka::concepts::Executor T_Executor, typename T_AtomicScope>
             struct Op
             {
                 constexpr decltype(auto) operator()(T_Executor const) const
@@ -177,10 +177,10 @@ namespace alpaka
             };
         };
 
-        template<alpaka::concepts::Executor T_Executor>
-        constexpr decltype(auto) getAtomicImpl(T_Executor const executor)
+        template<alpaka::concepts::Executor T_Executor, typename T_AtomicScope>
+        constexpr decltype(auto) getAtomicImpl(T_Executor const executor, T_AtomicScope const atomicScope)
         {
-            return GetAtomicImpl::Op<T_Executor>{}(executor);
+            return GetAtomicImpl::Op<T_Executor, T_AtomicScope>{}(executor, atomicScope);
         }
     } // namespace onAcc::trait
 } // namespace alpaka

--- a/include/alpaka/onAcc/atomic.hpp
+++ b/include/alpaka/onAcc/atomic.hpp
@@ -22,10 +22,10 @@ namespace alpaka::onAcc
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     template<typename TOp, typename T, typename T_Scope = scope::Device>
-    constexpr auto atomicOp(auto const& acc, T* const addr, T const& value, T_Scope const = T_Scope()) -> T
+    constexpr auto atomicOp(auto const& acc, T* const addr, T const& value, T_Scope const scope = T_Scope()) -> T
     {
         static_assert(!std::is_same_v<T_Scope, scope::System>, "System scope is currently not supported.");
-        auto atomicImpl = trait::getAtomicImpl(acc[object::exec]);
+        auto atomicImpl = trait::getAtomicImpl(acc[object::exec], scope);
         return internalCompute::Atomic::Op<TOp, ALPAKA_TYPEOF(atomicImpl), T, T_Scope>::atomicOp(
             atomicImpl,
             addr,
@@ -45,10 +45,10 @@ namespace alpaka::onAcc
         T* const addr,
         T const& compare,
         T const& value,
-        T_Scope const = T_Scope()) -> T
+        T_Scope const scope = T_Scope()) -> T
     {
         static_assert(!std::is_same_v<T_Scope, scope::System>, "System scope is currently not supported.");
-        auto atomicImpl = trait::getAtomicImpl(acc[object::exec]);
+        auto atomicImpl = trait::getAtomicImpl(acc[object::exec], scope);
         return internalCompute::Atomic::Op<TOp, ALPAKA_TYPEOF(atomicImpl), T, T_Scope>::atomicOp(
             atomicImpl,
             addr,

--- a/include/alpaka/onAcc/internal/atomic.hpp
+++ b/include/alpaka/onAcc/internal/atomic.hpp
@@ -1,0 +1,40 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/onAcc/atomicOp.hpp"
+#include "alpaka/onAcc/internal/interface.hpp"
+
+namespace alpaka::onAcc::internal
+{
+    struct NonAtomic
+    {
+    };
+
+    /** Execute the operation as non-atomic operation */
+    constexpr auto nonAtomic = NonAtomic{};
+
+} // namespace alpaka::onAcc::internal
+
+namespace alpaka::onAcc::internalCompute
+{
+    template<typename T, typename T_AtomicOp, typename T_Scope>
+    struct Atomic::Op<T_AtomicOp, onAcc::internal::NonAtomic, T, T_Scope>
+    {
+        static auto atomicOp(onAcc::internal::NonAtomic const&, T* const addr, T const& value) -> T
+        {
+            return T_AtomicOp{}(addr, value);
+        }
+    };
+
+    template<typename T, typename T_Scope>
+    struct Atomic::Op<AtomicCas, internal::NonAtomic, T, T_Scope>
+    {
+        static auto atomicOp(internal::NonAtomic const&, T* const addr, T const& compare, T const& value) -> T
+        {
+            return AtomicCas{}(addr, compare, value);
+        }
+    };
+} // namespace alpaka::onAcc::internalCompute


### PR DESCRIPTION
…scopes.

This PR adds support for executing atomic calls as non-atomic operations, depending on the code and the executor. This mirrors mainline alpaka, where certain accelerators can execute atomic functions as regular non-atomic operations within defined scopes.

This PR defines that thread serial executors execute atomic operations within the block scope as regular functions.

note: alpaka3 does not have the atomic unit tests from alpaka mainline. This will follow in an independent PR.