### PR TITLE
Span support + minor bugfix for getExtent

### DIFF
--- a/docs/snippets/cheatsheet/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet/cheatsheet.cpp
@@ -287,7 +287,22 @@ auto main() -> int
 
             unused(hostView, deviceView);
         }
-
+        {
+            // BEGIN-CHEATSHEET-allocLike
+            // This allocLike + memcpy pattern is not specific to std::span; it also works with std::vector/std::array
+            // and with alpaka Buffers/Views.
+            DataType arr[]{0, 1, 2, 3, 4, 5, 6, 7, 8};
+            // construct a span to an existing container
+            std::span myHostSpan = std::span{arr};
+            // create a one-dimensional deviceBuffer with the same extent as 'myHostSpan'
+            auto deviceBuffer = alpaka::onHost::allocLike(device, myHostSpan);
+            // Copy host -> device directly from the span into the allocated device buffer.
+            // Note: if the queue is asynchronous, ensure the source memory container stays alive until the copy
+            // completes.
+            alpaka::onHost::memcpy(blockingQueue, deviceBuffer, myHostSpan);
+            // END-CHEATSHEET-allocLike
+            unused(myHostSpan, deviceBuffer);
+        }
         {
             concepts::IBuffer auto buffer = onHost::allocHost<DataType>(numElements);
             buffer.destructorWaitFor(queue);

--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -252,6 +252,14 @@ Copy multidimensional buffer/view or span data
     :end-before: END-CHEATSHEET-memcpy
     :dedent:
 
+Allocate a buffer with the same extents from a std::span, std::vector or std::array
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  .. literalinclude:: ../../snippets/cheatsheet/cheatsheet.cpp
+    :language: cpp
+    :start-after: BEGIN-CHEATSHEET-allocLike
+    :end-before: END-CHEATSHEET-allocLike
+    :dedent:
+
 Kernel Execution
 ----------------
 

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -275,7 +275,7 @@ namespace alpaka::onHost
      */
     inline auto allocLike(concepts::Device auto const& device, auto const& view)
     {
-        return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, getExtents(view));
+        return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, internal::getExtents(view));
     }
 
     ///@}

--- a/include/alpaka/onHost/mem/stdContainer.hpp
+++ b/include/alpaka/onHost/mem/stdContainer.hpp
@@ -13,6 +13,7 @@
 
 #include <array>
 #include <cstdint>
+#include <span>
 #include <vector>
 
 namespace alpaka
@@ -54,6 +55,15 @@ namespace alpaka
         };
 
         template<typename T_Type, size_t T_size>
+        struct GetExtents::Op<std::span<T_Type, T_size>>
+        {
+            decltype(auto) operator()(auto&& stdSpan) const
+            {
+                return Vec{stdSpan.size()};
+            }
+        };
+
+        template<typename T_Type, size_t T_size>
         struct GetExtents::Op<std::array<T_Type, T_size>>
         {
             decltype(auto) operator()(auto&& stdArray) const
@@ -69,6 +79,16 @@ namespace alpaka
             decltype(auto) operator()(auto&& stdVector) const
             {
                 alpaka::unused(stdVector);
+                return Vec{sizeof(T_Type)};
+            }
+        };
+
+        template<typename T_Type, size_t T_size>
+        struct GetPitches::Op<std::span<T_Type, T_size>>
+        {
+            decltype(auto) operator()(auto&& stdSpan) const
+            {
+                alpaka::unused(stdSpan);
                 return Vec{sizeof(T_Type)};
             }
         };
@@ -93,9 +113,21 @@ namespace alpaka
         };
 
         template<typename T_Type, size_t T_size>
+        struct GetValueType<std::span<T_Type, T_size>>
+        {
+            using type = T_Type;
+        };
+
+        template<typename T_Type, size_t T_size>
         struct GetValueType<std::array<T_Type, T_size>>
         {
             using type = T_Type;
+        };
+
+        template<typename T_Type, size_t T_size>
+        struct GetDim<std::span<T_Type, T_size>>
+        {
+            static constexpr uint32_t value = 1u;
         };
 
         template<typename T_Type, typename T_Allocator>


### PR DESCRIPTION
This PR adds support for std::span such that it can be used in as a source or destination type for memory allocations.
concretely  support for std span (getExtent + getPitched overloads).
Additionally this fixes a bug that caused getExtent to fail on certain allocation (internal namespace was missing missing)
