### PR TITLE
fix rand test warning

### DIFF
--- a/tests/unit/rand/uniformReal.cpp
+++ b/tests/unit/rand/uniformReal.cpp
@@ -72,8 +72,9 @@ struct DummyUniformEngine
 
     constexpr type operator()() noexcept
     {
-        currentIdx = (currentIdx++) % nums.size();
-        return nums[currentIdx];
+        auto idx = currentIdx;
+        currentIdx = (idx + type{1u}) % nums.size();
+        return nums[idx];
     }
 
     std::array<type, 2> nums{type{0}, std::numeric_limits<T_Result>::max()};


### PR DESCRIPTION
fix warning:
```
warning: operation on ‘((DummyUniformEngine<long unsigned int>*)this)->DummyUniformEngine<long unsigned int>::currentIdx’ may be undefined [-Wsequence-point]
```