### PR TITLE
refactor `enabledExecutors`

### DIFF
--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -3,7 +3,6 @@
 #include "catch2/catch_session.hpp"
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
 
 #include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_template_test_macros.hpp>
@@ -512,7 +511,7 @@ void testKernels(auto const deviceSpec, auto const exec)
     std::cout << metaData.serializeAsTable() << std::endl;
 }
 
-using Backends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using Backends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 // Run for all Accs given by the argument
 TEMPLATE_LIST_TEST_CASE("TEST: Babelstream Kernels<Float>", "[benchmark-test]", Backends)

--- a/example/alpaka-ls/src/libls.cpp
+++ b/example/alpaka-ls/src/libls.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <iostream>
 #include <random>
@@ -30,7 +28,7 @@ void forEachDeviceType(auto const deviceSpec)
         std::cout << "\t\tmulti processor count: " << devProps.multiProcessorCount << "\n";
         std::cout << "\t\twarp size            : " << devProps.warpSize << "\n";
         std::cout << "\t\tmax threads per block: " << devProps.maxThreadsPerBlock << "\n";
-        auto executors = onHost::getExecutorsList(deviceSpec, onHost::example::enabledExecutors);
+        auto executors = onHost::getExecutorsList(deviceSpec, exec::enabledExecutors);
         std::cout << "\t\texecutors            : ";
         std::apply(
             [](auto... executors)

--- a/example/alpaka-ls/src/ls.cpp
+++ b/example/alpaka-ls/src/ls.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #if ALPAKA_OS_WINDOWS
 #    include <direct.h>

--- a/example/boundaryIter/src/boundaryIter.cpp
+++ b/example/boundaryIter/src/boundaryIter.cpp
@@ -2,10 +2,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-#include "alpaka/onHost/example/executors.hpp"
-
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <iostream>
 
@@ -176,5 +173,5 @@ auto main() -> int
      */
     return onHost::executeForEachIfHasDevice(
         [=](auto const& backend) { return example(backend[object::deviceSpec], backend[object::exec]); },
-        onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
 }

--- a/example/grayScale/src/grayScale.cpp
+++ b/example/grayScale/src/grayScale.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <algorithm>
 #include <chrono>
@@ -354,5 +352,5 @@ auto main(int argc, char* argv[]) -> int
      */
     return onHost::executeForEachIfHasDevice(
         [=](auto const& tag) { return example(tag, numElements, numberOfRuns, enableStdForEach); },
-        onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
 }

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -13,8 +13,6 @@
 #endif
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -357,5 +355,5 @@ auto main(int argc, char* argv[]) -> int
                 tMax,
                 enableCheck);
         },
-        onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
 }

--- a/example/nBody/src/nBody.cpp
+++ b/example/nBody/src/nBody.cpp
@@ -13,8 +13,6 @@
 #endif
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <cassert>
 #include <chrono>
@@ -386,7 +384,7 @@ auto main(int argc, char* argv[]) -> int
         return onHost::executeForEachIfHasDevice(
             [=](auto const& backend)
             { return alpaka::example::nBody::benchmark(backend[object::deviceSpec], backend[object::exec], dt); },
-            onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+            onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
     }
     else
     {
@@ -402,6 +400,6 @@ auto main(int argc, char* argv[]) -> int
                     numTimeSteps,
                     dt);
             },
-            onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+            onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
     }
 }

--- a/example/randomInit/src/randomInit.cpp
+++ b/example/randomInit/src/randomInit.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <cmath>
 #include <iostream>
@@ -400,5 +398,5 @@ auto main(int argc, char* argv[]) -> int
     // Execute the example once for each enabled API and executor.
     return onHost::executeForEachIfHasDevice(
         [=](auto const& tag) { return example(tag, numElements); },
-        onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
 }

--- a/example/scan/src/scan.hpp
+++ b/example/scan/src/scan.hpp
@@ -9,8 +9,6 @@
 #include "common.hpp"
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <cstddef> // std::size_t
 #include <tuple> // std::tuple

--- a/example/scan/src/scan_improved.hpp
+++ b/example/scan/src/scan_improved.hpp
@@ -7,8 +7,6 @@
 #include "common.hpp"
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <array> // std::array
 #include <cstddef> // std::size_t

--- a/example/scan/src/scan_main.hpp
+++ b/example/scan/src/scan_main.hpp
@@ -210,7 +210,7 @@ auto main(int argc, char* argv[]) -> int
                 enableInPlace,
                 scanType);
         },
-        onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
 
     return result;
 }

--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -267,5 +267,5 @@ auto main() -> int
     return onHost::executeForEachIfHasDevice(
         [=](auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
-        onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
 }

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -285,5 +285,5 @@ auto main() -> int
     return onHost::executeForEachIfHasDevice(
         [=](auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
-        onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
 }

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -342,5 +342,5 @@ auto main() -> int
     return onHost::executeForEachIfHasDevice(
         [=](auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
-        onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
 }

--- a/example/tutorial/src/config.h
+++ b/example/tutorial/src/config.h
@@ -4,8 +4,6 @@
 #pragma once
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
-#include <alpaka/onHost/example/executors.hpp>
 
 #include <cstdint>
 #include <iostream>

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <chrono>
 #include <cstdlib>
@@ -279,5 +277,5 @@ auto main(int argc, char* argv[]) -> int
                 numElements,
                 numberOfRuns);
         },
-        onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
 }

--- a/include/alpaka/executor.hpp
+++ b/include/alpaka/executor.hpp
@@ -8,6 +8,7 @@
 #include "alpaka/api/hip/executor.hpp"
 #include "alpaka/api/host/executor.hpp"
 #include "alpaka/api/oneApi/executor.hpp"
+#include "alpaka/core/PP.hpp"
 
 namespace alpaka::exec
 {
@@ -18,4 +19,37 @@ namespace alpaka::exec
      * executor is used.
      */
     constexpr auto allExecutors = std::make_tuple(gpuCuda, gpuHip, oneApi, cpuOmpBlocks, cpuTbbBlocks, cpuSerial);
+
+    /** list of enabled executors
+     *
+     * - executors can be dis-/enabled by the CMake define alpaka_EXEC_<ExecutorName>
+     * - the second way to disable an executor is to define the preprocessor define ALPAKA_DISABLE_EXEC_<ExecutorName>,
+     * if not the executor is enabled
+     */
+    constexpr auto enabledExecutors = std::make_tuple(ALPAKA_PP_REMOVE_FIRST_COMMA(
+#ifndef ALPAKA_DISABLE_EXEC_CpuOmpBlocks
+        ,
+        exec::cpuOmpBlocks
+#endif
+#ifndef ALPAKA_DISABLE_EXEC_CpuTbbBlocks
+        ,
+        exec::cpuTbbBlocks
+#endif
+#ifndef ALPAKA_DISABLE_EXEC_CpuSerial
+        ,
+        exec::cpuSerial
+#endif
+#ifndef ALPAKA_DISABLE_EXEC_GpuCuda
+        ,
+        exec::gpuCuda
+#endif
+#ifndef ALPAKA_DISABLE_EXEC_GpuHip
+        ,
+        exec::gpuHip
+#endif
+#ifndef ALPAKA_DISABLE_EXEC_OneApi
+        ,
+        exec::oneApi
+#endif
+        ));
 } // namespace alpaka::exec

--- a/include/alpaka/onHost/example/executors.hpp
+++ b/include/alpaka/onHost/example/executors.hpp
@@ -2,49 +2,20 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-
 #pragma once
 
-#include "alpaka/core/Dict.hpp"
 #include "alpaka/executor.hpp"
-#include "alpaka/meta/filter.hpp"
-#include "alpaka/onHost/DeviceSelector.hpp"
-#include "alpaka/tag.hpp"
-
-#include <algorithm>
 
 namespace alpaka::onHost::example
 {
     /** list of enabled executors
      *
-     * - executors can be dis/en-abled by the CMake define alpaka_EXEC_<ExecutorName>
-     * - the second way to disable an executor is to define the preprocessor define ALPAKA_DISABLE_EXEC_<ExecutorName>,
-     * if not the executor is enabled
+     * @deprecated The variable will be removed before the release 3.0.0, please use alpaka::exec::enabledExecutors
+     *
+     * @see exec::enabledExecutors
      */
-    constexpr auto enabledExecutors = std::make_tuple(ALPAKA_PP_REMOVE_FIRST_COMMA(
-#ifndef ALPAKA_DISABLE_EXEC_CpuOmpBlocks
-        ,
-        exec::cpuOmpBlocks
-#endif
-#ifndef ALPAKA_DISABLE_EXEC_CpuTbbBlocks
-        ,
-        exec::cpuTbbBlocks
-#endif
-#ifndef ALPAKA_DISABLE_EXEC_CpuSerial
-        ,
-        exec::cpuSerial
-#endif
-#ifndef ALPAKA_DISABLE_EXEC_GpuCuda
-        ,
-        exec::gpuCuda
-#endif
-#ifndef ALPAKA_DISABLE_EXEC_GpuHip
-        ,
-        exec::gpuHip
-#endif
-#ifndef ALPAKA_DISABLE_EXEC_OneApi
-        ,
-        exec::oneApi
-#endif
-        ));
+    [[deprecated(
+        "This variable will be removed before the release 3.0.0, please use alpaka::exec::enabledExecutors "
+        "instead!")]] constexpr auto enabledExecutors
+        = alpaka::exec::enabledExecutors;
 } // namespace alpaka::onHost::example

--- a/tests/unit/algorithm/concurrent.cpp
+++ b/tests/unit/algorithm/concurrent.cpp
@@ -4,8 +4,6 @@
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/meta/CartesianProduct.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -17,8 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 /** Stencil SIMD functor
  *

--- a/tests/unit/algorithm/iota.cpp
+++ b/tests/unit/algorithm/iota.cpp
@@ -4,8 +4,6 @@
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/meta/CartesianProduct.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -17,8 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 template<typename T_DataType>
 void executeTest(concepts::Executor auto exec, auto const& computeQueue, concepts::Vector auto extentMd)

--- a/tests/unit/algorithm/reduce.cpp
+++ b/tests/unit/algorithm/reduce.cpp
@@ -4,8 +4,6 @@
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/meta/CartesianProduct.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -17,8 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 // This functor des not support Simd and must be wrapped by @see ScalarFunc
 struct MinValue

--- a/tests/unit/algorithm/transform.cpp
+++ b/tests/unit/algorithm/transform.cpp
@@ -4,8 +4,6 @@
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/meta/CartesianProduct.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -17,8 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 /** Stencil SIMD functor
  *

--- a/tests/unit/algorithm/transformReduce.cpp
+++ b/tests/unit/algorithm/transformReduce.cpp
@@ -4,8 +4,6 @@
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/meta/CartesianProduct.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -17,8 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 /** Stencil SIMD functor
  *

--- a/tests/unit/atomic/atomic.cpp
+++ b/tests/unit/atomic/atomic.cpp
@@ -6,7 +6,6 @@
 #include "atomicHelpers.hpp"
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -15,7 +14,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 using namespace alpaka::test::unit::atomic;
 

--- a/tests/unit/atomic/atomicAdd.cpp
+++ b/tests/unit/atomic/atomicAdd.cpp
@@ -3,7 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -12,7 +11,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 struct AtomicIncrementKernel
 {

--- a/tests/unit/block/block.cpp
+++ b/tests/unit/block/block.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -17,7 +15,7 @@
 using namespace alpaka;
 using namespace alpaka::onHost;
 
-using TestApis = std::decay_t<decltype(allBackends(enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(allBackends(enabledApis, exec::enabledExecutors))>;
 
 struct BlockIotaKernel
 {

--- a/tests/unit/cvecKernelCall/cvecKernelCall.cpp
+++ b/tests/unit/cvecKernelCall/cvecKernelCall.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -21,7 +19,7 @@
 using namespace alpaka;
 using namespace alpaka::onHost;
 
-using TestApis = std::decay_t<decltype(allBackends(enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(allBackends(enabledApis, exec::enabledExecutors))>;
 
 struct KernelCVecFrameExtents
 {

--- a/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -14,7 +12,7 @@
 using namespace alpaka;
 using namespace alpaka::onHost;
 
-using TestApis = std::decay_t<decltype(allBackends(enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(allBackends(enabledApis, exec::enabledExecutors))>;
 
 /* We can not check passing the attributes 'const', 'static' or 'constexpr' because this is not supported by OneApi
  * 2025.2 with AMD gpus.

--- a/tests/unit/event/event.cpp
+++ b/tests/unit/event/event.cpp
@@ -5,8 +5,6 @@
 #include "eventHelper.hpp"
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -35,7 +33,7 @@
 using namespace alpaka;
 using namespace alpaka::test::event;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 /** This test takes care that kernel in different queues can run concurrent and if we can communicate between host and
  * the device via mapped memory. Even if the concurrent queue test says true it could be that kernels can run under the

--- a/tests/unit/intrinsic/clz.cpp
+++ b/tests/unit/intrinsic/clz.cpp
@@ -3,7 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 
@@ -11,8 +10,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 struct PopcountKernel
 {

--- a/tests/unit/intrinsic/ffs.cpp
+++ b/tests/unit/intrinsic/ffs.cpp
@@ -3,7 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 
@@ -11,8 +10,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 struct TestKernel
 {

--- a/tests/unit/intrinsic/popc.cpp
+++ b/tests/unit/intrinsic/popc.cpp
@@ -3,7 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 
@@ -11,8 +10,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 struct TestKernel
 {

--- a/tests/unit/math/ADL.cpp
+++ b/tests/unit/math/ADL.cpp
@@ -11,8 +11,6 @@
 #include <alpaka/alpaka.hpp>
 #include <alpaka/math/Complex.hpp>
 #include <alpaka/meta/meta.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -20,8 +18,7 @@
 #include <cmath>
 
 using namespace alpaka;
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 namespace custom
 {

--- a/tests/unit/math/ComplexDouble.cpp
+++ b/tests/unit/math/ComplexDouble.cpp
@@ -8,8 +8,6 @@
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/meta/meta.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -18,8 +16,7 @@
 #include <tuple>
 #include <type_traits>
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 // This file only has unit tests for complex numbers in order to split the tests between object files and save compiler
 // memory. For the same reason single- and double-precision are done separately and not wrapped into a common template.

--- a/tests/unit/math/ComplexFloat.cpp
+++ b/tests/unit/math/ComplexFloat.cpp
@@ -8,8 +8,6 @@
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/meta/meta.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -18,8 +16,7 @@
 #include <tuple>
 #include <type_traits>
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 // This file only has unit tests for complex numbers in order to split the tests between object files and save compiler
 // memory. For the same reason single- and double-precision are done separately and not wrapped into a common template.

--- a/tests/unit/math/Double.cpp
+++ b/tests/unit/math/Double.cpp
@@ -7,8 +7,6 @@
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/meta/meta.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 
@@ -16,8 +14,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 // This file only has unit tests for real numbers in order to split the tests between object files
 using FunctorsReal = alpaka::meta::

--- a/tests/unit/math/Float.cpp
+++ b/tests/unit/math/Float.cpp
@@ -7,8 +7,6 @@
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/meta/meta.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 
@@ -16,8 +14,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 // This file only has unit tests for real numbers in order to split the tests between object files
 using FunctorsReal = alpaka::meta::

--- a/tests/unit/math/powMixedTypes.cpp
+++ b/tests/unit/math/powMixedTypes.cpp
@@ -8,8 +8,6 @@
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/meta/meta.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -68,8 +66,7 @@ struct PowMixedTypesTestKernel
     }
 };
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 TEMPLATE_LIST_TEST_CASE("powMixedTypes", "[powMixedTypes]", TestBackends)
 {

--- a/tests/unit/math/sincos.cpp
+++ b/tests/unit/math/sincos.cpp
@@ -7,8 +7,6 @@
 #include "executeOnComputeDevice.hpp"
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -18,8 +16,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 struct SinCosTestKernel
 {

--- a/tests/unit/mem/alloc.cpp
+++ b/tests/unit/mem/alloc.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -13,8 +11,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 struct IotaValidate
 {

--- a/tests/unit/mem/allocDeferred.cpp
+++ b/tests/unit/mem/allocDeferred.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -13,7 +11,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 struct RaceCheckKernel
 {

--- a/tests/unit/mem/constCorrectness.cpp
+++ b/tests/unit/mem/constCorrectness.cpp
@@ -4,8 +4,6 @@
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/mem/concepts/detail/CopyConstructableDataSource.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/tests/unit/mem/keepAlive.cpp
+++ b/tests/unit/mem/keepAlive.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -14,7 +12,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 using IdxType = std::size_t;
 using ValType = int;
 

--- a/tests/unit/mem/mdIterator.cpp
+++ b/tests/unit/mem/mdIterator.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/tests/unit/mem/memFenceBasic.cpp
+++ b/tests/unit/mem/memFenceBasic.cpp
@@ -7,8 +7,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -17,7 +15,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 // Compilation and stability test kernel. Does not validate correctness of the fence implementations.
 struct MemoryFenceTestKernel

--- a/tests/unit/mem/memFenceProducerConsumer.cpp
+++ b/tests/unit/mem/memFenceProducerConsumer.cpp
@@ -9,15 +9,13 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 // Producer-Consumer kernel documentation:
 //  - Producer (thread 0) publishes a payload (value = iteration index) to global memory,

--- a/tests/unit/mem/memcpy.cpp
+++ b/tests/unit/mem/memcpy.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/tests/unit/platform/platform.cpp
+++ b/tests/unit/platform/platform.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/tests/unit/precision/precision.cpp
+++ b/tests/unit/precision/precision.cpp
@@ -5,8 +5,6 @@
 #include "alpaka/meta/NdLoop.hpp"
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -25,7 +23,7 @@
 using namespace alpaka;
 using namespace alpaka::onHost;
 
-using TestApis = std::decay_t<decltype(allBackends(enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(allBackends(enabledApis, exec::enabledExecutors))>;
 
 template<typename T_LoopIdxType>
 struct IotaKernelND

--- a/tests/unit/queue/blockingQueue.cpp
+++ b/tests/unit/queue/blockingQueue.cpp
@@ -10,8 +10,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -24,7 +22,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 // Any value for testing
 constexpr uint32_t kTestFillValue = 49u;

--- a/tests/unit/queue/kernelMD.cpp
+++ b/tests/unit/queue/kernelMD.cpp
@@ -9,8 +9,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -19,7 +17,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 struct LastSetDataBlockIdx
 {

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -13,7 +11,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 struct NoArgumentsKernel
 {

--- a/tests/unit/rand/uniformReal.cpp
+++ b/tests/unit/rand/uniformReal.cpp
@@ -6,7 +6,6 @@
 #include <alpaka/alpaka.hpp>
 #include <alpaka/meta/CartesianProduct.hpp>
 #include <alpaka/meta/TypeListOps.hpp>
-#include <alpaka/onHost/example/executors.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -18,8 +17,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 template<
     rand::concepts::UniformRandomEngine T_Engine,

--- a/tests/unit/sharedMem/sharedMem.cpp
+++ b/tests/unit/sharedMem/sharedMem.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -16,7 +14,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 template<uint32_t T_blockSize>
 struct SharedBlockIotaKernel

--- a/tests/unit/wait/device.cpp
+++ b/tests/unit/wait/device.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -14,7 +12,7 @@ using namespace alpaka;
 // any value for testing
 int const testValue = 49;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 // Simple write kernel used to create actual device work for testing wait(device).
 struct WaitTestWriteKernel

--- a/tests/unit/warp/iota.cpp
+++ b/tests/unit/warp/iota.cpp
@@ -3,8 +3,6 @@
  */
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
-#include <alpaka/onHost/executeForEach.hpp>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
@@ -13,7 +11,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 struct IotaKernelND
 {

--- a/tests/unit/warp/utils.hpp
+++ b/tests/unit/warp/utils.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/onHost/example/executors.hpp>
 
 #include <algorithm>
 #include <cstdint>
@@ -13,8 +12,7 @@
 
 namespace alpaka::test::warp
 {
-    using WarpTestBackends
-        = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+    using WarpTestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
     template<typename SuccessView>
     // Marks the shared success flag false when a lane detects a failure without aborting execution.


### PR DESCRIPTION
- deprecate `alpaka::onHost::example::enabledExecutors`
- the new variable will be  `alpaka::cmake::enabledExecutors`
  - the reason is that the name space `onHost` was wrong
  - the namespace `example` was misleading too

I was very long struggling with myself to expose this variable to the user, therefore it was never included from `alpaka.hpp`.
IMO with the new namespace it is clearer how to control what's enabled.


issue #396: takes care that we will remove `alpaka::onHost::example::enabledExecutors` before the release.
I deprecated the variable to avoid invalidating the current one, and I may have used Godbolt examples.

