### PR TITLE
change auther and copyright for the docmentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,8 +57,8 @@ def setup(app):
 # -- Project information -----------------------------------------------------
 
 project = "alpaka"
-copyright = "Documentation under CC-BY 4.0, Benjamin Worpitz, René Widera, Axel Huebl, Michael Bussmann"
-author = "Benjamin Worpitz, René Widera, Axel Huebl, Michael Bussmann"
+copyright = "Documentation under CC-BY 4.0"
+author = "The alpaka team."
 # The short X.Y version.
 version = "3.0.0"
 # The full version, including alpha/beta/rc tags.


### PR DESCRIPTION
The author list in the documenation will always be autdated, tehrefore it is simply set to `The alpaka team`.
The content was copied blindly from mainline alpaka. Contributors are listed in the zenodo file.