### PR TITLE
expose warps to the user for iterations via `makeIdxMap`

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -35,6 +35,7 @@
 #include "alpaka/onAcc/atomic.hpp"
 #include "alpaka/onAcc/globalMem.hpp"
 #include "alpaka/onAcc/interface.hpp"
+#include "alpaka/onAcc/internal/interfaceImpl.hpp"
 #include "alpaka/onAcc/memFence.hpp"
 #include "alpaka/onAcc/range.hpp"
 #include "alpaka/onAcc/tag.hpp"

--- a/include/alpaka/api/cuda/warp.hpp
+++ b/include/alpaka/api/cuda/warp.hpp
@@ -26,14 +26,27 @@ namespace alpaka::onAcc::warp::internal
     };
 
     template<alpaka::onAcc::concepts::Acc T_Acc>
-    struct GetLanIdx::Op<T_Acc, api::Cuda>
+    struct GetLaneIdx::Op<T_Acc, api::Cuda>
     {
         constexpr __device__ auto operator()(T_Acc const& acc, api::Cuda) const
         {
-            constexpr uint32_t warpExtent = onAcc::warp::internal::getSize<ALPAKA_TYPEOF(acc)>();
             unsigned lIdx;
             asm volatile("mov.u32 %0, %laneid;" : "=r"(lIdx));
-            return lIdx % warpExtent;
+            return lIdx;
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct GetWarpIdx::Op<T_Acc, api::Cuda>
+    {
+        constexpr __device__ uint32_t operator()(T_Acc const& acc, api::Cuda) const
+        {
+            constexpr uint32_t warpExtent = onAcc::warp::internal::getSize<ALPAKA_TYPEOF(acc)>();
+            alpaka::concepts::Vector auto blockThreadCount
+                = acc.getExtentsOf(onAcc::origin::block, onAcc::unit::threads);
+            alpaka::concepts::Vector auto threadIdxInBlock
+                = acc.getIdxWithin(alpaka::onAcc::origin::block, alpaka::onAcc::unit::threads);
+            return linearize(blockThreadCount, threadIdxInBlock) / warpExtent;
         }
     };
 

--- a/include/alpaka/api/hip/computeApi.hpp
+++ b/include/alpaka/api/hip/computeApi.hpp
@@ -38,7 +38,8 @@ namespace alpaka::onAcc::unifiedCudaHip::internal
 #            endif
 #        endif
 #    else
-            return std::integral_constant<uint32_t, 0u>{};
+            // return one to avoid division by zero warnings when the host path is parsed.
+            return std::integral_constant<uint32_t, 1u>{};
 #    endif
         }
     };

--- a/include/alpaka/api/hip/warp.hpp
+++ b/include/alpaka/api/hip/warp.hpp
@@ -30,12 +30,8 @@ namespace alpaka::onAcc::warp::internal
     {
         constexpr __device__ auto operator()(T_Acc const& acc, api::Hip) const
         {
-#    if defined(__HIP_DEVICE_COMPILE__)
+            // for the host side deduction path, result is wrong but this is fine
             return __lane_id();
-#    else
-            // only for the host side deduction path, result is wrong but this is fine
-            return __lane_id();
-#    endif
         }
     };
 

--- a/include/alpaka/api/hip/warp.hpp
+++ b/include/alpaka/api/hip/warp.hpp
@@ -26,17 +26,30 @@ namespace alpaka::onAcc::warp::internal
     };
 
     template<alpaka::onAcc::concepts::Acc T_Acc>
-    struct GetLanIdx::Op<T_Acc, api::Hip>
+    struct GetLaneIdx::Op<T_Acc, api::Hip>
     {
         constexpr __device__ auto operator()(T_Acc const& acc, api::Hip) const
         {
 #    if defined(__HIP_DEVICE_COMPILE__)
-            constexpr uint32_t warpExtent = onAcc::warp::internal::getSize<ALPAKA_TYPEOF(acc)>();
-            return __lane_id() % warpExtent;
+            return __lane_id();
 #    else
             // only for the host side deduction path, result is wrong but this is fine
             return __lane_id();
 #    endif
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct GetWarpIdx::Op<T_Acc, api::Hip>
+    {
+        constexpr __device__ uint32_t operator()(T_Acc const& acc, api::Hip) const
+        {
+            constexpr uint32_t warpExtent = onAcc::warp::internal::getSize<ALPAKA_TYPEOF(acc)>();
+            alpaka::concepts::Vector auto blockThreadCount
+                = acc.getExtentsOf(onAcc::origin::block, onAcc::unit::threads);
+            alpaka::concepts::Vector auto threadIdxInBlock
+                = acc.getIdxWithin(alpaka::onAcc::origin::block, alpaka::onAcc::unit::threads);
+            return linearize(blockThreadCount, threadIdxInBlock) / warpExtent;
         }
     };
 

--- a/include/alpaka/api/host/warp.hpp
+++ b/include/alpaka/api/host/warp.hpp
@@ -24,7 +24,16 @@ namespace alpaka::onAcc::warp::internal
     };
 
     template<alpaka::onAcc::concepts::Acc T_Acc>
-    struct GetLanIdx::Op<T_Acc, api::Host>
+    struct GetLaneIdx::Op<T_Acc, api::Host>
+    {
+        constexpr auto operator()(T_Acc const& acc, api::Host) const
+        {
+            return uint32_t{0u};
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct GetWarpIdx::Op<T_Acc, api::Host>
     {
         constexpr auto operator()(T_Acc const& acc, api::Host) const
         {

--- a/include/alpaka/api/oneApi/warp.hpp
+++ b/include/alpaka/api/oneApi/warp.hpp
@@ -41,13 +41,24 @@ namespace alpaka::onAcc::warp::internal
     };
 
     template<alpaka::onAcc::concepts::Acc T_Acc>
-    struct GetLanIdx::Op<T_Acc, api::OneApi>
+    struct GetLaneIdx::Op<T_Acc, api::OneApi>
     {
         constexpr auto operator()(T_Acc const& acc, api::OneApi) const
         {
             sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
             // lane id within the warp subgroup
             return sg.get_local_id()[0];
+        }
+    };
+
+    template<alpaka::onAcc::concepts::Acc T_Acc>
+    struct GetWarpIdx::Op<T_Acc, api::OneApi>
+    {
+        constexpr auto operator()(T_Acc const& acc, api::OneApi) const
+        {
+            sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+            // lane id within the warp subgroup
+            return sg.get_group_linear_id();
         }
     };
 

--- a/include/alpaka/onAcc/Acc.hpp
+++ b/include/alpaka/onAcc/Acc.hpp
@@ -30,7 +30,10 @@ namespace alpaka::onAcc
         constexpr Acc& operator=(Acc const&) = delete;
         constexpr Acc& operator=(Acc&&) = delete;
 
-        /** Get the n-dimensional indices within the origin in the quantity of the selected unit */
+        /** Get the n-dimensional indices within the origin in the quantity of the selected unit
+         *
+         * @attention if origin or unit is warp/s a one dimensional vector is returned
+         */
         constexpr alpaka::concepts::Vector auto getIdxWithin(concepts::Origin auto origin, concepts::Unit auto unit)
             const
         {
@@ -40,7 +43,10 @@ namespace alpaka::onAcc
                 unit);
         }
 
-        /** Get the n-dimensional extents of an origin in the quantity of the selected unit */
+        /** Get the n-dimensional extents of an origin in the quantity of the selected unit
+         *
+         * @attention if origin or unit is warp/s a one dimensional vector is returned
+         */
         constexpr alpaka::concepts::Vector auto getExtentsOf(concepts::Origin auto origin, concepts::Unit auto unit)
             const
         {

--- a/include/alpaka/onAcc/WorkerGroup.hpp
+++ b/include/alpaka/onAcc/WorkerGroup.hpp
@@ -106,8 +106,24 @@ namespace alpaka::onAcc
         constexpr auto blocksInGrid = WorkerGroup{origin::grid, unit::blocks};
         constexpr auto threadsInBlock = WorkerGroup{origin::block, unit::threads};
 
-        constexpr auto linearThreadsInGrid = WorkerGroup{origin::grid, unit::threads, linearized};
+        /** Representation of all threads in a warp as a linearized worker group */
+        constexpr auto linearThreadsInWarp = WorkerGroup{origin::warp, unit::threads};
         constexpr auto linearThreadsInBlock = WorkerGroup{origin::block, unit::threads, linearized};
+        constexpr auto linearThreadsInGrid = WorkerGroup{origin::grid, unit::threads, linearized};
+
+        /** Representation of all warps in a thread block as a linearized worker group
+         *
+         * @attention If the number of threads in a block is not a multiple of the warp size you can have partial
+         * warps.
+         */
+        constexpr auto linearWarpsInBlock = WorkerGroup{origin::block, unit::warps};
+        /** Representation of all warps in the grid as a linearized worker group
+         *
+         * @attention Since a thread block is not required to have as many threads a warp has, you can not assume that
+         * number of warps * warp size is the total number of threads.
+         */
+        constexpr auto linearWarpsInGrid = WorkerGroup{origin::grid, unit::warps};
+
         constexpr auto linearBlocksInGrid = WorkerGroup{origin::grid, unit::blocks, linearized};
     } // namespace worker
 

--- a/include/alpaka/onAcc/internal/interface.hpp
+++ b/include/alpaka/onAcc/internal/interface.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/CVec.hpp"
 #include "alpaka/UniqueId.hpp"
 #include "alpaka/Vec.hpp"
 #include "alpaka/core/common.hpp"
@@ -82,42 +83,6 @@ namespace alpaka::onAcc
                 constexpr alpaka::concepts::Vector auto operator()(T_Acc const& acc, T_Origin origin, T_Unit unit)
                     const;
             };
-
-            template<typename T_Acc>
-            struct Op<T_Acc, ALPAKA_TYPEOF(origin::block), ALPAKA_TYPEOF(unit::threads)>
-            {
-                constexpr alpaka::concepts::Vector auto operator()(
-                    T_Acc const& acc,
-                    ALPAKA_TYPEOF(origin::block),
-                    ALPAKA_TYPEOF(unit::threads)) const
-                {
-                    return acc[layer::thread].idx();
-                }
-            };
-
-            template<typename T_Acc>
-            struct Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::threads)>
-            {
-                constexpr alpaka::concepts::Vector auto operator()(
-                    T_Acc const& acc,
-                    ALPAKA_TYPEOF(origin::grid),
-                    ALPAKA_TYPEOF(unit::threads)) const
-                {
-                    return acc[layer::thread].count() * acc[layer::block].idx() + acc[layer::thread].idx();
-                }
-            };
-
-            template<typename T_Acc>
-            struct Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::blocks)>
-            {
-                constexpr alpaka::concepts::Vector auto operator()(
-                    T_Acc const& acc,
-                    ALPAKA_TYPEOF(origin::grid),
-                    ALPAKA_TYPEOF(unit::blocks)) const
-                {
-                    return acc[layer::block].idx();
-                }
-            };
         };
 
         /** Get the number of elments in a layer in the selected units*/
@@ -128,42 +93,6 @@ namespace alpaka::onAcc
             {
                 constexpr alpaka::concepts::Vector auto operator()(T_Acc const& acc, T_Origin origin, T_Unit unit)
                     const;
-            };
-
-            template<typename T_Acc>
-            struct Op<T_Acc, ALPAKA_TYPEOF(origin::block), ALPAKA_TYPEOF(unit::threads)>
-            {
-                constexpr alpaka::concepts::Vector auto operator()(
-                    T_Acc const& acc,
-                    ALPAKA_TYPEOF(origin::block),
-                    ALPAKA_TYPEOF(unit::threads)) const
-                {
-                    return acc[layer::thread].count();
-                }
-            };
-
-            template<typename T_Acc>
-            struct Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::blocks)>
-            {
-                constexpr alpaka::concepts::Vector auto operator()(
-                    T_Acc const& acc,
-                    ALPAKA_TYPEOF(origin::grid),
-                    ALPAKA_TYPEOF(unit::blocks)) const
-                {
-                    return acc[layer::block].count();
-                }
-            };
-
-            template<typename T_Acc>
-            struct Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::threads)>
-            {
-                constexpr alpaka::concepts::Vector auto operator()(
-                    T_Acc const& acc,
-                    ALPAKA_TYPEOF(origin::grid),
-                    ALPAKA_TYPEOF(unit::threads)) const
-                {
-                    return acc[layer::block].count() * acc[layer::thread].count();
-                }
             };
         };
 

--- a/include/alpaka/onAcc/internal/interfaceImpl.hpp
+++ b/include/alpaka/onAcc/internal/interfaceImpl.hpp
@@ -1,0 +1,172 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+/** @file This file contains specializations of interfaces for the accelerator scope.
+ * The specializations must be separated from the definitions to avoid cyclic include dependencies.
+ */
+
+#include "alpaka/onAcc/internal/interface.hpp"
+#include "alpaka/onAcc/internal/warp.hpp"
+
+namespace alpaka::onAcc
+{
+    namespace internalCompute
+    {
+        template<typename T_Acc>
+        struct GetIdxWithin::Op<T_Acc, ALPAKA_TYPEOF(origin::warp), ALPAKA_TYPEOF(unit::threads)>
+        {
+            constexpr alpaka::concepts::Vector<uint32_t, 1u> auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::warp),
+                ALPAKA_TYPEOF(unit::threads)) const
+            {
+                return Vec{warp::internal::getLaneIdx(acc)};
+            }
+        };
+
+        template<typename T_Acc>
+        struct GetIdxWithin::Op<T_Acc, ALPAKA_TYPEOF(origin::block), ALPAKA_TYPEOF(unit::threads)>
+        {
+            constexpr alpaka::concepts::Vector auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::block),
+                ALPAKA_TYPEOF(unit::threads)) const
+            {
+                return acc[layer::thread].idx();
+            }
+        };
+
+        template<typename T_Acc>
+        struct GetIdxWithin::Op<T_Acc, ALPAKA_TYPEOF(origin::block), ALPAKA_TYPEOF(unit::warps)>
+        {
+            constexpr alpaka::concepts::Vector<uint32_t, 1u> auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::block),
+                ALPAKA_TYPEOF(unit::warps)) const
+            {
+                return Vec{warp::internal::getWarpIdx(acc)};
+            }
+        };
+
+        template<typename T_Acc>
+        struct GetIdxWithin::Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::threads)>
+        {
+            constexpr alpaka::concepts::Vector auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::grid),
+                ALPAKA_TYPEOF(unit::threads)) const
+            {
+                return acc[layer::thread].count() * acc[layer::block].idx() + acc[layer::thread].idx();
+            }
+        };
+
+        template<typename T_Acc>
+        struct GetIdxWithin::Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::warps)>
+        {
+            constexpr alpaka::concepts::Vector<uint32_t, 1u> auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::grid),
+                ALPAKA_TYPEOF(unit::warps)) const
+            {
+                auto blockIdxInGrid = acc.getIdxWithin(onAcc::origin::grid, onAcc::unit::blocks);
+                auto numBlocksInGrid = acc.getExtentsOf(onAcc::origin::grid, onAcc::unit::blocks);
+                auto linearBlockIdx = linearize(numBlocksInGrid, blockIdxInGrid);
+                return linearBlockIdx + Vec{warp::internal::getWarpIdx(acc)};
+            }
+        };
+
+        template<typename T_Acc>
+        struct GetIdxWithin::Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::blocks)>
+        {
+            constexpr alpaka::concepts::Vector auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::grid),
+                ALPAKA_TYPEOF(unit::blocks)) const
+            {
+                return acc[layer::block].idx();
+            }
+        };
+
+        template<typename T_Acc>
+        struct GetExtentsOf::Op<T_Acc, ALPAKA_TYPEOF(origin::warp), ALPAKA_TYPEOF(unit::threads)>
+        {
+            constexpr alpaka::concepts::CVector<uint32_t> auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::warp),
+                ALPAKA_TYPEOF(unit::threads)) const
+            {
+                return alpaka::CVec<uint32_t, T_Acc::getWarpSize()>{};
+            }
+        };
+
+        template<typename T_Acc>
+        struct GetExtentsOf::Op<T_Acc, ALPAKA_TYPEOF(origin::block), ALPAKA_TYPEOF(unit::threads)>
+        {
+            constexpr alpaka::concepts::Vector auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::block),
+                ALPAKA_TYPEOF(unit::threads)) const
+            {
+                return acc[layer::thread].count();
+            }
+        };
+
+        template<typename T_Acc>
+        struct GetExtentsOf::Op<T_Acc, ALPAKA_TYPEOF(origin::block), ALPAKA_TYPEOF(unit::warps)>
+        {
+            constexpr alpaka::concepts::Vector<alpaka::NotRequired, 1u> auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::block),
+                ALPAKA_TYPEOF(unit::warps)) const
+            {
+                std::integral auto linearThreadsInBlock
+                    = acc.getExtentsOf(onAcc::origin::block, onAcc::unit::threads).product();
+                using IndexType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(linearThreadsInBlock)>;
+                return Vec{divCeil(linearThreadsInBlock, static_cast<IndexType>(T_Acc::getWarpSize()))};
+            }
+        };
+
+        template<typename T_Acc>
+        struct GetExtentsOf::Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::blocks)>
+        {
+            constexpr alpaka::concepts::Vector auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::grid),
+                ALPAKA_TYPEOF(unit::blocks)) const
+            {
+                return acc[layer::block].count();
+            }
+        };
+
+        template<typename T_Acc>
+        struct GetExtentsOf::Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::warps)>
+        {
+            constexpr alpaka::concepts::Vector<alpaka::NotRequired, 1u> auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::grid),
+                ALPAKA_TYPEOF(unit::warps)) const
+            {
+                std::integral auto linearNumWarpsInBlock
+                    = acc.getExtentsOf(onAcc::origin::block, onAcc::unit::warps).product();
+                std::integral auto linearNumBlocks
+                    = acc.getExtentsOf(onAcc::origin::grid, onAcc::unit::blocks).product();
+                return Vec{linearNumBlocks * linearNumWarpsInBlock};
+            }
+        };
+
+        template<typename T_Acc>
+        struct GetExtentsOf::Op<T_Acc, ALPAKA_TYPEOF(origin::grid), ALPAKA_TYPEOF(unit::threads)>
+        {
+            constexpr alpaka::concepts::Vector auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::grid),
+                ALPAKA_TYPEOF(unit::threads)) const
+            {
+                return acc[layer::block].count() * acc[layer::thread].count();
+            }
+        };
+    } // namespace internalCompute
+} // namespace alpaka::onAcc

--- a/include/alpaka/onAcc/internal/warp.hpp
+++ b/include/alpaka/onAcc/internal/warp.hpp
@@ -23,7 +23,7 @@
 
 namespace alpaka::onAcc::warp::internal
 {
-    template<concepts::Acc T_Acc>
+    template<alpaka::onAcc::concepts::Acc T_Acc>
     constexpr uint32_t getSize()
     {
         return T_Acc::getWarpSize();
@@ -43,18 +43,47 @@ namespace alpaka::onAcc::warp::internal
         };
     };
 
-    struct GetLanIdx
+    struct GetLaneIdx
     {
         template<alpaka::onAcc::concepts::Acc T_Acc, alpaka::concepts::Api T_Api>
         struct Op
         {
             constexpr auto operator()(T_Acc const&, T_Api api) const
             {
-                static_assert(sizeof(T_Acc) && false, "Missing warp GetLanIdx implementation for the accelerator.");
+                static_assert(sizeof(T_Acc) && false, "Missing warp GetLaneIdx implementation for the accelerator.");
                 return 0u;
             }
         };
     };
+
+    /** Return the lane index of the current thread within its warp. */
+    constexpr uint32_t getLaneIdx(alpaka::onAcc::concepts::Acc auto const& acc)
+    {
+        using Acc = ALPAKA_TYPEOF(acc);
+        using Api = ALPAKA_TYPEOF(acc[object::api]);
+        return GetLaneIdx::Op<Acc, Api>{}(acc, Api{});
+    }
+
+    struct GetWarpIdx
+    {
+        template<alpaka::onAcc::concepts::Acc T_Acc, alpaka::concepts::Api T_Api>
+        struct Op
+        {
+            constexpr auto operator()(T_Acc const&, T_Api api) const
+            {
+                static_assert(sizeof(T_Acc) && false, "Missing warp GetWarpIdx implementation for the accelerator.");
+                return 0u;
+            }
+        };
+    };
+
+    /** Return the warp index within the block. */
+    constexpr uint32_t getWarpIdx(alpaka::onAcc::concepts::Acc auto const& acc)
+    {
+        using Acc = ALPAKA_TYPEOF(acc);
+        using Api = ALPAKA_TYPEOF(acc[object::api]);
+        return GetWarpIdx::Op<Acc, Api>{}(acc, Api{});
+    }
 
     struct All
     {

--- a/include/alpaka/onAcc/range.hpp
+++ b/include/alpaka/onAcc/range.hpp
@@ -20,6 +20,14 @@ namespace alpaka::onAcc
 
         constexpr auto linearThreadsInGrid = internal::IdxRangeLazy{origin::grid, unit::threads, linearized};
         constexpr auto linearBlocksInGrid = internal::IdxRangeLazy{origin::grid, unit::blocks, linearized};
+        /** Range of all warps in a grid. */
+        constexpr auto linearWarpsInGrid = internal::IdxRangeLazy{origin::grid, unit::warps};
+
+        /** Range of all warps in a block. */
+        constexpr auto linearWarpsInBlock = internal::IdxRangeLazy{origin::block, unit::warps};
         constexpr auto linearThreadsInBlock = internal::IdxRangeLazy{origin::block, unit::threads, linearized};
+
+        /** Range of all threads in a warp. */
+        constexpr auto linearThreadsInWarp = internal::IdxRangeLazy{origin::warp, unit::threads};
     } // namespace range
 } // namespace alpaka::onAcc

--- a/include/alpaka/onAcc/tag.hpp
+++ b/include/alpaka/onAcc/tag.hpp
@@ -19,6 +19,7 @@ namespace alpaka::onAcc
      */
     namespace origin
     {
+        ALPAKA_TAG(warp);
         ALPAKA_TAG(block);
         ALPAKA_TAG(grid);
     } // namespace origin
@@ -29,6 +30,7 @@ namespace alpaka::onAcc
      */
     namespace unit
     {
+        ALPAKA_TAG(warps);
         ALPAKA_TAG(threads);
         ALPAKA_TAG(blocks);
     } // namespace unit
@@ -37,6 +39,11 @@ namespace alpaka::onAcc
     {
         template<typename T>
         struct IsOrigin : std::false_type
+        {
+        };
+
+        template<>
+        struct IsOrigin<ALPAKA_TYPEOF(origin::warp)> : std::true_type
         {
         };
 
@@ -57,6 +64,11 @@ namespace alpaka::onAcc
 
         template<>
         struct IsUnit<ALPAKA_TYPEOF(unit::threads)> : std::true_type
+        {
+        };
+
+        template<>
+        struct IsUnit<ALPAKA_TYPEOF(unit::warps)> : std::true_type
         {
         };
 

--- a/include/alpaka/onAcc/warp.hpp
+++ b/include/alpaka/onAcc/warp.hpp
@@ -40,9 +40,13 @@ namespace alpaka::onAcc::warp
     /** Return the lane index of the current thread within its warp. */
     constexpr uint32_t getLaneIdx(alpaka::onAcc::concepts::Acc auto const& acc)
     {
-        using Acc = ALPAKA_TYPEOF(acc);
-        using Api = ALPAKA_TYPEOF(acc[object::api]);
-        return internal::GetLanIdx::Op<Acc, Api>{}(acc, Api{});
+        return internal::getLaneIdx(acc);
+    }
+
+    /** Return the warp index within the block. */
+    constexpr uint32_t getWarpIdx(alpaka::onAcc::concepts::Acc auto const& acc)
+    {
+        return internal::getWarpIdx(acc);
     }
 
     /** Evaluates predicate for all active threads of the warp

--- a/tests/unit/warp/getSize.cpp
+++ b/tests/unit/warp/getSize.cpp
@@ -40,8 +40,34 @@ namespace
             constexpr uint32_t warpExtent = onAcc::warp::getSize<ALPAKA_TYPEOF(acc)>();
             warpCheck(success, warpExtent == expectedWarpSize);
             // laneIdx should be in range [0;warpSize)
-            auto const laneIdx = static_cast<std::int32_t>(onAcc::warp::getLaneIdx(acc));
+            uint32_t const laneIdx = onAcc::warp::getLaneIdx(acc);
             warpCheck(success, laneIdx < warpExtent);
+
+            concepts::Vector auto numTheradsPerWarp = acc.getExtentsOf(onAcc::origin::warp, onAcc::unit::threads);
+            warpCheck(success, warpExtent == numTheradsPerWarp.x());
+
+            uint32_t const numWarps = acc[layer::thread].count().product() / warpExtent;
+            uint32_t const warpIdx = onAcc::warp::getWarpIdx(acc);
+            warpCheck(success, warpIdx < numWarps);
+            concepts::Vector auto blockThreadCount = acc.getExtentsOf(onAcc::origin::block, onAcc::unit::threads);
+            concepts::Vector auto threadIdx = acc.getIdxWithin(onAcc::origin::block, onAcc::unit::threads);
+            uint32_t warpIdxByThreadIdx = linearize(blockThreadCount, threadIdx) / warpExtent;
+            warpCheck(success, warpIdx == warpIdxByThreadIdx);
+
+            concepts::Vector auto warpIdxInBlock = acc.getIdxWithin(onAcc::origin::block, onAcc::unit::warps);
+            warpCheck(success, warpIdx == warpIdxInBlock.x());
+
+            // we started one warp per block therefore the block index is equal to the warp index in the grid
+            concepts::Vector auto warpIdxInGrid = acc.getIdxWithin(onAcc::origin::grid, onAcc::unit::warps);
+            warpCheck(success, acc[layer::block].idx().x() == warpIdxInGrid.x());
+
+            // number of threads per block is equal to the warp size so we have always one warp ni  ablock
+            concepts::Vector auto numWarpsInBlock = acc.getExtentsOf(onAcc::origin::block, onAcc::unit::warps);
+            warpCheck(success, 1u == numWarpsInBlock.x());
+
+            // we started 5 thread blocks each with warp size threads
+            concepts::Vector auto numWarpsInGrid = acc.getExtentsOf(onAcc::origin::grid, onAcc::unit::warps);
+            warpCheck(success, 5u == numWarpsInGrid.x());
         }
     };
 } // namespace
@@ -68,12 +94,12 @@ TEMPLATE_LIST_TEST_CASE("warp size trait matches runtime size", "[warp][getSize]
     auto successHost = onHost::allocHost<bool>(1u);
     auto successDev = onHost::allocLike(device, successHost);
     auto const blocks = Vec<std::uint32_t, 1u>{5u};
-    auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
+    auto const threads = Vec<std::uint32_t, 1u>{warpExtent};
 
     onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
     queue.enqueue(
         exec,
-        onHost::FrameSpec{blocks, threads},
+        onHost::ThreadSpec{blocks, threads},
         // Pass the host-side expectation down to the device for verification.
         KernelBundle{GetSizeKernel{}, successDev, static_cast<std::uint32_t>(warpExtent)});
     onHost::memcpy(queue, successHost, successDev);

--- a/tests/unit/warp/iota.cpp
+++ b/tests/unit/warp/iota.cpp
@@ -70,7 +70,7 @@ TEMPLATE_LIST_TEST_CASE("warp iota1D", "", TestApis)
 
     onHost::wait(queue);
     /* Use an odd number that to avoid any assumptions about number of threads.
-     * Note that for a thread serialized executor alpaak will internally use a single thread per block what is equal to
+     * Note that for a thread serialized executor alpaka will internally use a single thread per block what is equal to
      * the warp size.
      */
     auto frameSize = Vec{warpSize + 3u};

--- a/tests/unit/warp/iota.cpp
+++ b/tests/unit/warp/iota.cpp
@@ -1,0 +1,82 @@
+/* Copyright 2023 Axel Hübl, Benjamin Worpitz, Bernhard Manfred Gruber, Jan Stephan, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/onHost/example/executors.hpp>
+#include <alpaka/onHost/executeForEach.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <iostream>
+
+using namespace alpaka;
+
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+
+struct IotaKernelND
+{
+    ALPAKA_FN_ACC void operator()(auto const& acc, auto out, auto outSize) const
+    {
+        constexpr uint32_t warpSize = onAcc::warp::getSize<ALPAKA_TYPEOF(acc)>();
+        concepts::Vector auto numThreadsPerBlock = acc.getExtentsOf(onAcc::origin::block, onAcc::unit::threads);
+        // test using some of the predefined warp worker and range types
+        for(auto bOffset :
+            onAcc::makeIdxMap(acc, onAcc::worker::linearBlocksInGrid, IdxRange{Vec{0u}, outSize, numThreadsPerBlock}))
+            for(auto w : onAcc::makeIdxMap(acc, onAcc::worker::linearWarpsInBlock, onAcc::range::linearWarpsInBlock))
+            {
+                for(auto t :
+                    onAcc::makeIdxMap(acc, onAcc::worker::linearThreadsInWarp, onAcc::range::linearThreadsInWarp))
+                {
+                    auto idx = bOffset + warpSize * w + t;
+                    /* use atomic to avoid that multiple threads change the same location, if so we will detect it in
+                     * our verification
+                     */
+                    if(idx < outSize)
+                        onAcc::atomicAdd(acc, &out[idx].x(), idx.x());
+                }
+            }
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("warp iota1D", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    std::cout << deviceSpec.getApi().getName() << std::endl;
+    onHost::Device device = devSelector.makeDevice(0);
+
+    std::cout << device.getName() << std::endl;
+
+    auto deviceProperties = devSelector.getDeviceProperties(0);
+    uint32_t warpSize = deviceProperties.m_warpSize;
+
+    onHost::Queue queue = device.makeQueue();
+    Vec extent = Vec{warpSize * 123u};
+    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
+    auto dBuff = onHost::alloc<Vec<uint32_t, 1u>>(device, extent);
+
+    auto hBuff = onHost::allocHostLike(dBuff);
+
+    onHost::wait(queue);
+    /* Use an odd number that to avoid any assumptions about number of threads.
+     * Note that for a thread serialized executor alpaak will internally use a single thread per block what is equal to
+     * the warp size.
+     */
+    auto frameSize = Vec{warpSize + 3u};
+    onHost::fill(queue, dBuff, Vec{0u});
+    queue.enqueue(exec, onHost::FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernelND{}, dBuff, extent});
+    onHost::memcpy(queue, hBuff, dBuff);
+    onHost::wait(queue);
+    meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(idx == hBuff[idx]); });
+}


### PR DESCRIPTION
- provide `onAcc::range` predefinitions
- provide `onAcc::worker` predefinitions
- add missing warp function: `getWarpIdx()`
- separate interface specializations from the definition to avoid cyclic inlcude dependencies