### PR TITLE
fix using `onHost::example::enabledExecutors`

### DIFF
--- a/example/randomInit/src/randomInit.cpp
+++ b/example/randomInit/src/randomInit.cpp
@@ -399,5 +399,5 @@ auto main(int argc, char* argv[]) -> int
             auto retVal = exampleUniformDist(tag, numElements) || exampleNormalDist(tag, numElementsNormal);
             return retVal;
         },
-        onHost::allBackends(onHost::enabledApis, onHost::example::enabledExecutors));
+        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
 }


### PR DESCRIPTION
`onHost::example::enabledExecutors` is deprecated and should be removed by `exec::enabledExecutors`.

I merged #386 but saw afterwards that the deprecated variable is used.