### PR TITLE
Add adjustAlignment trait

### DIFF
--- a/include/alpaka/api/oneApi/Api.hpp
+++ b/include/alpaka/api/oneApi/Api.hpp
@@ -130,6 +130,27 @@ namespace alpaka
                 return 16u;
             }
         };
+
+        template<typename T_Type>
+        struct GetAdjustedAlignment::Op<T_Type, api::OneApi, deviceKind::IntelGpu>
+        {
+            consteval uint32_t operator()(api::OneApi const, deviceKind::IntelGpu const, uint32_t const alignmentBytes)
+                const
+            {
+                /* Level Zero imposes a 64 KiB alignment limit.
+                 @see https://www.intel.com/content/www/us/en/developer/articles/release-notes/oneapi-dpcpp/2024.html
+                 Quote: "Limit alignment of allocation requests at 64KB which is the only alignment supported by Level
+                 Zero."
+                */
+                constexpr uint32_t onePageSize = 64u * 1024u;
+                uint32_t tmp = alignmentBytes;
+                while(tmp > onePageSize && tmp >= alignof(T_Type) * 2)
+                {
+                    tmp /= 2;
+                }
+                return tmp;
+            }
+        };
     } // namespace trait
 
     namespace onAcc::internal::trait

--- a/include/alpaka/api/trait.hpp
+++ b/include/alpaka/api/trait.hpp
@@ -103,6 +103,19 @@ namespace alpaka
         struct IsExecutor : std::false_type
         {
         };
+
+        /** Adjusting the requested in alignment in order to meet device specific constraints. */
+        struct GetAdjustedAlignment
+        {
+            template<typename T_Type, concepts::Api T_Api, concepts::DeviceKind T_DeviceKind>
+            struct Op
+            {
+                consteval uint32_t operator()(T_Api const, T_DeviceKind const, uint32_t const alignment) const
+                {
+                    return alignment;
+                }
+            };
+        };
     } // namespace trait
 
     template<typename T>
@@ -179,6 +192,25 @@ namespace alpaka
         alpaka::concepts::DeviceKind auto const deviceType)
     {
         return trait::GetCachelineSize::Op<ALPAKA_TYPEOF(api), ALPAKA_TYPEOF(deviceType)>{}(api, deviceType);
+    }
+
+    /**
+     * @brief Adjusts the memory alignment based on a specific API and device kind.
+     * @tparam T_Type The data type being allocated.
+     * @param alignment the previously selected alignment
+     * @return adjusted alignment in bytes
+     */
+    template<typename T_Type>
+    consteval uint32_t getAdjustedAlignment(
+        concepts::Api auto const api,
+        concepts::DeviceKind auto const deviceType,
+        auto const alignment)
+    {
+        auto val = trait::GetAdjustedAlignment::Op<T_Type, ALPAKA_TYPEOF(api), ALPAKA_TYPEOF(deviceType)>{}(
+            api,
+            deviceType,
+            alignment);
+        return val;
     }
 
     namespace onAcc::trait

--- a/include/alpaka/api/util.hpp
+++ b/include/alpaka/api/util.hpp
@@ -143,7 +143,8 @@ namespace alpaka::api::util
         constexpr uint32_t simdPackBytes
             = alpaka::getArchSimdWidth<T_ValueType>(api, deviceKind) * sizeof(T_ValueType);
         constexpr uint32_t bestSimdPackBytes = highestPowerOfTwo(simdPackBytes);
-        constexpr uint32_t alignment = std::max(bestSimdPackBytes, typeAlignmentBytes);
-        return alignment;
+        constexpr uint32_t optimalAlignment = std::max(bestSimdPackBytes, typeAlignmentBytes);
+        constexpr uint32_t adjustedAlignment = getAdjustedAlignment<T_ValueType>(api, deviceKind, optimalAlignment);
+        return adjustedAlignment;
     }
 } // namespace alpaka::api::util


### PR DESCRIPTION
Introduces a alignment trait to enable device specific adjustment of the alignment returned from simdOptimizedAlignment.

This PR is related to a bug that caused memory allocation of large fields to fail on Sycl/Intel GPUs since level zero only supports memory alignment up to 64 KiB. 
