### PR TITLE
Add scan algorithms

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -48,6 +48,7 @@
 #include "alpaka/onHost/algo/concurrent.hpp"
 #include "alpaka/onHost/algo/iota.hpp"
 #include "alpaka/onHost/algo/reduce.hpp"
+#include "alpaka/onHost/algo/scan.hpp"
 #include "alpaka/onHost/algo/transform.hpp"
 #include "alpaka/onHost/algo/transformReduce.hpp"
 #include "alpaka/onHost/demangledName.hpp"

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -303,14 +303,12 @@ namespace alpaka::onHost
         void operator()(syclGeneric::Queue<T_Device>& queue, T_Task const& task) const
         {
             ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-            // using the queue by reference is fine here, because the queue is not destroyed while the task is
-            // executed.
-            auto userQueue = queue.getSharedPtr();
+            auto queueDependency = queue.getSharedPtr();
             [[maybe_unused]] sycl::event ev = queue.m_queue.submit(
-                [userQueue, task](sycl::handler& cgh)
+                [queueDependency, task](sycl::handler& cgh)
                 {
-                    cgh.host_task([userQueue, task]()
-                                  { userQueue.get()->m_callBackThread.submit([t = std::move(task)] { t(); }); });
+                    cgh.host_task([queueDependency, task]()
+                                  { queueDependency.get()->m_callBackThread.submit([t = std::move(task)] { t(); }); });
                 });
             if(queue.isBlocking())
                 ev.wait_and_throw();

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -305,10 +305,12 @@ namespace alpaka::onHost
             ALPAKA_LOG_FUNCTION(onHost::logger::queue);
             // using the queue by reference is fine here, because the queue is not destroyed while the task is
             // executed.
+            auto userQueue = queue.getSharedPtr();
             [[maybe_unused]] sycl::event ev = queue.m_queue.submit(
-                [&queue, task](sycl::handler& cgh)
+                [userQueue, task](sycl::handler& cgh)
                 {
-                    cgh.host_task([&queue, task]() { queue.m_callBackThread.submit([t = std::move(task)] { t(); }); });
+                    cgh.host_task([userQueue, task]()
+                                  { userQueue.get()->m_callBackThread.submit([t = std::move(task)] { t(); }); });
                 });
             if(queue.isBlocking())
                 ev.wait_and_throw();

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -392,8 +392,8 @@ namespace alpaka::onHost
             {
                 auto data = std::unique_ptr<HostFuncData>(reinterpret_cast<HostFuncData*>(arg));
                 auto& queue = data->q;
-                auto userQueue = queue.getSharedPtr();
-                queue.m_callBackThread.submit([d = std::move(data), userQueue] { d->t(); });
+                auto queueDependency = queue.getSharedPtr();
+                queue.m_callBackThread.submit([d = std::move(data), queueDependency] { d->t(); });
                 // don't wait, we're async
             }
 

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -96,10 +96,10 @@ namespace alpaka::onHost
             core::CallbackThread m_callBackThread;
             bool m_isBlocking{false};
 
-            /** Waits until all operations are finished depending wather the queue is blocking or non-blocking.
+            /** Waits until all operations are finished depending on whether the queue is blocking or non-blocking.
              *
              * If the queue is a blocking queue the control flow will be blocked and the method is not returning until
-             * all work in the queue is processed. This methoid should be called after the task is enqueued into the
+             * all work in the queue is processed. This method should be called after the task is enqueued into the
              * native CUDA/HIP queue. There is no need to call this method before enqueuing because the queues are
              * in-order queues and even if another thread is enqueued something before the order is guaranteed.
              */
@@ -392,7 +392,8 @@ namespace alpaka::onHost
             {
                 auto data = std::unique_ptr<HostFuncData>(reinterpret_cast<HostFuncData*>(arg));
                 auto& queue = data->q;
-                queue.m_callBackThread.submit([d = std::move(data)] { d->t(); });
+                auto userQueue = queue.getSharedPtr();
+                queue.m_callBackThread.submit([d = std::move(data), userQueue] { d->t(); });
                 // don't wait, we're async
             }
 

--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -33,6 +33,7 @@ namespace alpaka::onHost::internal
     constexpr std::size_t numNvidiaBanks = 32u;
     constexpr std::size_t numAmdBanks = 32u;
     constexpr std::size_t numIntelBanks = 16u;
+    constexpr std::size_t chunkSize = 2048u;
 
     template<alpaka::concepts::DeviceKind TDeviceKind, typename T_Idx, typename T_Data>
     consteval T_Idx maximumMiniBlockSize()
@@ -52,7 +53,7 @@ namespace alpaka::onHost::internal
      * unknown/unimplemented device kinds, infinite memory banks are assumed, i.e., no padding is used.
      */
     template<typename TDeviceKind, typename T_Idx>
-    constexpr T_Idx conflictFreeAccess(auto const& n)
+    constexpr T_Idx conflictFreeAccess(T_Idx const& n)
     {
         if constexpr(TDeviceKind{} == deviceKind::nvidiaGpu)
             return n + n / static_cast<T_Idx>(numNvidiaBanks);
@@ -124,7 +125,7 @@ namespace alpaka::onHost::internal
     {
     public:
         ALPAKA_FN_ACC void operator()(
-            alpaka::onHost::concepts::Device auto const& acc,
+            auto const& acc,
             alpaka::concepts::IDataSource auto const& inputVec,
             alpaka::concepts::IMdSpan auto outputVec,
             auto... blockSums) const
@@ -145,21 +146,6 @@ namespace alpaka::onHost::internal
             constexpr auto LocalArrayLength = miniBlocksPerThread * miniBlockSize;
             using LocalArray = T_Data[LocalArrayLength];
 
-            ALPAKA_LOG_INFO(
-                onHost::logger::memory,
-                [&]()
-                {
-                    std::stringstream ss;
-                    ss << "scan kernel: {";
-                    ss << "frameExtent: " << frameExtent;
-                    ss << ", numThreadsPerBlock: " << numThreadsPerBlock;
-                    ss << ", elsPerThread: " << elsPerThread;
-                    ss << ", chunkExtent: " << chunkExtent;
-                    ss << ", miniBlockSize: " << miniBlockSize;
-                    ss << ", miniBlocksPerThread: " << miniBlocksPerThread;
-                    ss << "}" return ss.str();
-                });
-
             auto const validElementsInLastFrame = (numElements - T_Idx{1}) % chunkExtent + T_Idx{1};
 
             /* This kernel is called with 1-dimensional frame extents.
@@ -178,7 +164,7 @@ namespace alpaka::onHost::internal
 
                 auto tmp = onAcc::declareSharedMdArray<T_Data, uniqueId()>(
                     acc,
-                    CVec<T_Idx, conflictFreeAccess<DeviceType>(miniBlocksPerChunk - T_Idx{1}) + T_Idx{1}>{});
+                    CVec<T_Idx, conflictFreeAccess<DeviceType, T_Idx>(miniBlocksPerChunk - T_Idx{1}) + T_Idx{1}>{});
                 auto const frameOffset = chunkExtent * frameIdx;
 
                 for(auto frameElem : onAcc::makeIdxMap(
@@ -220,7 +206,8 @@ namespace alpaka::onHost::internal
                         miniBlockOffset += miniBlockSize)
                     {
                         // scan miniblock
-                        auto miniBlockSum = scanMiniBlock(regMem + miniBlockOffset, CVec<T_Idx, miniBlockSize>{});
+                        auto miniBlockSum
+                            = scanMiniBlock<T_Idx, T_Data>(regMem + miniBlockOffset, CVec<T_Idx, miniBlockSize>{});
 
                         // write miniblock sum into shared memory
                         tmp[conflictFreeAccess<DeviceType>((frameElem + miniBlockOffset) / miniBlockSize)]
@@ -355,7 +342,7 @@ namespace alpaka::onHost::internal
     {
     public:
         ALPAKA_FN_ACC void operator()(
-            alpaka::onHost::concepts::Device auto const& acc,
+            auto const& acc,
             alpaka::concepts::IMdSpan auto const& blockSums,
             alpaka::concepts::IMdSpan auto outputVec) const
         {
@@ -377,19 +364,17 @@ namespace alpaka::onHost::internal
 
     auto scanBufferSize(alpaka::concepts::Vector auto const& extents)
     {
-        static_assert(extents.size() == 1);
-
         using T_Idx = ALPAKA_TYPEOF(extents)::type;
-        constexpr auto chunkExtent = CVec<T_Idx, 2048u>{};
-        auto elements = extents;
+        constexpr auto chunkExtent = CVec<T_Idx, chunkSize>{};
+        auto elements = divCeil(extents, chunkExtent);
 
-        auto bufSize = T_Idx{0};
+        auto bufSize = Vec<T_Idx, 1>{0};
         while(elements > T_Idx{1})
         {
-            elements = divCeil(elements, chunkExtent);
-
             // buffer is for increments and blockSums, so *2 is necessary
-            bufSize += 2 * elements;
+            bufSize += Vec<T_Idx, 1>{2u} * elements;
+
+            elements = divCeil(elements, chunkExtent);
         }
 
         return bufSize;
@@ -408,9 +393,26 @@ namespace alpaka::onHost::internal
         Scan_ScanBlocksKernel<SCAN_TYPE, T_Idx, T_Data> scanBlocks;
 
         // Define chunkExtent
-        constexpr auto chunkExtent = CVec<T_Idx, 2048u>{};
+        constexpr auto chunkExtent = CVec<T_Idx, chunkSize>{};
         auto numFrames = divCeil(inputVec.getExtents(), chunkExtent);
         auto const frameSpec = onHost::FrameSpec{numFrames, chunkExtent, CVec<T_Idx, 256u>{}};
+
+        ALPAKA_LOG_INFO(
+            onHost::logger::memory,
+            [&]()
+            {
+                std::stringstream ss;
+                ss << "scan: {";
+                if(SCAN_TYPE == INCLUSIVE_SCAN)
+                    ss << ", scanType= INCLUSIVE_SCAN";
+                else if(SCAN_TYPE == EXCLUSIVE_SCAN)
+                    ss << ", scanType= EXCLUSIVE_SCAN";
+                ss << ", numFrames= " << numFrames;
+                ss << ", chunkExtent= " << chunkExtent;
+                ss << ", value_type=" << onHost::demangledName<T_Data>();
+                ss << "}";
+                return ss.str();
+            });
 
         if(frameSpec.m_numFrames > T_Idx{1})
         {
@@ -424,13 +426,15 @@ namespace alpaka::onHost::internal
             auto blockSums = buffer.getSubView(frameSpec.m_numFrames, frameSpec.m_numFrames);
 
             // the unused elements in the buffer are used for recursion to the next scan call
-            auto bufferNext = buffer.getSubView(frameSpec.m_numFrames * 2, buffer.size() - frameSpec.m_numFrames * 2);
+            auto bufferNext = buffer.getSubView(
+                frameSpec.m_numFrames * CVec<T_Idx, 2>{},
+                buffer.getExtents() - frameSpec.m_numFrames * CVec<T_Idx, 2>{});
 
             // enqueue the kernel execution tasks
             queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
 
             // always recurse into exclusive scan
-            scan<EXCLUSIVE_SCAN, T_Idx>(exec, devAcc, queue, increments, blockSums, bufferNext);
+            scan<EXCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, increments, blockSums, bufferNext);
             queue.enqueue(exec, frameSpec, KernelBundle{addIncrements, blockSums, outputVec});
         }
         else

--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/core/common.hpp"
 #include "alpaka/onAcc/Acc.hpp"
 #include "alpaka/onAcc/SimdAlgo.hpp"
+#include "alpaka/onAcc/warp.hpp"
 #include "alpaka/onHost/interface.hpp"
 #include "alpaka/onHost/logger/logger.hpp"
 #include "alpaka/trait.hpp"
@@ -29,10 +30,6 @@ namespace alpaka::onHost::internal
         INCLUSIVE_SCAN
     };
 
-    // TODO: use compile time warp sizes
-    constexpr std::size_t numNvidiaBanks = 32u;
-    constexpr std::size_t numAmdBanks = 32u;
-    constexpr std::size_t numIntelBanks = 16u;
     constexpr std::size_t chunkSize = 2048u;
 
     template<alpaka::concepts::DeviceKind TDeviceKind, typename T_Idx, typename T_Data>
@@ -52,17 +49,11 @@ namespace alpaka::onHost::internal
      * template parameter is the device kind, which dictates how many memory banks are assumed. For CPU or
      * unknown/unimplemented device kinds, infinite memory banks are assumed, i.e., no padding is used.
      */
-    template<typename TDeviceKind, typename T_Idx>
+    template<typename T_Acc, typename T_Idx>
     constexpr T_Idx conflictFreeAccess(T_Idx const& n)
     {
-        if constexpr(TDeviceKind{} == deviceKind::nvidiaGpu)
-            return n + n / static_cast<T_Idx>(numNvidiaBanks);
-        else if constexpr(TDeviceKind{} == deviceKind::amdGpu)
-            return n + n / static_cast<T_Idx>(numAmdBanks);
-        else if constexpr(TDeviceKind{} == deviceKind::intelGpu)
-            return n + n / static_cast<T_Idx>(numIntelBanks);
-        else // cpu or unknown backend does nothing
-            return n;
+        constexpr auto warpSize = static_cast<T_Idx>(onAcc::warp::getSize<T_Acc>());
+        return n + n / warpSize;
     }
 
     /* Do a muting exclusive scan on the given miniblock, and return the total sum.
@@ -131,6 +122,7 @@ namespace alpaka::onHost::internal
             auto... blockSums) const
         {
             using DeviceType = ALPAKA_TYPEOF(acc.getDeviceKind());
+            using AccType = ALPAKA_TYPEOF(acc);
             alpaka::concepts::Vector auto numFrames = acc[frame::count];
 
             alpaka::concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
@@ -162,9 +154,8 @@ namespace alpaka::onHost::internal
                 // allocate "per-thread" register memory to store all mini blocks of a thread persistently
                 LocalArray regMem;
 
-                auto tmp = onAcc::declareSharedMdArray<T_Data, uniqueId()>(
-                    acc,
-                    CVec<T_Idx, conflictFreeAccess<DeviceType, T_Idx>(miniBlocksPerChunk - T_Idx{1}) + T_Idx{1}>{});
+                constexpr auto conflictFreeAdr = conflictFreeAccess<AccType>(miniBlocksPerChunk - T_Idx{1}) + T_Idx{1};
+                auto tmp = onAcc::declareSharedMdArray<T_Data, uniqueId()>(acc, CVec<T_Idx, conflictFreeAdr>{});
                 auto const frameOffset = chunkExtent * frameIdx;
 
                 for(auto frameElem : onAcc::makeIdxMap(
@@ -210,8 +201,7 @@ namespace alpaka::onHost::internal
                             = scanMiniBlock<T_Idx, T_Data>(regMem + miniBlockOffset, CVec<T_Idx, miniBlockSize>{});
 
                         // write miniblock sum into shared memory
-                        tmp[conflictFreeAccess<DeviceType>((frameElem + miniBlockOffset) / miniBlockSize)]
-                            = miniBlockSum;
+                        tmp[conflictFreeAccess<AccType>((frameElem + miniBlockOffset) / miniBlockSize)] = miniBlockSum;
                     }
                 }
 
@@ -226,8 +216,8 @@ namespace alpaka::onHost::internal
                     {
                         T_Idx left = offset * (frameElem + T_Idx{1}).x() - T_Idx{1};
                         T_Idx right = offset * (frameElem + T_Idx{2}).x() - T_Idx{1};
-                        left = conflictFreeAccess<DeviceType>(left);
-                        right = conflictFreeAccess<DeviceType>(right);
+                        left = conflictFreeAccess<AccType>(left);
+                        right = conflictFreeAccess<AccType>(right);
                         tmp[right] += tmp[left];
                     }
                 }
@@ -240,11 +230,11 @@ namespace alpaka::onHost::internal
                     if constexpr(sizeof...(blockSums))
                     {
                         auto _blockSums = std::get<0>(std::make_tuple(blockSums...));
-                        _blockSums[frameIdx] = tmp[conflictFreeAccess<DeviceType>(miniBlocksPerChunk - T_Idx{1})];
+                        _blockSums[frameIdx] = tmp[conflictFreeAccess<AccType>(miniBlocksPerChunk - T_Idx{1})];
                     }
 
                     // -- SET 0 --
-                    tmp[conflictFreeAccess<DeviceType>(miniBlocksPerChunk - T_Idx{1})] = 0;
+                    tmp[conflictFreeAccess<AccType>(miniBlocksPerChunk - T_Idx{1})] = 0;
                 }
 
                 // -- DOWN-SWEEP --
@@ -258,8 +248,8 @@ namespace alpaka::onHost::internal
                     {
                         T_Idx left = offset * (frameElem.x() + T_Idx{1}) - T_Idx{1};
                         T_Idx right = offset * (frameElem.x() + T_Idx{2}) - T_Idx{1};
-                        left = conflictFreeAccess<DeviceType>(left);
-                        right = conflictFreeAccess<DeviceType>(right);
+                        left = conflictFreeAccess<AccType>(left);
+                        right = conflictFreeAccess<AccType>(right);
                         auto t = tmp[left];
                         tmp[left] = tmp[right];
                         tmp[right] += t;
@@ -281,8 +271,8 @@ namespace alpaka::onHost::internal
                         T_Data blockSum;
                         if(frameOffset + frameElem + miniBlockOffset < numElements)
                         {
-                            blockSum = tmp[conflictFreeAccess<DeviceType>(
-                                (frameElem.x() + miniBlockOffset) / miniBlockSize)];
+                            blockSum
+                                = tmp[conflictFreeAccess<AccType>((frameElem.x() + miniBlockOffset) / miniBlockSize)];
                         }
 
                         // add block sum to mini block

--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -9,7 +9,6 @@
 #include "alpaka/Simd.hpp"
 #include "alpaka/Vec.hpp"
 #include "alpaka/core/common.hpp"
-#include "alpaka/mem/MdSpan.hpp"
 #include "alpaka/onAcc/Acc.hpp"
 #include "alpaka/onAcc/SimdAlgo.hpp"
 #include "alpaka/onHost/interface.hpp"

--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -1,0 +1,458 @@
+/* Copyright 2025 Anton Reinhard
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+
+#include "alpaka/CVec.hpp"
+#include "alpaka/Simd.hpp"
+#include "alpaka/Vec.hpp"
+#include "alpaka/core/common.hpp"
+#include "alpaka/mem/MdSpan.hpp"
+#include "alpaka/onAcc/Acc.hpp"
+#include "alpaka/onAcc/SimdAlgo.hpp"
+#include "alpaka/onHost/interface.hpp"
+#include "alpaka/onHost/logger/logger.hpp"
+#include "alpaka/trait.hpp"
+
+#include <array> // std::array
+#include <cstddef> // std::size_t
+#include <tuple> // std::tuple
+#include <type_traits> // is_same_v
+#include <typeinfo>
+
+namespace alpaka::onHost::internal
+{
+    enum ScanType
+    {
+        EXCLUSIVE_SCAN,
+        INCLUSIVE_SCAN
+    };
+
+    constexpr std::size_t numNvidiaBanks = 32u;
+    constexpr std::size_t numAmdBanks = 32u;
+    constexpr std::size_t numIntelBanks = 16u;
+
+    template<alpaka::concepts::DeviceKind TDeviceKind, typename T_Idx, typename T_Data>
+    consteval T_Idx maximumMiniBlockSize()
+    {
+        if constexpr(TDeviceKind{} == deviceKind::nvidiaGpu)
+            return static_cast<T_Idx>(8);
+        else if constexpr(TDeviceKind{} == deviceKind::amdGpu)
+            return static_cast<T_Idx>(8);
+        else if constexpr(TDeviceKind{} == deviceKind::intelGpu)
+            return static_cast<T_Idx>(8);
+        else
+            return static_cast<T_Idx>(32768) / sizeof(T_Data);
+    }
+
+    /* This function introduces padding to the shared memory accesses to reduce bank conflicts between threads. The
+     * template parameter is the device kind, which dictates how many memory banks are assumed. For CPU or
+     * unknown/unimplemented device kinds, infinite memory banks are assumed, i.e., no padding is used.
+     */
+    template<typename TDeviceKind, typename T_Idx>
+    constexpr T_Idx conflictFreeAccess(auto const& n)
+    {
+        if constexpr(TDeviceKind{} == deviceKind::nvidiaGpu)
+            return n + n / static_cast<T_Idx>(numNvidiaBanks);
+        else if constexpr(TDeviceKind{} == deviceKind::amdGpu)
+            return n + n / static_cast<T_Idx>(numAmdBanks);
+        else if constexpr(TDeviceKind{} == deviceKind::intelGpu)
+            return n + n / static_cast<T_Idx>(numIntelBanks);
+        else // cpu or unknown backend does nothing
+            return n;
+    }
+
+    /* Do a muting exclusive scan on the given miniblock, and return the total sum.
+     */
+    template<typename T_Idx, typename T_Data>
+    ALPAKA_FN_ACC T_Data scanMiniBlock(T_Data* block, alpaka::concepts::CVector<T_Idx> auto const& extent)
+    {
+        // -- UP-SWEEP / REDUCE --
+        for(T_Idx d = extent.x() / T_Idx{2}, offset = T_Idx{1}; d > 0; d >>= 1, offset <<= 1)
+        {
+            for(auto frameElem = T_Idx{0}; frameElem < T_Idx{2} * d; frameElem += T_Idx{2})
+            {
+                T_Idx left = offset * (frameElem + T_Idx{1}) - T_Idx{1};
+                T_Idx right = offset * (frameElem + T_Idx{2}) - T_Idx{1};
+                block[right] += block[left];
+            }
+        }
+
+        // save total sum
+        T_Data blockSum = block[extent.x() - T_Idx{1}];
+
+        // set 0
+        block[extent.x() - T_Idx{1}] = T_Data{0};
+
+        // -- DOWN-SWEEP --
+        for(T_Idx d = 1, offset = extent.x() / T_Idx{2}; d < extent.x(); d <<= 1, offset >>= 1)
+        {
+            for(auto frameElem = T_Idx{0}; frameElem < T_Idx{2} * d; frameElem += T_Idx{2})
+            {
+                T_Idx left = offset * (frameElem + T_Idx{1}) - T_Idx{1};
+                T_Idx right = offset * (frameElem + T_Idx{2}) - T_Idx{1};
+                auto t = block[left];
+                block[left] = block[right];
+                block[right] += t;
+            }
+        }
+        return blockSum;
+    }
+
+    /* Do an add increment on the given miniblock, adding the given blockSum to each element.
+     */
+    template<typename T_Idx, typename T_Data>
+    ALPAKA_FN_ACC void addIncrements(
+        T_Data* block,
+        T_Data const& blockSum,
+        alpaka::concepts::CVector<T_Idx> auto const& extent)
+    {
+        for(auto i = T_Idx{0}; i < extent.x(); ++i)
+        {
+            block[i] += blockSum;
+        }
+    }
+
+    /* This kernel calculates an exclusive scan for each block individually. The algorithm is based on Blelloch, with
+     * the improvement from Lichterman, written up in the CUDA blog (see 39.2.5):
+     * https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-39-parallel-prefix-sum-scan-cuda
+     */
+    template<ScanType SCAN_TYPE, typename T_Idx, typename T_Data>
+    class Scan_ScanBlocksKernel
+    {
+    public:
+        ALPAKA_FN_ACC void operator()(
+            alpaka::onHost::concepts::Device auto const& acc,
+            alpaka::concepts::IDataSource auto const& inputVec,
+            alpaka::concepts::IMdSpan auto outputVec,
+            auto... blockSums) const
+        {
+            using DeviceType = ALPAKA_TYPEOF(acc.getDeviceKind());
+            alpaka::concepts::Vector auto numFrames = acc[frame::count];
+
+            alpaka::concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
+            alpaka::concepts::CVector auto frameExtent = acc[frame::extent];
+            constexpr auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
+            alpaka::concepts::CVector auto chunkExtent = CVec<T_Idx, elsPerThread * numThreadsPerBlock.x()>{};
+            alpaka::concepts::Vector auto numElements = inputVec.getExtents();
+
+            constexpr auto miniBlockSize = std::min(maximumMiniBlockSize<DeviceType, T_Idx, T_Data>(), elsPerThread);
+            constexpr auto miniBlocksPerThread = elsPerThread / miniBlockSize;
+            constexpr auto miniBlocksPerChunk = chunkExtent.x() / miniBlockSize;
+
+            constexpr auto LocalArrayLength = miniBlocksPerThread * miniBlockSize;
+            using LocalArray = T_Data[LocalArrayLength];
+
+            ALPAKA_LOG_INFO(
+                onHost::logger::memory,
+                [&]()
+                {
+                    std::stringstream ss;
+                    ss << "scan kernel: {";
+                    ss << "frameExtent: " << frameExtent;
+                    ss << ", numThreadsPerBlock: " << numThreadsPerBlock;
+                    ss << ", elsPerThread: " << elsPerThread;
+                    ss << ", chunkExtent: " << chunkExtent;
+                    ss << ", miniBlockSize: " << miniBlockSize;
+                    ss << ", miniBlocksPerThread: " << miniBlocksPerThread;
+                    ss << "}" return ss.str();
+                });
+
+            auto const validElementsInLastFrame = (numElements - T_Idx{1}) % chunkExtent + T_Idx{1};
+
+            /* This kernel is called with 1-dimensional frame extents.
+             *
+             * All thread blocks will be used to iterate over the frames. Each thread block will handle one or more
+             * frames.
+             */
+            for(auto frameIdx :
+                onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec<T_Idx, 1u>{0}, numFrames}))
+            {
+                bool const lastFrameFull = validElementsInLastFrame == chunkExtent;
+                bool const isLastFrame = frameIdx == numFrames - T_Idx{1};
+
+                // allocate "per-thread" register memory to store all mini blocks of a thread persistently
+                LocalArray regMem;
+
+                auto tmp = onAcc::declareSharedMdArray<T_Data, uniqueId()>(
+                    acc,
+                    CVec<T_Idx, conflictFreeAccess<DeviceType>(miniBlocksPerChunk - T_Idx{1}) + T_Idx{1}>{});
+                auto const frameOffset = chunkExtent * frameIdx;
+
+                for(auto frameElem : onAcc::makeIdxMap(
+                        acc,
+                        onAcc::worker::threadsInBlock,
+                        IdxRange{CVec<T_Idx, 0u>{}, chunkExtent, CVec<T_Idx, elsPerThread>{}}))
+                {
+                    // -- COPY TO SHARED MEM --
+                    if((!lastFrameFull && isLastFrame) || elsPerThread % T_Idx{4} != T_Idx{0})
+                    {
+                        // load into miniblocks buffer, from frameElem to frameElem + elsPerThread
+                        for(auto i = T_Idx{0}; i < elsPerThread; ++i)
+                        {
+                            if(frameOffset + frameElem + i < numElements)
+                                regMem[i] = inputVec[frameOffset + frameElem + i];
+                            else
+                                regMem[i] = 0;
+                        }
+                    }
+                    else
+                    {
+                        MdSpanArray<LocalArray, alpaka::Alignment<16>> regMemMd{regMem};
+
+                        for(auto i = T_Idx{0}; i < elsPerThread; i += T_Idx{4})
+                        {
+                            auto inputVecView = SimdPtr{
+                                inputVec,
+                                Vec{frameOffset + frameElem + i},
+                                Alignment<16>{},
+                                CVec<T_Idx, 4>{}};
+                            auto regView = SimdPtr{regMemMd, Vec{i}, Alignment<16>{}, CVec<T_Idx, 4>{}};
+
+                            regView = inputVecView.load();
+                        }
+                    }
+
+                    // -- HANDLE MINI BLOCKS OF THIS THREAD --
+                    for(auto miniBlockOffset = T_Idx{0}; miniBlockOffset < elsPerThread;
+                        miniBlockOffset += miniBlockSize)
+                    {
+                        // scan miniblock
+                        auto miniBlockSum = scanMiniBlock(regMem + miniBlockOffset, CVec<T_Idx, miniBlockSize>{});
+
+                        // write miniblock sum into shared memory
+                        tmp[conflictFreeAccess<DeviceType>((frameElem + miniBlockOffset) / miniBlockSize)]
+                            = miniBlockSum;
+                    }
+                }
+
+                // -- UP-SWEEP / REDUCE --
+                for(T_Idx d = miniBlocksPerChunk / T_Idx{2}, offset = T_Idx{1}; d > 0; d >>= 1, offset <<= 1)
+                {
+                    onAcc::syncBlockThreads(acc);
+                    for(auto frameElem : onAcc::makeIdxMap(
+                            acc,
+                            onAcc::worker::threadsInBlock,
+                            IdxRange{CVec<T_Idx, 0>{}, Vec<T_Idx, 1>{T_Idx{2} * d}, T_Idx{2}}))
+                    {
+                        T_Idx left = offset * (frameElem + T_Idx{1}).x() - T_Idx{1};
+                        T_Idx right = offset * (frameElem + T_Idx{2}).x() - T_Idx{1};
+                        left = conflictFreeAccess<DeviceType>(left);
+                        right = conflictFreeAccess<DeviceType>(right);
+                        tmp[right] += tmp[left];
+                    }
+                }
+                onAcc::syncBlockThreads(acc);
+
+                for([[maybe_unused]] auto frameElem :
+                    onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{1}))
+                {
+                    // -- SAVE BLOCK SUMS --
+                    if constexpr(sizeof...(blockSums))
+                    {
+                        auto _blockSums = std::get<0>(std::make_tuple(blockSums...));
+                        _blockSums[frameIdx] = tmp[conflictFreeAccess<DeviceType>(miniBlocksPerChunk - T_Idx{1})];
+                    }
+
+                    // -- SET 0 --
+                    tmp[conflictFreeAccess<DeviceType>(miniBlocksPerChunk - T_Idx{1})] = 0;
+                }
+
+                // -- DOWN-SWEEP --
+                for(T_Idx d = 1, offset = miniBlocksPerChunk / T_Idx{2}; d < miniBlocksPerChunk; d <<= 1, offset >>= 1)
+                {
+                    onAcc::syncBlockThreads(acc);
+                    for(auto frameElem : onAcc::makeIdxMap(
+                            acc,
+                            onAcc::worker::threadsInBlock,
+                            IdxRange{CVec<T_Idx, 0>{}, Vec<T_Idx, 1>{T_Idx{2} * d}, T_Idx{2}}))
+                    {
+                        T_Idx left = offset * (frameElem.x() + T_Idx{1}) - T_Idx{1};
+                        T_Idx right = offset * (frameElem.x() + T_Idx{2}) - T_Idx{1};
+                        left = conflictFreeAccess<DeviceType>(left);
+                        right = conflictFreeAccess<DeviceType>(right);
+                        auto t = tmp[left];
+                        tmp[left] = tmp[right];
+                        tmp[right] += t;
+                    }
+                }
+                onAcc::syncBlockThreads(acc);
+
+                // -- WRITE BACK --
+                for(auto frameElem : onAcc::makeIdxMap(
+                        acc,
+                        onAcc::worker::threadsInBlock,
+                        IdxRange{CVec<T_Idx, 0u>{}, chunkExtent, CVec<T_Idx, elsPerThread>{}}))
+                {
+                    // -- HANDLE MINI BLOCKS OF THIS THREAD --
+                    for(auto miniBlockOffset = T_Idx{0}; miniBlockOffset < elsPerThread;
+                        miniBlockOffset += miniBlockSize)
+                    {
+                        // load block sum from shared memory
+                        T_Data blockSum;
+                        if(frameOffset + frameElem + miniBlockOffset < numElements)
+                        {
+                            blockSum = tmp[conflictFreeAccess<DeviceType>(
+                                (frameElem.x() + miniBlockOffset) / miniBlockSize)];
+                        }
+
+                        // add block sum to mini block
+                        addIncrements<T_Idx>(regMem + miniBlockOffset, blockSum, CVec<T_Idx, miniBlockSize>{});
+                    }
+
+                    if((!lastFrameFull && isLastFrame) || elsPerThread % T_Idx{4} != T_Idx{0})
+                    {
+                        // write back to global mem, from frameElem to frameElem + elsPerThread
+                        for(auto i = T_Idx{0}; i < elsPerThread; ++i)
+                        {
+                            if(frameOffset + frameElem + i < numElements)
+                            {
+                                if constexpr(SCAN_TYPE == EXCLUSIVE_SCAN)
+                                    outputVec[frameOffset + frameElem + i] = regMem[i];
+                                else if constexpr(SCAN_TYPE == INCLUSIVE_SCAN)
+                                    outputVec[frameOffset + frameElem + i]
+                                        = inputVec[frameOffset + frameElem + i] + regMem[i];
+                            }
+                        }
+                    }
+                    else
+                    {
+                        MdSpanArray<LocalArray, alpaka::Alignment<16>> regMemMd{regMem};
+
+                        for(auto i = T_Idx{0}; i < elsPerThread; i += T_Idx{4})
+                        {
+                            auto outputVecView = SimdPtr{
+                                outputVec,
+                                Vec{frameOffset + frameElem + i},
+                                Alignment<16>{},
+                                CVec<T_Idx, 4>{}};
+                            auto regView = SimdPtr{regMemMd, Vec{i}, Alignment<16>{}, CVec<T_Idx, 4>{}};
+                            if constexpr(SCAN_TYPE == EXCLUSIVE_SCAN)
+                                outputVecView = regView.load();
+                            else if constexpr(SCAN_TYPE == INCLUSIVE_SCAN)
+                            {
+                                auto inputVecView = SimdPtr{
+                                    inputVec,
+                                    Vec{frameOffset + frameElem + i},
+                                    Alignment<16>{},
+                                    CVec<T_Idx, 4>{}};
+                                outputVecView = inputVecView.load() + regView.load();
+                            }
+                        }
+                    }
+                }
+                onAcc::syncBlockThreads(acc);
+            }
+        }
+    };
+
+    /* Add prefix sum from previous blocks (blockSums) to all elements in each block.
+     */
+    template<typename T_Idx>
+    class Scan_AddIncrementsKernel
+    {
+    public:
+        ALPAKA_FN_ACC void operator()(
+            alpaka::onHost::concepts::Device auto const& acc,
+            alpaka::concepts::IMdSpan auto const& blockSums,
+            alpaka::concepts::IMdSpan auto outputVec) const
+        {
+            alpaka::concepts::Vector auto numElements = outputVec.getExtents();
+            alpaka::concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
+            alpaka::concepts::CVector auto frameExtent = acc[frame::extent];
+            constexpr auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
+            alpaka::concepts::CVector auto chunkExtent = CVec<T_Idx, elsPerThread * numThreadsPerBlock.x()>{};
+
+            auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
+            simdGrid.concurrent(
+                acc,
+                numElements,
+                [&](auto const&, auto&& simdOut) constexpr
+                { simdOut = simdOut.load() + blockSums[simdOut.getIdx() / chunkExtent]; },
+                outputVec);
+        }
+    };
+
+    auto scanBufferSize(alpaka::concepts::Vector auto const& extents)
+    {
+        static_assert(extents.size() == 1);
+
+        using T_Idx = ALPAKA_TYPEOF(extents)::type;
+        constexpr auto chunkExtent = CVec<T_Idx, 2048u>{};
+        auto elements = extents;
+
+        auto bufSize = T_Idx{0};
+        while(elements > T_Idx{1})
+        {
+            elements = divCeil(elements, chunkExtent);
+
+            // buffer is for increments and blockSums, so *2 is necessary
+            bufSize += 2 * elements;
+        }
+
+        return bufSize;
+    }
+
+    template<ScanType SCAN_TYPE, typename T_Idx, typename T_Data>
+    void scan(
+        alpaka::concepts::Executor auto& exec,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        auto& queue,
+        alpaka::concepts::IDataSource<T_Data> auto& inputVec,
+        alpaka::concepts::IMdSpan<T_Data> auto& outputVec,
+        alpaka::concepts::IMdSpan<T_Data> auto& buffer)
+    {
+        // Instantiate the kernel function object with the given scan type
+        Scan_ScanBlocksKernel<SCAN_TYPE, T_Idx, T_Data> scanBlocks;
+
+        // Define chunkExtent
+        constexpr auto chunkExtent = CVec<T_Idx, 2048u>{};
+        auto numFrames = divCeil(inputVec.getExtents(), chunkExtent);
+        auto const frameSpec = onHost::FrameSpec{numFrames, chunkExtent, CVec<T_Idx, 256u>{}};
+
+        if(frameSpec.m_numFrames > T_Idx{1})
+        {
+            // problem does not fit in 1 frame, recurse
+            Scan_AddIncrementsKernel<T_Idx> addIncrements;
+
+            assert(buffer.getExtents() >= frameSpec.m_numFrames * 2);
+
+            // get the view to the necessary elements in the buffer for increments and blockSums
+            auto increments = buffer.getSubView(frameSpec.m_numFrames);
+            auto blockSums = buffer.getSubView(frameSpec.m_numFrames, frameSpec.m_numFrames);
+
+            // the unused elements in the buffer are used for recursion to the next scan call
+            auto bufferNext = buffer.getSubView(frameSpec.m_numFrames * 2, buffer.size() - frameSpec.m_numFrames * 2);
+
+            // enqueue the kernel execution tasks
+            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
+
+            // always recurse into exclusive scan
+            scan<EXCLUSIVE_SCAN, T_Idx>(exec, devAcc, queue, increments, blockSums, bufferNext);
+            queue.enqueue(exec, frameSpec, KernelBundle{addIncrements, blockSums, outputVec});
+        }
+        else
+        {
+            // problem fits within 1 frame
+            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec});
+        }
+    }
+
+    template<ScanType SCAN_TYPE, typename T_Idx, typename T_Data>
+    void scan(
+        alpaka::concepts::Executor auto& exec,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        auto& queue,
+        alpaka::concepts::IDataSource<T_Data> auto& inputVec,
+        alpaka::concepts::IMdSpan<T_Data> auto& outputVec)
+    {
+        auto buf = onHost::allocDeferred<T_Data>(queue, scanBufferSize(inputVec.getExtents()));
+
+        scan<SCAN_TYPE, T_Idx, T_Data>(exec, devAcc, queue, inputVec, outputVec, buf);
+
+        buf.keepAlive(queue);
+    }
+
+} // namespace alpaka::onHost::internal

--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -352,6 +352,7 @@ namespace alpaka::onHost::internal
         }
     };
 
+    template<typename T_Data>
     auto scanBufferSize(std::integral auto const& extent)
     {
         using T_Idx = ALPAKA_TYPEOF(extent);
@@ -364,13 +365,14 @@ namespace alpaka::onHost::internal
             elements = divCeil(elements, T_Idx{chunkSize});
         }
 
-        return bufSize;
+        return bufSize * T_Idx{sizeof(T_Data)};
     }
 
+    template<typename T_Data>
     auto scanBufferSize(alpaka::concepts::Vector auto const& extents)
     {
         static_assert(ALPAKA_TYPEOF(extents)::dim() == 1, "scan is only usable for one dimensional buffers");
-        return Vec{scanBufferSize(extents.x())};
+        return Vec{scanBufferSize<T_Data>(extents.x())};
     }
 
     template<ScanType SCAN_TYPE>
@@ -383,14 +385,12 @@ namespace alpaka::onHost::internal
         alpaka::concepts::IDataSource auto& inputVec)
     {
         using T_Data = ALPAKA_TYPEOF(inputVec)::value_type;
+        using T_BufData = ALPAKA_TYPEOF(buffer)::value_type;
         using T_Idx = ALPAKA_TYPEOF(inputVec)::index_type;
 
         static_assert(
             std::is_same_v<T_Data, typename ALPAKA_TYPEOF(outputVec)::value_type>,
             "output vector must have the same data type as input vector");
-        static_assert(
-            std::is_same_v<T_Data, typename ALPAKA_TYPEOF(buffer)::value_type>,
-            "buffer must have the same data type as input vector");
 
         // Instantiate the kernel function object with the given scan type
         Scan_ScanBlocksKernel<SCAN_TYPE, T_Idx, T_Data> scanBlocks;
@@ -422,13 +422,18 @@ namespace alpaka::onHost::internal
             // problem does not fit in 1 frame, recurse
             Scan_AddIncrementsKernel<T_Idx> addIncrements;
 
-            assert(buffer.getExtents() >= frameSpec.m_numFrames);
+            auto bufSizeBytes = frameSpec.m_numFrames * T_Idx{sizeof(T_Data)};
+            assert(buffer.getExtents() * T_Idx{sizeof(T_BufData)} >= bufSizeBytes);
 
-            // get the view to the necessary elements in the buffer for increments and blockSums
-            auto increments = buffer.getSubView(frameSpec.m_numFrames);
+            // get the view to the necessary elements in the buffer for increments
+            auto subBuf = buffer.getSubView(bufSizeBytes);
+            auto increments = MdSpan{
+                reinterpret_cast<T_Data*>(subBuf.data()),
+                frameSpec.m_numFrames,
+                Vec<T_Idx, 1>{sizeof(T_Data)}};
 
             // the unused elements in the buffer are used for recursion to the next scan call
-            auto bufferNext = buffer.getSubView(frameSpec.m_numFrames, buffer.getExtents() - frameSpec.m_numFrames);
+            auto bufferNext = buffer.getSubView(bufSizeBytes, buffer.getExtents() - bufSizeBytes);
 
             // enqueue the kernel execution tasks
             queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
@@ -454,7 +459,7 @@ namespace alpaka::onHost::internal
     {
         using T_Data = ALPAKA_TYPEOF(inputVec)::value_type;
 
-        auto buf = onHost::allocDeferred<T_Data>(queue, scanBufferSize(inputVec.getExtents()));
+        auto buf = onHost::alloc<char>(devAcc, scanBufferSize<T_Data>(inputVec.getExtents()));
 
         scan<SCAN_TYPE>(exec, devAcc, queue, buf, outputVec, inputVec);
 

--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -30,6 +30,7 @@ namespace alpaka::onHost::internal
         INCLUSIVE_SCAN
     };
 
+    // TODO: use compile time warp sizes
     constexpr std::size_t numNvidiaBanks = 32u;
     constexpr std::size_t numAmdBanks = 32u;
     constexpr std::size_t numIntelBanks = 16u;
@@ -362,33 +363,46 @@ namespace alpaka::onHost::internal
         }
     };
 
-    auto scanBufferSize(alpaka::concepts::Vector auto const& extents)
+    auto scanBufferSize(std::integral auto const& extent)
     {
-        using T_Idx = ALPAKA_TYPEOF(extents)::type;
-        constexpr auto chunkExtent = CVec<T_Idx, chunkSize>{};
-        auto elements = divCeil(extents, chunkExtent);
+        using T_Idx = ALPAKA_TYPEOF(extent);
+        auto elements = divCeil(extent, T_Idx{chunkSize});
 
-        auto bufSize = Vec<T_Idx, 1>{0};
+        auto bufSize = T_Idx{0};
         while(elements > T_Idx{1})
         {
-            // buffer is for increments and blockSums, so *2 is necessary
-            bufSize += Vec<T_Idx, 1>{2u} * elements;
-
-            elements = divCeil(elements, chunkExtent);
+            bufSize += elements;
+            elements = divCeil(elements, T_Idx{chunkSize});
         }
 
         return bufSize;
     }
 
-    template<ScanType SCAN_TYPE, typename T_Idx, typename T_Data>
+    auto scanBufferSize(alpaka::concepts::Vector auto const& extents)
+    {
+        static_assert(ALPAKA_TYPEOF(extents)::dim() == 1, "scan is only usable for one dimensional buffers");
+        return Vec{scanBufferSize(extents.x())};
+    }
+
+    template<ScanType SCAN_TYPE>
     void scan(
         alpaka::concepts::Executor auto& exec,
         alpaka::onHost::concepts::Device auto& devAcc,
         auto& queue,
-        alpaka::concepts::IDataSource<T_Data> auto& inputVec,
-        alpaka::concepts::IMdSpan<T_Data> auto& outputVec,
-        alpaka::concepts::IMdSpan<T_Data> auto& buffer)
+        alpaka::concepts::IMdSpan auto& buffer,
+        alpaka::concepts::IMdSpan auto& outputVec,
+        alpaka::concepts::IDataSource auto& inputVec)
     {
+        using T_Data = ALPAKA_TYPEOF(inputVec)::value_type;
+        using T_Idx = ALPAKA_TYPEOF(inputVec)::index_type;
+
+        static_assert(
+            std::is_same_v<T_Data, typename ALPAKA_TYPEOF(outputVec)::value_type>,
+            "output vector must have the same data type as input vector");
+        static_assert(
+            std::is_same_v<T_Data, typename ALPAKA_TYPEOF(buffer)::value_type>,
+            "buffer must have the same data type as input vector");
+
         // Instantiate the kernel function object with the given scan type
         Scan_ScanBlocksKernel<SCAN_TYPE, T_Idx, T_Data> scanBlocks;
 
@@ -419,23 +433,20 @@ namespace alpaka::onHost::internal
             // problem does not fit in 1 frame, recurse
             Scan_AddIncrementsKernel<T_Idx> addIncrements;
 
-            assert(buffer.getExtents() >= frameSpec.m_numFrames * 2);
+            assert(buffer.getExtents() >= frameSpec.m_numFrames);
 
             // get the view to the necessary elements in the buffer for increments and blockSums
             auto increments = buffer.getSubView(frameSpec.m_numFrames);
-            auto blockSums = buffer.getSubView(frameSpec.m_numFrames, frameSpec.m_numFrames);
 
             // the unused elements in the buffer are used for recursion to the next scan call
-            auto bufferNext = buffer.getSubView(
-                frameSpec.m_numFrames * CVec<T_Idx, 2>{},
-                buffer.getExtents() - frameSpec.m_numFrames * CVec<T_Idx, 2>{});
+            auto bufferNext = buffer.getSubView(frameSpec.m_numFrames, buffer.getExtents() - frameSpec.m_numFrames);
 
             // enqueue the kernel execution tasks
             queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
 
             // always recurse into exclusive scan
-            scan<EXCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, increments, blockSums, bufferNext);
-            queue.enqueue(exec, frameSpec, KernelBundle{addIncrements, blockSums, outputVec});
+            scan<EXCLUSIVE_SCAN>(exec, devAcc, queue, bufferNext, increments, increments);
+            queue.enqueue(exec, frameSpec, KernelBundle{addIncrements, increments, outputVec});
         }
         else
         {
@@ -444,17 +455,19 @@ namespace alpaka::onHost::internal
         }
     }
 
-    template<ScanType SCAN_TYPE, typename T_Idx, typename T_Data>
+    template<ScanType SCAN_TYPE>
     void scan(
         alpaka::concepts::Executor auto& exec,
         alpaka::onHost::concepts::Device auto& devAcc,
         auto& queue,
-        alpaka::concepts::IDataSource<T_Data> auto& inputVec,
-        alpaka::concepts::IMdSpan<T_Data> auto& outputVec)
+        alpaka::concepts::IMdSpan auto& outputVec,
+        alpaka::concepts::IDataSource auto const& inputVec)
     {
+        using T_Data = ALPAKA_TYPEOF(inputVec)::value_type;
+
         auto buf = onHost::allocDeferred<T_Data>(queue, scanBufferSize(inputVec.getExtents()));
 
-        scan<SCAN_TYPE, T_Idx, T_Data>(exec, devAcc, queue, inputVec, outputVec, buf);
+        scan<SCAN_TYPE>(exec, devAcc, queue, buf, outputVec, inputVec);
 
         buf.keepAlive(queue);
     }

--- a/include/alpaka/onHost/algo/scan.hpp
+++ b/include/alpaka/onHost/algo/scan.hpp
@@ -8,6 +8,9 @@
 #include "alpaka/concepts.hpp"
 #include "alpaka/onHost/algo/internal/scan.hpp"
 
+// TODO: add assertion function for whether a device/api is compatible with a number of buffers
+// (`onHost::isDataAccessible`)
+
 namespace alpaka::onHost
 {
     /** @brief For a scan of some size, this function returns the necessary buffer size.
@@ -30,40 +33,36 @@ namespace alpaka::onHost
     /** @brief Perform an inclusive scan on the input data and write the result to the output data.
      *
      * @param exec The executor to run with.
-     * @param devAcc The device to run on. TODO: remove
      * @param queue The queue to enqueue to.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
      * @param outputVec The output data. To perform an in-place scan, use the overload with only one data object.
      * @param inputVec The input data. Can be const.
-     *
-     * TODO:
      */
     void inclusiveScan(
         alpaka::concepts::Executor auto& exec,
-        alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
+        auto devAcc = queue.getDevice();
         internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, buffer, outputVec, inputVec);
     }
 
     void inclusiveScan(
         alpaka::concepts::Executor auto& exec,
-        alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
+        auto devAcc = queue.getDevice();
         internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, outputVec, inputVec);
     }
 
     /** @brief Perform an inclusive scan on data in-place.
      *
      * @param exec The executor to run with.
-     * @param devAcc The device to run on.
      * @param queue The queue to enqueue to.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
@@ -71,27 +70,26 @@ namespace alpaka::onHost
      */
     void inclusiveScanInPlace(
         alpaka::concepts::Executor auto& exec,
-        alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
+        auto devAcc = queue.getDevice();
         internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, buffer, dataVec, dataVec);
     }
 
     void inclusiveScanInPlace(
         alpaka::concepts::Executor auto& exec,
-        alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
+        auto devAcc = queue.getDevice();
         internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, dataVec, dataVec);
     }
 
     /** @brief Perform an exclusive scan on the input data and write the result to the output data.
      *
      * @param exec The executor to run with.
-     * @param devAcc The device to run on.
      * @param queue The queue to enqueue to.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
@@ -100,29 +98,28 @@ namespace alpaka::onHost
      */
     void exclusiveScan(
         alpaka::concepts::Executor auto& exec,
-        alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
+        auto devAcc = queue.getDevice();
         internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, buffer, outputVec, inputVec);
     }
 
     void exclusiveScan(
         alpaka::concepts::Executor auto& exec,
-        alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
+        auto devAcc = queue.getDevice();
         internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, outputVec, inputVec);
     }
 
     /** @brief Perform an exclusive scan on data in-place.
      *
      * @param exec The executor to run with.
-     * @param devAcc The device to run on.
      * @param queue The queue to enqueue to.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
@@ -130,20 +127,20 @@ namespace alpaka::onHost
      */
     void exclusiveScanInPlace(
         alpaka::concepts::Executor auto& exec,
-        alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
+        auto devAcc = queue.getDevice();
         internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, buffer, dataVec, dataVec);
     }
 
     void exclusiveScanInPlace(
         alpaka::concepts::Executor auto& exec,
-        alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
+        auto devAcc = queue.getDevice();
         internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, dataVec, dataVec);
     }
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/algo/scan.hpp
+++ b/include/alpaka/onHost/algo/scan.hpp
@@ -19,144 +19,131 @@ namespace alpaka::onHost
      * @param extents The extents of the scan.
      * @return The size of the buffer to allocate in number of elements. The buffer must have the same data type as the
      * object being scanned.
+     *
+     * TODO: in bytes, require element type
      */
-    auto getScanBufferSize(alpaka::concepts::Vector auto const& extents)
+    auto getScanBufferSize(alpaka::concepts::VectorOrScalar auto const& extents)
     {
         return internal::scanBufferSize(extents);
     }
 
     /** @brief Perform an inclusive scan on the input data and write the result to the output data.
      *
-     * @tparam T_Data Data type that will be scanned. T_Data{0} should be the neutral element for addition.
      * @param exec The executor to run with.
-     * @param devAcc The device to run on.
+     * @param devAcc The device to run on. TODO: remove
      * @param queue The queue to enqueue to.
-     * @param inputVec The input data. Can be const.
-     * @param outputVec The output data. To perform an in-place scan, use the overload with only one data object.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     * @param outputVec The output data. To perform an in-place scan, use the overload with only one data object.
+     * @param inputVec The input data. Can be const.
+     *
+     * TODO:
      */
-    template<typename T_Data>
     void inclusiveScan(
         alpaka::concepts::Executor auto& exec,
         alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
-        alpaka::concepts::IDataSource<T_Data> auto const& inputVec,
-        alpaka::concepts::IMdSpan<T_Data> auto outputVec,
-        auto... buffer)
+        alpaka::concepts::IMdSpan auto& buffer,
+        alpaka::concepts::IMdSpan auto& outputVec,
+        alpaka::concepts::IDataSource auto const& inputVec)
     {
-        using T_Idx = ALPAKA_TYPEOF(inputVec.getExtents())::type;
+        internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, buffer, outputVec, inputVec);
+    }
 
-        if constexpr(sizeof...(buffer))
-        {
-            // use the passed buffer
-            auto _buffer = std::get<0>(std::make_tuple(buffer...));
-            internal::scan<internal::INCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, inputVec, outputVec, _buffer);
-        }
-        else
-        {
-            // buffer will be allocated on the fly
-            internal::scan<internal::INCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, inputVec, outputVec);
-        }
+    void inclusiveScan(
+        alpaka::concepts::Executor auto& exec,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        auto const& queue,
+        alpaka::concepts::IMdSpan auto& outputVec,
+        alpaka::concepts::IDataSource auto const& inputVec)
+    {
+        internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, outputVec, inputVec);
     }
 
     /** @brief Perform an inclusive scan on data in-place.
      *
-     * @tparam T_Data Data type that will be scanned. T_Data{0} should be the neutral element for addition.
      * @param exec The executor to run with.
      * @param devAcc The device to run on.
      * @param queue The queue to enqueue to.
-     * @param dataVec The vector to scan, will be overwritten with the result.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     * @param dataVec The vector to scan, will be overwritten with the result.
      */
-    template<typename T_Data>
     void inclusiveScanInPlace(
         alpaka::concepts::Executor auto& exec,
         alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
-        alpaka::concepts::IMdSpan<T_Data> auto& dataVec,
-        auto... buffer)
+        alpaka::concepts::IMdSpan auto& buffer,
+        alpaka::concepts::IMdSpan auto& dataVec)
     {
-        using T_Idx = ALPAKA_TYPEOF(dataVec.getExtents())::type;
+        internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, buffer, dataVec, dataVec);
+    }
 
-        if constexpr(sizeof...(buffer))
-        {
-            // use the passed buffer
-            auto _buffer = std::get<0>(std::make_tuple(buffer...));
-            internal::scan<internal::INCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, dataVec, dataVec, _buffer);
-        }
-        else
-        {
-            // buffer will be allocated on the fly
-            internal::scan<internal::INCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, dataVec, dataVec);
-        }
+    void inclusiveScanInPlace(
+        alpaka::concepts::Executor auto& exec,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        auto const& queue,
+        alpaka::concepts::IMdSpan auto& dataVec)
+    {
+        internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, dataVec, dataVec);
     }
 
     /** @brief Perform an exclusive scan on the input data and write the result to the output data.
      *
-     * @tparam T_Data Data type that will be scanned. T_Data{0} should be the neutral element for addition.
      * @param exec The executor to run with.
      * @param devAcc The device to run on.
      * @param queue The queue to enqueue to.
-     * @param inputVec The input data. Can be const.
-     * @param outputVec The output data. To perform an in-place scan, use the overload with only one data object.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     * @param outputVec The output data. To perform an in-place scan, use the overload with only one data object.
+     * @param inputVec The input data. Can be const.
      */
-    template<typename T_Data>
     void exclusiveScan(
         alpaka::concepts::Executor auto& exec,
         alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
-        alpaka::concepts::IDataSource<T_Data> auto const& inputVec,
-        alpaka::concepts::IMdSpan<T_Data> auto outputVec,
-        auto... buffer)
+        alpaka::concepts::IMdSpan auto& buffer,
+        alpaka::concepts::IMdSpan auto& outputVec,
+        alpaka::concepts::IDataSource auto const& inputVec)
     {
-        using T_Idx = ALPAKA_TYPEOF(inputVec.getExtents())::type;
+        internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, buffer, outputVec, inputVec);
+    }
 
-        if constexpr(sizeof...(buffer))
-        {
-            // use the passed buffer
-            auto _buffer = std::get<0>(std::make_tuple(buffer...));
-            internal::scan<internal::EXCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, inputVec, outputVec, _buffer);
-        }
-        else
-        {
-            // buffer will be allocated on the fly
-            internal::scan<internal::EXCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, inputVec, outputVec);
-        }
+    void exclusiveScan(
+        alpaka::concepts::Executor auto& exec,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        auto const& queue,
+        alpaka::concepts::IMdSpan auto& outputVec,
+        alpaka::concepts::IDataSource auto const& inputVec)
+    {
+        internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, outputVec, inputVec);
     }
 
     /** @brief Perform an exclusive scan on data in-place.
      *
-     * @tparam T_Data Data type that will be scanned. T_Data{0} should be the neutral element for addition.
      * @param exec The executor to run with.
      * @param devAcc The device to run on.
      * @param queue The queue to enqueue to.
-     * @param dataVec The vector to scan, will be overwritten with the result.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     * @param dataVec The vector to scan, will be overwritten with the result.
      */
-    template<typename T_Data>
     void exclusiveScanInPlace(
         alpaka::concepts::Executor auto& exec,
         alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
-        alpaka::concepts::IMdSpan<T_Data> auto& dataVec,
-        auto... buffer)
+        alpaka::concepts::IMdSpan auto& buffer,
+        alpaka::concepts::IMdSpan auto& dataVec)
     {
-        using T_Idx = ALPAKA_TYPEOF(dataVec.getExtents())::type;
-        if constexpr(sizeof...(buffer))
-        {
-            // use the passed buffer
-            auto _buffer = std::get<0>(std::make_tuple(buffer...));
-            internal::scan<internal::EXCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, dataVec, dataVec, _buffer);
-        }
-        else
-        {
-            // buffer will be allocated on the fly
-            internal::scan<internal::EXCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, dataVec, dataVec);
-        }
+        internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, buffer, dataVec, dataVec);
+    }
+
+    void exclusiveScanInPlace(
+        alpaka::concepts::Executor auto& exec,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        auto const& queue,
+        alpaka::concepts::IMdSpan auto& dataVec)
+    {
+        internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, dataVec, dataVec);
     }
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/algo/scan.hpp
+++ b/include/alpaka/onHost/algo/scan.hpp
@@ -13,21 +13,20 @@
 
 namespace alpaka::onHost
 {
-    /** @brief For a scan of some size, this function returns the necessary buffer size.
+    /** @brief For a scan of some size, this function returns the necessary buffer size in bytes.
      *
      * When multiple scans of the same extents are needed (for example in a loop), this function can be used to only
      * allocate an intermediate buffer once, removing alloc/free overhead. For unique scan calls, the buffer can be
      * omitted in the scan call, in which case it will be allocated and freed on the fly.
      *
+     * @tparam T_Data The type of the data to be scanned.
      * @param extents The extents of the scan.
-     * @return The size of the buffer to allocate in number of elements. The buffer must have the same data type as the
-     * object being scanned.
-     *
-     * TODO: in bytes, require element type
+     * @return The size of the buffer to allocate in **number of bytes**.
      */
+    template<typename T_Data>
     auto getScanBufferSize(alpaka::concepts::VectorOrScalar auto const& extents)
     {
-        return internal::scanBufferSize(extents);
+        return internal::scanBufferSize<T_Data>(extents);
     }
 
     /** @brief Perform an inclusive scan on the input data and write the result to the output data.

--- a/include/alpaka/onHost/algo/scan.hpp
+++ b/include/alpaka/onHost/algo/scan.hpp
@@ -45,27 +45,18 @@ namespace alpaka::onHost
         alpaka::concepts::IMdSpan<T_Data> auto outputVec,
         auto... buffer)
     {
+        using T_Idx = ALPAKA_TYPEOF(inputVec.getExtents())::type;
+
         if constexpr(sizeof...(buffer))
         {
             // use the passed buffer
             auto _buffer = std::get<0>(std::make_tuple(buffer...));
-            internal::scan<internal::INCLUSIVE_SCAN, inputVec.index_type, T_Data>(
-                exec,
-                devAcc,
-                queue,
-                inputVec,
-                outputVec,
-                _buffer);
+            internal::scan<internal::INCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, inputVec, outputVec, _buffer);
         }
         else
         {
             // buffer will be allocated on the fly
-            internal::scan<internal::INCLUSIVE_SCAN, inputVec.index_type, T_Data>(
-                exec,
-                devAcc,
-                queue,
-                inputVec,
-                outputVec);
+            internal::scan<internal::INCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, inputVec, outputVec);
         }
     }
 
@@ -80,34 +71,25 @@ namespace alpaka::onHost
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
      */
     template<typename T_Data>
-    void inclusiveScan(
+    void inclusiveScanInPlace(
         alpaka::concepts::Executor auto& exec,
         alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
         alpaka::concepts::IMdSpan<T_Data> auto& dataVec,
         auto... buffer)
     {
+        using T_Idx = ALPAKA_TYPEOF(dataVec.getExtents())::type;
+
         if constexpr(sizeof...(buffer))
         {
             // use the passed buffer
             auto _buffer = std::get<0>(std::make_tuple(buffer...));
-            internal::scan<internal::INCLUSIVE_SCAN, dataVec.index_type, T_Data>(
-                exec,
-                devAcc,
-                queue,
-                dataVec,
-                dataVec,
-                _buffer);
+            internal::scan<internal::INCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, dataVec, dataVec, _buffer);
         }
         else
         {
             // buffer will be allocated on the fly
-            internal::scan<internal::INCLUSIVE_SCAN, dataVec.index_type, T_Data>(
-                exec,
-                devAcc,
-                queue,
-                dataVec,
-                dataVec);
+            internal::scan<internal::INCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, dataVec, dataVec);
         }
     }
 
@@ -131,27 +113,18 @@ namespace alpaka::onHost
         alpaka::concepts::IMdSpan<T_Data> auto outputVec,
         auto... buffer)
     {
+        using T_Idx = ALPAKA_TYPEOF(inputVec.getExtents())::type;
+
         if constexpr(sizeof...(buffer))
         {
             // use the passed buffer
             auto _buffer = std::get<0>(std::make_tuple(buffer...));
-            internal::scan<internal::EXCLUSIVE_SCAN, inputVec.index_type, T_Data>(
-                exec,
-                devAcc,
-                queue,
-                inputVec,
-                outputVec,
-                _buffer);
+            internal::scan<internal::EXCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, inputVec, outputVec, _buffer);
         }
         else
         {
             // buffer will be allocated on the fly
-            internal::scan<internal::EXCLUSIVE_SCAN, inputVec.index_type, T_Data>(
-                exec,
-                devAcc,
-                queue,
-                inputVec,
-                outputVec);
+            internal::scan<internal::EXCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, inputVec, outputVec);
         }
     }
 
@@ -166,34 +139,24 @@ namespace alpaka::onHost
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
      */
     template<typename T_Data>
-    void exclusiveScan(
+    void exclusiveScanInPlace(
         alpaka::concepts::Executor auto& exec,
         alpaka::onHost::concepts::Device auto& devAcc,
         auto const& queue,
         alpaka::concepts::IMdSpan<T_Data> auto& dataVec,
         auto... buffer)
     {
+        using T_Idx = ALPAKA_TYPEOF(dataVec.getExtents())::type;
         if constexpr(sizeof...(buffer))
         {
             // use the passed buffer
             auto _buffer = std::get<0>(std::make_tuple(buffer...));
-            internal::scan<internal::EXCLUSIVE_SCAN, dataVec.index_type, T_Data>(
-                exec,
-                devAcc,
-                queue,
-                dataVec,
-                dataVec,
-                _buffer);
+            internal::scan<internal::EXCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, dataVec, dataVec, _buffer);
         }
         else
         {
             // buffer will be allocated on the fly
-            internal::scan<internal::EXCLUSIVE_SCAN, dataVec.index_type, T_Data>(
-                exec,
-                devAcc,
-                queue,
-                dataVec,
-                dataVec);
+            internal::scan<internal::EXCLUSIVE_SCAN, T_Idx, T_Data>(exec, devAcc, queue, dataVec, dataVec);
         }
     }
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/algo/scan.hpp
+++ b/include/alpaka/onHost/algo/scan.hpp
@@ -1,0 +1,199 @@
+/* Copyright 2025 Anton Reinhard
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/trait.hpp"
+#include "alpaka/concepts.hpp"
+#include "alpaka/onHost/algo/internal/scan.hpp"
+
+namespace alpaka::onHost
+{
+    /** @brief For a scan of some size, this function returns the necessary buffer size.
+     *
+     * When multiple scans of the same extents are needed (for example in a loop), this function can be used to only
+     * allocate an intermediate buffer once, removing alloc/free overhead. For unique scan calls, the buffer can be
+     * omitted in the scan call, in which case it will be allocated and freed on the fly.
+     *
+     * @param extents The extents of the scan.
+     * @return The size of the buffer to allocate in number of elements. The buffer must have the same data type as the
+     * object being scanned.
+     */
+    auto getScanBufferSize(alpaka::concepts::Vector auto const& extents)
+    {
+        return internal::scanBufferSize(extents);
+    }
+
+    /** @brief Perform an inclusive scan on the input data and write the result to the output data.
+     *
+     * @tparam T_Data Data type that will be scanned. T_Data{0} should be the neutral element for addition.
+     * @param exec The executor to run with.
+     * @param devAcc The device to run on.
+     * @param queue The queue to enqueue to.
+     * @param inputVec The input data. Can be const.
+     * @param outputVec The output data. To perform an in-place scan, use the overload with only one data object.
+     * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
+     * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     */
+    template<typename T_Data>
+    void inclusiveScan(
+        alpaka::concepts::Executor auto& exec,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        auto const& queue,
+        alpaka::concepts::IDataSource<T_Data> auto const& inputVec,
+        alpaka::concepts::IMdSpan<T_Data> auto outputVec,
+        auto... buffer)
+    {
+        if constexpr(sizeof...(buffer))
+        {
+            // use the passed buffer
+            auto _buffer = std::get<0>(std::make_tuple(buffer...));
+            internal::scan<internal::INCLUSIVE_SCAN, inputVec.index_type, T_Data>(
+                exec,
+                devAcc,
+                queue,
+                inputVec,
+                outputVec,
+                _buffer);
+        }
+        else
+        {
+            // buffer will be allocated on the fly
+            internal::scan<internal::INCLUSIVE_SCAN, inputVec.index_type, T_Data>(
+                exec,
+                devAcc,
+                queue,
+                inputVec,
+                outputVec);
+        }
+    }
+
+    /** @brief Perform an inclusive scan on data in-place.
+     *
+     * @tparam T_Data Data type that will be scanned. T_Data{0} should be the neutral element for addition.
+     * @param exec The executor to run with.
+     * @param devAcc The device to run on.
+     * @param queue The queue to enqueue to.
+     * @param dataVec The vector to scan, will be overwritten with the result.
+     * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
+     * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     */
+    template<typename T_Data>
+    void inclusiveScan(
+        alpaka::concepts::Executor auto& exec,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        auto const& queue,
+        alpaka::concepts::IMdSpan<T_Data> auto& dataVec,
+        auto... buffer)
+    {
+        if constexpr(sizeof...(buffer))
+        {
+            // use the passed buffer
+            auto _buffer = std::get<0>(std::make_tuple(buffer...));
+            internal::scan<internal::INCLUSIVE_SCAN, dataVec.index_type, T_Data>(
+                exec,
+                devAcc,
+                queue,
+                dataVec,
+                dataVec,
+                _buffer);
+        }
+        else
+        {
+            // buffer will be allocated on the fly
+            internal::scan<internal::INCLUSIVE_SCAN, dataVec.index_type, T_Data>(
+                exec,
+                devAcc,
+                queue,
+                dataVec,
+                dataVec);
+        }
+    }
+
+    /** @brief Perform an exclusive scan on the input data and write the result to the output data.
+     *
+     * @tparam T_Data Data type that will be scanned. T_Data{0} should be the neutral element for addition.
+     * @param exec The executor to run with.
+     * @param devAcc The device to run on.
+     * @param queue The queue to enqueue to.
+     * @param inputVec The input data. Can be const.
+     * @param outputVec The output data. To perform an in-place scan, use the overload with only one data object.
+     * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
+     * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     */
+    template<typename T_Data>
+    void exclusiveScan(
+        alpaka::concepts::Executor auto& exec,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        auto const& queue,
+        alpaka::concepts::IDataSource<T_Data> auto const& inputVec,
+        alpaka::concepts::IMdSpan<T_Data> auto outputVec,
+        auto... buffer)
+    {
+        if constexpr(sizeof...(buffer))
+        {
+            // use the passed buffer
+            auto _buffer = std::get<0>(std::make_tuple(buffer...));
+            internal::scan<internal::EXCLUSIVE_SCAN, inputVec.index_type, T_Data>(
+                exec,
+                devAcc,
+                queue,
+                inputVec,
+                outputVec,
+                _buffer);
+        }
+        else
+        {
+            // buffer will be allocated on the fly
+            internal::scan<internal::EXCLUSIVE_SCAN, inputVec.index_type, T_Data>(
+                exec,
+                devAcc,
+                queue,
+                inputVec,
+                outputVec);
+        }
+    }
+
+    /** @brief Perform an exclusive scan on data in-place.
+     *
+     * @tparam T_Data Data type that will be scanned. T_Data{0} should be the neutral element for addition.
+     * @param exec The executor to run with.
+     * @param devAcc The device to run on.
+     * @param queue The queue to enqueue to.
+     * @param dataVec The vector to scan, will be overwritten with the result.
+     * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
+     * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     */
+    template<typename T_Data>
+    void exclusiveScan(
+        alpaka::concepts::Executor auto& exec,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        auto const& queue,
+        alpaka::concepts::IMdSpan<T_Data> auto& dataVec,
+        auto... buffer)
+    {
+        if constexpr(sizeof...(buffer))
+        {
+            // use the passed buffer
+            auto _buffer = std::get<0>(std::make_tuple(buffer...));
+            internal::scan<internal::EXCLUSIVE_SCAN, dataVec.index_type, T_Data>(
+                exec,
+                devAcc,
+                queue,
+                dataVec,
+                dataVec,
+                _buffer);
+        }
+        else
+        {
+            // buffer will be allocated on the fly
+            internal::scan<internal::EXCLUSIVE_SCAN, dataVec.index_type, T_Data>(
+                exec,
+                devAcc,
+                queue,
+                dataVec,
+                dataVec);
+        }
+    }
+} // namespace alpaka::onHost

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -34,7 +34,7 @@ namespace alpaka::onHost
      *   The functor should support Simd packages. If not you can enforce the element wise execution by wrapping into
      * @see ScalarFunc. If you would like to support stencil executions wrapp fn into @see StencilFunc. StencilFunc is
      * getting all arguments as @see SimdPtr. If StencilFunc is used you should take care to not read outside of valid
-     * memory ranges by using sub-views to your input and output data. Optionally a transformFn can have a accelerator
+     * memory ranges by using sub-views to your input and output data. Optionally a transformFn can have an accelerator
      * as first argument.
      * @param in The input data to transform, all input data is passed to fn. transformFn must support as many
      * arguments as input data is provided. An optional argument for the accelerator is support as first argument if
@@ -78,7 +78,7 @@ namespace alpaka::onHost
     }
 
     /**
-     * A available default executor will be selected automaticlally. The default executor is a executor with most
+     * An available default executor will be selected automatically. The default executor is the executor with the most
      * parallelism/performance.
      */
     template<typename DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>

--- a/tests/unit/algorithm/scan.cpp
+++ b/tests/unit/algorithm/scan.cpp
@@ -97,7 +97,7 @@ void testExclusiveScan(
 
 
     onHost::SharedBuffer intermediateBuffer
-        = onHost::alloc<T_Data>(computeDev, onHost::getScanBufferSize(inBuf.getExtents()));
+        = onHost::alloc<char>(computeDev, onHost::getScanBufferSize<T_Data>(inBuf.getExtents()));
 
     // exclusive scan, with buffer
     std::cout << "exclusive scan, with buffer" << std::endl;
@@ -139,7 +139,7 @@ void testInclusiveScan(
 
 
     onHost::SharedBuffer intermediateBuffer
-        = onHost::allocDeferred<T_Data>(computeQueue, onHost::getScanBufferSize(inBuf.getExtents()));
+        = onHost::alloc<char>(computeDev, onHost::getScanBufferSize<T_Data>(inBuf.getExtents()));
 
     // inclusive scan, with buffer
     std::cout << "inclusive scan, with buffer" << std::endl;

--- a/tests/unit/algorithm/scan.cpp
+++ b/tests/unit/algorithm/scan.cpp
@@ -97,7 +97,7 @@ void testExclusiveScan(
 
 
     onHost::SharedBuffer intermediateBuffer
-        = onHost::alloc<char>(computeDev, onHost::getScanBufferSize<T_Data>(inBuf.getExtents()));
+        = onHost::alloc<std::byte>(computeDev, onHost::getScanBufferSize<T_Data>(inBuf.getExtents()));
 
     // exclusive scan, with buffer
     std::cout << "exclusive scan, with buffer" << std::endl;
@@ -139,7 +139,7 @@ void testInclusiveScan(
 
 
     onHost::SharedBuffer intermediateBuffer
-        = onHost::alloc<char>(computeDev, onHost::getScanBufferSize<T_Data>(inBuf.getExtents()));
+        = onHost::alloc<std::byte>(computeDev, onHost::getScanBufferSize<T_Data>(inBuf.getExtents()));
 
     // inclusive scan, with buffer
     std::cout << "inclusive scan, with buffer" << std::endl;

--- a/tests/unit/algorithm/scan.cpp
+++ b/tests/unit/algorithm/scan.cpp
@@ -9,7 +9,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <chrono>
 #include <functional>
 #include <iostream>
 #include <type_traits>
@@ -66,13 +65,10 @@ int validateResult(
     {
         return EXIT_SUCCESS;
     }
-    else
-    {
-        std::cout << "Found " << falseResults << " false results, printed no more than " << MAX_PRINT_FALSE_RESULTS
-                  << "\n"
-                  << "Execution results incorrect!" << std::endl;
-        return EXIT_FAILURE;
-    }
+
+    std::cout << "Found " << falseResults << " false results, printed no more than " << MAX_PRINT_FALSE_RESULTS << "\n"
+              << "Execution results incorrect!" << std::endl;
+    return EXIT_FAILURE;
 }
 
 template<typename T_Data>
@@ -89,13 +85,13 @@ void testExclusiveScan(
     // exclusive scan, no buffer
     std::cout << "exclusive scan, no buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::exclusiveScan(exec, computeDev, computeQueue, outBuf, inBuf);
+    onHost::exclusiveScan(exec, computeQueue, outBuf, inBuf);
     auto res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // exclusive scan, in-place
     std::cout << "exclusive scan, no buffer, in-place" << std::endl;
-    onHost::exclusiveScanInPlace(exec, computeDev, computeQueue, inBuf);
+    onHost::exclusiveScanInPlace(exec, computeQueue, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
@@ -106,13 +102,13 @@ void testExclusiveScan(
     // exclusive scan, with buffer
     std::cout << "exclusive scan, with buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::exclusiveScan(exec, computeDev, computeQueue, intermediateBuffer, outBuf, inBuf);
+    onHost::exclusiveScan(exec, computeQueue, intermediateBuffer, outBuf, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // exclusive scan, in-place with buffer
     std::cout << "exclusive scan, with buffer, in-place" << std::endl;
-    onHost::exclusiveScanInPlace(exec, computeDev, computeQueue, intermediateBuffer, inBuf);
+    onHost::exclusiveScanInPlace(exec, computeQueue, intermediateBuffer, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 }
@@ -131,13 +127,13 @@ void testInclusiveScan(
     // inclusive scan, no buffer
     std::cout << "inclusive scan, no buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::inclusiveScan(exec, computeDev, computeQueue, outBuf, inBuf);
+    onHost::inclusiveScan(exec, computeQueue, outBuf, inBuf);
     auto res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // inclusive scan, in-place
     std::cout << "inclusive scan, no buffer, in-place" << std::endl;
-    onHost::inclusiveScanInPlace(exec, computeDev, computeQueue, inBuf);
+    onHost::inclusiveScanInPlace(exec, computeQueue, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
@@ -148,13 +144,13 @@ void testInclusiveScan(
     // inclusive scan, with buffer
     std::cout << "inclusive scan, with buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::inclusiveScan(exec, computeDev, computeQueue, intermediateBuffer, outBuf, inBuf);
+    onHost::inclusiveScan(exec, computeQueue, intermediateBuffer, outBuf, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // inclusive scan, in-place with buffer
     std::cout << "inclusive scan, with buffer, in-place" << std::endl;
-    onHost::inclusiveScanInPlace(exec, computeDev, computeQueue, intermediateBuffer, inBuf);
+    onHost::inclusiveScanInPlace(exec, computeQueue, intermediateBuffer, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 }

--- a/tests/unit/algorithm/scan.cpp
+++ b/tests/unit/algorithm/scan.cpp
@@ -22,8 +22,8 @@ using TestBackends
 template<typename T_Data>
 int validateResult(
     auto queue,
-    concepts::IDataSource<T_Data> auto& inputData,
-    auto const& bufY,
+    concepts::IDataSource<T_Data> auto const& inputData,
+    concepts::IDataSource<T_Data> auto const& bufY,
     std::size_t numElements,
     onHost::internal::ScanType scanType)
 {
@@ -89,13 +89,13 @@ void testExclusiveScan(
     // exclusive scan, no buffer
     std::cout << "exclusive scan, no buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::exclusiveScan<T_Data>(exec, computeDev, computeQueue, inBuf, outBuf);
+    onHost::exclusiveScan(exec, computeDev, computeQueue, outBuf, inBuf);
     auto res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // exclusive scan, in-place
     std::cout << "exclusive scan, no buffer, in-place" << std::endl;
-    onHost::exclusiveScanInPlace<T_Data>(exec, computeDev, computeQueue, inBuf);
+    onHost::exclusiveScanInPlace(exec, computeDev, computeQueue, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
@@ -106,13 +106,13 @@ void testExclusiveScan(
     // exclusive scan, with buffer
     std::cout << "exclusive scan, with buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::exclusiveScan<T_Data>(exec, computeDev, computeQueue, inBuf, outBuf, intermediateBuffer);
+    onHost::exclusiveScan(exec, computeDev, computeQueue, intermediateBuffer, outBuf, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // exclusive scan, in-place with buffer
     std::cout << "exclusive scan, with buffer, in-place" << std::endl;
-    onHost::exclusiveScanInPlace<T_Data>(exec, computeDev, computeQueue, inBuf, intermediateBuffer);
+    onHost::exclusiveScanInPlace(exec, computeDev, computeQueue, intermediateBuffer, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 }
@@ -131,13 +131,13 @@ void testInclusiveScan(
     // inclusive scan, no buffer
     std::cout << "inclusive scan, no buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::inclusiveScan<T_Data>(exec, computeDev, computeQueue, inBuf, outBuf);
+    onHost::inclusiveScan(exec, computeDev, computeQueue, outBuf, inBuf);
     auto res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // inclusive scan, in-place
     std::cout << "inclusive scan, no buffer, in-place" << std::endl;
-    onHost::inclusiveScanInPlace<T_Data>(exec, computeDev, computeQueue, inBuf);
+    onHost::inclusiveScanInPlace(exec, computeDev, computeQueue, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
@@ -148,13 +148,13 @@ void testInclusiveScan(
     // inclusive scan, with buffer
     std::cout << "inclusive scan, with buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::inclusiveScan<T_Data>(exec, computeDev, computeQueue, inBuf, outBuf, intermediateBuffer);
+    onHost::inclusiveScan(exec, computeDev, computeQueue, intermediateBuffer, outBuf, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // inclusive scan, in-place with buffer
     std::cout << "inclusive scan, with buffer, in-place" << std::endl;
-    onHost::inclusiveScanInPlace<T_Data>(exec, computeDev, computeQueue, inBuf, intermediateBuffer);
+    onHost::inclusiveScanInPlace(exec, computeDev, computeQueue, intermediateBuffer, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 }

--- a/tests/unit/algorithm/scan.cpp
+++ b/tests/unit/algorithm/scan.cpp
@@ -1,0 +1,215 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/onHost/example/executors.hpp>
+#include <alpaka/onHost/executeForEach.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <type_traits>
+
+using namespace alpaka;
+
+using TestBackends
+    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+
+template<typename T_Data>
+int validateResult(
+    auto queue,
+    concepts::IDataSource<T_Data> auto& inputData,
+    auto const& bufY,
+    std::size_t numElements,
+    onHost::internal::ScanType scanType)
+{
+    // Copy back the result
+    auto bufHostY = onHost::allocHost<T_Data>(numElements);
+
+    onHost::memcpy(queue, bufHostY, bufY);
+    onHost::wait(queue);
+
+    // validate results
+    int falseResults = 0;
+    static constexpr int MAX_PRINT_FALSE_RESULTS = 20;
+
+    auto groundtruth = onHost::allocHost<T_Data>(numElements);
+
+    switch(scanType)
+    {
+    case onHost::internal::EXCLUSIVE_SCAN:
+        std::exclusive_scan(inputData.data(), inputData.data() + numElements, groundtruth.data(), 0);
+        break;
+    case onHost::internal::INCLUSIVE_SCAN:
+        std::inclusive_scan(inputData.data(), inputData.data() + numElements, groundtruth.data());
+        break;
+    }
+
+    for(std::size_t i = 0u; i < numElements; ++i)
+    {
+        T_Data const& computedY = bufHostY[i];
+        T_Data const& correctResult = groundtruth[i];
+
+        if(computedY != correctResult)
+        {
+            if(falseResults < MAX_PRINT_FALSE_RESULTS)
+                std::cerr << "bufY[" << i << "] == " << computedY << " != " << correctResult << std::endl;
+            ++falseResults;
+        }
+    }
+
+    if(falseResults == 0)
+    {
+        return EXIT_SUCCESS;
+    }
+    else
+    {
+        std::cout << "Found " << falseResults << " false results, printed no more than " << MAX_PRINT_FALSE_RESULTS
+                  << "\n"
+                  << "Execution results incorrect!" << std::endl;
+        return EXIT_FAILURE;
+    }
+}
+
+template<typename T_Data>
+void testExclusiveScan(
+    concepts::Executor auto& exec,
+    alpaka::onHost::concepts::Device auto& computeDev,
+    auto& computeQueue,
+    concepts::IView<T_Data> auto& hostIn,
+    concepts::IView<T_Data> auto& inBuf,
+    concepts::IView<T_Data> auto& outBuf)
+{
+    auto numEl = hostIn.getExtents().x();
+
+    // exclusive scan, no buffer
+    std::cout << "exclusive scan, no buffer" << std::endl;
+    onHost::memcpy(computeQueue, inBuf, hostIn);
+    onHost::exclusiveScan<T_Data>(exec, computeDev, computeQueue, inBuf, outBuf);
+    auto res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
+    CHECK(res == EXIT_SUCCESS);
+
+    // exclusive scan, in-place
+    std::cout << "exclusive scan, no buffer, in-place" << std::endl;
+    onHost::exclusiveScanInPlace<T_Data>(exec, computeDev, computeQueue, inBuf);
+    res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
+    CHECK(res == EXIT_SUCCESS);
+
+
+    onHost::SharedBuffer intermediateBuffer
+        = onHost::alloc<T_Data>(computeDev, onHost::getScanBufferSize(inBuf.getExtents()));
+
+    // exclusive scan, with buffer
+    std::cout << "exclusive scan, with buffer" << std::endl;
+    onHost::memcpy(computeQueue, inBuf, hostIn);
+    onHost::exclusiveScan<T_Data>(exec, computeDev, computeQueue, inBuf, outBuf, intermediateBuffer);
+    res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
+    CHECK(res == EXIT_SUCCESS);
+
+    // exclusive scan, in-place with buffer
+    std::cout << "exclusive scan, with buffer, in-place" << std::endl;
+    onHost::exclusiveScanInPlace<T_Data>(exec, computeDev, computeQueue, inBuf, intermediateBuffer);
+    res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
+    CHECK(res == EXIT_SUCCESS);
+}
+
+template<typename T_Data>
+void testInclusiveScan(
+    concepts::Executor auto& exec,
+    alpaka::onHost::concepts::Device auto& computeDev,
+    auto& computeQueue,
+    concepts::IView<T_Data> auto& hostIn,
+    concepts::IView<T_Data> auto& inBuf,
+    concepts::IView<T_Data> auto& outBuf)
+{
+    auto numEl = hostIn.getExtents().x();
+
+    // inclusive scan, no buffer
+    std::cout << "inclusive scan, no buffer" << std::endl;
+    onHost::memcpy(computeQueue, inBuf, hostIn);
+    onHost::inclusiveScan<T_Data>(exec, computeDev, computeQueue, inBuf, outBuf);
+    auto res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
+    CHECK(res == EXIT_SUCCESS);
+
+    // inclusive scan, in-place
+    std::cout << "inclusive scan, no buffer, in-place" << std::endl;
+    onHost::inclusiveScanInPlace<T_Data>(exec, computeDev, computeQueue, inBuf);
+    res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
+    CHECK(res == EXIT_SUCCESS);
+
+
+    onHost::SharedBuffer intermediateBuffer
+        = onHost::allocDeferred<T_Data>(computeQueue, onHost::getScanBufferSize(inBuf.getExtents()));
+
+    // inclusive scan, with buffer
+    std::cout << "inclusive scan, with buffer" << std::endl;
+    onHost::memcpy(computeQueue, inBuf, hostIn);
+    onHost::inclusiveScan<T_Data>(exec, computeDev, computeQueue, inBuf, outBuf, intermediateBuffer);
+    res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
+    CHECK(res == EXIT_SUCCESS);
+
+    // inclusive scan, in-place with buffer
+    std::cout << "inclusive scan, with buffer, in-place" << std::endl;
+    onHost::inclusiveScanInPlace<T_Data>(exec, computeDev, computeQueue, inBuf, intermediateBuffer);
+    res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
+    CHECK(res == EXIT_SUCCESS);
+}
+
+template<typename T_Data>
+void prepareTest(auto cfg, concepts::Vector auto extents)
+{
+    using DataType = T_Data;
+
+    auto deviceSpec = cfg[object::deviceSpec];
+    concepts::Executor auto exec = cfg[object::exec];
+
+    auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!computeDevSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device computeDev = computeDevSelector.makeDevice(0);
+
+    std::cout << "device spec: " << getName(deviceSpec) << std::endl;
+    std::cout << "device name: " << computeDev.getName() << std::endl;
+    std::cout << "executor   : " << exec.getName() << std::endl;
+
+    onHost::Queue computeQueue = computeDev.makeQueue();
+
+    // allocate buffers
+    onHost::SharedBuffer inputBuf = onHost::alloc<T_Data>(computeDev, extents);
+    onHost::SharedBuffer outputBuf = onHost::alloc<T_Data>(computeDev, extents);
+
+    // allocate host buffers
+    onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(inputBuf);
+    onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(outputBuf);
+
+    // initialize with the linearized index
+    DataType iotaCounter = 0;
+    for(auto& value : hostBufferIota)
+    {
+        value = iotaCounter;
+        ++iotaCounter;
+    }
+
+    testExclusiveScan<T_Data>(exec, computeDev, computeQueue, hostBufferIota, inputBuf, outputBuf);
+    testInclusiveScan<T_Data>(exec, computeDev, computeQueue, hostBufferIota, inputBuf, outputBuf);
+}
+
+TEMPLATE_LIST_TEST_CASE("scan", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    using DataType = int;
+
+    // different extents for testing
+    auto extentList = std::make_tuple(Vec{12}, Vec{1024}, Vec{654321}, Vec{20'971'520});
+
+    std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents), ...); }, extentList);
+}


### PR DESCRIPTION
This adds the scan algorithm that was previously implemented as an example to the `alpaka::onHost` namespace.

The interface consists of 
- `getScanBufferSize` -> for an extent of a vector to scan, get the buffer size necessary (may be 0 for small scans)
- `exclusiveScan` -> perform an exclusive scan, with or without specifically passed intermediate buffer
- `inclusiveScan` -> perform an inclusive scan, with or without specifically passed intermediate buffer
- `exclusiveScanInPlace` -> perform an exclusive scan, with or without specifically passed intermediate buffer, only taking one buffer and using it as input+output, overwriting
- `inclusiveScanInPlace` -> perform an inclusive scan, with or without specifically passed intermediate buffer, only taking one buffer and using it as input+output, overwriting

The inplace versions need a separate overload because the optional intermediate buffer would otherwise make the functions ambiguous, but I think it's a good idea anyway to have more explicit names.

I added one relatively large test to have a case where the recursion needs two iterations, but it might be too large/take too long in CI.