### PR TITLE
fix `SimdAlgo::transformReduce()`

### DIFF
--- a/include/alpaka/onAcc/SimdAlgo.hpp
+++ b/include/alpaka/onAcc/SimdAlgo.hpp
@@ -273,7 +273,7 @@ namespace alpaka::onAcc
         {
             return ReduceAlgo::template transformReduce<T_maxConcurrencyInByte, T_MemAlignment>(
                 acc,
-                data0.getExtents(),
+                extents,
                 neutralElement,
                 ALPAKA_FORWARD(reduceFunc),
                 ALPAKA_FORWARD(transformFunc),


### PR DESCRIPTION
The reduce algorithm used always the full buffer instead of the explicit given extents.