### PR TITLE
refactored ThreadSpec

### DIFF
--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -123,14 +123,14 @@ void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto comp
         /* Some executors allow only a single thread for the block.
          * You must write your kernel independent of the number of threads per block.
          */
-        threadSpec.m_numThreads = 1u;
+        threadSpec = alpaka::onHost::ThreadSpec{threadSpec.getNumBlocks(), 1u};
     }
 
     // fill the output buffer with zeros; the size is known from the buffer objects
     alpaka::onHost::memset(queue, out_d, 0x00);
 
-    std::cout << "Testing VectorAddKernel with vector indices with " << threadSpec.m_numBlocks << " blocks and "
-              << threadSpec.m_numThreads << "\n";
+    std::cout << "Testing VectorAddKernel with vector indices with " << threadSpec.getNumBlocks() << " blocks and "
+              << threadSpec.getNumThreads() << "\n";
     queue.enqueue(computeExec, threadSpec, VectorAddKernel1D{}, in1_d, in2_d, out_d, Vec1D{size});
 
     // copy the results from the device to the host
@@ -208,12 +208,12 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
         /* Some executors allow only a single thread for the block.
          * We map threads to blocks in this example.
          */
-        threadSpec.m_numBlocks *= threadSpec.m_numThreads;
-        threadSpec.m_numThreads = Vec3D::fill(1u);
+        threadSpec
+            = alpaka::onHost::ThreadSpec{threadSpec.getNumBlocks() * threadSpec.getNumThreads(), Vec3D::fill(1u)};
     }
 
-    std::cout << "Testing VectorAddKernel with vector indices with " << threadSpec.m_numBlocks << " blocks and "
-              << threadSpec.m_numThreads << "\n";
+    std::cout << "Testing VectorAddKernel with vector indices with " << threadSpec.getNumBlocks() << " blocks and "
+              << threadSpec.getNumThreads() << "\n";
 
     queue.enqueue(computeExec, threadSpec, VectorAddKernel3D{}, in1_d, in2_d, out_d, ndsize);
 

--- a/include/alpaka/api/cuda/IdxLayer.hpp
+++ b/include/alpaka/api/cuda/IdxLayer.hpp
@@ -33,7 +33,7 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return mapToND(m_optimizedThreadSpec.m_numBlocks, static_cast<IdxType>(::blockIdx.x));
+                    return mapToND(m_optimizedThreadSpec.getNumBlocks(), static_cast<IdxType>(::blockIdx.x));
                 }
             }
 
@@ -45,7 +45,7 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return m_optimizedThreadSpec.m_numBlocks;
+                    return m_optimizedThreadSpec.getNumBlocks();
                 }
             }
         };
@@ -70,7 +70,7 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return mapToND(m_optimizedThreadSpec.m_numThreads, static_cast<IdxType>(::threadIdx.x));
+                    return mapToND(m_optimizedThreadSpec.getNumThreads(), static_cast<IdxType>(::threadIdx.x));
                 }
             }
 
@@ -82,7 +82,7 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return m_optimizedThreadSpec.m_numThreads;
+                    return m_optimizedThreadSpec.getNumThreads();
                 }
             }
 

--- a/include/alpaka/api/hip/IdxLayer.hpp
+++ b/include/alpaka/api/hip/IdxLayer.hpp
@@ -33,7 +33,7 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return mapToND(m_optimizedThreadSpec.m_numBlocks, static_cast<IdxType>(hipBlockIdx_x));
+                    return mapToND(m_optimizedThreadSpec.getNumBlocks(), static_cast<IdxType>(hipBlockIdx_x));
                 }
             }
 
@@ -45,7 +45,7 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return m_optimizedThreadSpec.m_numBlocks;
+                    return m_optimizedThreadSpec.getNumBlocks();
                 }
             }
         };
@@ -70,7 +70,7 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return mapToND(m_optimizedThreadSpec.m_numThreads, static_cast<IdxType>(hipThreadIdx_x));
+                    return mapToND(m_optimizedThreadSpec.getNumThreads(), static_cast<IdxType>(hipThreadIdx_x));
                 }
             }
 
@@ -82,7 +82,7 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return m_optimizedThreadSpec.m_numThreads;
+                    return m_optimizedThreadSpec.getNumThreads();
                 }
             }
 

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -319,7 +319,7 @@ namespace alpaka::onHost
             {
                 alpaka::unused(device, executor, kernelBundle);
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel);
-                auto numThreadBlocks = dataBlocking.getThreadSpec().m_numBlocks;
+                auto numThreadBlocks = dataBlocking.getThreadSpec().getNumBlocks();
                 return ThreadSpec{numThreadBlocks, T_NumThreads::template fill<1u>()};
             }
 
@@ -331,7 +331,7 @@ namespace alpaka::onHost
             {
                 alpaka::unused(device, executor, kernelBundle);
                 ALPAKA_LOG_FUNCTION(alpaka::onHost::logger::kernel);
-                auto numThreadBlocks = dataBlocking.getThreadSpec().m_numBlocks;
+                auto numThreadBlocks = dataBlocking.getThreadSpec().getNumBlocks();
                 auto const numThreads = Vec<typename T_NumThreads::type, T_NumThreads::dim()>::fill(1);
                 return ThreadSpec{numThreadBlocks, numThreads};
             }

--- a/include/alpaka/api/host/exec/OmpBlocks.hpp
+++ b/include/alpaka/api/host/exec/OmpBlocks.hpp
@@ -37,12 +37,12 @@ namespace alpaka::onHost
             {
                 using NumThreadsVecType = typename T_ThreadSpec::NumThreadsVecType;
 
-                if(m_threadBlocking.m_numThreads.product() != 1u)
+                if(m_threadBlocking.getNumThreads().product() != 1u)
                     throw std::runtime_error("Thread block extent must be 1.");
 #    pragma omp parallel
                 {
                     // copy from num blocks to derive correct index type
-                    auto blockIdx = m_threadBlocking.m_numBlocks;
+                    auto blockIdx = m_threadBlocking.getNumBlocks();
                     constexpr uint32_t simdWidth
                         = alpaka::getArchSimdWidth<uint8_t>(api::host, ALPAKA_TYPEOF(dict[object::deviceKind]){});
                     auto blockSharedMem = onAcc::cpu::SingleThreadStaticShared<simdWidth>{};
@@ -63,7 +63,7 @@ namespace alpaka::onHost
                         dict,
                         Dict{blockDynSharedMemEntry, blockDynSharedMemBytesEntry});
 
-                    auto blockCount = m_threadBlocking.m_numBlocks;
+                    auto blockCount = m_threadBlocking.getNumBlocks();
 
                     auto const blockLayerEntry = DictEntry{
                         layer::block,

--- a/include/alpaka/api/host/exec/Serial.hpp
+++ b/include/alpaka/api/host/exec/Serial.hpp
@@ -33,14 +33,14 @@ namespace alpaka::onHost
             void operator()(auto const& kernelBundle, auto const& dict) const
             {
                 // copy from num blocks to derive correct index type
-                auto blockIdx = m_threadBlocking.m_numBlocks;
+                auto blockIdx = m_threadBlocking.getNumBlocks();
                 constexpr uint32_t simdWidth
                     = alpaka::getArchSimdWidth<uint8_t>(api::host, ALPAKA_TYPEOF(dict[object::deviceKind]){});
                 auto blockSharedMem = onAcc::cpu::SingleThreadStaticShared<simdWidth>{};
 
                 auto const blockLayerEntry = DictEntry{
                     layer::block,
-                    onAcc::cpu::GenericLayer{std::cref(blockIdx), std::cref(m_threadBlocking.m_numBlocks)}};
+                    onAcc::cpu::GenericLayer{std::cref(blockIdx), std::cref(m_threadBlocking.getNumBlocks())}};
                 auto const threadLayerEntry = DictEntry{layer::thread, onAcc::cpu::OneLayer<NumThreadsVecType>{}};
                 auto const blockSharedMemEntry = DictEntry{layer::shared, std::ref(blockSharedMem)};
                 auto const blockSyncEntry = DictEntry{action::threadBlockSync, onAcc::cpu::NoOp{}};
@@ -68,7 +68,7 @@ namespace alpaka::onHost
                     additionalDict));
                 meta::ndLoopIncIdx(
                     blockIdx,
-                    m_threadBlocking.m_numBlocks,
+                    m_threadBlocking.getNumBlocks(),
                     [&](auto const&)
                     {
                         kernelBundle(acc);

--- a/include/alpaka/api/host/exec/TbbBlocks.hpp
+++ b/include/alpaka/api/host/exec/TbbBlocks.hpp
@@ -38,10 +38,10 @@ namespace alpaka::onHost
 
             void operator()(auto const& kernelBundle, auto const& dict) const
             {
-                if(m_threadBlocking.m_numThreads.product() != 1u)
+                if(m_threadBlocking.getNumThreads().product() != 1u)
                     throw std::runtime_error("Thread block extent must be 1.");
 
-                auto blockCount = m_threadBlocking.m_numBlocks;
+                auto blockCount = m_threadBlocking.getNumBlocks();
 
                 constexpr uint32_t simdWidth
                     = alpaka::getArchSimdWidth<uint8_t>(api::host, ALPAKA_TYPEOF(dict[object::deviceKind]){});

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -229,14 +229,14 @@ namespace alpaka::onHost::internal
             if constexpr(T_ThreadSpec::dim() >= 4u)
             {
                 gridRange = sycl::nd_range<syclDim>{
-                    (threadSpec.m_numBlocks * threadSpec.m_numThreads).product(),
-                    threadSpec.m_numThreads.product()};
+                    (threadSpec.getNumBlocks() * threadSpec.getNumThreads()).product(),
+                    threadSpec.getNumThreads().product()};
             }
             else
             {
                 gridRange = sycl::nd_range<T_ThreadSpec::dim()>{
-                    detail::vecToSyclRange(threadSpec.m_numBlocks * threadSpec.m_numThreads),
-                    detail::vecToSyclRange(threadSpec.m_numThreads)};
+                    detail::vecToSyclRange(threadSpec.getNumBlocks() * threadSpec.getNumThreads()),
+                    detail::vecToSyclRange(threadSpec.getNumThreads())};
             }
 
             using ThreadSpecType = std::conditional_t<
@@ -246,7 +246,7 @@ namespace alpaka::onHost::internal
                     typename ALPAKA_TYPEOF(threadSpec)::NumBlocksVecType,
                     typename ALPAKA_TYPEOF(threadSpec)::NumThreadsVecType>>;
             // thread spec which is only holding data if the dimension is larger than 3u
-            auto optimizedThreadSpec = ThreadSpecType(threadSpec.m_numBlocks, threadSpec.m_numThreads);
+            auto optimizedThreadSpec = ThreadSpecType(threadSpec.getNumBlocks(), threadSpec.getNumThreads());
             return std::make_pair(gridRange, optimizedThreadSpec);
         }
 

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -306,7 +306,7 @@ namespace alpaka::onHost
             {
                 alpaka::unused(device, executor, kernelBundle);
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::device);
-                auto numThreads = dataBlocking.getThreadSpec().m_numThreads;
+                auto numThreads = dataBlocking.getThreadSpec().getNumThreads();
 
                 /** This limit is not exact but for typical GPUs, Intel, NVIDIA and AMD we can at least use 1024
                  * threads per block.
@@ -316,7 +316,7 @@ namespace alpaka::onHost
                 constexpr typename ALPAKA_TYPEOF(numThreads)::type hardwareLimitThreadsPerBlock = 1024u;
 
                 constexpr auto result = api::util::adjustToLimit<hardwareLimitThreadsPerBlock, 0u, 1u>(numThreads);
-                return ThreadSpec{dataBlocking.getThreadSpec().m_numBlocks, result};
+                return ThreadSpec{dataBlocking.getThreadSpec().getNumBlocks(), result};
             }
 
             auto operator()(
@@ -327,11 +327,11 @@ namespace alpaka::onHost
             {
                 alpaka::unused(executor, kernelBundle);
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::device);
-                auto numThreadsPerBlocks = dataBlocking.getThreadSpec().m_numThreads;
+                auto numThreadsPerBlocks = dataBlocking.getThreadSpec().getNumThreads();
                 auto const maxThreadsPerBlock = device.m_properties.maxThreadsPerBlock;
 
                 auto result = api::util::adjustToLimit(numThreadsPerBlocks, maxThreadsPerBlock);
-                return ThreadSpec{dataBlocking.getThreadSpec().m_numBlocks, result};
+                return ThreadSpec{dataBlocking.getThreadSpec().getNumBlocks(), result};
             }
         };
 

--- a/include/alpaka/api/syclGeneric/onAcc.hpp
+++ b/include/alpaka/api/syclGeneric/onAcc.hpp
@@ -53,7 +53,7 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return mapToND(m_optimizedThreadSpec.m_numBlocks, static_cast<IdxType>(m_item.get_group(0)));
+                    return mapToND(m_optimizedThreadSpec.getNumBlocks(), static_cast<IdxType>(m_item.get_group(0)));
                 }
             }
 
@@ -76,7 +76,7 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return m_optimizedThreadSpec.m_numBlocks;
+                    return m_optimizedThreadSpec.getNumBlocks();
                 }
             }
         };
@@ -114,7 +114,9 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return mapToND(m_optimizedThreadSpec.m_numThreads, static_cast<IdxType>(m_item.get_local_id(0)));
+                    return mapToND(
+                        m_optimizedThreadSpec.getNumThreads(),
+                        static_cast<IdxType>(m_item.get_local_id(0)));
                 }
             }
 
@@ -137,7 +139,7 @@ namespace alpaka::onAcc
                 }
                 else
                 {
-                    return m_optimizedThreadSpec.m_numThreads;
+                    return m_optimizedThreadSpec.getNumThreads();
                 }
             }
 

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -387,7 +387,7 @@ namespace alpaka::onHost
                 T_KernelBundle const&) const requires alpaka::concepts::CVector<T_NumThreads>
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::device);
-                auto numThreads = dataBlocking.getThreadSpec().m_numThreads;
+                auto numThreads = dataBlocking.getThreadSpec().getNumThreads();
 
                 /** All modern NVIDIA and AMD GPUs support at least 1014 threads.
                  * @attention: Due to lmem, shared memory or register usage the limit could be lower. In this case the
@@ -397,7 +397,7 @@ namespace alpaka::onHost
                 constexpr typename ALPAKA_TYPEOF(numThreads)::type hardwareLimitThreadsPerBlock = 1024u;
 
                 constexpr auto result = api::util::adjustToLimit<hardwareLimitThreadsPerBlock, 0u, 1u>(numThreads);
-                return ThreadSpec{dataBlocking.getThreadSpec().m_numBlocks, result};
+                return ThreadSpec{dataBlocking.getThreadSpec().getNumBlocks(), result};
             }
 
             auto operator()(
@@ -407,11 +407,11 @@ namespace alpaka::onHost
                 T_KernelBundle const&) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::device);
-                auto numThreadsPerBlocks = dataBlocking.getThreadSpec().m_numThreads;
+                auto numThreadsPerBlocks = dataBlocking.getThreadSpec().getNumThreads();
                 auto const maxThreadsPerBlock = device.m_properties.maxThreadsPerBlock;
 
                 auto result = api::util::adjustToLimit(numThreadsPerBlocks, maxThreadsPerBlock);
-                return ThreadSpec{dataBlocking.getThreadSpec().m_numBlocks, result};
+                return ThreadSpec{dataBlocking.getThreadSpec().getNumBlocks(), result};
             }
         };
     } // namespace internal

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -282,13 +282,13 @@ namespace alpaka::onHost
 
                 if constexpr(dim >= 4u)
                 {
-                    numBlocks = threadSpec.m_numBlocks.product();
-                    numThreadsPerBlock = threadSpec.m_numThreads.product();
+                    numBlocks = threadSpec.getNumBlocks().product();
+                    numThreadsPerBlock = threadSpec.getNumThreads().product();
                 }
                 else
                 {
-                    numBlocks = threadSpec.m_numBlocks;
-                    numThreadsPerBlock = threadSpec.m_numThreads;
+                    numBlocks = threadSpec.getNumBlocks();
+                    numThreadsPerBlock = threadSpec.getNumThreads();
                 }
 
                 using ThreadSpecType = std::conditional_t<
@@ -298,7 +298,7 @@ namespace alpaka::onHost
                         typename ALPAKA_TYPEOF(threadSpec)::NumBlocksVecType,
                         typename ALPAKA_TYPEOF(threadSpec)::NumThreadsVecType>>;
                 // thread spec which is only holding data if the dimension is larger than 3u
-                auto optimizedThreadSpec = ThreadSpecType(threadSpec.m_numBlocks, threadSpec.m_numThreads);
+                auto optimizedThreadSpec = ThreadSpecType(threadSpec.getNumBlocks(), threadSpec.getNumThreads());
 
                 auto kernelName = gpuKernel<
                     ALPAKA_TYPEOF(getApi(queue)),

--- a/include/alpaka/onHost/ThreadSpec.hpp
+++ b/include/alpaka/onHost/ThreadSpec.hpp
@@ -18,22 +18,34 @@ namespace alpaka::onHost
         alpaka::concepts::Vector<typename T_NumBlocks::type, T_NumBlocks::dim()> T_NumThreads>
     struct ThreadSpec
     {
-        using type = typename T_NumBlocks::type;
+        using index_type = typename T_NumBlocks::type;
         using NumBlocksVecType = typename T_NumBlocks::UniVec;
         using NumThreadsVecType = T_NumThreads;
 
-        static consteval uint32_t dim()
-        {
-            return T_NumThreads::dim();
-        }
-
+    private:
         NumBlocksVecType m_numBlocks;
         NumThreadsVecType m_numThreads;
 
+    public:
         constexpr ThreadSpec(T_NumBlocks const& numBlocks, T_NumThreads const& numThreadsPerBlock)
             : m_numBlocks(numBlocks)
             , m_numThreads(numThreadsPerBlock)
         {
+        }
+
+        [[nodiscard]] constexpr NumThreadsVecType const& getNumThreads() const noexcept
+        {
+            return m_numThreads;
+        }
+
+        [[nodiscard]] constexpr NumBlocksVecType const& getNumBlocks() const noexcept
+        {
+            return m_numBlocks;
+        }
+
+        [[nodiscard]] static consteval uint32_t dim()
+        {
+            return T_NumThreads::dim();
         }
     };
 
@@ -70,12 +82,12 @@ namespace alpaka::onHost
         template<typename T, typename T_IndexType = alpaka::NotRequired, uint32_t T_dim = alpaka::notRequiredDim>
         concept ThreadSpec
             = isThreadSpec_v<T>
-              && (std::same_as<T_IndexType, alpaka::NotRequired> || std::same_as<typename T::type, T_IndexType>)
+              && (std::same_as<T_IndexType, alpaka::NotRequired> || std::same_as<typename T::index_type, T_IndexType>)
               && ((T_dim == alpaka::notRequiredDim) || (T::dim() == T_dim));
     } // namespace concepts
 
     std::ostream& operator<<(std::ostream& s, concepts::ThreadSpec auto const& t)
     {
-        return s << "ThreadSpec{ blocks=" << t.m_numBlocks << ", threads=" << t.m_numThreads << " }";
+        return s << "ThreadSpec{ blocks=" << t.getNumBlocks() << ", threads=" << t.getNumThreads() << " }";
     }
 } // namespace alpaka::onHost


### PR DESCRIPTION
- rename member type `type` to `value_type`
- make member variables `m_numBlocks` and `m_numThreads` private and add getters
- ThreadSpec is not mutable anymore

I think it make more sense that ThreadSpec is immutable to avoid undefined behavior/bugs. There was only one use case, where the value of a ThreadSpec was changed. I replaced it by constructing a new threadSpec. It is in an example not performance critical.  