### PR TITLE
fix wrong include usage

### DIFF
--- a/include/alpaka/mem/concepts/IndexVec.hpp
+++ b/include/alpaka/mem/concepts/IndexVec.hpp
@@ -3,7 +3,7 @@
  */
 
 #pragma once
-#include <alpaka/Vec.hpp>
+#include "alpaka/Vec.hpp"
 
 namespace alpaka::concepts
 {


### PR DESCRIPTION
For includes in alpaka we must use `inlcude "alpaka/..."` to avoid breaking the single headers.