### PR TITLE
add device method `getFreeGlobalMemBytes()`

### DIFF
--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/api/host/Api.hpp"
 #include "alpaka/api/host/Event.hpp"
 #include "alpaka/api/host/Queue.hpp"
+#include "alpaka/api/host/sysInfo.hpp"
 #include "alpaka/api/util.hpp"
 #include "alpaka/core/alignedAlloc.hpp"
 #include "alpaka/internal/interface.hpp"
@@ -149,9 +150,15 @@ namespace alpaka::onHost
                 return alpaka::internal::getDeviceKind(*m_platform.get());
             }
 
+            auto getFreeGlobalMemBytes() const
+            {
+                return onHost::getFreeGlobalMemBytes();
+            }
+
             friend struct internal::Alloc;
             friend struct alpaka::internal::GetApi;
             friend struct internal::GetDeviceProperties;
+            friend struct internal::GetFreeGlobalMemBytes;
             friend struct internal::AdjustThreadSpec;
             friend struct internal::AllocDeferred;
             friend struct internal::AllocUnified;

--- a/include/alpaka/api/host/sysInfo.hpp
+++ b/include/alpaka/api/host/sysInfo.hpp
@@ -207,7 +207,7 @@ namespace alpaka::onHost
 
     //! \return The free number of bytes of global memory.
     //! \throws std::logic_error if not implemented on the system and std::runtime_error on other errors.
-    inline auto getFreeGlobalMemSizeBytes() -> std::size_t
+    inline auto getFreeGlobalMemBytes() -> std::size_t
     {
 #if ALPAKA_OS_WINDOWS
         MEMORYSTATUSEX status;

--- a/include/alpaka/api/oneApi/Device.hpp
+++ b/include/alpaka/api/oneApi/Device.hpp
@@ -4,19 +4,44 @@
 
 #pragma once
 
+#include "alpaka/api/host/sysInfo.hpp"
 #include "alpaka/api/syclGeneric/Device.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/onHost/trait.hpp"
 #include "executor.hpp"
 
+#if ALPAKA_LANG_ONEAPI
+
+#    include <sycl/sycl.hpp>
+
 namespace alpaka::onHost::trait
 {
-#if ALPAKA_LANG_ONEAPI
     template<typename T_Platform>
     struct IsExecutorSupportedBy::Op<alpaka::exec::OneApi, alpaka::onHost::syclGeneric::Device<T_Platform>>
         : std::true_type
     {
     };
-#endif
-
 } // namespace alpaka::onHost::trait
+
+namespace alpaka::onHost::internal
+{
+    template<typename T_Platform>
+    struct GetFreeGlobalMemBytes::Op<syclGeneric::Device<T_Platform>>
+    {
+        size_t operator()(syclGeneric::Device<T_Platform> const& device) const
+        {
+            /* OneApi for CPU is not defining the ext_intel_free_memory aspect, therefore we fall back to query it
+             * directly from the host.
+             */
+            if constexpr(ALPAKA_TYPEOF(device.getDeviceKind()){} == deviceKind::cpu)
+            {
+                return onHost::getFreeGlobalMemBytes();
+            }
+
+            sycl::device const dev = std::get<0>(device.getNativeHandle());
+            return dev.get_info<sycl::ext::intel::info::device::free_memory>();
+        }
+    };
+} // namespace alpaka::onHost::internal
+
+#endif

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -132,6 +132,7 @@ namespace alpaka::onHost
 
             friend struct alpaka::internal::GetApi;
             friend struct internal::GetDeviceProperties;
+            friend struct internal::GetFreeGlobalMemBytes;
             friend struct internal::AdjustThreadSpec;
             friend struct onHost::internal::AllocDeferred;
             friend struct onHost::internal::AllocUnified;

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -146,12 +146,23 @@ namespace alpaka::onHost
                 return alpaka::internal::getDeviceKind(*m_platform.get());
             }
 
+            auto getFreeGlobalMemBytes() const
+            {
+                std::size_t freeGlobalMemBytes(0u);
+                std::size_t globalMemCapacityBytes(0u);
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::memGetInfo(&freeGlobalMemBytes, &globalMemCapacityBytes));
+                return freeGlobalMemBytes;
+            }
+
             friend struct onHost::internal::Alloc;
             friend struct onHost::internal::AllocDeferred;
             friend struct onHost::internal::AllocUnified;
             friend struct onHost::internal::AllocMapped;
             friend struct alpaka::internal::GetApi;
             friend struct internal::GetDeviceProperties;
+            friend struct internal::GetFreeGlobalMemBytes;
             friend struct internal::AdjustThreadSpec;
             friend struct onHost::internal::IsDataAccessible;
         };

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -133,6 +133,11 @@ namespace alpaka::onHost
             return internal::GetDeviceProperties::Op<ALPAKA_TYPEOF(*m_device.get())>{}(*m_device.get());
         }
 
+        size_t getFreeGlobalMemBytes() const
+        {
+            return internal::GetFreeGlobalMemBytes::Op<ALPAKA_TYPEOF(*m_device.get())>{}(*m_device.get());
+        }
+
         constexpr auto getDeviceKind() const
         {
             return T_DeviceKind{};

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -414,6 +414,18 @@ namespace alpaka::onHost
             };
         };
 
+        struct GetFreeGlobalMemBytes
+        {
+            template<typename T_Any>
+            struct Op
+            {
+                size_t operator()(auto const& device) const
+                {
+                    return device.getFreeGlobalMemBytes();
+                }
+            };
+        };
+
         inline DeviceProperties getDeviceProperties(auto const& platform, uint32_t idx)
         {
             return GetDeviceProperties::Op<ALPAKA_TYPEOF(platform)>{}(platform, idx);

--- a/tests/unit/queue/queue.cpp
+++ b/tests/unit/queue/queue.cpp
@@ -41,6 +41,8 @@ TEMPLATE_LIST_TEST_CASE("kernel no arguments", "", TestApis)
     onHost::Device device = devSelector.makeDevice(0);
 
     std::cout << device.getName() << std::endl;
+    std::cout << "mem     :" << device.getDeviceProperties().globalMemCapacityBytes << std::endl;
+    std::cout << "free mem:" << device.getFreeGlobalMemBytes() << std::endl;
 
     onHost::Queue queue = device.makeQueue(queueKind::blocking);
     std::cout << "exec=" << onHost::demangledName(exec) << std::endl;


### PR DESCRIPTION
Add method to query the current amount of free device memory.

- [x] rebase against #418 (included in the first commit)