### PR TITLE
Implement begin() and end() iterator for IdxRange

### DIFF
--- a/include/alpaka/mem/FlatIdxContainer.hpp
+++ b/include/alpaka/mem/FlatIdxContainer.hpp
@@ -9,7 +9,6 @@
 #include "alpaka/core/Dict.hpp"
 #include "alpaka/core/PP.hpp"
 #include "alpaka/core/common.hpp"
-#include "alpaka/mem/IdxRange.hpp"
 #include "alpaka/mem/ThreadSpace.hpp"
 #include "alpaka/onAcc/layout.hpp"
 #include "alpaka/tag.hpp"

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -8,6 +8,7 @@
 #include "alpaka/core/PP.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/mem/BoundaryIter.hpp"
+#include "alpaka/mem/FlatIdxContainer.hpp"
 
 #include <cstdint>
 
@@ -73,6 +74,35 @@ namespace alpaka
         constexpr auto distance() const
         {
             return m_end - m_begin;
+        }
+
+        /** Begin iterator to iterate all positions in the range. It first iterates the fastest index (the one on the
+         * far right -> x-dimension) and then moves sequentially to the slowest index (the one on the far left) until
+         * it reaches the end.
+         *
+         * If you want to iterate the index in parallel with many threads, use the function
+         * alpaka::onAcc::makeIdxMap().
+         *
+         * @return Begin iterator
+         */
+        [[nodiscard]] constexpr auto begin() const
+        {
+            return alpaka::onAcc::FlatIdxContainer{
+                *this,
+                alpaka::ThreadSpace{T_End::fill(0), T_End::fill(1)},
+                alpaka::onAcc::layout::contiguous,
+                alpaka::iotaCVec<typename ALPAKA_TYPEOF(distance())::type, ALPAKA_TYPEOF(distance())::dim()>()}
+                .begin();
+        }
+
+        [[nodiscard]] constexpr auto end() const
+        {
+            return alpaka::onAcc::FlatIdxContainer{
+                *this,
+                alpaka::ThreadSpace{T_End::fill(0), T_End::fill(1)},
+                alpaka::onAcc::layout::contiguous,
+                alpaka::iotaCVec<typename ALPAKA_TYPEOF(distance())::type, ALPAKA_TYPEOF(distance())::dim()>()}
+                .end();
         }
 
         std::string toString(std::string const separator = ",", std::string const enclosings = "{}") const

--- a/tests/unit/mem/idxRange.cpp
+++ b/tests/unit/mem/idxRange.cpp
@@ -1,0 +1,61 @@
+/* Copyright 2025 Simeon Ehrig
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("IdxRange::begin() and end()", "[mem][IdxRange][iterator]")
+{
+    SECTION("only end extents")
+    {
+        constexpr int y = 4;
+        for(int counter = 0; auto vec : alpaka::IdxRange(alpaka::Vec{y, 3}))
+        {
+            REQUIRE(vec == alpaka::Vec{counter / (y - 1), counter % (y - 1)});
+            counter++;
+        }
+    }
+
+    SECTION("begin and end extents")
+    {
+        constexpr int y = 4;
+        constexpr int x = 3;
+        constexpr int y_begin = 2;
+        constexpr int x_begin = 1;
+        for(auto expected_vec = alpaka::Vec{y_begin, x_begin};
+            auto vec : alpaka::IdxRange(alpaka::Vec{y_begin, x_begin}, alpaka::Vec{y, x}))
+        {
+            REQUIRE(vec == expected_vec);
+            expected_vec.x()++;
+            if(expected_vec.x() == x)
+            {
+                expected_vec.y()++;
+                expected_vec.x() = x_begin;
+            }
+        }
+    }
+
+    SECTION("begin and end extents and stride")
+    {
+        constexpr int y = 15;
+        constexpr int x = 12;
+        constexpr int y_begin = 2;
+        constexpr int x_begin = 0;
+        constexpr int y_stride = 4;
+        constexpr int x_stride = 3;
+        for(auto expected_vec = alpaka::Vec{y_begin, x_begin};
+            auto vec :
+            alpaka::IdxRange(alpaka::Vec{y_begin, x_begin}, alpaka::Vec{y, x}, alpaka::Vec{y_stride, x_stride}))
+        {
+            REQUIRE(vec == expected_vec);
+            expected_vec.x() += x_stride;
+            if(expected_vec.x() >= x)
+            {
+                expected_vec.y() += y_stride;
+                expected_vec.x() = x_begin;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- The begin() and end() function can be used on host side, to iterate all positions.
- On host side, it implements the FlatIdxContainer iterator for a serial executor and a contiguous layout.
- On accelerator side, still use makeMapIdx to iterate in parallel.