### PR TITLE
fix `FrameSpec` and `ThreadSpec` can not be mutated

### DIFF
--- a/include/alpaka/onHost/FrameSpec.hpp
+++ b/include/alpaka/onHost/FrameSpec.hpp
@@ -86,12 +86,27 @@ namespace alpaka::onHost
             return m_numFrames;
         }
 
+        [[nodiscard]] constexpr NumFramesVecType& getNumFrames() noexcept
+        {
+            return m_numFrames;
+        }
+
         [[nodiscard]] constexpr FrameExtentsVecType const& getFrameExtents() const noexcept
         {
             return m_frameExtents;
         }
 
+        [[nodiscard]] constexpr FrameExtentsVecType& getFrameExtents() noexcept
+        {
+            return m_frameExtents;
+        }
+
         [[nodiscard]] constexpr ThreadSpecType const& getThreadSpec() const noexcept
+        {
+            return m_threadSpec;
+        }
+
+        [[nodiscard]] constexpr ThreadSpecType& getThreadSpec() noexcept
         {
             return m_threadSpec;
         }

--- a/include/alpaka/onHost/ThreadSpec.hpp
+++ b/include/alpaka/onHost/ThreadSpec.hpp
@@ -38,7 +38,17 @@ namespace alpaka::onHost
             return m_numThreads;
         }
 
+        [[nodiscard]] constexpr NumThreadsVecType& getNumThreads() noexcept
+        {
+            return m_numThreads;
+        }
+
         [[nodiscard]] constexpr NumBlocksVecType const& getNumBlocks() const noexcept
+        {
+            return m_numBlocks;
+        }
+
+        [[nodiscard]] constexpr NumBlocksVecType& getNumBlocks() noexcept
         {
             return m_numBlocks;
         }


### PR DESCRIPTION
Add operators to mutate the state.

With the last refactoring, we removed the possibility of generating the frame specification with `onHost::getFrameSpec()` and then post mortem change it. 
I use this very often for performance optimizations or testing effects like different numbers of thread blocks and frames.