### PR TITLE
CI: fix `keepAlive` test

### DIFF
--- a/include/alpaka/onHost/mem/SharedBuffer.hpp
+++ b/include/alpaka/onHost/mem/SharedBuffer.hpp
@@ -244,6 +244,9 @@ namespace alpaka::onHost
          * This differs from `destructorWaitFor`, because that function waits, while `keepAlive` does not block
          * anything, it just extends lifetime.
          *
+         * @attention Do not apply this function to a buffer allocated with alpaka::onHost::allocDeferred, see
+         * https://github.com/alpaka-group/alpaka3/issues/394
+         *
          * @param queue The queue to enqueue to.
          */
         void keepAlive(auto& queue)

--- a/tests/unit/mem/keepAlive.cpp
+++ b/tests/unit/mem/keepAlive.cpp
@@ -55,7 +55,7 @@ TEMPLATE_LIST_TEST_CASE("keep alive", "", TestApis)
 
     {
         // enqueue everything in this scope
-        auto scopedBuffer = onHost::allocDeferred<int>(queue, N);
+        auto scopedBuffer = onHost::alloc<int>(device, N);
 
         auto framespec = getFrameSpec<int>(device, scopedBuffer.getExtents());
 


### PR DESCRIPTION
Remove usage of keepAlive on buffers allocated with `alpaka::onHost::allocDeferred()`

see issue #394

Fix the error seen with `icpx` in the CI: `ERROR in ~CallbackThread: thread joins itself`