### PR TITLE
remove usage of `alpaka_fetchcontent_finalize()`

### DIFF
--- a/docs/snippets/fetchContent/CMakeLists.txt
+++ b/docs/snippets/fetchContent/CMakeLists.txt
@@ -17,10 +17,6 @@ FetchContent_Declare(alpaka3 GIT_REPOSITORY https://github.com/alpaka-group/alpa
 # Make alpaka3 available for use in this project
 # This downloads, configures, and makes the library targets available
 FetchContent_MakeAvailable(alpaka3)
-# Finalize the alpaka FetchContent setup and activate the required CMake languages
-# This can be removed and is only required for the transition from the current development branch to the version where
-# alpaka_finalize() is handling everything.
-alpaka_fetchcontent_finalize()
 
 # Define the device specification for your application
 # Format: "api:deviceKind" where:


### PR DESCRIPTION
follow up of #377, the dev branch we pull in this example contains now the updated `alpaka_finalize()` 

fix: #379 