### PR TITLE
CMake: fix broken fast math disable option for HIP/OneApi

### DIFF
--- a/cmake/alpakaHip.cmake
+++ b/cmake/alpakaHip.cmake
@@ -58,7 +58,7 @@ if(CMAKE_HIP_COMPILER)
 
     if(alpaka_FAST_MATH STREQUAL ON)
         alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-ffast-math>")
-    elseif(alpaka_MATH STREQUAL OFF)
+    elseif(alpaka_FAST_MATH STREQUAL OFF)
         alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fno-fast-math>")
     endif()
 

--- a/cmake/alpakaOneApi.cmake
+++ b/cmake/alpakaOneApi.cmake
@@ -91,7 +91,7 @@ endif()
 
 if(alpaka_FAST_MATH STREQUAL ON)
     alpaka_set_compiler_options(DEVICE target alpaka_target_oneapi "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-ffast-math>")
-elseif(alpaka_MATH STREQUAL OFF)
+elseif(alpaka_FAST_MATH STREQUAL OFF)
     alpaka_set_compiler_options(DEVICE target alpaka_target_oneapi "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-fno-fast-math>")
 endif()
 


### PR DESCRIPTION
We checked in CMake for the wrong variable name