### PR TITLE
rename device property members

### DIFF
--- a/docs/snippets/example/05_device.cpp
+++ b/docs/snippets/example/05_device.cpp
@@ -42,9 +42,8 @@ TEST_CASE("show host devices", "[docs]")
     {
         std::cout << "Device " << i << ":\n";
         std::cout << "  - name              " << computeDevSelector.getDeviceProperties(i).getName() << "\n";
-        std::cout << "  - #multi-processors " << computeDevSelector.getDeviceProperties(i).m_multiProcessorCount
-                  << "\n";
-        std::cout << "  - warp size         " << computeDevSelector.getDeviceProperties(i).m_warpSize << "\n";
+        std::cout << "  - #multi-processors " << computeDevSelector.getDeviceProperties(i).multiProcessorCount << "\n";
+        std::cout << "  - warp size         " << computeDevSelector.getDeviceProperties(i).warpSize << "\n";
     }
     // END-TUTORIAL-devProperties
 }

--- a/example/alpaka-ls/src/libls.cpp
+++ b/example/alpaka-ls/src/libls.cpp
@@ -27,9 +27,9 @@ void forEachDeviceType(auto const deviceSpec)
         onHost::DeviceProperties devProps = computeDevSelector.getDeviceProperties(d);
         std::cout << "\t\tid                   : " << d << "\n";
         std::cout << "\t\tname                 : " << devProps.getName() << "\n";
-        std::cout << "\t\tmulti processor count: " << devProps.m_multiProcessorCount << "\n";
-        std::cout << "\t\twarp size            : " << devProps.m_warpSize << "\n";
-        std::cout << "\t\tmax threads per block: " << devProps.m_maxThreadsPerBlock << "\n";
+        std::cout << "\t\tmulti processor count: " << devProps.multiProcessorCount << "\n";
+        std::cout << "\t\twarp size            : " << devProps.warpSize << "\n";
+        std::cout << "\t\tmax threads per block: " << devProps.maxThreadsPerBlock << "\n";
         auto executors = onHost::getExecutorsList(deviceSpec, onHost::example::enabledExecutors);
         std::cout << "\t\texecutors            : ";
         std::apply(

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -36,7 +36,7 @@ namespace alpaka::onHost
                 , m_properties{internal::getDeviceProperties(*m_platform.get(), m_idx)}
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::device);
-                m_properties.m_name += " id=" + std::to_string(m_idx);
+                m_properties.name += " id=" + std::to_string(m_idx);
             }
 
             ~Device()
@@ -101,7 +101,7 @@ namespace alpaka::onHost
 
             std::string getName() const
             {
-                return m_properties.m_name;
+                return m_properties.name;
             }
 
             friend struct internal::GetNativeHandle;
@@ -325,7 +325,7 @@ namespace alpaka::onHost
 #if 0
                using IdxType = typename T_NumBlocks::type;
                // @todo get this number from device properties
-               static auto const maxBlocks = device.m_properties.m_multiProcessorCount;
+               static auto const maxBlocks = device.m_properties.multiProcessorCount;
 
 
                while(numThreadBlocks.product() > maxBlocks)

--- a/include/alpaka/api/host/Platform.hpp
+++ b/include/alpaka/api/host/Platform.hpp
@@ -115,10 +115,10 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(alpaka::onHost::logger::device);
                 auto prop = DeviceProperties{};
-                prop.m_name = getCpuName();
-                prop.m_maxThreadsPerBlock = std::numeric_limits<uint32_t>::max();
-                prop.m_warpSize = 1u;
-                prop.m_multiProcessorCount = std::thread::hardware_concurrency();
+                prop.name = getCpuName();
+                prop.maxThreadsPerBlock = std::numeric_limits<uint32_t>::max();
+                prop.warpSize = 1u;
+                prop.multiProcessorCount = std::thread::hardware_concurrency();
 
                 return prop;
             }

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -325,7 +325,7 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::device);
                 auto numThreadsPerBlocks = dataBlocking.getThreadSpec().m_numThreads;
-                auto const maxThreadsPerBlock = device.m_properties.m_maxThreadsPerBlock;
+                auto const maxThreadsPerBlock = device.m_properties.maxThreadsPerBlock;
 
                 auto result = api::util::adjustToLimit(numThreadsPerBlocks, maxThreadsPerBlock);
                 return ThreadSpec{dataBlocking.getThreadSpec().m_numBlocks, result};

--- a/include/alpaka/api/syclGeneric/Platform.hpp
+++ b/include/alpaka/api/syclGeneric/Platform.hpp
@@ -227,11 +227,11 @@ namespace alpaka
                     sycl::device const dev = platform.syclDevices[deviceIdx];
 
                     auto prop = DeviceProperties{};
-                    prop.m_name = dev.get_info<sycl::info::device::name>();
-                    prop.m_maxThreadsPerBlock = dev.get_info<sycl::info::device::max_work_group_size>();
+                    prop.name = dev.get_info<sycl::info::device::name>();
+                    prop.maxThreadsPerBlock = dev.get_info<sycl::info::device::max_work_group_size>();
                     std::vector<std::size_t> wrap_sizes = dev.get_info<sycl::info::device::sub_group_sizes>();
                     // @todo do not reduce wrap size to a single value, return all values
-                    prop.m_warpSize = static_cast<uint32_t>(std::reduce(
+                    prop.warpSize = static_cast<uint32_t>(std::reduce(
                         wrap_sizes.begin(),
                         wrap_sizes.end(),
                         std::size_t{0},
@@ -244,7 +244,7 @@ namespace alpaka
                             else
                                 return std::max(a, b);
                         }));
-                    prop.m_multiProcessorCount = dev.get_info<sycl::info::device::max_compute_units>();
+                    prop.multiProcessorCount = dev.get_info<sycl::info::device::max_compute_units>();
 
                     return prop;
                 }

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -164,7 +164,7 @@ namespace alpaka::onHost
             inline constexpr auto dispatchWarpSize(auto&& fn) const
             {
                 auto warpSize
-                    = internal::GetDeviceProperties::Op<ALPAKA_TYPEOF(*m_device.get())>{}(*m_device.get()).m_warpSize;
+                    = internal::GetDeviceProperties::Op<ALPAKA_TYPEOF(*m_device.get())>{}(*m_device.get()).warpSize;
 
                 return Warpsize::Dispatch<ALPAKA_TYPEOF(getDeviceKind())>{}(
                     getDeviceKind(),

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -36,7 +36,7 @@ namespace alpaka::onHost
                 , m_properties{internal::getDeviceProperties(*m_platform.get(), m_idx)}
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::device);
-                m_properties.m_name += " id=" + std::to_string(m_idx);
+                m_properties.name += " id=" + std::to_string(m_idx);
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::setDevice(idx));
             }
 
@@ -95,7 +95,7 @@ namespace alpaka::onHost
 
             std::string getName() const
             {
-                return m_properties.m_name;
+                return m_properties.name;
             }
 
             friend struct onHost::internal::GetNativeHandle;
@@ -399,7 +399,7 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::device);
                 auto numThreadsPerBlocks = dataBlocking.getThreadSpec().m_numThreads;
-                auto const maxThreadsPerBlock = device.m_properties.m_maxThreadsPerBlock;
+                auto const maxThreadsPerBlock = device.m_properties.maxThreadsPerBlock;
 
                 auto result = api::util::adjustToLimit(numThreadsPerBlocks, maxThreadsPerBlock);
                 return ThreadSpec{dataBlocking.getThreadSpec().m_numBlocks, result};

--- a/include/alpaka/api/unifiedCudaHip/Platform.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Platform.hpp
@@ -129,10 +129,10 @@ namespace alpaka::onHost
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::getDeviceProperties(&devProp, deviceIdx));
 
                 auto prop = DeviceProperties{};
-                prop.m_name = devProp.name;
-                prop.m_maxThreadsPerBlock = devProp.maxThreadsPerBlock;
-                prop.m_warpSize = devProp.warpSize;
-                prop.m_multiProcessorCount = devProp.multiProcessorCount;
+                prop.name = devProp.name;
+                prop.maxThreadsPerBlock = devProp.maxThreadsPerBlock;
+                prop.warpSize = devProp.warpSize;
+                prop.multiProcessorCount = devProp.multiProcessorCount;
 
                 return prop;
             }

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -324,7 +324,7 @@ namespace alpaka::onHost
         using ExtentVecType = ALPAKA_TYPEOF(extents);
         using IndexType = alpaka::trait::GetValueType_t<ExtentVecType>;
         auto props = device.getDeviceProperties();
-        IndexType warpSize = static_cast<IndexType>(props.m_warpSize);
+        IndexType warpSize = static_cast<IndexType>(props.warpSize);
         // try to create a specification with a frame size of 512 elements
         IndexType numFrameElemets = 512;
         // avoid non-power of two values

--- a/include/alpaka/onHost/DeviceProperties.hpp
+++ b/include/alpaka/onHost/DeviceProperties.hpp
@@ -15,21 +15,21 @@ namespace alpaka::onHost
     {
         auto getName() const
         {
-            return m_name;
+            return name;
         }
 
-        std::string m_name;
-        uint32_t m_multiProcessorCount;
-        uint32_t m_warpSize;
-        uint32_t m_maxThreadsPerBlock;
+        std::string name;
+        uint32_t multiProcessorCount;
+        uint32_t warpSize;
+        uint32_t maxThreadsPerBlock;
     };
 
     inline std::ostream& operator<<(std::ostream& s, DeviceProperties const& p)
     {
-        s << "name: " << p.m_name << "\n";
-        s << "multiProcessorCount: " << p.m_multiProcessorCount << "\n";
-        s << "warpSize: " << p.m_warpSize << "\n";
-        s << "maxThreadsPerBlock: " << p.m_maxThreadsPerBlock << "\n";
+        s << "name: " << p.name << "\n";
+        s << "multiProcessorCount: " << p.multiProcessorCount << "\n";
+        s << "warpSize: " << p.warpSize << "\n";
+        s << "maxThreadsPerBlock: " << p.maxThreadsPerBlock << "\n";
         return s;
     };
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -235,7 +235,7 @@ namespace alpaka::onHost::internal
                 multiprocessorScaling = 32u;
             }
 
-            auto const numMultiProcessors = queue.getDevice().getDeviceProperties().m_multiProcessorCount;
+            auto const numMultiProcessors = queue.getDevice().getDeviceProperties().multiProcessorCount;
             auto adjsutedNumFrames = alpaka::api::util::adjustToLimit(
                 frameSpec.m_numFrames,
                 static_cast<IndexType>(numMultiProcessors * multiprocessorScaling));

--- a/tests/unit/warp/activemask.cpp
+++ b/tests/unit/warp/activemask.cpp
@@ -75,7 +75,7 @@ TEMPLATE_LIST_TEST_CASE("warp activemask reflects participating lanes", "[warp][
     }
 
     auto deviceProperties = selector.getDeviceProperties(0);
-    auto const warpExtent = deviceProperties.m_warpSize;
+    auto const warpExtent = deviceProperties.warpSize;
 
     auto device = selector.makeDevice(0);
     auto queue = device.makeQueue(queueKind::blocking);

--- a/tests/unit/warp/all.cpp
+++ b/tests/unit/warp/all.cpp
@@ -81,7 +81,7 @@ TEMPLATE_LIST_TEST_CASE("warp all vote honours only active lanes", "[warp][all]"
     }
 
     auto deviceProperties = selector.getDeviceProperties(0);
-    auto const warpExtent = deviceProperties.m_warpSize;
+    auto const warpExtent = deviceProperties.warpSize;
 
     auto device = selector.makeDevice(0);
     auto queue = device.makeQueue(queueKind::blocking);

--- a/tests/unit/warp/any.cpp
+++ b/tests/unit/warp/any.cpp
@@ -81,7 +81,7 @@ TEMPLATE_LIST_TEST_CASE("warp any vote observes active lanes", "[warp][any]", Wa
     }
 
     auto deviceProperties = selector.getDeviceProperties(0);
-    auto const warpExtent = deviceProperties.m_warpSize;
+    auto const warpExtent = deviceProperties.warpSize;
 
     auto device = selector.makeDevice(0);
     auto queue = device.makeQueue(queueKind::blocking);

--- a/tests/unit/warp/ballot.cpp
+++ b/tests/unit/warp/ballot.cpp
@@ -91,7 +91,7 @@ TEMPLATE_LIST_TEST_CASE("warp ballot captures predicate lanes", "[warp][ballot]"
     }
 
     auto deviceProperties = selector.getDeviceProperties(0);
-    auto const warpExtent = deviceProperties.m_warpSize;
+    auto const warpExtent = deviceProperties.warpSize;
 
     auto device = selector.makeDevice(0);
     auto queue = device.makeQueue(queueKind::blocking);

--- a/tests/unit/warp/getSize.cpp
+++ b/tests/unit/warp/getSize.cpp
@@ -86,7 +86,7 @@ TEMPLATE_LIST_TEST_CASE("warp size trait matches runtime size", "[warp][getSize]
     }
 
     auto deviceProperties = selector.getDeviceProperties(0);
-    auto const warpExtent = deviceProperties.m_warpSize;
+    auto const warpExtent = deviceProperties.warpSize;
 
     auto device = selector.makeDevice(0);
     auto queue = device.makeQueue(queueKind::blocking);

--- a/tests/unit/warp/iota.cpp
+++ b/tests/unit/warp/iota.cpp
@@ -59,7 +59,7 @@ TEMPLATE_LIST_TEST_CASE("warp iota1D", "", TestApis)
     std::cout << device.getName() << std::endl;
 
     auto deviceProperties = devSelector.getDeviceProperties(0);
-    uint32_t warpSize = deviceProperties.m_warpSize;
+    uint32_t warpSize = deviceProperties.warpSize;
 
     onHost::Queue queue = device.makeQueue();
     Vec extent = Vec{warpSize * 123u};

--- a/tests/unit/warp/shfl.cpp
+++ b/tests/unit/warp/shfl.cpp
@@ -111,7 +111,7 @@ TEMPLATE_LIST_TEST_CASE("warp shfl moves values between lanes", "[warp][shfl]", 
     }
 
     auto deviceProperties = selector.getDeviceProperties(0);
-    auto const warpExtent = deviceProperties.m_warpSize;
+    auto const warpExtent = deviceProperties.warpSize;
 
     auto device = selector.makeDevice(0);
     auto queue = device.makeQueue(queueKind::blocking);

--- a/tests/unit/warp/shfl_down.cpp
+++ b/tests/unit/warp/shfl_down.cpp
@@ -121,7 +121,7 @@ TEMPLATE_LIST_TEST_CASE("warp shflDown shifts toward higher lanes", "[warp][shfl
     }
 
     auto deviceProperties = selector.getDeviceProperties(0);
-    auto const warpExtent = deviceProperties.m_warpSize;
+    auto const warpExtent = deviceProperties.warpSize;
 
     auto device = selector.makeDevice(0);
     auto queue = device.makeQueue(queueKind::blocking);

--- a/tests/unit/warp/shfl_up.cpp
+++ b/tests/unit/warp/shfl_up.cpp
@@ -111,7 +111,7 @@ TEMPLATE_LIST_TEST_CASE("warp shflUp shifts toward lower lanes", "[warp][shfl_up
     }
 
     auto deviceProperties = selector.getDeviceProperties(0);
-    auto const warpExtent = deviceProperties.m_warpSize;
+    auto const warpExtent = deviceProperties.warpSize;
 
     auto device = selector.makeDevice(0);
     auto queue = device.makeQueue(queueKind::blocking);

--- a/tests/unit/warp/shfl_xor.cpp
+++ b/tests/unit/warp/shfl_xor.cpp
@@ -109,7 +109,7 @@ TEMPLATE_LIST_TEST_CASE("warp shflXor exchanges partner lanes", "[warp][shfl_xor
     }
 
     auto deviceProperties = selector.getDeviceProperties(0);
-    auto const warpExtent = deviceProperties.m_warpSize;
+    auto const warpExtent = deviceProperties.warpSize;
 
     auto device = selector.makeDevice(0);
     auto queue = device.makeQueue(queueKind::blocking);


### PR DESCRIPTION
Since the device property members are part of the user interface having `m_` in the name is't nice.