### PR TITLE
Fix broken documentation `std::span` snippet

### DIFF
--- a/docs/snippets/cheatsheet/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet/cheatsheet.cpp
@@ -289,19 +289,18 @@ auto main() -> int
         }
         {
             // BEGIN-CHEATSHEET-allocLike
-            // This allocLike + memcpy pattern is not specific to std::span; it also works with std::vector/std::array
+            // This allocLike + memcpy pattern is not specific to std::vector; it also works with std::array
             // and with alpaka Buffers/Views.
-            DataType arr[]{0, 1, 2, 3, 4, 5, 6, 7, 8};
-            // construct a span to an existing container
-            std::span myHostSpan = std::span{arr};
-            // create a one-dimensional deviceBuffer with the same extent as 'myHostSpan'
-            auto deviceBuffer = alpaka::onHost::allocLike(device, myHostSpan);
-            // Copy host -> device directly from the span into the allocated device buffer.
+            // Construct a host container (here: std::vector) with arbitrary values.
+            std::vector vec(42u, DataType{10});
+            // Create a one-dimensional deviceBuffer with the same extent as 'vec'
+            auto deviceBuffer = alpaka::onHost::allocLike(device, vec);
+            // Copy host -> device directly from the vector into the allocated device buffer.
             // Note: if the queue is asynchronous, ensure the source memory container stays alive until the copy
             // completes.
-            alpaka::onHost::memcpy(blockingQueue, deviceBuffer, myHostSpan);
+            alpaka::onHost::memcpy(blockingQueue, deviceBuffer, vec);
             // END-CHEATSHEET-allocLike
-            unused(myHostSpan, deviceBuffer);
+            unused(vec, deviceBuffer);
         }
         {
             concepts::IBuffer auto buffer = onHost::allocHost<DataType>(numElements);

--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -252,7 +252,7 @@ Copy multidimensional buffer/view or span data
     :end-before: END-CHEATSHEET-memcpy
     :dedent:
 
-Allocate a buffer with the same extents from a std::span, std::vector or std::array
+Allocate a buffer with the same extents from a std::vector or std::array
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   .. literalinclude:: ../../snippets/cheatsheet/cheatsheet.cpp
     :language: cpp


### PR DESCRIPTION
`std::span` does not provide an API therefore it cannot be used with `alpaka::memcpy` directly. I modified the docu snippet that was using `std::span` - it now shows how to use a host container (`std::vector`) in combination with `allocLike` and `memcpy` instead. This version has been verified through dedicated testing across multiple backends and devices.