### PR TITLE
use `alpaka::concepts::IndexVec` where it is useful

### DIFF
--- a/include/alpaka/SimdPtr.hpp
+++ b/include/alpaka/SimdPtr.hpp
@@ -8,11 +8,10 @@
 #include "alpaka/Vec.hpp"
 #include "alpaka/internal/interface.hpp"
 #include "alpaka/mem/Alignment.hpp"
-#include "alpaka/mem/concepts/IDataStorage.hpp"
 #include "alpaka/mem/concepts/IMdSpan.hpp"
+#include "alpaka/mem/concepts/IndexVec.hpp"
 #include "alpaka/trait.hpp"
 
-#include <array>
 #include <concepts>
 #include <cstdint>
 #include <type_traits>
@@ -82,7 +81,7 @@ namespace alpaka
          *
          * @{
          */
-        constexpr auto operator[](alpaka::concepts::Vector auto const& idx) const
+        constexpr auto operator[](alpaka::concepts::IndexVec<IdxType, T_MdSpan::dim()> auto const& idx) const
         {
             constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(value_type));
             constexpr auto align = Alignment<valueAlignment>{};
@@ -93,7 +92,7 @@ namespace alpaka
                 T_SimdWidth{}};
         }
 
-        constexpr auto operator[](alpaka::concepts::Vector auto const& idx)
+        constexpr auto operator[](alpaka::concepts::IndexVec<IdxType, T_MdSpan::dim()> auto const& idx)
         {
             constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(value_type));
             constexpr auto align = Alignment<valueAlignment>{};

--- a/include/alpaka/mem/LinearizedIdxGenerator.hpp
+++ b/include/alpaka/mem/LinearizedIdxGenerator.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/Simd.hpp"
 #include "alpaka/internal/interface.hpp"
 #include "alpaka/mem/DataPitches.hpp"
+#include "alpaka/mem/concepts/IndexVec.hpp"
 
 namespace alpaka
 {
@@ -41,7 +42,7 @@ namespace alpaka
          * @param idx n-dimensional offset, range [0, extents)
          * @return linearized index
          */
-        constexpr value_type operator[](alpaka::concepts::Vector auto const& idx) const
+        constexpr value_type operator[](alpaka::concepts::IndexVec<T_IndexType, T_dim> auto const& idx) const
         {
             return linearize(m_extents, idx);
         }
@@ -51,7 +52,7 @@ namespace alpaka
          * @param idx n-dimensional offset, range [0, extents)
          * @return linearized index
          */
-        constexpr value_type operator[](alpaka::concepts::Vector auto const& idx)
+        constexpr value_type operator[](alpaka::concepts::IndexVec<T_IndexType, T_dim> auto const& idx)
         {
             return linearize(m_extents, idx);
         }


### PR DESCRIPTION
follows up PR #451 and #453