### PR TITLE
improve FrameSpec

### DIFF
--- a/example/scan/src/scan.hpp
+++ b/example/scan/src/scan.hpp
@@ -188,14 +188,14 @@ namespace alpaka::example::scan
         constexpr auto const adjustedFrameExtent = frameExtent * elsPerThread;
         auto const frameSpec = onHost::FrameSpec{divCeil(inputVec.getExtents(), adjustedFrameExtent), frameExtent};
 
-        if(frameSpec.m_numFrames > 1_idx)
+        if(frameSpec.getNumFrames() > 1_idx)
         {
             // problem does not fit in 1 frame, recurse
             Scan_AddIncrementsKernel addIncrements;
 
             // allocate block increments, one element per frame
-            auto increments = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
-            auto blockSums = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
+            auto increments = onHost::alloc<Data>(devAcc, frameSpec.getNumFrames());
+            auto blockSums = onHost::alloc<Data>(devAcc, frameSpec.getNumFrames());
 
             IdxType elementsPerWorker = getNumElemPerThread<Data>(queue);
             auto addIncrementsFrameSpec = onHost::FrameSpec{

--- a/example/scan/src/scan_improved.hpp
+++ b/example/scan/src/scan_improved.hpp
@@ -368,14 +368,14 @@ namespace alpaka::example::scan
         auto numFrames = divCeil(inputVec.getExtents(), chunkExtent);
         auto const frameSpec = onHost::FrameSpec{numFrames, chunkExtent, CVec<IdxType, 256u>{}};
 
-        if(frameSpec.m_numFrames > 1_idx)
+        if(frameSpec.getNumFrames() > 1_idx)
         {
             // problem does not fit in 1 frame, recurse
             Scan_AddIncrementsKernel addIncrements;
 
             // allocate block increments, one element per frame
-            auto increments = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
-            auto blockSums = onHost::alloc<Data>(devAcc, frameSpec.m_numFrames);
+            auto increments = onHost::alloc<Data>(devAcc, frameSpec.getNumFrames());
+            auto blockSums = onHost::alloc<Data>(devAcc, frameSpec.getNumFrames());
 
             // enqueue the kernel execution tasks
             queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -172,8 +172,8 @@ namespace alpaka::onHost
                     [kernelBundle, executor, threadBlocking, deviceKind, frameSpec]()
                     {
                         auto moreLayer = Dict{
-                            DictEntry(frame::count, frameSpec.m_numFrames),
-                            DictEntry(frame::extent, frameSpec.m_frameExtent),
+                            DictEntry(frame::count, frameSpec.getNumFrames()),
+                            DictEntry(frame::extent, frameSpec.getFrameExtents()),
                             DictEntry(object::api, api::host),
                             DictEntry(object::deviceKind, deviceKind),
                             DictEntry(object::exec, executor)};

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -439,8 +439,8 @@ namespace alpaka::onHost::internal
                                 DictEntry(object::api, ApiType{}),
                                 DictEntry(object::deviceKind, DeviceKindType{}),
                                 DictEntry(object::exec, T_Executor{}),
-                                DictEntry(frame::count, frameSpec.m_numFrames),
-                                DictEntry(frame::extent, frameSpec.m_frameExtent),
+                                DictEntry(frame::count, frameSpec.getNumFrames()),
+                                DictEntry(frame::extent, frameSpec.getFrameExtents()),
                                 DictEntry(object::warpSize, warpSize));
                         });
                 });

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -475,8 +475,8 @@ namespace alpaka::onHost
                     queue,
                     threadBlocking,
                     kernelBundle,
-                    frameSpec.m_numFrames,
-                    frameSpec.m_frameExtent);
+                    frameSpec.getNumFrames(),
+                    frameSpec.getFrameExtents());
             }
         };
 

--- a/include/alpaka/onHost/FrameSpec.hpp
+++ b/include/alpaka/onHost/FrameSpec.hpp
@@ -40,50 +40,65 @@ namespace alpaka::onHost
         alpaka::concepts::Vector<typename T_NumFrames::type, T_NumFrames::dim()> T_ThreadExtents>
     struct FrameSpec
     {
-        using type = typename T_NumFrames::type;
+        using index_type = typename T_NumFrames::type;
 
         using NumFramesVecType = T_NumFrames;
         using FrameExtentsVecType = T_FrameExtents;
         using ThreadExtentsVecType = T_ThreadExtents;
         using ThreadSpecType = ThreadSpec<T_NumFrames, T_ThreadExtents>;
 
-        static consteval uint32_t dim()
-        {
-            return T_FrameExtents::dim();
-        }
-
-        T_NumFrames m_numFrames;
-        T_FrameExtents m_frameExtent;
+    private:
+        NumFramesVecType m_numFrames;
+        FrameExtentsVecType m_frameExtents;
         ThreadSpecType m_threadSpec;
 
-        FrameSpec(T_NumFrames const& numFrames, T_FrameExtents const& frameExtent)
+    public:
+        constexpr FrameSpec(T_NumFrames const& numFrames, T_FrameExtents const& frameExtent)
             : m_numFrames(numFrames)
-            , m_frameExtent(frameExtent)
+            , m_frameExtents(frameExtent)
             , m_threadSpec(numFrames, frameExtent)
         {
         }
 
-        FrameSpec(T_NumFrames const& numFrames, T_FrameExtents const& frameExtent, T_ThreadExtents const& numThreads)
+        constexpr FrameSpec(
+            T_NumFrames const& numFrames,
+            T_FrameExtents const& frameExtent,
+            T_ThreadExtents const& numThreads)
             : m_numFrames(numFrames)
-            , m_frameExtent(frameExtent)
+            , m_frameExtents(frameExtent)
             , m_threadSpec(numFrames, numThreads)
         {
         }
 
-        FrameSpec(
+        constexpr FrameSpec(
             T_NumFrames const& numFrames,
             T_FrameExtents const& frameExtent,
             T_NumFrames numBlocks,
             T_FrameExtents const& numThreads)
             : m_numFrames(numFrames)
-            , m_frameExtent(frameExtent)
+            , m_frameExtents(frameExtent)
             , m_threadSpec(numBlocks, numThreads)
         {
         }
 
-        auto getThreadSpec() const
+        [[nodiscard]] constexpr NumFramesVecType getNumFrames() const noexcept
+        {
+            return m_numFrames;
+        }
+
+        [[nodiscard]] constexpr FrameExtentsVecType getFrameExtents() const noexcept
+        {
+            return m_frameExtents;
+        }
+
+        [[nodiscard]] constexpr ThreadSpecType getThreadSpec() const noexcept
         {
             return m_threadSpec;
+        }
+
+        [[nodiscard]] static consteval uint32_t dim()
+        {
+            return T_FrameExtents::dim();
         }
     };
 
@@ -139,7 +154,7 @@ namespace alpaka::onHost
         template<typename T, typename T_IndexType = alpaka::NotRequired, uint32_t T_dim = alpaka::notRequiredDim>
         concept FrameSpec
             = isFrameSpec_v<T>
-              && (std::same_as<T_IndexType, alpaka::NotRequired> || std::same_as<typename T::type, T_IndexType>)
+              && (std::same_as<T_IndexType, alpaka::NotRequired> || std::same_as<typename T::index_type, T_IndexType>)
               && ((T_dim == alpaka::notRequiredDim) || (T::dim() == T_dim));
 
         /** Concept to check if a type is a ThreadSpec or a FrameSpec
@@ -152,7 +167,7 @@ namespace alpaka::onHost
 
     std::ostream& operator<<(std::ostream& s, concepts::FrameSpec auto const& d)
     {
-        return s << "FrameSpec{ frames=" << d.m_numFrames << ", frameExtent=" << d.m_frameExtent << ", "
+        return s << "FrameSpec{ frames=" << d.getNumFrames() << ", frameExtent=" << d.getNumFrames() << ", "
                  << d.getThreadSpec() << " }";
     }
 

--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -416,19 +416,19 @@ namespace alpaka::onHost::internal
                 return ss.str();
             });
 
-        if(frameSpec.m_numFrames > T_Idx{1})
+        if(frameSpec.getNumFrames() > T_Idx{1})
         {
             // problem does not fit in 1 frame, recurse
             Scan_AddIncrementsKernel<T_Idx> addIncrements;
 
-            auto bufSizeBytes = frameSpec.m_numFrames * T_Idx{sizeof(T_Data)};
+            auto bufSizeBytes = frameSpec.getNumFrames() * T_Idx{sizeof(T_Data)};
             assert(buffer.getExtents() * T_Idx{sizeof(typename ALPAKA_TYPEOF(buffer)::value_type)} >= bufSizeBytes);
 
             // get the view to the necessary elements in the buffer for increments
             auto subBuf = buffer.getSubView(bufSizeBytes);
             auto increments = MdSpan{
                 reinterpret_cast<T_Data*>(subBuf.data()),
-                frameSpec.m_numFrames,
+                frameSpec.getNumFrames(),
                 Vec<T_Idx, 1>{sizeof(T_Data)}};
 
             // the unused elements in the buffer are used for recursion to the next scan call

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -237,13 +237,13 @@ namespace alpaka::onHost::internal
 
             auto const numMultiProcessors = queue.getDevice().getDeviceProperties().multiProcessorCount;
             auto adjsutedNumFrames = alpaka::api::util::adjustToLimit(
-                frameSpec.m_numFrames,
+                frameSpec.getNumFrames(),
                 static_cast<IndexType>(numMultiProcessors * multiprocessorScaling));
-            frameSpec = FrameSpec{adjsutedNumFrames, frameSpec.m_frameExtent};
+            frameSpec = FrameSpec{adjsutedNumFrames, frameSpec.getFrameExtents()};
         }
 
-        auto kernelFn
-            = SimdTransformReduceKernel{static_cast<uint32_t>(frameSpec.m_frameExtent.product() * sizeof(T_DataType))};
+        auto kernelFn = SimdTransformReduceKernel{
+            static_cast<uint32_t>(frameSpec.getFrameExtents().product() * sizeof(T_DataType))};
 
         ALPAKA_LOG_INFO(
             onHost::logger::memory,


### PR DESCRIPTION
- make constructors constexpr
- move `m_numFrames`, `m_frameExtent` and `m_threadSpec` to private scope and add getters
- rename member type `type` to `value_type`