### PR TITLE
refactor scan interface

### DIFF
--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -377,9 +377,9 @@ namespace alpaka::onHost::internal
 
     template<ScanType SCAN_TYPE>
     void scan(
-        alpaka::concepts::Executor auto& exec,
-        alpaka::onHost::concepts::Device auto& devAcc,
         auto& queue,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        alpaka::concepts::Executor auto& exec,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto& inputVec)
@@ -438,7 +438,7 @@ namespace alpaka::onHost::internal
             queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
 
             // always recurse into exclusive scan
-            scan<EXCLUSIVE_SCAN>(exec, devAcc, queue, bufferNext, increments, increments);
+            scan<EXCLUSIVE_SCAN>(queue, devAcc, exec, bufferNext, increments, increments);
             queue.enqueue(exec, frameSpec, KernelBundle{addIncrements, increments, outputVec});
         }
         else
@@ -450,9 +450,9 @@ namespace alpaka::onHost::internal
 
     template<ScanType SCAN_TYPE>
     void scan(
-        alpaka::concepts::Executor auto& exec,
-        alpaka::onHost::concepts::Device auto& devAcc,
         auto& queue,
+        alpaka::onHost::concepts::Device auto& devAcc,
+        alpaka::concepts::Executor auto& exec,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
@@ -460,7 +460,7 @@ namespace alpaka::onHost::internal
 
         auto buf = onHost::alloc<char>(devAcc, scanBufferSize<T_Data>(inputVec.getExtents()));
 
-        scan<SCAN_TYPE>(exec, devAcc, queue, buf, outputVec, inputVec);
+        scan<SCAN_TYPE>(queue, devAcc, exec, buf, outputVec, inputVec);
 
         buf.keepAlive(queue);
     }

--- a/include/alpaka/onHost/algo/scan.hpp
+++ b/include/alpaka/onHost/algo/scan.hpp
@@ -31,115 +31,115 @@ namespace alpaka::onHost
 
     /** @brief Perform an inclusive scan on the input data and write the result to the output data.
      *
-     * @param exec The executor to run with.
      * @param queue The queue to enqueue to.
+     * @param exec The executor to run with.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
      * @param outputVec The output data. To perform an in-place scan, use the overload with only one data object.
      * @param inputVec The input data. Can be const.
      */
     void inclusiveScan(
-        alpaka::concepts::Executor auto& exec,
         auto const& queue,
+        alpaka::concepts::Executor auto& exec,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, buffer, outputVec, inputVec);
+        internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, buffer, outputVec, inputVec);
     }
 
     void inclusiveScan(
-        alpaka::concepts::Executor auto& exec,
         auto const& queue,
+        alpaka::concepts::Executor auto& exec,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, outputVec, inputVec);
+        internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, outputVec, inputVec);
     }
 
     /** @brief Perform an inclusive scan on data in-place.
      *
-     * @param exec The executor to run with.
      * @param queue The queue to enqueue to.
+     * @param exec The executor to run with.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
      * @param dataVec The vector to scan, will be overwritten with the result.
      */
     void inclusiveScanInPlace(
-        alpaka::concepts::Executor auto& exec,
         auto const& queue,
+        alpaka::concepts::Executor auto& exec,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, buffer, dataVec, dataVec);
+        internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, buffer, dataVec, dataVec);
     }
 
     void inclusiveScanInPlace(
-        alpaka::concepts::Executor auto& exec,
         auto const& queue,
+        alpaka::concepts::Executor auto& exec,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::INCLUSIVE_SCAN>(exec, devAcc, queue, dataVec, dataVec);
+        internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, dataVec, dataVec);
     }
 
     /** @brief Perform an exclusive scan on the input data and write the result to the output data.
      *
-     * @param exec The executor to run with.
      * @param queue The queue to enqueue to.
+     * @param exec The executor to run with.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
      * @param outputVec The output data. To perform an in-place scan, use the overload with only one data object.
      * @param inputVec The input data. Can be const.
      */
     void exclusiveScan(
-        alpaka::concepts::Executor auto& exec,
         auto const& queue,
+        alpaka::concepts::Executor auto& exec,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, buffer, outputVec, inputVec);
+        internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, buffer, outputVec, inputVec);
     }
 
     void exclusiveScan(
-        alpaka::concepts::Executor auto& exec,
         auto const& queue,
+        alpaka::concepts::Executor auto& exec,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, outputVec, inputVec);
+        internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, outputVec, inputVec);
     }
 
     /** @brief Perform an exclusive scan on data in-place.
      *
-     * @param exec The executor to run with.
      * @param queue The queue to enqueue to.
+     * @param exec The executor to run with.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
      * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
      * @param dataVec The vector to scan, will be overwritten with the result.
      */
     void exclusiveScanInPlace(
-        alpaka::concepts::Executor auto& exec,
         auto const& queue,
+        alpaka::concepts::Executor auto& exec,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, buffer, dataVec, dataVec);
+        internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, buffer, dataVec, dataVec);
     }
 
     void exclusiveScanInPlace(
-        alpaka::concepts::Executor auto& exec,
         auto const& queue,
+        alpaka::concepts::Executor auto& exec,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::EXCLUSIVE_SCAN>(exec, devAcc, queue, dataVec, dataVec);
+        internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, dataVec, dataVec);
     }
 } // namespace alpaka::onHost

--- a/tests/unit/algorithm/scan.cpp
+++ b/tests/unit/algorithm/scan.cpp
@@ -15,8 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends
-    = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
 
 template<typename T_Data>
 int validateResult(
@@ -85,13 +84,13 @@ void testExclusiveScan(
     // exclusive scan, no buffer
     std::cout << "exclusive scan, no buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::exclusiveScan(exec, computeQueue, outBuf, inBuf);
+    onHost::exclusiveScan(computeQueue, exec, outBuf, inBuf);
     auto res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // exclusive scan, in-place
     std::cout << "exclusive scan, no buffer, in-place" << std::endl;
-    onHost::exclusiveScanInPlace(exec, computeQueue, inBuf);
+    onHost::exclusiveScanInPlace(computeQueue, exec, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
@@ -102,13 +101,13 @@ void testExclusiveScan(
     // exclusive scan, with buffer
     std::cout << "exclusive scan, with buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::exclusiveScan(exec, computeQueue, intermediateBuffer, outBuf, inBuf);
+    onHost::exclusiveScan(computeQueue, exec, intermediateBuffer, outBuf, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // exclusive scan, in-place with buffer
     std::cout << "exclusive scan, with buffer, in-place" << std::endl;
-    onHost::exclusiveScanInPlace(exec, computeQueue, intermediateBuffer, inBuf);
+    onHost::exclusiveScanInPlace(computeQueue, exec, intermediateBuffer, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 }
@@ -127,13 +126,13 @@ void testInclusiveScan(
     // inclusive scan, no buffer
     std::cout << "inclusive scan, no buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::inclusiveScan(exec, computeQueue, outBuf, inBuf);
+    onHost::inclusiveScan(computeQueue, exec, outBuf, inBuf);
     auto res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // inclusive scan, in-place
     std::cout << "inclusive scan, no buffer, in-place" << std::endl;
-    onHost::inclusiveScanInPlace(exec, computeQueue, inBuf);
+    onHost::inclusiveScanInPlace(computeQueue, exec, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
@@ -144,13 +143,13 @@ void testInclusiveScan(
     // inclusive scan, with buffer
     std::cout << "inclusive scan, with buffer" << std::endl;
     onHost::memcpy(computeQueue, inBuf, hostIn);
-    onHost::inclusiveScan(exec, computeQueue, intermediateBuffer, outBuf, inBuf);
+    onHost::inclusiveScan(computeQueue, exec, intermediateBuffer, outBuf, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // inclusive scan, in-place with buffer
     std::cout << "inclusive scan, with buffer, in-place" << std::endl;
-    onHost::inclusiveScanInPlace(exec, computeQueue, intermediateBuffer, inBuf);
+    onHost::inclusiveScanInPlace(computeQueue, exec, intermediateBuffer, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 }


### PR DESCRIPTION
Unify the signature of `onHost::scan*` with other algorithms. The queue is always the first argument in the signature.

In the internal interface the device is moved in front of the executor.
Remove the usage of deprecated `onHost::example::enabledExecutors` in the scan tests.

The executor is for all algorithms optional, this is not included in this PR because for this doxygen group comments should be used. This would make the diff to complex, therefore I will add this feature later.