### PR TITLE
provided `ffs()` and support for `popcount()` 4 and 8 byte types

### DIFF
--- a/include/alpaka/api/syclGeneric/intrinsic.hpp
+++ b/include/alpaka/api/syclGeneric/intrinsic.hpp
@@ -1,10 +1,11 @@
-/* Copyright 2025 Luca Venerando Greco, René Widera
+/* Copyright 2025 Luca Venerando Greco, René Widera, Jan Stephan
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
 #include "alpaka/api/syclGeneric/tag.hpp"
+#include "alpaka/core/Unreachable.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/internal/intrinsic.hpp"
 
@@ -19,7 +20,41 @@ namespace alpaka::internal::intrinsic
     {
         constexpr auto operator()(alpaka::internal::SyclIntrinsic const, T_Arg const& val) const
         {
-            return sycl::popcount(val);
+            if constexpr(sizeof(T_Arg) == 4u)
+            {
+                return sycl::popcount(std::bit_cast<unsigned int>(val));
+            }
+            else if constexpr(sizeof(T_Arg) == 8u)
+            {
+                return sycl::popcount(std::bit_cast<unsigned long long>(val));
+            }
+            else
+                static_assert(!sizeof(T_Arg), "Unsupported data type, sizeof() must be 4 or 8");
+
+            ALPAKA_UNREACHABLE(int{});
+        }
+    };
+
+    template<typename T_Arg>
+    struct Ffs::Op<alpaka::internal::SyclIntrinsic, T_Arg>
+    {
+        constexpr auto operator()(alpaka::internal::SyclIntrinsic const, T_Arg const& val) const
+        {
+            // There is no FFS operation in SYCL but we can emulate it using popcount.
+            if constexpr(sizeof(T_Arg) == 4u)
+            {
+                auto value = std::bit_cast<unsigned int>(val);
+                return (value == 0u) ? 0 : sycl::popcount(value ^ ~(-value));
+            }
+            else if constexpr(sizeof(T_Arg) == 8u)
+            {
+                auto value = std::bit_cast<unsigned long long>(val);
+                return (value == 0u) ? 0 : sycl::popcount(value ^ ~(-value));
+            }
+            else
+                static_assert(!sizeof(T_Arg), "Unsupported data type, sizeof() must be 4 or 8");
+
+            ALPAKA_UNREACHABLE(int{});
         }
     };
 } // namespace alpaka::internal::intrinsic

--- a/include/alpaka/api/unifiedCudaHip/intrinsic.hpp
+++ b/include/alpaka/api/unifiedCudaHip/intrinsic.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/api/cuda/executor.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/api/unifiedCudaHip/tag.hpp"
+#include "alpaka/core/Unreachable.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/internal/intrinsic.hpp"
 
@@ -18,7 +19,7 @@ namespace alpaka::internal::intrinsic
     template<typename T_Arg>
     struct Popcount::Op<alpaka::internal::CudaHipIntrinsic, T_Arg>
     {
-        __device__ auto operator()(alpaka::internal::CudaHipIntrinsic const, T_Arg const& val) const
+        inline __device__ auto operator()(alpaka::internal::CudaHipIntrinsic const, T_Arg const& val) const
         {
             if constexpr(sizeof(T_Arg) == 4u)
             {
@@ -27,6 +28,26 @@ namespace alpaka::internal::intrinsic
             else if constexpr(sizeof(T_Arg) == 8u)
             {
                 return __popcll(std::bit_cast<unsigned long long>(val));
+            }
+            else
+                static_assert(!sizeof(T_Arg), "Unsupported data type, sizeof() must be 4 or 8");
+
+            ALPAKA_UNREACHABLE(int{});
+        }
+    };
+
+    template<typename T_Arg>
+    struct Ffs::Op<alpaka::internal::CudaHipIntrinsic, T_Arg>
+    {
+        inline __device__ auto operator()(alpaka::internal::CudaHipIntrinsic const, T_Arg const& val) const
+        {
+            if constexpr(sizeof(T_Arg) == 4u)
+            {
+                return __ffs(std::bit_cast<unsigned int>(val));
+            }
+            else if constexpr(sizeof(T_Arg) == 8u)
+            {
+                return __ffsll(std::bit_cast<unsigned long long>(val));
             }
             else
                 static_assert(!sizeof(T_Arg), "Unsupported data type, sizeof() must be 4 or 8");

--- a/include/alpaka/internal/intrinsic.hpp
+++ b/include/alpaka/internal/intrinsic.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace alpaka::internal::intrinsic
 {
     struct Popcount
@@ -11,7 +13,16 @@ namespace alpaka::internal::intrinsic
         template<typename T_IntrinsicImpl, typename T_Arg>
         struct Op
         {
-            auto operator()(T_IntrinsicImpl const, T_Arg const& val) const;
+            int32_t operator()(T_IntrinsicImpl const, T_Arg const& val) const;
+        };
+    };
+
+    struct Ffs
+    {
+        template<typename T_IntrinsicImpl, typename T_Arg>
+        struct Op
+        {
+            int32_t operator()(T_IntrinsicImpl const, T_Arg const& val) const;
         };
     };
 } // namespace alpaka::internal::intrinsic

--- a/include/alpaka/internal/stlIntrinsic.hpp
+++ b/include/alpaka/internal/stlIntrinsic.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/api/host/tag.hpp"
+#include "alpaka/core/Unreachable.hpp"
 #include "alpaka/internal/intrinsic.hpp"
 
 #include <bit>
@@ -17,14 +18,40 @@ namespace alpaka::internal::intrinsic
     {
         constexpr auto operator()(alpaka::internal::StlIntrinsic const, T_Arg const& val) const
         {
-            if constexpr(std::is_unsigned_v<T_Arg>)
+            if constexpr(sizeof(T_Arg) == 4u)
             {
-                return std::popcount(val);
+                return std::popcount(std::bit_cast<unsigned int>(val));
+            }
+            else if constexpr(sizeof(T_Arg) == 8u)
+            {
+                return std::popcount(std::bit_cast<unsigned long long>(val));
             }
             else
+                static_assert(!sizeof(T_Arg), "Unsupported data type, sizeof() must be 4 or 8");
+
+            ALPAKA_UNREACHABLE(int{});
+        }
+    };
+
+    template<typename T_Arg>
+    struct Ffs::Op<alpaka::internal::StlIntrinsic, T_Arg>
+    {
+        constexpr auto operator()(alpaka::internal::StlIntrinsic const, T_Arg const& val) const
+        {
+            if constexpr(sizeof(T_Arg) == 4u)
             {
-                return std::popcount(static_cast<std::make_unsigned_t<T_Arg>>(val));
+                auto value = std::bit_cast<unsigned int>(val);
+                return value == 0u ? 0u : std::countr_zero(value) + 1;
             }
+            else if constexpr(sizeof(T_Arg) == 8u)
+            {
+                auto value = std::bit_cast<unsigned long long>(val);
+                return value == 0u ? 0 : std::countr_zero(value) + 1;
+            }
+            else
+                static_assert(!sizeof(T_Arg), "Unsupported data type, sizeof() must be 4 or 8");
+
+            ALPAKA_UNREACHABLE(int{});
         }
     };
 } // namespace alpaka::internal::intrinsic

--- a/include/alpaka/intrinsic.hpp
+++ b/include/alpaka/intrinsic.hpp
@@ -9,13 +9,28 @@
 #include "alpaka/api/trait.hpp"
 #include "internal/intrinsic.hpp"
 
+#include <climits>
+
 namespace alpaka
 {
-    constexpr auto popcount(auto const& arg)
+    /** Returns the number of bits set to 1. */
+    constexpr int32_t popcount(auto const& arg)
+        requires(sizeof(ALPAKA_TYPEOF(arg)) == 4u || sizeof(ALPAKA_TYPEOF(arg)) == 8u)
     {
-        auto const intrinsicImpl = alpaka::trait::getIntrinsicImpl(thisApi());
+        constexpr auto intrinsicImpl = trait::getIntrinsicImpl(thisApi());
         return internal::intrinsic::Popcount::Op<ALPAKA_TYPEOF(intrinsicImpl), ALPAKA_TYPEOF(arg)>{}(
             intrinsicImpl,
             arg);
+    }
+
+    /* Position of the least significant bit set to 1.
+     *
+     * @return 1-based position of the first set bit, zero for input value 0.
+     */
+    constexpr int32_t ffs(auto const& arg)
+        requires(sizeof(ALPAKA_TYPEOF(arg)) == 4u || sizeof(ALPAKA_TYPEOF(arg)) == 8u)
+    {
+        constexpr auto intrinsicImpl = trait::getIntrinsicImpl(thisApi());
+        return internal::intrinsic::Ffs::Op<ALPAKA_TYPEOF(intrinsicImpl), ALPAKA_TYPEOF(arg)>{}(intrinsicImpl, arg);
     }
 } // namespace alpaka

--- a/tests/unit/intrinsic/ffs.cpp
+++ b/tests/unit/intrinsic/ffs.cpp
@@ -35,12 +35,26 @@ struct TestKernel
     {
         for(auto [index] : onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, IdxRange{input.getExtents()}))
         {
-            output[index] = popcount(input[index]);
+            output[index] = ffs(input[index]);
         }
     }
 };
 
-TEMPLATE_LIST_TEST_CASE("popcount", "[intrinsic][popc]", TestBackends)
+template<typename TValue>
+static int32_t naiveFfs(TValue value)
+{
+    if(value == 0)
+        return 0;
+    std::int32_t result = 1;
+    while((value & 1) == 0)
+    {
+        value >>= 1;
+        result++;
+    }
+    return result;
+}
+
+TEMPLATE_LIST_TEST_CASE("ffs", "[intrinsic][ffs]", TestBackends)
 {
     using Backend = TestType;
     auto cfg = Backend::makeDict();
@@ -59,14 +73,7 @@ TEMPLATE_LIST_TEST_CASE("popcount", "[intrinsic][popc]", TestBackends)
     alpaka::onHost::Queue queue = devAcc.makeQueue();
 
     // Input data
-    std::vector<uint64_t> hostInput = {
-        0,
-        1,
-        0x1234'5678'9ABC'DEF0,
-        0xFFFF'FFFF'FFFF'FFFF,
-        0xAAAA'AAAA'AAAA'AAAA,
-        0x5555'5555'5555'5555,
-    };
+    std::vector<uint64_t> hostInput = {0, 1, 2, 1llu << 32, 1llu << 63};
     size_t const size = hostInput.size();
 
     // Allocate device memory
@@ -97,7 +104,7 @@ TEMPLATE_LIST_TEST_CASE("popcount", "[intrinsic][popc]", TestBackends)
     for(size_t i = 0; i < size; ++i)
     {
         auto val = hostInput[i];
-        int expected = std::popcount(val);
+        int expected = naiveFfs(val);
         CHECK(hostOutput[i] == expected);
     }
 }


### PR DESCRIPTION
- intrinsic `ffs()`
  - add test
- `popcount()` add support for any 4 and 8 byte type


@LukeTheWalker This is maybe interesting for you.