### PR TITLE
fixed `index_type` of `MdSpanArray`

### DIFF
--- a/example/scan/src/scan_improved.hpp
+++ b/example/scan/src/scan_improved.hpp
@@ -180,7 +180,7 @@ namespace alpaka::example::scan
                     }
                     else
                     {
-                        MdSpanArray<LocalArray, alpaka::Alignment<16>> regMemMd{regMem};
+                        MdSpanArray<LocalArray, IdxType, alpaka::Alignment<16>> regMemMd{regMem};
 
                         for(auto i = 0_idx; i < elsPerThread; i += 4_idx)
                         {
@@ -297,7 +297,7 @@ namespace alpaka::example::scan
                     }
                     else
                     {
-                        MdSpanArray<LocalArray, alpaka::Alignment<16>> regMemMd{regMem};
+                        MdSpanArray<LocalArray, IdxType, alpaka::Alignment<16>> regMemMd{regMem};
 
                         for(auto i = 0_idx; i < elsPerThread; i += 4_idx)
                         {

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -179,14 +179,14 @@ namespace alpaka
          * @return reference to the value
          */
         constexpr const_reference operator[](
-            // cannot use dim() or alpaka::trait::GetDim_v<T_Extents> because the cause an segmentation fault in nvcc
+            // cannot use dim() or alpaka::trait::GetDim_v<T_Extents> because the cause a segmentation fault in nvcc
             concepts::IndexVec<index_type, alpaka::trait::GetDim<T_Extents>::value> auto const& idx) const
         {
             return *ptr(idx);
         }
 
         constexpr reference operator[](
-            // cannot use dim() or alpaka::trait::GetDim_v<T_Extents> because the cause an segmentation fault in nvcc
+            // cannot use dim() or alpaka::trait::GetDim_v<T_Extents> because the cause a segmentation fault in nvcc
             concepts::IndexVec<index_type, alpaka::trait::GetDim<T_Extents>::value> auto const& idx)
         {
             return *ptr(idx);

--- a/include/alpaka/mem/MdSpanArray.hpp
+++ b/include/alpaka/mem/MdSpanArray.hpp
@@ -14,6 +14,7 @@
 #include "alpaka/mem/concepts/detail/InnerTypeAllowedCast.hpp"
 #include "alpaka/mem/trait.hpp"
 #include "alpaka/trait.hpp"
+#include "concepts/IndexVec.hpp"
 
 #include <concepts>
 #include <type_traits>
@@ -53,7 +54,7 @@ namespace alpaka
         using type = T[T_Extents{}[0u]];
     };
 
-    template<typename T_ArrayType, concepts::Alignment T_MemAlignment = Alignment<>>
+    template<typename T_ArrayType, std::integral T_IndexType, concepts::Alignment T_MemAlignment = Alignment<>>
     struct MdSpanArray
     {
         static_assert(
@@ -61,21 +62,20 @@ namespace alpaka
             "MdSpanArray can only be used if std::is_array_v<T> is true for the given type.");
     };
 
-    template<alpaka::concepts::CStaticArray T_ArrayType, concepts::Alignment T_MemAlignment>
-    struct MdSpanArray<T_ArrayType, T_MemAlignment>
+    template<alpaka::concepts::CStaticArray T_ArrayType, std::integral T_IndexType, concepts::Alignment T_MemAlignment>
+    struct MdSpanArray<T_ArrayType, T_IndexType, T_MemAlignment>
     {
     private:
         using MutArrayType = std::remove_cv_t<T_ArrayType>;
         using ConstArrayType = std::add_const_t<MutArrayType>;
 
     public:
-        using extentType = std::extent<T_ArrayType, std::rank_v<T_ArrayType>>;
         using value_type = std::remove_all_extents_t<T_ArrayType>;
         using reference = value_type&;
         using const_reference = value_type const&;
         using pointer = value_type*;
         using const_pointer = value_type const*;
-        using index_type = typename extentType::value_type;
+        using index_type = T_IndexType;
 
         static consteval uint32_t dim()
         {
@@ -119,7 +119,7 @@ namespace alpaka
 
         constexpr auto getConstMdSpan() const
         {
-            return MdSpanArray<ConstArrayType, T_MemAlignment>(*m_ptr);
+            return MdSpanArray<ConstArrayType, T_IndexType, T_MemAlignment>(*m_ptr);
         }
 
         constexpr auto cbegin() const
@@ -145,7 +145,8 @@ namespace alpaka
 
         template<alpaka::concepts::CStaticArray T_OtherArrayType>
         requires internal::concepts::InnerTypeAllowedCast<T_ArrayType, T_OtherArrayType>
-        constexpr MdSpanArray(MdSpanArray<T_OtherArrayType, T_MemAlignment> const& other) : m_ptr(other.m_ptr)
+        constexpr MdSpanArray(MdSpanArray<T_OtherArrayType, T_IndexType, T_MemAlignment> const& other)
+            : m_ptr(other.m_ptr)
         {
         }
 
@@ -155,7 +156,7 @@ namespace alpaka
 
         template<alpaka::concepts::CStaticArray T_OtherArrayType>
         requires internal::concepts::InnerTypeAllowedCast<T_ArrayType, T_OtherArrayType>
-        constexpr MdSpanArray(MdSpanArray<T_OtherArrayType, T_MemAlignment>&& other) : m_ptr(other.m_ptr)
+        constexpr MdSpanArray(MdSpanArray<T_OtherArrayType, T_IndexType, T_MemAlignment>&& other) : m_ptr(other.m_ptr)
         {
         }
 
@@ -172,12 +173,16 @@ namespace alpaka
          * @return reference to the value
          * @{
          */
-        constexpr const_reference operator[](concepts::Vector auto const& idx) const
+        constexpr const_reference operator[](
+            // cannot use dim() or std::rank_v<T_ArrayType> because the cause a segmentation fault in nvcc
+            concepts::IndexVec<index_type, std::rank<T_ArrayType>::value> auto const& idx) const
         {
             return ResolveArrayAccess<dim()>{}(*m_ptr, idx);
         }
 
-        constexpr reference operator[](concepts::Vector auto const& idx)
+        constexpr reference operator[](
+            // cannot use dim() or std::rank_v<T_ArrayType> because the cause a segmentation fault in nvcc
+            concepts::IndexVec<index_type, std::rank<T_ArrayType>::value> auto const& idx)
         {
             return ResolveArrayAccess<dim()>{}(*m_ptr, idx);
         }
@@ -201,9 +206,10 @@ namespace alpaka
 
         constexpr auto getExtents() const
         {
-            auto const createExtents = []<auto... T_extent>(std::index_sequence<T_extent...>)
+            // uint32_t is the data type of dim()
+            auto const createExtents = []<uint32_t... T_extent>(std::integer_sequence<uint32_t, T_extent...>)
             { return CVec<index_type, std::extent_v<T_ArrayType, T_extent>...>{}; };
-            return createExtents(std::make_integer_sequence<index_type, dim()>{});
+            return createExtents(std::make_integer_sequence<uint32_t, dim()>{});
         }
 
         constexpr auto getPitches() const
@@ -224,8 +230,8 @@ namespace alpaka
 
         // Needs to be friend of itself with that the copy and move constructor can access the m_ptr of other, if the
         // const modifier of the C static array type of the other type is different.
-        friend MdSpanArray<MutArrayType, T_MemAlignment>;
-        friend MdSpanArray<ConstArrayType, T_MemAlignment>;
+        friend MdSpanArray<MutArrayType, T_IndexType, T_MemAlignment>;
+        friend MdSpanArray<ConstArrayType, T_IndexType, T_MemAlignment>;
 
     protected:
         // we store the C static array as mutable type that we can assign it another MdSpanArray with const or
@@ -234,10 +240,14 @@ namespace alpaka
         MutArrayType* m_ptr;
     };
 
-    template<alpaka::concepts::CStaticArray T_ArrayType, alpaka::concepts::Alignment T_MemAlignment>
-    struct internal::CopyConstructableDataSource<MdSpanArray<T_ArrayType, T_MemAlignment>> : std::true_type
+    template<
+        alpaka::concepts::CStaticArray T_ArrayType,
+        std::integral T_IndexType,
+        alpaka::concepts::Alignment T_MemAlignment>
+    struct internal::CopyConstructableDataSource<MdSpanArray<T_ArrayType, T_IndexType, T_MemAlignment>>
+        : std::true_type
     {
-        using InnerMutable = MdSpanArray<std::remove_const_t<T_ArrayType>, T_MemAlignment>;
-        using InnerConst = MdSpanArray<std::add_const_t<T_ArrayType>, T_MemAlignment>;
+        using InnerMutable = MdSpanArray<std::remove_const_t<T_ArrayType>, T_IndexType, T_MemAlignment>;
+        using InnerConst = MdSpanArray<std::add_const_t<T_ArrayType>, T_IndexType, T_MemAlignment>;
     };
 } // namespace alpaka

--- a/include/alpaka/onAcc/Acc.hpp
+++ b/include/alpaka/onAcc/Acc.hpp
@@ -157,7 +157,8 @@ namespace alpaka::onAcc
          */
         constexpr size_t id = T_uniqueId ^ 0x9e37'79b9'7f4a'7c15;
         constexpr auto alignment = Alignment<alignof(T)>{};
-        return MdSpanArray<CArrayType, ALPAKA_TYPEOF(alignment)>{declareSharedVar<CArrayType, id>(acc)};
+        return MdSpanArray<CArrayType, typename ALPAKA_TYPEOF(extent)::type, ALPAKA_TYPEOF(alignment)>{
+            declareSharedVar<CArrayType, id>(acc)};
     }
 
     /** Get block shared dynamic memory.

--- a/include/alpaka/onAcc/internal/globalMem.hpp
+++ b/include/alpaka/onAcc/internal/globalMem.hpp
@@ -213,7 +213,8 @@ namespace alpaka::onAcc::internal
 
         constexpr decltype(auto) get() const requires(std::is_array_v<type>)
         {
-            return alpaka::MdSpanArray<type>{T_Storage::get(thisApi())};
+            // a static array of type C also uses size_t to define its length
+            return alpaka::MdSpanArray<type, size_t>{T_Storage::get(thisApi())};
         }
 
         constexpr operator type&()

--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -127,13 +127,14 @@ namespace alpaka::onHost::internal
 
             alpaka::concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
             alpaka::concepts::CVector auto frameExtent = acc[frame::extent];
-            constexpr auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
+            constexpr std::integral auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
             alpaka::concepts::CVector auto chunkExtent = CVec<T_Idx, elsPerThread * numThreadsPerBlock.x()>{};
             alpaka::concepts::Vector auto numElements = inputVec.getExtents();
 
-            constexpr auto miniBlockSize = std::min(maximumMiniBlockSize<DeviceType, T_Idx, T_Data>(), elsPerThread);
-            constexpr auto miniBlocksPerThread = elsPerThread / miniBlockSize;
-            constexpr auto miniBlocksPerChunk = chunkExtent.x() / miniBlockSize;
+            constexpr std::integral auto miniBlockSize
+                = std::min(maximumMiniBlockSize<DeviceType, T_Idx, T_Data>(), elsPerThread);
+            constexpr std::integral auto miniBlocksPerThread = elsPerThread / miniBlockSize;
+            constexpr std::integral auto miniBlocksPerChunk = chunkExtent.x() / miniBlockSize;
 
             constexpr auto LocalArrayLength = miniBlocksPerThread * miniBlockSize;
             using LocalArray = T_Data[LocalArrayLength];
@@ -177,7 +178,7 @@ namespace alpaka::onHost::internal
                     }
                     else
                     {
-                        MdSpanArray<LocalArray, alpaka::Alignment<16>> regMemMd{regMem};
+                        MdSpanArray<LocalArray, T_Idx, alpaka::Alignment<16>> regMemMd{regMem};
 
                         for(auto i = T_Idx{0}; i < elsPerThread; i += T_Idx{4})
                         {
@@ -296,7 +297,7 @@ namespace alpaka::onHost::internal
                     }
                     else
                     {
-                        MdSpanArray<LocalArray, alpaka::Alignment<16>> regMemMd{regMem};
+                        MdSpanArray<LocalArray, T_Idx, alpaka::Alignment<16>> regMemMd{regMem};
 
                         for(auto i = T_Idx{0}; i < elsPerThread; i += T_Idx{4})
                         {
@@ -396,7 +397,7 @@ namespace alpaka::onHost::internal
 
         // Define chunkExtent
         constexpr auto chunkExtent = CVec<T_Idx, chunkSize>{};
-        auto numFrames = divCeil(inputVec.getExtents(), chunkExtent);
+        alpaka::Vec numFrames = divCeil(inputVec.getExtents(), chunkExtent);
         auto const frameSpec = onHost::FrameSpec{numFrames, chunkExtent, CVec<T_Idx, 256u>{}};
 
         ALPAKA_LOG_INFO(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,15 @@
 cmake_minimum_required(VERSION 3.25)
 
 ################################################################################
+# Test target.
+################################################################################
+
+set(_TEST_TARGET_NAME alpakaTest)
+add_library(${_TEST_TARGET_NAME} INTERFACE)
+target_include_directories(${_TEST_TARGET_NAME} INTERFACE include)
+add_library(alpaka::test ALIAS ${_TEST_TARGET_NAME})
+
+################################################################################
 # Add subdirectories.
 ################################################################################
 
@@ -61,7 +70,10 @@ function(alpaka_add_test_target target_prefix folder)
                         target_include_directories(${_test_target_name} PRIVATE ${test_folder}/include)
                     endif()
 
-                    target_link_libraries(${_test_target_name} PRIVATE Catch2::Catch2WithMain alpaka::alpaka)
+                    target_link_libraries(
+                        ${_test_target_name}
+                        PRIVATE Catch2::Catch2WithMain alpaka::alpaka alpaka::test
+                    )
                     alpaka_finalize(${_test_target_name})
                     catch_discover_tests(${_test_target_name})
                 endif()

--- a/tests/include/alpakaTest/testMacros.hpp
+++ b/tests/include/alpakaTest/testMacros.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+/* Copyright 2026 Simeon Ehrig
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#define CHECK_MESSAGE(cond, msg)                                                                                      \
+    do                                                                                                                \
+    {                                                                                                                 \
+        INFO(msg);                                                                                                    \
+        CHECK(cond);                                                                                                  \
+    } while((void) 0, 0)
+
+#define REQUIRE_MESSAGE(cond, msg)                                                                                    \
+    do                                                                                                                \
+    {                                                                                                                 \
+        INFO(msg);                                                                                                    \
+        REQUIRE(cond);                                                                                                \
+    } while((void) 0, 0)

--- a/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/tests/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -68,7 +68,7 @@ struct DeviceGlobalMemKernelCArray2D
     {
         for(auto globalTheradIdx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{numThreads}))
         {
-            out[globalTheradIdx] = fixed_sized_array2D.get()[Vec{1, 2}];
+            out[globalTheradIdx] = fixed_sized_array2D.get()[Vec<size_t, 2>{1, 2}];
         }
     }
 };

--- a/tests/unit/mem/concepts.cpp
+++ b/tests/unit/mem/concepts.cpp
@@ -135,7 +135,7 @@ TEMPLATE_TEST_CASE_SIG(
     {
         auto zero = static_cast<TElem>(0);
         TElem static_data[2][2] = {{zero, zero}, {zero, zero}};
-        using MdSpanArrayType = MdSpanArray<decltype(static_data), alpaka::Alignment<16>>;
+        using MdSpanArrayType = MdSpanArray<decltype(static_data), size_t, alpaka::Alignment<16>>;
         MdSpanArrayType mdSpanArray(static_data);
         STATIC_REQUIRE(std::same_as<typename MdSpanArrayType::value_type, TElem>);
 

--- a/tests/unit/mem/constCorrectness.cpp
+++ b/tests/unit/mem/constCorrectness.cpp
@@ -192,8 +192,8 @@ TEST_CASE("MdSpanArray inner const copy constructor", "[mem][mdspanarray][correc
 {
     int static_data[2][2] = {{0, 0}, {0, 0}};
     int const const_static_data[2][2] = {{0, 0}, {0, 0}};
-    using MutMdSpanArray = MdSpanArray<decltype(static_data), alpaka::Alignment<16>>;
-    using ConstMdSpanArray = MdSpanArray<decltype(const_static_data), alpaka::Alignment<16>>;
+    using MutMdSpanArray = MdSpanArray<decltype(static_data), size_t, alpaka::Alignment<16>>;
+    using ConstMdSpanArray = MdSpanArray<decltype(const_static_data), size_t, alpaka::Alignment<16>>;
 
     STATIC_REQUIRE(internal::CopyConstructableDataSource<MutMdSpanArray>::value);
 
@@ -222,8 +222,8 @@ TEST_CASE("MdSpanArray inner const assignment operator", "[mem][mdspanarray][cor
 {
     int static_data[2][2] = {{0, 0}, {0, 0}};
     int const const_static_data[2][2] = {{0, 0}, {0, 0}};
-    using MutMdSpanArray = MdSpanArray<decltype(static_data), alpaka::Alignment<16>>;
-    using ConstMdSpanArray = MdSpanArray<decltype(const_static_data), alpaka::Alignment<16>>;
+    using MutMdSpanArray = MdSpanArray<decltype(static_data), size_t, alpaka::Alignment<16>>;
+    using ConstMdSpanArray = MdSpanArray<decltype(const_static_data), size_t, alpaka::Alignment<16>>;
 
     MutMdSpanArray mut_md_span_array(static_data);
     ConstMdSpanArray const_md_span_array(const_static_data);
@@ -244,8 +244,8 @@ TEST_CASE(
 {
     int static_data[2][2] = {{0, 0}, {0, 0}};
     int const const_static_data[2][2] = {{0, 0}, {0, 0}};
-    using MutMdSpanArray = MdSpanArray<decltype(static_data), alpaka::Alignment<16>>;
-    using ConstMdSpanArray = MdSpanArray<decltype(const_static_data), alpaka::Alignment<16>>;
+    using MutMdSpanArray = MdSpanArray<decltype(static_data), size_t, alpaka::Alignment<16>>;
+    using ConstMdSpanArray = MdSpanArray<decltype(const_static_data), size_t, alpaka::Alignment<16>>;
 
     MutMdSpanArray constr_mut_md(static_data);
     ConstMdSpanArray constr_const_md(const_static_data);

--- a/tests/unit/mem/subDataStorage.cpp
+++ b/tests/unit/mem/subDataStorage.cpp
@@ -4,14 +4,8 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include <alpakaTest/testMacros.hpp>
 #include <catch2/catch_test_macros.hpp>
-
-#define REQUIRE_MESSAGE(cond, msg)                                                                                    \
-    do                                                                                                                \
-    {                                                                                                                 \
-        INFO(msg);                                                                                                    \
-        REQUIRE(cond);                                                                                                \
-    } while((void) 0, 0)
 
 TEST_CASE("1D alpaka::View::getSubView function tests", "[mem][view][SubDataStorage]")
 {

--- a/tests/unit/sharedMem/sharedMem.cpp
+++ b/tests/unit/sharedMem/sharedMem.cpp
@@ -4,13 +4,11 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include <alpakaTest/testMacros.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <chrono>
-#include <functional>
-#include <iostream>
-#include <thread>
+#include <type_traits>
 
 using namespace alpaka;
 
@@ -43,7 +41,7 @@ struct SharedBlockIotaKernel
     }
 };
 
-TEMPLATE_LIST_TEST_CASE("block shared iota", "", TestApis)
+TEMPLATE_LIST_TEST_CASE("block shared iota", "[sharedMem]", TestApis)
 {
     auto cfg = TestType::makeDict();
     auto deviceSpec = cfg[object::deviceSpec];
@@ -52,20 +50,18 @@ TEMPLATE_LIST_TEST_CASE("block shared iota", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        WARN("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << " " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " " << device.getName());
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec numBlocks = Vec{2u};
     constexpr Vec blockExtent = Vec{128u};
     constexpr Vec dataExtent = numBlocks * blockExtent;
-    std::cout << "block shared iota exec=" << onHost::demangledName(exec) << std::endl;
+    INFO("block shared iota exec=" << onHost::demangledName(exec));
     auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -182,7 +178,7 @@ namespace alpaka::onHost::trait
     };
 } // namespace alpaka::onHost::trait
 
-TEMPLATE_LIST_TEST_CASE("block shared alias", "", TestApis)
+TEMPLATE_LIST_TEST_CASE("block shared alias", "[SharedMem]", TestApis)
 {
     auto cfg = TestType::makeDict();
     auto deviceSpec = cfg[object::deviceSpec];
@@ -191,14 +187,12 @@ TEMPLATE_LIST_TEST_CASE("block shared alias", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        WARN("No device available for " << deviceSpec.getName());
         return;
     }
-    std::cout << deviceSpec.getApi().getName() << std::endl;
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << " " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " " << device.getName());
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec numBlocks = Vec{1u};
@@ -226,4 +220,58 @@ TEMPLATE_LIST_TEST_CASE("block shared alias", "", TestApis)
         alpaka::onHost::wait(queue);
         CHECK(hBuff[0] == true);
     }
+}
+
+template<typename T_Idx>
+struct IndexTypeKernel
+{
+    constexpr void operator()(alpaka::onAcc::concepts::Acc auto const& acc, alpaka::concepts::IMdSpan auto result)
+        const
+    {
+        auto a = declareSharedMdArray<float, uniqueId()>(acc, CVec<T_Idx, 2u>{});
+        using SharedMdArrayType = decltype(a);
+        result[0u] = std::is_same_v<typename SharedMdArrayType::index_type, T_Idx>;
+        result[1u] = std::is_same_v<typename ALPAKA_TYPEOF(a.getExtents())::type, T_Idx>;
+    }
+};
+
+template<typename T_Idx>
+void test_index_type(auto& queue, auto const& exec, auto name)
+{
+    auto dBuff = onHost::alloc<bool>(queue.getDevice(), Vec{2u});
+    auto hBuff = onHost::allocHostLike(dBuff);
+    onHost::wait(queue);
+
+    queue.enqueue(
+        exec,
+        onHost::FrameSpec{alpaka::Vec{1u}, alpaka::Vec{1u}},
+        KernelBundle{IndexTypeKernel<T_Idx>{}, dBuff});
+    alpaka::onHost::memcpy(queue, hBuff, dBuff);
+    onHost::wait(queue);
+
+    REQUIRE_MESSAGE(hBuff[0] == true, "SharedMdArrayType::index_type failed with index type: " << name);
+    REQUIRE_MESSAGE(hBuff[1] == true, "getExtents()::type failed with index type: " << name);
+}
+
+TEMPLATE_LIST_TEST_CASE("test shared memory index type", "[sharedMem]", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        WARN("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    INFO(deviceSpec.getApi().getName() << " " << device.getName());
+    alpaka::onHost::Queue queue = device.makeQueue();
+
+    test_index_type<uint32_t>(queue, exec, "uint32_t");
+    test_index_type<int64_t>(queue, exec, "int64_t");
+    test_index_type<int>(queue, exec, "int");
+    test_index_type<size_t>(queue, exec, "size_t");
 }


### PR DESCRIPTION
The index_type was hard coded to `size_t`, even an extents which was used to construct it had a different `value_type`. No `MdSpanArray` has the same `index_type` like the `extents`.

If the function `alpaka::onAcc::declareSharedMdArray(acc, extents);` is used, the get shared memory, the index type of the extents was ignored. Instead the index type of the SharedMdArray was `size_t` all the time. This caused problems, when I added the concept `alpaka::concepts::IndexVec` to the access operator of `alpaka::SharedMdArray`.

The following code throws an compiler error without fix because of potential precession lost:

```c++
auto m = alpaka::onAcc::declareSharedMdArray(acc, alpaka::CVec<int, 1>{});
// 0 is an `int`, therefore it can be negative
// the index_type of m is `size_t` 
m[0];
```

# Site note

I added CMake test target for the unit tests, that the macros `REQUIRE_MESSAGE` and `CHECK_MESSAGE` are available in each test case.