### PR TITLE
remove ID from device name

### DIFF
--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -37,7 +37,6 @@ namespace alpaka::onHost
                 , m_properties{internal::getDeviceProperties(*m_platform.get(), m_idx)}
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::device);
-                m_properties.name += " id=" + std::to_string(m_idx);
             }
 
             ~Device()

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -36,7 +36,6 @@ namespace alpaka::onHost
                 , m_properties{internal::getDeviceProperties(*m_platform.get(), m_idx)}
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::device);
-                m_properties.name += " id=" + std::to_string(m_idx);
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::setDevice(idx));
             }
 


### PR DESCRIPTION
Remove the device id from it's name to keep CPU, HIP/CUDA and SYCL devices equal.