### PR TITLE
optimize generic fill implementation

### DIFF
--- a/include/alpaka/api/generic.hpp
+++ b/include/alpaka/api/generic.hpp
@@ -67,30 +67,17 @@ namespace alpaka::internal::generic
         T_Value elementValue)
     {
         ALPAKA_LOG_FUNCTION(onHost::logger::memory);
-        uint32_t elementsPerFrameItem = getNumElemPerThread<T_Value>(internalQueue);
 
         auto extents = onHost::getExtents(dest);
-
-        using ExtentsType = ALPAKA_TYPEOF(extents);
-        using IndexType = typename ExtentsType::type;
-        auto virtualFrameExtent = ExtentsType::fill(1u);
-        // 512 is randomly chosen because it is on all devices a good value for a value assign kernel
-        virtualFrameExtent.x() = std::min(static_cast<IndexType>(512u * elementsPerFrameItem), extents.x());
-
-        auto numFrames = divExZero(extents, virtualFrameExtent);
-        auto realFrameExtent = ExtentsType::fill(1u);
-        realFrameExtent.x() = IndexType{512u};
-
-        auto frameSpec = onHost::FrameSpec{numFrames, realFrameExtent};
+        auto frameSpec = onHost::internal::getFrameSpec<T_Value>(*onHost::internal::getDevice(internalQueue), extents);
 
         ALPAKA_LOG_INFO(
             onHost::logger::memory,
             [&]()
             {
                 std::stringstream ss;
-                ss << "fill{ extents=" << extents << ", elementsPerFrameItem" << elementsPerFrameItem
-                   << ", dst=" << dest << ", value_type=" << onHost::demangledName(elementValue) << ", " << frameSpec
-                   << " }";
+                ss << "fill{ extents=" << extents << ", elementsPerFrameItem" << ", dst=" << dest
+                   << ", value_type=" << onHost::demangledName(elementValue) << ", frameSpec=" << frameSpec << " }";
                 return ss.str();
             });
 

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -321,43 +321,6 @@ namespace alpaka::onHost
     template<typename T_DataType, typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     inline constexpr auto getFrameSpec(onHost::Device<T_Api, T_DeviceKind> const& device, auto&& extents)
     {
-        using ExtentVecType = ALPAKA_TYPEOF(extents);
-        using IndexType = alpaka::trait::GetValueType_t<ExtentVecType>;
-        auto props = device.getDeviceProperties();
-        IndexType warpSize = static_cast<IndexType>(props.warpSize);
-        // try to create a specification with a frame size of 512 elements
-        IndexType numFrameElemets = 512;
-        // avoid non-power of two values
-        auto fastDimensionValue = roundDownToPowerOfTwo(std::min(warpSize, extents.x()));
-        auto frameExtents = ExtentVecType::fill(1).rAssign(fastDimensionValue);
-        numFrameElemets /= frameExtents.x();
-        // distribute remainder frame elements
-        while(numFrameElemets > IndexType{1})
-        {
-            uint32_t maxIdx = ExtentVecType::dim() - 1u;
-            IndexType maxValue = 0;
-            for(auto i = 0u; i < ExtentVecType::dim(); ++i)
-            {
-                auto v = extents[i] / frameExtents[i] / IndexType{2};
-                if(maxValue < v)
-                {
-                    maxIdx = i;
-                    maxValue = v;
-                }
-            }
-            // apply the change only if we not oversubscribe the extents
-            auto v = extents[maxIdx] / frameExtents[maxIdx] / IndexType{2};
-            if(v >= IndexType{1})
-                frameExtents[maxIdx] *= IndexType{2};
-            else
-                break;
-            numFrameElemets /= IndexType{2};
-        }
-        IndexType elementsPerFrameItem = static_cast<IndexType>(getNumElemPerThread<T_DataType>(device));
-        alpaka::concepts::Vector auto numFrames
-            = divExZero(extents, frameExtents * frameExtents.fill(1).rAssign(elementsPerFrameItem));
-        // The frame specification is not required to be a multiple of the extent, it can be smaller.
-        auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
-        return frameSpec;
+        return internal::getFrameSpec<T_DataType>(*device.get(), extents);
     }
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -465,5 +465,54 @@ namespace alpaka::onHost
             return GetPitches::Op<ALPAKA_TYPEOF(*any.get())>{}(*any.get());
         }
 
+        /** get a SIMD optimized frame spec
+         *
+         * @param internalDevice must be a alpaka internal device implementation
+         */
+        template<typename T_DataType>
+        inline constexpr auto getFrameSpec(auto const& internalDevice, auto&& extents)
+        {
+            auto deviceKind = alpaka::internal::getDeviceKind(internalDevice);
+            auto deviceApi = alpaka::internal::getApi(internalDevice);
+            using ExtentVecType = ALPAKA_TYPEOF(extents);
+            using IndexType = alpaka::trait::GetValueType_t<ExtentVecType>;
+            auto props = internal::GetDeviceProperties::Op<ALPAKA_TYPEOF(internalDevice)>{}(internalDevice);
+            IndexType warpSize = static_cast<IndexType>(props.warpSize);
+            // try to create a specification with a frame size of 512 elements
+            IndexType numFrameElements = 512;
+            // avoid non-power of two values
+            auto fastDimensionValue = roundDownToPowerOfTwo(std::min(warpSize, extents.x()));
+            auto frameExtents = ExtentVecType::fill(1).rAssign(fastDimensionValue);
+            numFrameElements /= frameExtents.x();
+            // distribute remainder frame elements
+            while(numFrameElements > IndexType{1})
+            {
+                uint32_t maxIdx = ExtentVecType::dim() - 1u;
+                IndexType maxValue = 0;
+                for(auto i = 0u; i < ExtentVecType::dim(); ++i)
+                {
+                    auto v = extents[i] / frameExtents[i] / IndexType{2};
+                    if(maxValue < v)
+                    {
+                        maxIdx = i;
+                        maxValue = v;
+                    }
+                }
+                // apply the change only if we not oversubscribe the extents
+                auto v = extents[maxIdx] / frameExtents[maxIdx] / IndexType{2};
+                if(v >= IndexType{1})
+                    frameExtents[maxIdx] *= IndexType{2};
+                else
+                    break;
+                numFrameElements /= IndexType{2};
+            }
+            IndexType elementsPerFrameItem
+                = static_cast<IndexType>(getNumElemPerThread<T_DataType>(deviceApi, deviceKind));
+            alpaka::concepts::Vector auto numFrames
+                = divExZero(extents, frameExtents * frameExtents.fill(1).rAssign(elementsPerFrameItem));
+            // The frame specification is not required to be a multiple of the extent, it can be smaller.
+            auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
+            return frameSpec;
+        }
     } // namespace internal
 } // namespace alpaka::onHost


### PR DESCRIPTION
Optimize the frame specification for `generic::fill()` for better SIMD utilization.

- move implementation of `onHost::getFrameSpec<>()` to the internal namespace to be able to used internally within alpaka too.
- call `onHost::internal::getFrameSpec()` from `onHost::getFrameSpec()`