### PR TITLE
fix `allocDeffered()` and `keepAlive()` usage

### DIFF
--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -421,13 +421,21 @@ namespace alpaka::onHost
             auto deleter = [queueDep = std::move(queueDependency), ptr]()
             {
                 sycl::queue sycl_queue = queueDep->getNativeHandle();
-                /* Always enqueue into a queue, even if the queue is blocking, to track possible in queue
-                 * dependencies. sycl::free() is safe to be called within a hast_task
+                /* in cases where the deleter lifetime is extended e.g. by using keepAlive() on a buffer it can be that
+                 * the queue callback thread is holding the last instance of the deleter. keepAlive() is executed
+                 * within a sycl host tasks, it is forbidden to create another host task in a host task, result will be
+                 * a deadlock. Therefore, we submit the host task to free the memory first to the callback thread which
+                 * is than enqueuing the host task. This means that we can guarantee that the memory is freed after all
+                 * work, enqueued at the moment where the deleter is executed, in the sycl queue is finished. The
+                 * memory will be freed a little bit later than it could in cases other threads enqueue now kernel,
+                 * tasks into the sycl queue while the callback thread is creating the host tasks.
                  */
-                [[maybe_unused]] sycl::event ev = sycl_queue.submit(
-                    [&](sycl::handler& cgh) { cgh.host_task([=]() { sycl::free(toVoidPtr(ptr), sycl_queue); }); });
-                if(queueDep->isBlocking())
-                    ev.wait_and_throw();
+                queueDep->m_callBackThread.submit(
+                    [sycl_queue, ptr]() mutable
+                    {
+                        sycl_queue.submit([&](sycl::handler& cgh)
+                                          { cgh.host_task([=]() { sycl::free(toVoidPtr(ptr), sycl_queue); }); });
+                    });
             };
 
             auto sharedBuffer = onHost::SharedBuffer{

--- a/include/alpaka/core/CallbackThread.hpp
+++ b/include/alpaka/core/CallbackThread.hpp
@@ -17,6 +17,11 @@
 
 namespace alpaka::core
 {
+    /** A thread queue executing tasks asynchronously.
+     *
+     * This object should be used as members of objects which are secured by smart pointers to avoid that a task is
+     * taking over the ownership of the callback thread and therefore can destroy itself before all tasks are executed.
+     */
     class CallbackThread
     {
 #if ALPAKA_COMP_CLANG
@@ -67,10 +72,21 @@ namespace alpaka::core
             {
                 if(std::this_thread::get_id() == m_thread.get_id())
                 {
-                    std::cerr << "ERROR in ~CallbackThread: thread joins itself" << std::endl;
-                    std::abort();
+                    // at this point there should be no tasks in the queue
+                    if(!m_tasks.empty())
+                    {
+                        std::cerr << "ERROR in ~CallbackThread: internal queue is not empty but object is destructed."
+                                  << std::endl;
+                        std::abort();
+                    }
+                    /* We can not joint our self.
+                     * We can only end here if a tasks the callback thread is executing is capturing the object which
+                     * is holding the callback thread.
+                     */
+                    m_thread.detach();
                 }
-                m_thread.join();
+                else
+                    m_thread.join();
             }
         }
 

--- a/include/alpaka/core/CallbackThread.hpp
+++ b/include/alpaka/core/CallbackThread.hpp
@@ -19,7 +19,7 @@ namespace alpaka::core
 {
     /** A thread queue executing tasks asynchronously.
      *
-     * This object should be used as members of objects which are secured by smart pointers to avoid that a task is
+     * This object should be used as a member of objects which are secured by smart pointers to avoid that a task is
      * taking over the ownership of the callback thread and therefore can destroy itself before all tasks are executed.
      */
     class CallbackThread
@@ -79,9 +79,9 @@ namespace alpaka::core
                                   << std::endl;
                         std::abort();
                     }
-                    /* We can not joint our self.
-                     * We can only end here if a tasks the callback thread is executing is capturing the object which
-                     * is holding the callback thread.
+                    /* We can not join ourselves.
+                     * We can only end here if a task that the callback thread is executing is capturing the object
+                     * which is holding the callback thread.
                      */
                     m_thread.detach();
                 }

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -368,6 +368,8 @@ namespace alpaka::onHost
      * memory is allowed to be used in other queues too. To avoid that a view to the memory is still in use during the
      * deallocation you can use @see addDestructorAction() and wait for a queue if it **differs** to the queue used for
      * the allocation.
+     * The first access could have higher latency compared to alpaka::onHost::alloc() due to the initial setup of the
+     * caching allocator used by some APIs. But subsequent accesses should have lower latency.
      *
      * @attention It is allowed that the function is blocking the caller until the memory is created.
      *
@@ -397,6 +399,8 @@ namespace alpaka::onHost
      * memory is allowed to be used in other queues too. To avoid that a view to the memory is still in use during the
      * deallocation you can use @see addDestructorAction() and wait for a queue if it **differs** to the queue used for
      * the allocation.
+     * The first access could have higher latency compared to alpaka::onHost::alloc() due to the initial setup of the
+     * caching allocator used by some APIs. But subsequent accesses should have lower latency.
      *
      * @attention It is allowed that the function is blocking the caller until the memory is created.
      *

--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -458,6 +458,9 @@ namespace alpaka::onHost::internal
     {
         using T_Data = ALPAKA_TYPEOF(inputVec)::value_type;
 
+        /* We do not use allocDeferred here since we measured up to a factor 40 higher latency compared to alloc for
+         * CUDA 12.8 on an A30 for the first call. The reason is the cuda per stream caching pool setup time.
+         */
         auto buf = onHost::alloc<char>(devAcc, scanBufferSize<T_Data>(inputVec.getExtents()));
 
         scan<SCAN_TYPE>(queue, devAcc, exec, buf, outputVec, inputVec);

--- a/include/alpaka/onHost/algo/scan.hpp
+++ b/include/alpaka/onHost/algo/scan.hpp
@@ -34,9 +34,13 @@ namespace alpaka::onHost
      * @param queue The queue to enqueue to.
      * @param exec The executor to run with.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
-     * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     * buffer needs to be. If omitted, it will be allocated and destructed on the fly. If you call this method
+     * repeatedly, it is recommended to reuse the buffer whenever possible, or to provide a buffer allocated with
+     * onHost::allocDeferred() to reduce the overhead of allocating and deallocating the buffer on each call.
      * @param outputVec The output data. To perform an in-place scan, use the overload with only one data object.
      * @param inputVec The input data. Can be const.
+     *
+     * @{
      */
     void inclusiveScan(
         auto const& queue,
@@ -59,13 +63,19 @@ namespace alpaka::onHost
         internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, outputVec, inputVec);
     }
 
+    /** @} */
+
     /** @brief Perform an inclusive scan on data in-place.
      *
      * @param queue The queue to enqueue to.
      * @param exec The executor to run with.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
-     * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     * buffer needs to be. If omitted, it will be allocated and destructed on the fly. If you call this method
+     * repeatedly, it is recommended to reuse the buffer whenever possible, or to provide a buffer allocated with
+     * onHost::allocDeferred() to reduce the overhead of allocating and deallocating the buffer on each call.
      * @param dataVec The vector to scan, will be overwritten with the result.
+     *
+     * @{
      */
     void inclusiveScanInPlace(
         auto const& queue,
@@ -86,14 +96,20 @@ namespace alpaka::onHost
         internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, dataVec, dataVec);
     }
 
+    /** @} */
+
     /** @brief Perform an exclusive scan on the input data and write the result to the output data.
      *
      * @param queue The queue to enqueue to.
      * @param exec The executor to run with.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
-     * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     * buffer needs to be. If omitted, it will be allocated and destructed on the fly. If you call this method
+     * repeatedly, it is recommended to reuse the buffer whenever possible, or to provide a buffer allocated with
+     * onHost::allocDeferred() to reduce the overhead of allocating and deallocating the buffer on each call.
      * @param outputVec The output data. To perform an in-place scan, use the overload with only one data object.
      * @param inputVec The input data. Can be const.
+     *
+     * @{
      */
     void exclusiveScan(
         auto const& queue,
@@ -116,13 +132,19 @@ namespace alpaka::onHost
         internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, outputVec, inputVec);
     }
 
+    /** @} */
+
     /** @brief Perform an exclusive scan on data in-place.
      *
      * @param queue The queue to enqueue to.
      * @param exec The executor to run with.
      * @param buffer (optional) The internally used buffer. Use the scanBufferSize() function to check how big the
-     * buffer needs to be. If omitted, it will be allocated and destructed on the fly.
+     * buffer needs to be. If omitted, it will be allocated and destructed on the fly. If you call this method
+     * repeatedly, it is recommended to reuse the buffer whenever possible, or to provide a buffer allocated with
+     * onHost::allocDeferred() to reduce the overhead of allocating and deallocating the buffer on each call.
      * @param dataVec The vector to scan, will be overwritten with the result.
+     *
+     * @{
      */
     void exclusiveScanInPlace(
         auto const& queue,
@@ -142,4 +164,6 @@ namespace alpaka::onHost
         auto devAcc = queue.getDevice();
         internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, dataVec, dataVec);
     }
+
+    /** @} */
 } // namespace alpaka::onHost

--- a/tests/unit/mem/keepAlive.cpp
+++ b/tests/unit/mem/keepAlive.cpp
@@ -55,7 +55,7 @@ TEMPLATE_LIST_TEST_CASE("keep alive", "", TestApis)
 
     {
         // enqueue everything in this scope
-        auto scopedBuffer = onHost::alloc<int>(device, N);
+        auto scopedBuffer = onHost::allocDeferred<int>(queue, N);
 
         auto framespec = getFrameSpec<int>(device, scopedBuffer.getExtents());
 


### PR DESCRIPTION
fix #394

OneApi Sycl deadlocked in cases where `allocDefeered()` was used together with buffers `keepAlive()`.
The reason was that a native sycl host task was enqueued within an sycl host task, which is not allowed.

Together with this PR I opened #449 to refactor the `CallBackThread` with modern C++ jthreads.

Note: I kept `alloc` instead of `allocDeferred` in the example and in the algorithms scan implementation.
If `allocDeferred` is only called once on CUDA the latency is very high due to the per stream caching pool setup time of CUDA.
IMO for the algorithm scan we should provide the user the possibility to define which type of memory he prefers for the temporary required memory.