### PR TITLE
fix ambigious function call

### DIFF
--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -59,7 +59,7 @@ namespace alpaka
     inline constexpr auto makeView(auto&& any)
     {
         return View{
-            getApi(ALPAKA_FORWARD(any)),
+            internal::getApi(ALPAKA_FORWARD(any)),
             onHost::data(ALPAKA_FORWARD(any)),
             onHost::getExtents(ALPAKA_FORWARD(any)),
             onHost::getPitches(ALPAKA_FORWARD(any)),


### PR DESCRIPTION
Use `internal` `getApi()` to avoid ambigious function call.