### PR TITLE
fix CMake alpaka_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ include(GNUInstallDirs)
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
+write_basic_package_version_file("alpakaConfigVersion.cmake" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion)
+
 install(
     FILES
         "${_alpaka_ROOT_DIR}/cmake/finalize.cmake"
@@ -106,6 +108,7 @@ install(
         "${_alpaka_ROOT_DIR}/cmake/alpakaOneApi.cmake"
         "${_alpaka_ROOT_DIR}/cmake/buildDependencies.cmake"
         "${_alpaka_ROOT_DIR}/cmake/common.cmake"
+        "${PROJECT_BINARY_DIR}/alpakaConfigVersion.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/alpaka
 )
 

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -114,7 +114,7 @@ if(NOT TARGET alpaka)
     target_compile_definitions(alpaka_target_headers INTERFACE ALPAKA_CMAKE_TARGET_HEADERS)
 
     add_library(alpaka INTERFACE)
-    set_target_properties(alpaka PROPERTIES VERSION ${PROJECT_VERSION})
+    set_target_properties(alpaka PROPERTIES VERSION ${alpaka_VERSION})
 
     get_target_property(version alpaka VERSION)
     message(STATUS "Alpaka version: ${version}")


### PR DESCRIPTION
fix #408

Remove using `PROJECT_VERSION` for the alpaka version. Create a file `alpakaConfigVersion.cmake` equal to mainline alpaka.