### PR TITLE
vendor API abstraction

### DIFF
--- a/example/scan/CMakeLists.txt
+++ b/example/scan/CMakeLists.txt
@@ -76,7 +76,7 @@ foreach(scanFile ${scanSource})
     endif()
     if(HAS_HIP_CUB)
         target_link_libraries(${scanName} PRIVATE hip::hipcub)
-        target_compile_definitions(${scanName} PRIVATE ALPAKA_HAS_HIPCUB=1)
+        target_compile_definitions(${scanName} PRIVATE ALPAKA_HAS_CUB=1)
     endif()
 
     add_test(NAME ${scanName} COMMAND ${scanName})

--- a/example/scan/src/scan_executors.hpp
+++ b/example/scan/src/scan_executors.hpp
@@ -9,6 +9,9 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include <pstl/glue_execution_defs.h>
+
+#include <execution>
 #include <numeric> // std::exclusive_scan, std::inclusive_scan
 
 namespace alpaka::example::scan
@@ -124,360 +127,81 @@ namespace alpaka::example::scan
         IdxType numElements,
         ScanType scanType,
         bool const enableCheck,
-        bool const /*enableStd*/)
-    {
-        // copy data to accelerator buffer
-        alpaka::onHost::memcpy(queue, bufX, inputData);
-        alpaka::onHost::wait(queue);
-
-        return runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
-    }
-
-    // overload for CpuSerial running std:: implementations if requested
-    int runExample(
-        exec::CpuSerial exec,
-        auto const& dev,
-        auto const& queue,
-        auto const& inputData,
-        auto& bufX,
-        auto& bufY,
-        IdxType numElements,
-        ScanType scanType,
-        bool const enableCheck,
         bool const enableStd)
     {
-        // copy data to accelerator buffer
-        alpaka::onHost::memcpy(queue, bufX, inputData);
-        alpaka::onHost::wait(queue);
-
-        int res = EXIT_SUCCESS;
-
-        if(enableStd)
         {
-            std::cout << std::endl << std::endl;
-            std::cout << "===== EXECUTOR CPU STDLIB =====" << std::endl;
-
-            alpaka::onHost::wait(queue);
-            auto const beginT = std::chrono::high_resolution_clock::now();
-
-            static_assert(!std::is_const_v<typename ALPAKA_TYPEOF(bufY)::value_type>);
-            switch(scanType)
-            {
-            case EXCLUSIVE_SCAN:
-                std::exclusive_scan(bufX.data(), bufX.data() + bufX.getExtents().x(), bufY.data(), 0);
-                break;
-            case INCLUSIVE_SCAN:
-                std::inclusive_scan(bufX.data(), bufX.data() + bufX.getExtents().x(), bufY.data());
-                break;
-            }
-
-            auto const endT = std::chrono::high_resolution_clock::now();
-            double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();
-
-            printResults(kernelRuntime, numElements);
-
-            if(enableCheck)
-            {
-                res = validateResult(queue, inputData, bufY, numElements, scanType);
-            }
-
-            // copy data to accelerator buffer for the next generic run
-            alpaka::onHost::memcpy(queue, bufX, inputData);
-            alpaka::onHost::wait(queue);
-        }
-
-        auto resGeneric
-            = runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
-
-        if(resGeneric != EXIT_SUCCESS || res != EXIT_SUCCESS)
-        {
-            return EXIT_FAILURE;
-        }
-        return EXIT_SUCCESS;
-    }
-} // namespace alpaka::example::scan
-
-#if ALPAKA_HAS_CUB
-// only do this when CUB is found
-
-#    include <cub/device/device_scan.cuh>
-
-#    define CUDA_CHECK(condition)                                                                                     \
-        do                                                                                                            \
-        {                                                                                                             \
-            auto error = condition;                                                                                   \
-            if(error != cudaSuccess)                                                                                  \
-            {                                                                                                         \
-                std::cout << "CUDA error: " << error << " line: " << __LINE__ << std::endl;                           \
-                exit(error);                                                                                          \
-            }                                                                                                         \
-        } while(0);
-
-namespace alpaka::example::scan
-{
-    // overload for GpuCuda running cub implementations if requested
-    int runExample(
-        exec::GpuCuda exec,
-        auto const& dev,
-        auto const& queue,
-        auto const& inputData,
-        auto& bufX,
-        auto& bufY,
-        IdxType numElements,
-        ScanType scanType,
-        bool const enableCheck,
-        bool const enableStd)
-    {
-        // copy data to accelerator buffer
-        alpaka::onHost::memcpy(queue, bufX, inputData);
-        alpaka::onHost::wait(queue);
-
-        int res = EXIT_SUCCESS;
-
-        if(enableStd)
-        {
-            std::cout << std::endl << std::endl;
-            std::cout << "===== EXECUTOR CUDA CUB =====" << std::endl;
-
-            // implementation see:
-            // https://nvidia.github.io/cccl/cub/api/structcub_1_1DeviceScan.html#_CPPv4N3cub10DeviceScanE
-
-            auto d_in = bufX.data();
-            auto d_out = bufY.data();
-
-            alpaka::onHost::wait(queue);
-            auto const beginT = std::chrono::high_resolution_clock::now();
-
-            // in order to be fair to the alpaka implementation, which allocates its temporary memory inside the
-            // measured time too, we need to do the same for the cub implementation
-
-            void* d_temp_storage = nullptr;
-            size_t temp_storage_bytes = 0;
-
-            switch(scanType)
-            {
-            case EXCLUSIVE_SCAN:
-                // Determine temporary device storage requirements
-                CUDA_CHECK(
-                    cub::DeviceScan::ExclusiveSum(
-                        d_temp_storage,
-                        temp_storage_bytes,
-                        d_in,
-                        d_out,
-                        numElements,
-                        queue.getNativeHandle()));
-
-                alpaka::onHost::wait(queue);
-
-                // Allocate temporary storage
-                CUDA_CHECK(cudaMalloc(&d_temp_storage, temp_storage_bytes));
-
-                CUDA_CHECK(
-                    cub::DeviceScan::ExclusiveSum(
-                        d_temp_storage,
-                        temp_storage_bytes,
-                        d_in,
-                        d_out,
-                        numElements,
-                        queue.getNativeHandle()));
-                break;
-            case INCLUSIVE_SCAN:
-                // Determine temporary device storage requirements
-                CUDA_CHECK(
-                    cub::DeviceScan::InclusiveSum(
-                        d_temp_storage,
-                        temp_storage_bytes,
-                        d_in,
-                        d_out,
-                        numElements,
-                        queue.getNativeHandle()));
-
-                alpaka::onHost::wait(queue);
-
-                // Allocate temporary storage
-                CUDA_CHECK(cudaMalloc(&d_temp_storage, temp_storage_bytes));
-
-                CUDA_CHECK(
-                    cub::DeviceScan::InclusiveSum(
-                        d_temp_storage,
-                        temp_storage_bytes,
-                        d_in,
-                        d_out,
-                        numElements,
-                        queue.getNativeHandle()));
-                break;
-            }
-            alpaka::onHost::wait(queue);
-
-            if(d_temp_storage)
-                cudaFree(d_temp_storage);
-
-            auto const endT = std::chrono::high_resolution_clock::now();
-            double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();
-
-            printResults(kernelRuntime, numElements);
-
-            if(enableCheck)
-            {
-                res = validateResult(queue, inputData, bufY, numElements, scanType);
-            }
-
             // copy data to accelerator buffer
             alpaka::onHost::memcpy(queue, bufX, inputData);
             alpaka::onHost::wait(queue);
-        }
 
-        auto resGeneric
-            = runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
+            int res = EXIT_SUCCESS;
 
-        if(resGeneric != EXIT_SUCCESS || res != EXIT_SUCCESS)
-        {
-            return EXIT_FAILURE;
-        }
-        return EXIT_SUCCESS;
-    }
-} // namespace alpaka::example::scan
-
-#endif
-
-#if ALPAKA_HAS_HIPCUB
-
-#    include <hipcub/device/device_scan.hpp>
-#    include <hipcub/util_allocator.hpp>
-
-namespace alpaka::example::scan
-{
-    using namespace hipcub;
-    hipcub::CachingDeviceAllocator g_allocator; // Caching allocator for device memory
-
-#    define HIP_CHECK(condition)                                                                                      \
-        do                                                                                                            \
-        {                                                                                                             \
-            hipError_t error = condition;                                                                             \
-            if(error != hipSuccess)                                                                                   \
-            {                                                                                                         \
-                std::cout << "HIP error: " << error << " line: " << __LINE__ << std::endl;                            \
-                exit(error);                                                                                          \
-            }                                                                                                         \
-        } while(0);
-
-    // overload for GpuHip running hipcub implementations if requested
-    int runExample(
-        exec::GpuHip exec,
-        auto const& dev,
-        auto const& queue,
-        auto const& inputData,
-        auto& bufX,
-        auto& bufY,
-        IdxType numElements,
-        ScanType scanType,
-        bool const enableCheck,
-        bool const enableStd)
-    {
-        // copy data to accelerator buffer
-        alpaka::onHost::memcpy(queue, bufX, inputData);
-        alpaka::onHost::wait(queue);
-
-        int res = EXIT_SUCCESS;
-
-        if(enableStd)
-        {
-            std::cout << std::endl << std::endl;
-            std::cout << "===== EXECUTOR HIP CUB =====" << std::endl;
-
-            auto d_in = bufX.data();
-            auto d_out = bufY.data();
-
-            alpaka::onHost::wait(queue);
-            auto const beginT = std::chrono::high_resolution_clock::now();
-
-            // in order to be fair to the alpaka implementation, which allocates its temporary memory inside the
-            // measured time too, we need to do the same for the hip cub implementation
-
-            void* d_temp_storage = nullptr;
-            size_t temp_storage_bytes = 0;
-
-            switch(scanType)
+            if(enableStd)
             {
-            case EXCLUSIVE_SCAN:
-                // Determine temporary device storage requirements
-                HIP_CHECK(
-                    hipcub::DeviceScan::ExclusiveSum(
-                        d_temp_storage,
-                        temp_storage_bytes,
-                        d_in,
-                        d_out,
-                        numElements,
-                        queue.getNativeHandle()));
+                constexpr bool disableVendorTest = std::is_same_v<exec::CpuOmpBlocks, ALPAKA_TYPEOF(exec)>;
+                auto scanFn = vendor::onHost::scanFn(dev);
+                if constexpr(scanFn && !disableVendorTest)
+                {
+                    std::cout << std::endl << std::endl;
+                    std::cout << "===== EXECUTOR " << onHost::demangledName(exec)
+                              << " native vendor API =====" << std::endl;
 
-                alpaka::onHost::wait(queue);
+                    // implementation see:
+                    // https://nvidia.github.io/cccl/cub/api/structcub_1_1DeviceScan.html#_CPPv4N3cub10DeviceScanE
+                    alpaka::onHost::wait(queue);
+                    auto const beginT = std::chrono::high_resolution_clock::now();
 
-                // Allocate temporary storage
-                HIP_CHECK(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+                    // in order to be fair to the alpaka implementation, which allocates its temporary memory inside
+                    // the measured time too, we need to do the same for the cub implementation
 
-                HIP_CHECK(
-                    hipcub::DeviceScan::ExclusiveSum(
-                        d_temp_storage,
-                        temp_storage_bytes,
-                        d_in,
-                        d_out,
-                        numElements,
-                        queue.getNativeHandle()));
-                break;
-            case INCLUSIVE_SCAN:
-                // Determine temporary device storage requirements
-                HIP_CHECK(
-                    hipcub::DeviceScan::InclusiveSum(
-                        d_temp_storage,
-                        temp_storage_bytes,
-                        d_in,
-                        d_out,
-                        numElements,
-                        queue.getNativeHandle()));
+                    switch(scanType)
+                    {
+                    case EXCLUSIVE_SCAN:
+                        {
+                            // Determine temporary device storage requirements
+                            size_t tmpBufferSize = scanFn.getBufferSize(queue, scanFn.exclusive, bufX, bufY);
+                            auto tmp = onHost::alloc<char>(dev, tmpBufferSize);
 
-                alpaka::onHost::wait(queue);
+                            scanFn(queue, scanFn.exclusive, tmp, bufX, bufY);
+                            tmp.keepAlive(queue);
+                        }
+                        break;
+                    case INCLUSIVE_SCAN:
+                        // Determine temporary device storage requirements
+                        size_t tmpBufferSize = scanFn.getBufferSize(queue, scanFn.inclusive, bufX, bufY);
+                        alpaka::onHost::wait(queue);
+                        auto tmp = onHost::alloc<char>(dev, tmpBufferSize);
 
-                // Allocate temporary storage
-                HIP_CHECK(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+                        scanFn(queue, scanFn.exclusive, tmp, bufX, bufY);
+                        tmp.keepAlive(queue);
+                        break;
+                    }
+                    alpaka::onHost::wait(queue);
 
-                HIP_CHECK(
-                    hipcub::DeviceScan::InclusiveSum(
-                        d_temp_storage,
-                        temp_storage_bytes,
-                        d_in,
-                        d_out,
-                        numElements,
-                        queue.getNativeHandle()));
-                break;
-            }
-            alpaka::onHost::wait(queue);
+                    auto const endT = std::chrono::high_resolution_clock::now();
+                    double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();
 
-            if(d_temp_storage)
-                HIP_CHECK(g_allocator.DeviceFree(d_temp_storage));
+                    printResults(kernelRuntime, numElements);
 
-            auto const endT = std::chrono::high_resolution_clock::now();
-            double kernelRuntime = std::chrono::duration<double>(endT - beginT).count();
+                    if(enableCheck)
+                    {
+                        res = validateResult(queue, inputData, bufY, numElements, scanType);
+                    }
 
-            printResults(kernelRuntime, numElements);
-
-            if(enableCheck)
-            {
-                res = validateResult(queue, inputData, bufY, numElements, scanType);
+                    // copy data to accelerator buffer
+                    alpaka::onHost::memcpy(queue, bufX, inputData);
+                    alpaka::onHost::wait(queue);
+                }
             }
 
-            // copy data to accelerator buffer
-            alpaka::onHost::memcpy(queue, bufX, inputData);
-            alpaka::onHost::wait(queue);
-        }
+            auto resGeneric
+                = runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
 
-        auto resGeneric
-            = runExampleGeneric(exec, dev, queue, inputData, bufX, bufY, numElements, scanType, enableCheck);
-
-        if(resGeneric != EXIT_SUCCESS || res != EXIT_SUCCESS)
-        {
-            return EXIT_FAILURE;
+            if(resGeneric != EXIT_SUCCESS || res != EXIT_SUCCESS)
+            {
+                return EXIT_FAILURE;
+            }
+            return EXIT_SUCCESS;
         }
-        return EXIT_SUCCESS;
     }
 } // namespace alpaka::example::scan
-#endif

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -61,6 +61,7 @@
 #include "alpaka/rand/engine/philox/philox.hpp"
 #include "alpaka/tag.hpp"
 #include "alpaka/utility.hpp"
+#include "alpaka/vendor/onHost/scan.hpp"
 
 /** main alpaka namespace.
  *

--- a/include/alpaka/interface.hpp
+++ b/include/alpaka/interface.hpp
@@ -108,7 +108,12 @@ namespace alpaka
      * important that only the argument type is used within the function and not the instance itself.
      * This can be used to keep the function interfaces clean and readable.
      */
-    inline constexpr void unused([[maybe_unused]] auto&&... values)
+    constexpr void unused([[maybe_unused]] auto&&... values)
+    {
+    }
+
+    template<typename... T_UnsedTypes>
+    constexpr void unused()
     {
     }
 

--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -388,6 +388,9 @@ namespace alpaka::onHost::internal
         using T_BufData = ALPAKA_TYPEOF(buffer)::value_type;
         using T_Idx = ALPAKA_TYPEOF(inputVec)::index_type;
 
+        // supress unused warning for release mode
+        alpaka::unused<T_BufData>();
+
         static_assert(
             std::is_same_v<T_Data, typename ALPAKA_TYPEOF(outputVec)::value_type>,
             "output vector must have the same data type as input vector");

--- a/include/alpaka/vendor/onHost/functions.hpp
+++ b/include/alpaka/vendor/onHost/functions.hpp
@@ -1,0 +1,55 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+namespace alpaka::vendor::onHost
+{
+    struct Unimplemented
+    {
+    };
+
+    struct ScanMode
+    {
+        struct Inclusive
+        {
+        };
+
+        static constexpr Inclusive inclusive{};
+
+        struct Exclusive
+        {
+        };
+
+        static constexpr Exclusive exclusive{};
+    };
+
+    template<typename T_FnImpl = Unimplemented>
+    struct Scan
+        : ScanMode
+        , T_FnImpl
+    {
+        constexpr size_t getBufferSize(
+            auto& queue,
+            auto scanType,
+            alpaka::concepts::IMdSpan auto&& input,
+            alpaka::concepts::IMdSpan auto&& output) const
+        {
+            return static_cast<T_FnImpl const&>(*this)
+                .getBufferSize(queue, scanType, ALPAKA_FORWARD(input), ALPAKA_FORWARD(output));
+        }
+
+        constexpr decltype(auto) operator()(
+            auto& queue,
+            auto scanType,
+            alpaka::concepts::IMdSpan auto& tmp,
+            alpaka::concepts::IMdSpan auto&& input,
+            alpaka::concepts::IMdSpan auto&& output) const
+        {
+            return static_cast<T_FnImpl const&>(
+                *this)(queue, scanType, tmp, ALPAKA_FORWARD(input), ALPAKA_FORWARD(output));
+        }
+    };
+
+} // namespace alpaka::vendor::onHost

--- a/include/alpaka/vendor/onHost/internal/Vendor.hpp
+++ b/include/alpaka/vendor/onHost/internal/Vendor.hpp
@@ -1,0 +1,27 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/tag.hpp"
+
+#include <type_traits>
+
+namespace alpaka::vendor::onHost::internal
+{
+    struct Vendor
+    {
+        template<typename T_Fn, typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
+        struct Fn : std::false_type
+        {
+            constexpr decltype(auto) operator()(auto&&... args) const
+            {
+                static_assert(
+                    sizeof(T_Fn) && false,
+                    "The called vendor function is not available for the Api and device kind.");
+            }
+        };
+    };
+
+} // namespace alpaka::vendor::onHost::internal

--- a/include/alpaka/vendor/onHost/internal/host/scan.hpp
+++ b/include/alpaka/vendor/onHost/internal/host/scan.hpp
@@ -1,0 +1,63 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/mem/concepts/IMdSpan.hpp"
+#include "alpaka/vendor/onHost/functions.hpp"
+#include "alpaka/vendor/onHost/internal/Vendor.hpp"
+
+#include <execution>
+#include <numeric>
+#include <type_traits>
+
+namespace alpaka::vendor::onHost::internal
+{
+    template<alpaka::concepts::DeviceKind T_DeviceKind>
+    struct Vendor::Fn<Scan<>, api::Host, T_DeviceKind> : std::true_type
+    {
+        constexpr size_t getBufferSize(
+            auto& queue,
+            Scan<>::Inclusive,
+            alpaka::concepts::IMdSpan auto&& input,
+            alpaka::concepts::IMdSpan auto&& output) const
+        {
+            return 0u;
+        }
+
+        constexpr decltype(auto) operator()(
+            auto& queue,
+            Scan<>::Inclusive,
+            alpaka::concepts::IMdSpan auto&,
+            alpaka::concepts::IMdSpan auto&& input,
+            alpaka::concepts::IMdSpan auto&& output) const
+        {
+            std::inclusive_scan(input.data(), input.data() + input.getExtents().product(), output.data());
+        }
+
+        // Exclusiv
+        constexpr size_t getBufferSize(
+            auto& queue,
+            Scan<>::Exclusive,
+            alpaka::concepts::IMdSpan auto&& input,
+            alpaka::concepts::IMdSpan auto&& output) const
+        {
+            return 0u;
+        }
+
+        constexpr decltype(auto) operator()(
+            auto& queue,
+            Scan<>::Exclusive,
+            alpaka::concepts::IMdSpan auto&,
+            alpaka::concepts::IMdSpan auto&& input,
+            alpaka::concepts::IMdSpan auto&& output) const
+        {
+            std::exclusive_scan(
+                input.data(),
+                input.data() + input.getExtents().product(),
+                output.data(),
+                typename ALPAKA_TYPEOF(input)::value_type{0});
+        }
+    };
+} // namespace alpaka::vendor::onHost::internal

--- a/include/alpaka/vendor/onHost/internal/unifiedCudaHip/scan.hpp
+++ b/include/alpaka/vendor/onHost/internal/unifiedCudaHip/scan.hpp
@@ -1,0 +1,133 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/config.hpp"
+#include "alpaka/mem/concepts/IMdSpan.hpp"
+#include "alpaka/vendor/onHost/functions.hpp"
+#include "alpaka/vendor/onHost/internal/Vendor.hpp"
+
+#include <type_traits>
+
+#if ALPAKA_HAS_CUB
+#    if ALPAKA_LANG_CUDA
+#        include <cub/device/device_scan.cuh>
+#    elif ALPAKA_LANG_HIP
+#        include <hipcub/hipcub.hpp>
+#    endif
+
+namespace alpaka::vendor::onHost::internal
+{
+    template<alpaka::concepts::UnifiedCudaHipApi T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
+    struct Vendor::Fn<Scan<>, T_Api, T_DeviceKind> : std::true_type
+    {
+        void check(auto errorCode, std::source_location const location = std::source_location::current()) const
+        {
+            if(errorCode != 0)
+            {
+                throw std::runtime_error(
+                    std::string("file: ") + location.file_name() + '(' + std::to_string(location.line()) + ':'
+                    + std::to_string(location.column()) + ") `" + location.function_name()
+                    + "`: " + " Error code: " + std::to_string(errorCode));
+            }
+        }
+
+        constexpr size_t getBufferSize(
+            auto& queue,
+            Scan<>::Inclusive,
+            alpaka::concepts::IMdSpan auto&& input,
+            alpaka::concepts::IMdSpan auto&& output) const
+        {
+#    if ALPAKA_LANG_CUDA
+            using namespace cub;
+#    elif ALPAKA_LANG_HIP
+            using namespace hipcub;
+#    endif
+            size_t tempStorageBytes = 0u;
+            check(
+                DeviceScan::InclusiveSum(
+                    (void*) nullptr,
+                    tempStorageBytes,
+                    input.data(),
+                    output.data(),
+                    input.getExtents().product(),
+                    queue.getNativeHandle()));
+            alpaka::onHost::wait(queue);
+            return tempStorageBytes;
+        }
+
+        constexpr decltype(auto) operator()(
+            auto& queue,
+            Scan<>::Inclusive,
+            alpaka::concepts::IMdSpan auto& tmp,
+            alpaka::concepts::IMdSpan auto&& input,
+            alpaka::concepts::IMdSpan auto&& output) const
+        {
+#    if ALPAKA_LANG_CUDA
+            using namespace cub;
+#    elif ALPAKA_LANG_HIP
+            using namespace hipcub;
+#    endif
+            size_t tempStorageBytes = tmp.getExtents().product();
+            check(
+                DeviceScan::InclusiveSum(
+                    alpaka::toVoidPtr(tmp.data()),
+                    tempStorageBytes,
+                    input.data(),
+                    output.data(),
+                    input.getExtents().product(),
+                    queue.getNativeHandle()));
+        }
+
+        // Exclusiv
+        constexpr size_t getBufferSize(
+            auto& queue,
+            Scan<>::Exclusive,
+            alpaka::concepts::IMdSpan auto&& input,
+            alpaka::concepts::IMdSpan auto&& output) const
+        {
+#    if ALPAKA_LANG_CUDA
+            using namespace cub;
+#    elif ALPAKA_LANG_HIP
+            using namespace hipcub;
+#    endif
+            size_t tempStorageBytes = 0u;
+            check(
+                DeviceScan::ExclusiveSum(
+                    (void*) nullptr,
+                    tempStorageBytes,
+                    input.data(),
+                    output.data(),
+                    input.getExtents().product(),
+                    queue.getNativeHandle()));
+            alpaka::onHost::wait(queue);
+            return tempStorageBytes;
+        }
+
+        constexpr decltype(auto) operator()(
+            auto& queue,
+            Scan<>::Exclusive,
+            alpaka::concepts::IMdSpan auto& tmp,
+            alpaka::concepts::IMdSpan auto&& input,
+            alpaka::concepts::IMdSpan auto&& output) const
+        {
+#    if ALPAKA_LANG_CUDA
+            using namespace cub;
+#    elif ALPAKA_LANG_HIP
+            using namespace hipcub;
+#    endif
+            size_t tempStorageBytes = tmp.getExtents().product();
+            check(
+                DeviceScan::ExclusiveSum(
+                    alpaka::toVoidPtr(tmp.data()),
+                    tempStorageBytes,
+                    input.data(),
+                    output.data(),
+                    input.getExtents().product(),
+                    queue.getNativeHandle()));
+        }
+    };
+} // namespace alpaka::vendor::onHost::internal
+#endif

--- a/include/alpaka/vendor/onHost/scan.hpp
+++ b/include/alpaka/vendor/onHost/scan.hpp
@@ -1,0 +1,21 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/vendor/onHost/functions.hpp"
+#include "alpaka/vendor/onHost/internal/Vendor.hpp"
+
+namespace alpaka::vendor::onHost
+{
+    constexpr auto scanFn(auto&& any)
+    {
+        return alpaka::vendor::onHost::Scan<
+            alpaka::vendor::onHost::internal::Vendor::
+                Fn<Scan<>, ALPAKA_TYPEOF(getApi(any)), ALPAKA_TYPEOF(getDeviceKind(any))>>{};
+    }
+} // namespace alpaka::vendor::onHost
+
+#include "alpaka/vendor/onHost/internal/host/scan.hpp"
+#include "alpaka/vendor/onHost/internal/unifiedCudaHip/scan.hpp"


### PR DESCRIPTION
This PR is a prove of concept if we could with minimal overhead integrate vendor functions.

- use scan as example

```C++
auto scanFn = vendor::onHost::scanFn(dev);
if constexpr(scanFn)
{
    size_t tmpBufferSize = scanFn.getBufferSize(queue, scanFn.exclusive, bufX, bufY);
    auto tmp = onHost::alloc<char>(dev, tmpBufferSize);
    scanFn(queue, scanFn.exclusive, tmp, bufX, bufY);
    alpaka::onHost::wait(queue);
}
```


note: The function call `getBufferSize()` is currently blocking. I was not sure how to design the interface to the vendor function, if I should expose the full C interface or if I should allow passing alpaka objects.
This is only a draft anf should show one possible way and provides a platform for discussions.

please ignore the CI I have only checked the scan example.

