### PR TITLE
refactoring `Vec` and `Simd`

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -81,9 +81,9 @@ struct SimdInitOp
     constexpr void operator()(auto const&, auto a, auto b, auto c) const
     {
         using SimdType = ALPAKA_TYPEOF(a.load());
-        a = SimdType::all(initA);
-        b = SimdType::all(initB);
-        c = SimdType::all(initC);
+        a = SimdType::fill(initA);
+        b = SimdType::fill(initB);
+        c = SimdType::fill(initC);
     }
 };
 

--- a/docs/snippets/example/20_simdKernel.cpp
+++ b/docs/snippets/example/20_simdKernel.cpp
@@ -81,7 +81,7 @@ TEST_CASE("MD vector simd add kernel", "[docs]")
     // We only reduce the frame specification for the fast moving dimension.
     int elementsPerFrameItem = getNumElemPerThread<DataType>(computeQueue);
     concepts::Vector auto numFrames
-        = divExZero(computeBufferOut.getExtents(), frameExtents * frameExtents.all(1).rAssign(elementsPerFrameItem));
+        = divExZero(computeBufferOut.getExtents(), frameExtents * frameExtents.fill(1).rAssign(elementsPerFrameItem));
     // The frame specification is not required to be a multiple of the extent, it can be smaller.
     auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
     std::cout << frameSpec << std::endl;

--- a/example/randomInit/src/randomInit.cpp
+++ b/example/randomInit/src/randomInit.cpp
@@ -80,7 +80,7 @@ struct RandomInitKernelUniform
 
 
             // Iterate over the workgroup
-            for(auto [index] : alpaka::onAcc::makeIdxMap(acc, workGroup, alpaka::IdxRange{size}))
+            for([[maybe_unused]] auto [index] : alpaka::onAcc::makeIdxMap(acc, workGroup, alpaka::IdxRange{size}))
             {
                 // Generate numbers in [0,1). Philox engine already generates uniform random numbers but they are
                 // integers.
@@ -126,7 +126,7 @@ struct RandomInitKernel
 
 
             // Iterate over the workgroup
-            for(auto [index] : alpaka::onAcc::makeIdxMap(acc, workGroup, alpaka::IdxRange{size}))
+            for([[maybe_unused]] auto [index] : alpaka::onAcc::makeIdxMap(acc, workGroup, alpaka::IdxRange{size}))
             {
                 // Generate a random 32-bit unsigned integer
                 uint32_t val = engine();

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -209,7 +209,7 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
          * We map threads to blocks in this example.
          */
         threadSpec.m_numBlocks *= threadSpec.m_numThreads;
-        threadSpec.m_numThreads = Vec3D::all(1u);
+        threadSpec.m_numThreads = Vec3D::fill(1u);
     }
 
     std::cout << "Testing VectorAddKernel with vector indices with " << threadSpec.m_numBlocks << " blocks and "

--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -204,7 +204,7 @@ namespace alpaka
          * @param value Value which is set for all dimensions
          * @return new Simd<...>
          */
-        static constexpr auto all(concepts::Convertible<T_Type> auto const& value)
+        static constexpr auto fill(concepts::Convertible<T_Type> auto const& value)
         {
             Simd result([=](uint32_t const) { return static_cast<T_Type>(value); });
             return result;

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -149,7 +149,7 @@ namespace alpaka
             }
 
             template<T T_value>
-            static constexpr auto all()
+            static constexpr auto fill()
             {
                 using IotaSeq = std::make_integer_sequence<T, dim()>;
                 return integerSequenceToCVec(IotaSeq{}, [](auto&&) constexpr { return T_value; });
@@ -273,7 +273,7 @@ namespace alpaka
          * @param value Value which is set for all dimensions
          * @return new Vec<...>
          */
-        static constexpr auto all(concepts::Convertible<T_Type> auto const& value)
+        static constexpr auto fill(concepts::Convertible<T_Type> auto const& value)
         {
             if constexpr(requires { detail::TemplateSignatureStorage_v<T_Storage>; })
             {
@@ -289,9 +289,9 @@ namespace alpaka
 
         template<auto T_v>
         requires(isConvertible_v<ALPAKA_TYPEOF(T_v), T_Type>)
-        static constexpr auto all() requires requires { T_Storage::template all<T_v>(); }
+        static constexpr auto fill() requires requires { T_Storage::template fill<T_v>(); }
         {
-            return Vec<T_Type, T_dim, ALPAKA_TYPEOF(T_Storage::template all<static_cast<T_Type>(T_v)>())>{};
+            return Vec<T_Type, T_dim, ALPAKA_TYPEOF(T_Storage::template fill<static_cast<T_Type>(T_v)>())>{};
         }
 
         constexpr Vec toRT() const
@@ -996,7 +996,7 @@ namespace alpaka
     requires(std::is_same_v<trait::GetValueType_t<T_Vector0>, trait::GetValueType_t<T_Vector1>>)
     [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr concepts::Vector auto divCeil(T_Vector0 a, T_Vector1 b)
     {
-        return (a + b - T_Vector0::all(1)) / b;
+        return (a + b - T_Vector0::fill(1)) / b;
     }
 
     template<concepts::Vector T_Vector0, concepts::Vector T_Vector1>

--- a/include/alpaka/api/generic.hpp
+++ b/include/alpaka/api/generic.hpp
@@ -53,7 +53,7 @@ namespace alpaka::internal::generic
                 [value](auto const& acc, auto destSimdPtr) constexpr
                 {
                     using SimdType = ALPAKA_TYPEOF(destSimdPtr.load());
-                    destSimdPtr = SimdType::all(value);
+                    destSimdPtr = SimdType::fill(value);
                 },
                 dest);
         }
@@ -73,12 +73,12 @@ namespace alpaka::internal::generic
 
         using ExtentsType = ALPAKA_TYPEOF(extents);
         using IndexType = typename ExtentsType::type;
-        auto virtualFrameExtent = ExtentsType::all(1u);
+        auto virtualFrameExtent = ExtentsType::fill(1u);
         // 512 is randomly chosen because it is on all devices a good value for a value assign kernel
         virtualFrameExtent.x() = std::min(static_cast<IndexType>(512u * elementsPerFrameItem), extents.x());
 
         auto numFrames = divExZero(extents, virtualFrameExtent);
-        auto realFrameExtent = ExtentsType::all(1u);
+        auto realFrameExtent = ExtentsType::fill(1u);
         realFrameExtent.x() = IndexType{512u};
 
         auto frameSpec = onHost::FrameSpec{numFrames, realFrameExtent};

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -275,7 +275,7 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel);
                 /// @todo add shortcut to create a CVec with equal values
                 auto const allOne
-                    = ALPAKA_TYPEOF(iotaCVec<typename T_NumThreads::type, T_NumThreads::dim()>())::template all<1u>();
+                    = ALPAKA_TYPEOF(iotaCVec<typename T_NumThreads::type, T_NumThreads::dim()>())::template fill<1u>();
                 return ThreadSpec{allOne, allOne};
             }
 
@@ -288,7 +288,7 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel);
                 /// @todo add shortcut to create a CVec with equal values
                 auto const allOne
-                    = ALPAKA_TYPEOF(iotaCVec<typename T_NumThreads::type, T_NumThreads::dim()>())::template all<1u>();
+                    = ALPAKA_TYPEOF(iotaCVec<typename T_NumThreads::type, T_NumThreads::dim()>())::template fill<1u>();
                 return ThreadSpec{allOne, allOne};
             }
         };
@@ -311,7 +311,7 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel);
                 auto numThreadBlocks = dataBlocking.getThreadSpec().m_numBlocks;
-                return ThreadSpec{numThreadBlocks, T_NumThreads::template all<1u>()};
+                return ThreadSpec{numThreadBlocks, T_NumThreads::template fill<1u>()};
             }
 
             auto operator()(
@@ -322,7 +322,7 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(alpaka::onHost::logger::kernel);
                 auto numThreadBlocks = dataBlocking.getThreadSpec().m_numBlocks;
-                auto const numThreads = Vec<typename T_NumThreads::type, T_NumThreads::dim()>::all(1);
+                auto const numThreads = Vec<typename T_NumThreads::type, T_NumThreads::dim()>::fill(1);
                 return ThreadSpec{numThreadBlocks, numThreads};
             }
         };

--- a/include/alpaka/api/host/IdxLayer.hpp
+++ b/include/alpaka/api/host/IdxLayer.hpp
@@ -22,22 +22,22 @@ namespace alpaka::onAcc
 
             constexpr auto idx() const
             {
-                return IndexVecType::all(0);
+                return IndexVecType::fill(0);
             }
 
             constexpr auto idx() const requires alpaka::concepts::CVector<IndexVecType>
             {
-                return IndexVecType::template all<0>();
+                return IndexVecType::template fill<0>();
             }
 
             constexpr auto count() const
             {
-                return IndexVecType::all(1);
+                return IndexVecType::fill(1);
             }
 
             constexpr auto count() const requires alpaka::concepts::CVector<IndexVecType>
             {
-                return IndexVecType::template all<1u>();
+                return IndexVecType::template fill<1u>();
             }
         };
 

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -33,11 +33,11 @@ namespace alpaka
         constexpr IdxRange(T_Begin const& begin, T_End const& end)
             : m_begin{begin}
             , m_end{end}
-            , m_stride{T_End::all(1u)}
+            , m_stride{T_End::fill(1u)}
         {
         }
 
-        constexpr IdxRange(T_End const& extent) : m_begin{T_End::all(0u)}, m_end{extent}, m_stride{T_End::all(1u)}
+        constexpr IdxRange(T_End const& extent) : m_begin{T_End::fill(0u)}, m_end{extent}, m_stride{T_End::fill(1u)}
         {
         }
 
@@ -107,8 +107,8 @@ namespace alpaka
         auto const range,
         alpaka::BoundaryDirection<T_dim, T_LowHaloVec, T_UpHaloVec> const& boundaryDir)
     {
-        auto m_begin = Vec<uint32_t, T_dim>::all(0u);
-        auto m_end = Vec<uint32_t, T_dim>::all(0u);
+        auto m_begin = Vec<uint32_t, T_dim>::fill(0u);
+        auto m_end = Vec<uint32_t, T_dim>::fill(0u);
         for(uint32_t i = 0; i < T_dim; ++i)
         {
             switch(boundaryDir.data[i])

--- a/include/alpaka/mem/LinearizedIdxGenerator.hpp
+++ b/include/alpaka/mem/LinearizedIdxGenerator.hpp
@@ -129,7 +129,7 @@ namespace alpaka
                     [&](auto i)
                     {
                         // rAssign() is used because, SIMD vectors can only be loaded from the fast moving index
-                        return linearIdxGenerator[idx + T_Idx::all(0).rAssign(i)];
+                        return linearIdxGenerator[idx + T_Idx::fill(0).rAssign(i)];
                     });
             }
         };

--- a/include/alpaka/mem/MdForwardIter.hpp
+++ b/include/alpaka/mem/MdForwardIter.hpp
@@ -74,7 +74,7 @@ namespace alpaka
         }
 
     public:
-        constexpr MdForwardIter(T_MdSpan const& mdSpan) : m_mdSpan(mdSpan), m_current{IterIdxVecType::all(0u)}
+        constexpr MdForwardIter(T_MdSpan const& mdSpan) : m_mdSpan(mdSpan), m_current{IterIdxVecType::fill(0u)}
         {
         }
 

--- a/include/alpaka/meta/NdLoop.hpp
+++ b/include/alpaka/meta/NdLoop.hpp
@@ -72,7 +72,7 @@ namespace alpaka::meta
     template<typename TExtentVec, typename TFnObj>
     auto ndLoopIncIdx(TExtentVec& idx, TExtentVec const& extent, TFnObj const& f) -> void
     {
-        idx = TExtentVec::all(0);
+        idx = TExtentVec::fill(0);
         ndLoop(std::make_index_sequence<TExtentVec::dim()>(), idx, extent, f);
     }
 
@@ -81,7 +81,7 @@ namespace alpaka::meta
     {
         // TExtentVec could be a CVec therefore we need to make it writable
         using IndexVector = typename TExtentVec::UniVec;
-        auto idx = IndexVector::all(0);
+        auto idx = IndexVector::fill(0);
 
         ndLoop(std::make_index_sequence<TExtentVec::dim()>(), idx, IndexVector{extent}, f);
     }

--- a/include/alpaka/onAcc/internal/SimdConcurrent.hpp
+++ b/include/alpaka/onAcc/internal/SimdConcurrent.hpp
@@ -162,7 +162,7 @@ namespace alpaka::onAcc::internal
 
             // we SIMDfy only over the fast moving dimension (columns of memory)
             auto domainSize = numElements.rAssign(remainderBegin);
-            auto stride = ALPAKA_TYPEOF(numElements)::all(1).rAssign(T_simdWidth);
+            auto stride = ALPAKA_TYPEOF(numElements)::fill(1).rAssign(T_simdWidth);
             using IdxType = ALPAKA_TYPEOF(numElements);
 
             if constexpr(
@@ -191,8 +191,8 @@ namespace alpaka::onAcc::internal
                         asParent().getIdxLayoutPolicy()))
                 {
                     // build a worker group with fast-moving dimension threads for the inner loop
-                    auto wIdxInner = ALPAKA_TYPEOF(domainSize)::all(0).rAssign(workGroup.idx(acc).back());
-                    auto wSizeInner = ALPAKA_TYPEOF(domainSize)::all(1).rAssign(workGroup.size(acc).back());
+                    auto wIdxInner = ALPAKA_TYPEOF(domainSize)::fill(0).rAssign(workGroup.idx(acc).back());
+                    auto wSizeInner = ALPAKA_TYPEOF(domainSize)::fill(1).rAssign(workGroup.size(acc).back());
                     auto wInner = WorkerGroup{wIdxInner, wSizeInner};
 
                     // iterate over the fast-moving dimension
@@ -220,7 +220,7 @@ namespace alpaka::onAcc::internal
                 auto simdIdxContainer = onAcc::makeIdxMap(
                     acc,
                     workGroup,
-                    IdxRange{IdxType::all(0), domainSize, stride},
+                    IdxRange{IdxType::fill(0), domainSize, stride},
                     asParent().getTraversePolicy(),
                     asParent().getIdxLayoutPolicy());
 
@@ -236,7 +236,7 @@ namespace alpaka::onAcc::internal
                 }
             }
 
-            ALPAKA_TYPEOF(numElements) remainderDomainSize = numElements.all(0).rAssign(remainderBegin);
+            ALPAKA_TYPEOF(numElements) remainderDomainSize = numElements.fill(0).rAssign(remainderBegin);
 
             for(auto idx : onAcc::makeIdxMap(
                     acc,

--- a/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
+++ b/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
@@ -77,7 +77,7 @@ namespace alpaka::onAcc::internal
                 SimdPtr{data0, *(traverse.begin()), T_MemAlignment{}, CVec<uint32_t, 1u>{}},
                 SimdPtr{dataN, *(traverse.begin()), T_MemAlignment{}, CVec<uint32_t, 1u>{}}...));
 
-            auto retValue = ReturnType::all(neutralElement);
+            auto retValue = ReturnType::fill(neutralElement);
             for(auto idx : traverse)
             {
                 retValue = reduceFunc(
@@ -262,13 +262,13 @@ namespace alpaka::onAcc::internal
 
             // we SIMDfy only over the fast moving dimension (columns of memory)
             auto domainSize = numElements.rAssign(remainderBegin);
-            auto stride = ALPAKA_TYPEOF(numElements)::all(1).rAssign(T_simdWidth);
+            auto stride = ALPAKA_TYPEOF(numElements)::fill(1).rAssign(T_simdWidth);
 
             using IdxType = ALPAKA_TYPEOF(numElements);
             auto simdIdxContainer = onAcc::makeIdxMap(
                 acc,
                 workGroup,
-                IdxRange{IdxType::all(0), domainSize, stride},
+                IdxRange{IdxType::fill(0), domainSize, stride},
                 asParent().getTraversePolicy(),
                 asParent().getIdxLayoutPolicy());
 
@@ -282,7 +282,7 @@ namespace alpaka::onAcc::internal
                 ALPAKA_FORWARD(data0),
                 ALPAKA_FORWARD(dataN)...));
 
-            auto tmpReturn = SimdReturn::all(neutralElement);
+            auto tmpReturn = SimdReturn::fill(neutralElement);
 
             if constexpr(
                 domainSize.dim() > 1u && std::is_same_v<ALPAKA_TYPEOF(asParent().getTraversePolicy()), traverse::Flat>)
@@ -310,8 +310,8 @@ namespace alpaka::onAcc::internal
                         asParent().getIdxLayoutPolicy()))
                 {
                     // build a worker group with fast-moving dimension threads for the inner loop
-                    auto wIdxInner = ALPAKA_TYPEOF(domainSize)::all(0).rAssign(workGroup.idx(acc).back());
-                    auto wSizeInner = ALPAKA_TYPEOF(domainSize)::all(1).rAssign(workGroup.size(acc).back());
+                    auto wIdxInner = ALPAKA_TYPEOF(domainSize)::fill(0).rAssign(workGroup.idx(acc).back());
+                    auto wSizeInner = ALPAKA_TYPEOF(domainSize)::fill(1).rAssign(workGroup.size(acc).back());
                     auto wInner = WorkerGroup{wIdxInner, wSizeInner};
 
                     // iterate over the fast-moving dimension
@@ -354,7 +354,7 @@ namespace alpaka::onAcc::internal
                 }
             }
 
-            ALPAKA_TYPEOF(numElements) remainderDomainSize = numElements.all(0).rAssign(remainderBegin);
+            ALPAKA_TYPEOF(numElements) remainderDomainSize = numElements.fill(0).rAssign(remainderBegin);
 
             for(auto idx : onAcc::makeIdxMap(
                     acc,

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -329,7 +329,7 @@ namespace alpaka::onHost
         IndexType numFrameElemets = 512;
         // avoid non-power of two values
         auto fastDimensionValue = roundDownToPowerOfTwo(std::min(warpSize, extents.x()));
-        auto frameExtents = ExtentVecType::all(1).rAssign(fastDimensionValue);
+        auto frameExtents = ExtentVecType::fill(1).rAssign(fastDimensionValue);
         numFrameElemets /= frameExtents.x();
         // distribute remainder frame elements
         while(numFrameElemets > IndexType{1})
@@ -355,7 +355,7 @@ namespace alpaka::onHost
         }
         IndexType elementsPerFrameItem = static_cast<IndexType>(getNumElemPerThread<T_DataType>(device));
         alpaka::concepts::Vector auto numFrames
-            = divExZero(extents, frameExtents * frameExtents.all(1).rAssign(elementsPerFrameItem));
+            = divExZero(extents, frameExtents * frameExtents.fill(1).rAssign(elementsPerFrameItem));
         // The frame specification is not required to be a multiple of the extent, it can be smaller.
         auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
         return frameSpec;

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -64,7 +64,7 @@ namespace alpaka::onHost::internal
             auto traverseOverFrames = alpaka::onAcc::makeIdxMap(
                 acc,
                 alpaka::onAcc::worker::blocksInGrid,
-                alpaka::IdxRange{frameDataExtent.all(0), frameDataExtent, frameExtent});
+                alpaka::IdxRange{frameDataExtent.fill(0), frameDataExtent, frameExtent});
 
             for(auto frameIdx : traverseOverFrames)
             {
@@ -256,7 +256,7 @@ namespace alpaka::onHost::internal
                 return ss.str();
             });
 
-        onHost::fill(queue, out, neutralElement, out.getExtents().all(1));
+        onHost::fill(queue, out, neutralElement, out.getExtents().fill(1));
         queue.enqueue(
             exec,
             frameSpec,

--- a/tests/unit/algorithm/reduce.cpp
+++ b/tests/unit/algorithm/reduce.cpp
@@ -64,7 +64,7 @@ struct TestWithMdSpan
         auto computeDev = computeQueue.getDevice();
         using DataType = T_DataType;
         using OutDataType = ALPAKA_TYPEOF(std::get<0>(setup));
-        onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd.all(1));
+        onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd.fill(1));
         onHost::SharedBuffer computeBufferIn = onHost::allocDeferred<DataType>(computeQueue, extentMd);
         onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn);
         onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);
@@ -169,7 +169,7 @@ struct TestWithGenerator
 
         auto computeDev = computeQueue.getDevice();
         using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
-        onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd.all(1));
+        onHost::SharedBuffer computeBufferOut = onHost::allocDeferred<OutDataType>(computeQueue, extentMd.fill(1));
         auto generator = LinearizedIdxGenerator{extentMd};
 
         onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);

--- a/tests/unit/algorithm/transformReduce.cpp
+++ b/tests/unit/algorithm/transformReduce.cpp
@@ -95,7 +95,7 @@ struct TestWithMdSpan
         auto computeDev = computeQueue.getDevice();
         using DataType = T_DataType;
         using OutDataType = ALPAKA_TYPEOF(std::get<0>(setup));
-        onHost::SharedBuffer computeBufferOut = onHost::alloc<OutDataType>(computeDev, extentMd.all(1));
+        onHost::SharedBuffer computeBufferOut = onHost::alloc<OutDataType>(computeDev, extentMd.fill(1));
         onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
         onHost::SharedBuffer computeBufferIn1 = onHost::allocLike(computeDev, computeBufferIn0);
         onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn0);
@@ -252,7 +252,7 @@ struct TestWithGenerator
         auto computeDev = computeQueue.getDevice();
         using DataType = T_DataType;
         using OutDataType = ALPAKA_TYPEOF(std::get<0>(setup));
-        onHost::SharedBuffer computeBufferOut = onHost::alloc<OutDataType>(computeDev, extentMd.all(1));
+        onHost::SharedBuffer computeBufferOut = onHost::alloc<OutDataType>(computeDev, extentMd.fill(1));
         onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
         auto generator = LinearizedIdxGenerator{extentMd};
         onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn0);

--- a/tests/unit/block/block.cpp
+++ b/tests/unit/block/block.cpp
@@ -27,7 +27,7 @@ struct BlockIotaKernel
         for(auto blockIdx : onAcc::makeIdxMap(
                 acc,
                 onAcc::worker::blocksInGrid,
-                IdxRange{ALPAKA_TYPEOF(numBlocks)::all(0), numBlocks * numDataElemInBlock, numDataElemInBlock},
+                IdxRange{ALPAKA_TYPEOF(numBlocks)::fill(0), numBlocks * numDataElemInBlock, numDataElemInBlock},
                 onAcc::traverse::tiled,
                 onAcc::layout::contiguous))
         {

--- a/tests/unit/mem/concepts.cpp
+++ b/tests/unit/mem/concepts.cpp
@@ -89,7 +89,7 @@ TEMPLATE_TEST_CASE_SIG(
 {
     constexpr size_t size = 10;
     TElem* ptr = nullptr;
-    concepts::Vector auto const extents = Vec<uint32_t, Dim>{}.all(size);
+    concepts::Vector auto const extents = Vec<uint32_t, Dim>{}.fill(size);
     concepts::Vector auto const pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     SECTION("test alpaka::LinearizedIdxGenerator object")

--- a/tests/unit/mem/constCorrectness.cpp
+++ b/tests/unit/mem/constCorrectness.cpp
@@ -38,7 +38,7 @@ TEST_CASE("mdspan inner const copy constructor", "[mem][mdspan][correctness][cop
     constexpr size_t size = 10;
     int* ptr = nullptr;
     int const* const_ptr = nullptr;
-    concepts::Vector auto extents = Vec<uint32_t, 3>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 3>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     using MutMdSpan = MdSpan<int, decltype(extents), decltype(pitches)>;
@@ -71,7 +71,7 @@ TEST_CASE("mdspan inner const assignment operator", "[mem][mdspan][correctness][
     constexpr size_t size = 10;
     int* ptr = nullptr;
     int const* const_ptr = nullptr;
-    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     using MutMdSpan = MdSpan<int, decltype(extents), decltype(pitches)>;
@@ -95,7 +95,7 @@ TEST_CASE("mdspan inner const move operator", "[mem][mdspan][correctness][moveCo
     constexpr size_t size = 10;
     int* ptr = nullptr;
     int const* const_ptr = nullptr;
-    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     using MutMdSpan = MdSpan<int, decltype(extents), decltype(pitches)>;
@@ -161,7 +161,7 @@ TEST_CASE("function calls with mdspan object", "[mem][mdspan][correctness]")
     constexpr size_t size = 10;
     int* ptr = nullptr;
     int const* const_ptr = nullptr;
-    concepts::Vector auto extents = Vec<uint32_t, 1>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 1>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     MdSpan mdspan{ptr, extents, pitches};
@@ -273,7 +273,7 @@ TEST_CASE("View inner const copy constructor", "[mem][view][correctness][copyCon
     constexpr size_t size = 10;
     int* ptr = nullptr;
     int const* const_ptr = nullptr;
-    concepts::Vector auto extents = Vec<uint32_t, 3>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 3>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     using MutView = View<alpaka::api::Host, int, decltype(extents)>;
@@ -306,7 +306,7 @@ TEST_CASE("View inner const assignment operator", "[mem][view][correctness][copy
     constexpr size_t size = 10;
     int* ptr = nullptr;
     int const* const_ptr = nullptr;
-    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     using MutView = View<alpaka::api::Host, int, decltype(extents)>;
@@ -330,7 +330,7 @@ TEST_CASE("View inner const move constructor and move assignment operator", "[me
     constexpr size_t size = 10;
     int* ptr = nullptr;
     int const* const_ptr = nullptr;
-    concepts::Vector auto extents = Vec<uint32_t, 3>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 3>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     using MutView = View<alpaka::api::Host, int, decltype(extents)>;
@@ -360,7 +360,7 @@ TEST_CASE("sharedBuffer inner const copy constructor", "[mem][sharedBuffer][corr
     constexpr size_t size = 10;
     int* ptr = nullptr;
     int const* const_ptr = nullptr;
-    concepts::Vector auto extents = Vec<uint32_t, 3>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 3>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     using MutSharedBuffer = onHost::SharedBuffer<alpaka::api::Host, int, decltype(extents)>;
@@ -393,7 +393,7 @@ TEST_CASE("sharedBuffer inner const assignment operator", "[mem][sharedBuffer][c
     constexpr size_t size = 10;
     int* ptr = nullptr;
     int const* const_ptr = nullptr;
-    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     using MutSharedBuffer = onHost::SharedBuffer<alpaka::api::Host, int, decltype(extents)>;
@@ -417,7 +417,7 @@ TEST_CASE("sharedBuffer inner const move operator", "[mem][sharedBuffer][correct
     constexpr size_t size = 10;
     int* ptr = nullptr;
     int const* const_ptr = nullptr;
-    concepts::Vector auto extents = Vec<uint32_t, 3>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 3>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     using MutSharedBuffer = onHost::SharedBuffer<alpaka::api::Host, int, decltype(extents)>;

--- a/tests/unit/mem/lifetime.cpp
+++ b/tests/unit/mem/lifetime.cpp
@@ -15,7 +15,7 @@ TEST_CASE("move MdSpan", "[mem][mdspan][lifetime]")
     constexpr size_t size = 10;
     std::vector<int> data(size);
     int* ptr = data.data();
-    concepts::Vector auto extents = Vec<uint32_t, 1>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 1>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     using MutMdSpan = MdSpan<int, decltype(extents), decltype(pitches)>;
@@ -46,7 +46,7 @@ TEST_CASE("move View", "[mem][view][lifetime]")
     constexpr size_t size = 10;
     std::vector<int> data(size);
     int* ptr = data.data();
-    concepts::Vector auto extents = Vec<uint32_t, 1>{}.all(size);
+    concepts::Vector auto extents = Vec<uint32_t, 1>{}.fill(size);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     using MutView = View<alpaka::api::Host, int, decltype(extents)>;
@@ -108,7 +108,7 @@ struct LivingMemory
 
 TEST_CASE("lifetime of shared memory", "[mem][sharedBuffer][lifetime]")
 {
-    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(1);
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.fill(1);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     LivingMemory lv_mem1;
@@ -186,7 +186,7 @@ void funcUniversalRefMoved(auto&& buffer, long const expected_use_count)
 
 TEST_CASE("pass shared memory to function", "[mem][sharedBuffer][lifetime]")
 {
-    concepts::Vector auto extents = Vec<uint32_t, 2>{}.all(1);
+    concepts::Vector auto extents = Vec<uint32_t, 2>{}.fill(1);
     concepts::Vector auto pitches = alpaka::calculatePitchesFromExtents<int>(extents);
 
     LivingMemory lv_mem1;

--- a/tests/unit/queue/kernelMD.cpp
+++ b/tests/unit/queue/kernelMD.cpp
@@ -74,7 +74,7 @@ void validate(auto& queue, auto& device, auto exec, auto testCase)
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);
     // validate that all data is zero
-    meta::ndLoopIncIdx(extentMd, [&](auto idx) { CHECK(hBuff[idx] == ALPAKA_TYPEOF(extentMd)::all(0)); });
+    meta::ndLoopIncIdx(extentMd, [&](auto idx) { CHECK(hBuff[idx] == ALPAKA_TYPEOF(extentMd)::fill(0)); });
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelCallMD", "", TestApis)

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -222,7 +222,7 @@ struct IotaKernelNDSelection
              */
             for(auto frameIdx : onAcc::makeIdxMap(
                     acc,
-                    onAcc::WorkerGroup{numFrames.all(0), numFrames.all(1)},
+                    onAcc::WorkerGroup{numFrames.fill(0), numFrames.fill(1)},
                     IdxRange{fameBaseIdx, numFrames})[T_Selection{}])
             {
                 for(auto elemIdx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, onAcc::range::frameExtent))

--- a/tests/unit/vec/vec.cpp
+++ b/tests/unit/vec/vec.cpp
@@ -126,7 +126,7 @@ struct CompileTimeKernel2D
         static_assert(iota2 == Vec{0, 1});
 
         // CVec fallback to Vec for different operations
-        constexpr auto allVec = CVec<int, 2u, 2u>::all(1u);
+        constexpr auto allVec = CVec<int, 2u, 2u>::fill(1u);
         static_assert(allVec == Vec{1, 1});
 
         constexpr auto typeLambda = [](auto const typeDummy) constexpr

--- a/tests/unit/warp/shfl_down.cpp
+++ b/tests/unit/warp/shfl_down.cpp
@@ -29,7 +29,7 @@ namespace
         ALPAKA_FN_ACC void operator()(TAcc const& acc, concepts::IMdSpan<bool> auto success) const
         {
             auto const warpExtent = static_cast<std::int32_t>(onAcc::warp::getSize(acc));
-            warpCheck(success, warpExtent >= 1u);
+            warpCheck(success, warpExtent >= 1);
 
             auto const threadsPerBlock = static_cast<std::int32_t>(acc[alpaka::layer::thread].count().product());
             warpCheck(success, threadsPerBlock % warpExtent == 0);


### PR DESCRIPTION
Rename the method `all()` to `fill()`.

I sneaked in two small warning fixes: 
  - signed, unsigned compare issue
  - unused variable in a loop

Offline, we discussed that we will rename the method to a better name.
In the future, `all()` will be reused for shorthand reduction.