### PR TITLE
fix usage of alpaka via `add_subdirectory()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.25)
 project(alpaka)
 
 # This file's directory.
-set(_alpaka_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
+set(_alpaka_ROOT_DIR ${alpaka_SOURCE_DIR})
 
 # Compiler feature tests.
 set(_alpaka_FEATURE_TESTS_DIR "${_alpaka_ROOT_DIR}/cmake/tests")
@@ -41,22 +41,22 @@ endif()
 if(alpaka_DOCS)
     include(CTest)
     enable_testing()
-    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/docs/snippets")
+    add_subdirectory("${_alpaka_ROOT_DIR}/docs/snippets")
 endif()
 
 if(alpaka_BENCHMARKS)
     enable_testing()
-    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/benchmark")
+    add_subdirectory("${_alpaka_ROOT_DIR}/benchmark")
 endif()
 
 if(alpaka_EXAMPLES)
     enable_testing()
-    add_subdirectory(example)
+    add_subdirectory("${_alpaka_ROOT_DIR}/example")
 endif()
 
 if(alpaka_HEADERCHECKS)
     enable_testing()
-    add_subdirectory(headerCheck)
+    add_subdirectory("${_alpaka_ROOT_DIR}/headerCheck")
 endif()
 
 # Installation and config
@@ -96,5 +96,8 @@ install(FILES "${_alpaka_FEATURE_TESTS_DIR}/StdAtomicRef.cpp" DESTINATION ${CMAK
 # This macro must be called after FetchContent_MakeAvailable() used to load alpaka.
 # The reason is that this is the only way in CMake allowing alpaka to load the required languages.
 macro(alpaka_fetchcontent_finalize)
-    include("${alpaka_SOURCE_DIR}/cmake/alpakaFetchContentFinalize.cmake")
+    message(
+        WARNING
+        "alpaka_fetchcontent_finalize() is deprecated and will be removed soon. Except for removing the call to this function, no additional changes are required."
+    )
 endmacro()

--- a/cmake/alpakaCuda.cmake
+++ b/cmake/alpakaCuda.cmake
@@ -99,7 +99,7 @@ if(CMAKE_CUDA_COMPILER)
         target_link_libraries(alpaka INTERFACE alpaka_target_cuda)
     endif()
 
-    message(STATUS "cuda" ${_alpaka_CUDA_HOST_COMPILER})
+    message(STATUS "cuda with host compiler: " ${_alpaka_CUDA_HOST_COMPILER})
 
     ## GCC compiler flag to show a longer stack for concept diagnostics
     if(${_alpaka_CUDA_HOST_COMPILER} STREQUAL "GNU")

--- a/cmake/alpakaPrepareForAddSubdirectoryUsage.cmake
+++ b/cmake/alpakaPrepareForAddSubdirectoryUsage.cmake
@@ -3,12 +3,10 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 
-# @file This file simply load alpakaCommon.cmake after alpaka is installed with FetchContent.
-# The reason is that languages bust be set in the configure setup of CMake.
-# Calling FetchContent_MakeAvailable() is not enough therefore this file must be loaded.
-# alpaka's CMakeLists.txt is providing a helper alpaka_FetchContent_Finalize() to load this cmake files.
-
-# alpaka root directory provided after FetchContent_MakeAvailable() was called.
+# @file This file simply load alpakaCommon.cmake after alpaka is installed with FetchContent or is used via add_subdirectory.
+# The reason is that languages must be set in the configure setup of CMake.
+# Using alpaka via add_Subdirectory or FetchContent_Declare is not loading the languages correctly.
+# This file will be included from alpaka_finalize() once it detects that _alpaka_ROOT_DIR is not set.
 set(_alpaka_ROOT_DIR "${alpaka_SOURCE_DIR}")
 
 # Compiler feature tests.

--- a/cmake/finalize.cmake
+++ b/cmake/finalize.cmake
@@ -114,18 +114,7 @@ function(copy_with_structure SRC_FILE api_name OUT_VAR)
     set(${OUT_VAR} ${DEST_FILE} PARENT_SCOPE)
 endfunction()
 
-### Update target properties and source file properties to enable compilation with the selected alpaka targets.
-##
-## This function must be called after all alpaka targets have been linked to the target.
-## It will set the LANGUAGE property of source files to CUDA or HIP if necessary.
-## Depending on the linked targets some source files will be copied to a different location in the build tree to avoid conflicts with the LANGUAGE property.
-## All source file properties added to the original source files before the finalize call will be copied to the copied files.
-## Attention: Source file properties added to the original source files after the finalize call can not be captured and will not forward to the compiler.
-##
-## Calling this method twice for the same target will result in an undefined behaviour.
-## Linking non alpaka targets after calling this method is allowed.
-## If new source files are added to the target after calling this method they will not be handled by alpaka.
-function(alpaka_finalize target)
+function(alpaka_internal_finalize target)
     # Decide backend based on linked alpaka target
     list(REMOVE_DUPLICATES alpaka_target_list)
     alpaka_get_targets(${target} alpaka_target_list)
@@ -279,3 +268,22 @@ function(alpaka_finalize target)
         endif()
     endif()
 endfunction()
+
+### Update target properties and source file properties to enable compilation with the selected alpaka targets.
+##
+## This function must be called after all alpaka targets have been linked to the target.
+## It will set the LANGUAGE property of source files to CUDA or HIP if necessary.
+## Depending on the linked targets some source files will be copied to a different location in the build tree to avoid conflicts with the LANGUAGE property.
+## All source file properties added to the original source files before the finalize call will be copied to the copied files.
+## Attention: Source file properties added to the original source files after the finalize call can not be captured and will not forward to the compiler.
+##
+## Calling this method twice for the same target will result in an undefined behaviour.
+## Linking non alpaka targets after calling this method is allowed.
+## If new source files are added to the target after calling this method they will not be handled by alpaka.
+## In cases where alpaka is used via cmake fetch content or add_subdirectory the languages depending on alpaka's CMake flags will be loaded.
+macro(alpaka_finalize target)
+    if(NOT _alpaka_ROOT_DIR)
+        include("${alpaka_SOURCE_DIR}/cmake/alpakaPrepareForAddSubdirectoryUsage.cmake")
+    endif()
+    alpaka_internal_finalize(${target})
+endmacro()

--- a/docs/snippets/fetchContent/CMakeLists.txt
+++ b/docs/snippets/fetchContent/CMakeLists.txt
@@ -18,6 +18,8 @@ FetchContent_Declare(alpaka3 GIT_REPOSITORY https://github.com/alpaka-group/alpa
 # This downloads, configures, and makes the library targets available
 FetchContent_MakeAvailable(alpaka3)
 # Finalize the alpaka FetchContent setup and activate the required CMake languages
+# This can be removed and is only required for the transition from the current development branch to the version where
+# alpaka_finalize() is handling everything.
 alpaka_fetchcontent_finalize()
 
 # Define the device specification for your application


### PR DESCRIPTION
The same issue we saw when using alpaka with CMake's fetch content is present when using alpaka via `add_subdirectory()`.

- rename `alpakaFetchContentFinalize.cmake` to `cmake/alpakaPrepareForAddSubdirectoryUsage.cmake`
- add handling of optional load of `cmake/alpakaPrepareForAddSubdirectoryUsage.cmake` to `alpaka_finalize()`
- change `alpaka_finalize()` to a macro
- fix tiny message in the cuda cmake file
