### PR TITLE
SIMD where expression

### DIFF
--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -87,6 +87,44 @@ namespace alpaka
         typename T_Storage = detail::SimdArrayStorage<T_Type, T_width, T_Alignment>>
     struct Simd;
 
+    namespace trait
+    {
+        template<typename T>
+        struct IsSimd : std::false_type
+        {
+        };
+
+        template<typename T_Type, uint32_t T_width, concepts::Alignment T_Alignment, typename T_Storage>
+        struct IsSimd<Simd<T_Type, T_width, T_Alignment, T_Storage>> : std::true_type
+        {
+        };
+    } // namespace trait
+
+    template<typename T>
+    constexpr bool isSimd_v = trait::IsSimd<T>::value;
+
+    namespace concepts
+    {
+        template<typename T>
+        concept Simd = isSimd_v<T>;
+
+        template<typename T>
+        concept SimdMask = Simd<T> && std::same_as<bool, typename T::type>;
+
+        template<typename T>
+        concept SimdOrScalar = (isSimd_v<T> || std::integral<T> || std::floating_point<T>);
+
+        template<typename T, typename T_RequiredComponent>
+        concept TypeOrSimd = (isSimd_v<T> || std::is_same_v<T, T_RequiredComponent>);
+
+        template<typename T, typename T_RequiredComponent>
+        concept SimdOrConvertibleType = (isSimd_v<T> || std::is_convertible_v<T, T_RequiredComponent>);
+    } // namespace concepts
+
+    // friend forward declaration
+    template<concepts::SimdMask T_Mask, concepts::Simd T_Simd>
+    struct SimdWhereExpr;
+
     template<typename T_Type, uint32_t T_width, concepts::Alignment T_Alignment, typename T_Storage>
     struct Simd : private T_Storage
     {
@@ -467,7 +505,7 @@ namespace alpaka
         /** Compares if values in each lane are not equal
          *
          * @param other Simd to compare to
-         * @return true if one component in both SIMD packs are not equal, else false
+         * @return true if one component in both vectors are not equal, else false
          */
         template<typename T_OtherStorage>
         constexpr bool operator!=(Simd<T_Type, T_width, T_OtherStorage> const& rhs) const
@@ -556,6 +594,77 @@ namespace alpaka
                 reduce_range<mid, T_end>(ALPAKA_FORWARD(reduceFunc)));
 #endif
         }
+
+        template<concepts::SimdMask Mask, concepts::Simd T_Simd>
+        friend struct SimdWhereExpr;
+
+        /** create a SIMD vector where all bits are zero or one depedning on the mask value
+         *
+         * @return per lane: all bits one if mask is true, else all bits zero
+         */
+        static constexpr auto valueMask(concepts::Simd auto const& mask)
+            requires(sizeof(T_Type) == 4u || sizeof(T_Type) == 8u)
+        {
+            using ValueMaskType = std::conditional_t<sizeof(T_Type) == 4u, uint32_t, uint64_t>;
+            Simd<ValueMaskType, T_width> result(
+                [&](uint32_t const idx)
+                { return mask[idx] ? std::numeric_limits<ValueMaskType>::max() : ValueMaskType{0u}; });
+            return result;
+        }
+
+        /** element wise conditional value update
+         *
+         * Executes (*this)[i] = mask[i] ? (*this)[i] : t[i] where i is the index of the component.
+         * The implementation is using a control flow free solution.
+         */
+        constexpr auto& update(concepts::SimdMask auto const& mask, concepts::Simd auto const& t)
+            requires(std::is_same_v<typename ALPAKA_TYPEOF(t)::type, T_Type> && requires { t.valueMask(mask); })
+        {
+            auto vm = t.valueMask(mask);
+            using ValueBitMaskType = typename ALPAKA_TYPEOF(vm)::type;
+            for(uint32_t i = 0u; i < T_width; ++i)
+                (*this)[i] = std::bit_cast<T_Type>(
+                    (vm[i] & std::bit_cast<ValueBitMaskType>(t[i]))
+                    | (~vm[i] & std::bit_cast<ValueBitMaskType>((*this)[i])));
+            return *this;
+        }
+
+        /** element wise conditional value update
+         *
+         * Executes (*this)[i] = mask[i] ? (*this)[i] : t[i] where i is the index of the component.
+         */
+        constexpr auto& update(concepts::SimdMask auto const& mask, concepts::Simd auto const& t)
+            requires(std::is_same_v<typename ALPAKA_TYPEOF(t)::type, T_Type> && !requires { t.valueMask(mask); })
+        {
+            for(uint32_t i = 0u; i < T_width; ++i)
+                (*this)[i] = (mask[i] ? static_cast<T_Type>(t[i]) : (*this)[i]);
+            return *this;
+        }
+
+        /** element wise conditional value update where t is a scalar
+         *
+         * The implementation is using a control flow free solution.
+         */
+        constexpr auto& update(concepts::SimdMask auto const& mask, auto const& t)
+            requires concepts::LosslesslyConvertible<ALPAKA_TYPEOF(t), T_Type> && requires { t.valueMask(mask); }
+        {
+            auto vm = t.valueMask(mask);
+            using ValueBitMaskType = typename ALPAKA_TYPEOF(vm)::type;
+            for(uint32_t i = 0u; i < T_width; ++i)
+                (*this)[i] = std::bit_cast<T_Type>(
+                    (vm[i] & std::bit_cast<ValueBitMaskType>(static_cast<T_Type>(t)))
+                    | (~vm[i] & std::bit_cast<ValueBitMaskType>((*this)[i])));
+            return *this;
+        }
+
+        /** element wise conditional value update where t is a scalar */
+        constexpr auto& update(concepts::SimdMask auto const& mask, auto const& t)
+            requires(concepts::LosslesslyConvertible<ALPAKA_TYPEOF(t), T_Type> && !requires { t.valueMask(mask); })
+        {
+            for(uint32_t i = 0u; i < T_width; ++i)
+                (*this)[i] = (mask[i] ? static_cast<T_Type>(t) : (*this)[i]);
+            return (*this);
+        }
     };
 
     template<std::size_t I, typename T_Type, uint32_t T_width, concepts::Alignment T_Alignment, typename T_Storage>
@@ -628,9 +737,9 @@ namespace alpaka
             uint32_t(sizeof...(T_Args) + 1u),
             Alignment<sizeof(T_1) * uint32_t(sizeof...(T_Args) + 1u)>>>;
 
-/** binary operators
- * @{
- */
+    /** binary operators
+     * @{
+     */
 #define ALPAKA_VECTOR_BINARY_OP(typenameOrConcept, resultScalarType, op)                                              \
     template<                                                                                                         \
         typenameOrConcept T_Type,                                                                                     \
@@ -705,35 +814,6 @@ namespace alpaka
 
     /** @} */
 
-
-    template<typename T>
-    struct IsSimd : std::false_type
-    {
-    };
-
-    template<typename T_Type, uint32_t T_width, concepts::Alignment T_Alignment, typename T_Storage>
-    struct IsSimd<Simd<T_Type, T_width, T_Alignment, T_Storage>> : std::true_type
-    {
-    };
-
-    template<typename T>
-    constexpr bool isSimd_v = IsSimd<T>::value;
-
-    namespace concepts
-    {
-        template<typename T>
-        concept Simd = isSimd_v<T>;
-
-        template<typename T>
-        concept SimdOrScalar = (isSimd_v<T> || std::integral<T>);
-
-
-        template<typename T, typename T_RequiredComponent>
-        concept TypeOrSimd = (isSimd_v<T> || std::is_same_v<T, T_RequiredComponent>);
-
-        template<typename T, typename T_RequiredComponent>
-        concept SimdOrConvertibleType = (isSimd_v<T> || std::is_convertible_v<T, T_RequiredComponent>);
-    } // namespace concepts
 
     namespace trait
     {

--- a/include/alpaka/SimdWhereExpr.hpp
+++ b/include/alpaka/SimdWhereExpr.hpp
@@ -1,0 +1,79 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file This file provides a basic implementation of a SIMD vector.
+ *
+ * The implementation is based on the class Vec:
+ *   - the storge policy should become the native SIMD implementation e.g. std::simd
+ *   - load/ store and simd specifis should be implemented in the storage policy
+ *   - the name of storage policy should be changed
+ *
+ *   The current operator operations relay on compilers auto vectorization.
+ */
+
+#pragma once
+
+#include "alpaka/Simd.hpp"
+
+namespace alpaka
+{
+    template<concepts::SimdMask Mask, concepts::Simd T_Simd>
+    struct SimdWhereExpr
+    {
+        Mask const& mask;
+        T_Simd& value;
+
+        constexpr SimdWhereExpr(Mask const& m, T_Simd& v) : mask(m), value(v)
+        {
+        }
+
+        // disable copy and move constructors/operators to avoid pointing to invalid references.
+        constexpr SimdWhereExpr(SimdWhereExpr const&) = delete;
+        constexpr SimdWhereExpr(SimdWhereExpr&&) = delete;
+        constexpr SimdWhereExpr& operator=(SimdWhereExpr const&) = default;
+        constexpr SimdWhereExpr& operator=(SimdWhereExpr&&) = default;
+
+        using value_type = typename T_Simd::type;
+
+        constexpr void operator=(concepts::Simd auto const& rhs)
+        {
+            value.update(mask, rhs);
+        }
+
+        constexpr void operator=(concepts::LosslesslyConvertible<value_type> auto const& rhs)
+        {
+            value.update(mask, rhs);
+        }
+
+#define ALPAKA_SIMD_EXPR_ASSIGN_OP(op_name, op)                                                                       \
+    constexpr void operator op_name(concepts::Simd auto const& rhs)                                                   \
+    {                                                                                                                 \
+        value.update(mask, value op rhs);                                                                             \
+    }                                                                                                                 \
+    constexpr void operator op_name(concepts::LosslesslyConvertible<value_type> auto const& rhs)                      \
+    {                                                                                                                 \
+        value.update(mask, value op rhs);                                                                             \
+    }
+
+        ALPAKA_SIMD_EXPR_ASSIGN_OP(+=, +)
+        ALPAKA_SIMD_EXPR_ASSIGN_OP(-=, -)
+        ALPAKA_SIMD_EXPR_ASSIGN_OP(/=, -)
+        ALPAKA_SIMD_EXPR_ASSIGN_OP(*=, *)
+
+
+#undef ALPAKA_SIMD_EXPR_ASSIGN_OP
+    };
+
+    /** Conditional editional update
+     *
+     * @param mask SIMD pack where each component is true for the element in v which should be overwritten with the
+     * value assigned to the returned expression
+     * @param value value on which the mask is applied on
+     */
+    template<concepts::SimdMask T_Mask, concepts::Simd T_Simd>
+    constexpr SimdWhereExpr<T_Mask, T_Simd> where(T_Mask const& mask, T_Simd& value)
+    {
+        return {mask, value};
+    }
+} // namespace alpaka

--- a/include/alpaka/SimdWhereExpr.hpp
+++ b/include/alpaka/SimdWhereExpr.hpp
@@ -6,10 +6,10 @@
  *
  * The implementation is based on the class Vec:
  *   - the storge policy should become the native SIMD implementation e.g. std::simd
- *   - load/ store and simd specifis should be implemented in the storage policy
+ *   - load/ store and simd specifics should be implemented in the storage policy
  *   - the name of storage policy should be changed
  *
- *   The current operator operations relay on compilers auto vectorization.
+ *   The current operator operations rely on compilers auto vectorization.
  */
 
 #pragma once
@@ -31,8 +31,8 @@ namespace alpaka
         // disable copy and move constructors/operators to avoid pointing to invalid references.
         constexpr SimdWhereExpr(SimdWhereExpr const&) = delete;
         constexpr SimdWhereExpr(SimdWhereExpr&&) = delete;
-        constexpr SimdWhereExpr& operator=(SimdWhereExpr const&) = default;
-        constexpr SimdWhereExpr& operator=(SimdWhereExpr&&) = default;
+        constexpr SimdWhereExpr& operator=(SimdWhereExpr const&) = delete;
+        constexpr SimdWhereExpr& operator=(SimdWhereExpr&&) = delete;
 
         using value_type = typename T_Simd::type;
 
@@ -65,11 +65,11 @@ namespace alpaka
 #undef ALPAKA_SIMD_EXPR_ASSIGN_OP
     };
 
-    /** Conditional editional update
+    /** Conditionally update each component of an SIMD pack
      *
-     * @param mask SIMD pack where each component is true for the element in v which should be overwritten with the
-     * value assigned to the returned expression
-     * @param value value on which the mask is applied on
+     * @param mask SIMD pack of booleans, where each component is true for the element in v which should be overwritten
+     * with the value assigned to the returned expression
+     * @param value SIMD vector to which the mask is applied
      */
     template<concepts::SimdMask T_Mask, concepts::Simd T_Simd>
     constexpr SimdWhereExpr<T_Mask, T_Simd> where(T_Mask const& mask, T_Simd& value)

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -6,6 +6,7 @@
 
 #include "alpaka/CVec.hpp"
 #include "alpaka/Simd.hpp"
+#include "alpaka/SimdWhereExpr.hpp"
 #include "alpaka/UniqueId.hpp"
 #include "alpaka/Vec.hpp"
 #include "alpaka/api/api.hpp"

--- a/tests/unit/simd/where.cpp
+++ b/tests/unit/simd/where.cpp
@@ -1,0 +1,53 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <tuple>
+
+/** @file
+ *
+ *  This file is testing simd where expression
+ */
+
+TEST_CASE("simd where", "[simd vector]")
+{
+    using namespace alpaka;
+
+    Simd<double, 8> a{1, 2, 3, 4, 5, 6, 7, 8};
+    Simd<double, 8> b{8, 7, 6, 5, 4, 3, 2, 1};
+
+    auto m = a > b;
+    Simd<bool, 8> m_reference{false, false, false, false, true, true, true, true};
+    CHECK(m == m_reference);
+
+    where(m, a) = b;
+    Simd<double, 8> a0_reference{1, 2, 3, 4, 4, 3, 2, 1};
+    CHECK(a == a0_reference);
+
+    where(m, a) += b;
+    Simd<double, 8> a1_reference{1, 2, 3, 4, 8, 6, 4, 2};
+    CHECK(a == a1_reference);
+
+    where(b >= 5., b) = 42.;
+    Simd<double, 8> b0_reference{42, 42, 42, 42, 4, 3, 2, 1};
+    CHECK(b == b0_reference);
+    where(b >= 5., b) += 1.;
+    Simd<double, 8> b1_reference{43, 43, 43, 43, 4, 3, 2, 1};
+    CHECK(b == b1_reference);
+
+    // test upcast of scalar values
+    where(b >= float{4}, b) = float{43};
+    Simd<double, 8> b2_reference{43, 43, 43, 43, 43, 3, 2, 1};
+    CHECK(b == b2_reference);
+
+    where(b < float{4}, b) -= float{3};
+    Simd<double, 8> b3_reference{43, 43, 43, 43, 43, 0, -1, -2};
+    CHECK(b == b3_reference);
+}

--- a/tests/unit/simd/where.cpp
+++ b/tests/unit/simd/where.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 René Widera
+/* Copyright 2026 René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
 


### PR DESCRIPTION
- Simd: fix `SimdOrScalar`, missed support for floating point numbers
- add concept `SimdMask`
- implement `SimdWhereExpr` which can be created with `alpaka::where()`


Currently, only the non-const where is implemented, `std::simd` defines a constant where expression too, which can be implemented later.
The `SimdMask` is currently a `Simd<bool>` most likely a bitmask can be beneficial.