### PR TITLE
add `-Wundef` to CI tests

### DIFF
--- a/cmake/alpakaCompilePedantic.cmake
+++ b/cmake/alpakaCompilePedantic.cmake
@@ -33,6 +33,7 @@ if(TARGET alpaka_target_host)
     alpaka_set_compiler_options(HOST target alpaka_target_host "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-Wall>")
     alpaka_set_compiler_options(HOST target alpaka_target_host "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-Wextra>")
     alpaka_set_compiler_options(HOST target alpaka_target_host "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-Werror>")
+    alpaka_set_compiler_options(HOST target alpaka_target_host "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-Wundef>")
     if((alpaka_TSAN OR alpaka_ASAN) AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
         # Avoid GNU issue when using ASAN or TSAN
         # error: '*(std::function<bool(char)>*)((char*)&__tmp + offsetof(std::__detail::_StateT, std::__detail::_State<char>::<unnamed>.std::__detail::_State_base::<unnamed>)).std::function<bool(char)>::_M_invoker' may be used uninitialized [-Werror=maybe-uninitialized]

--- a/cmake/test/StdSimd.cpp
+++ b/cmake/test/StdSimd.cpp
@@ -6,15 +6,9 @@
 #if __has_include(<simd>)
 #    include <simd>
 namespace alpakaStdSimd = std;
-#    if !defined(ALPAKA_HAS_STD_SIMD)
-#        define ALPAKA_HAS_STD_SIMD 1
-#    endif
 #elif __has_include(<experimental/simd>)
 #    include <experimental/simd>
 namespace alpakaStdSimd = std::experimental;
-#    if !defined(ALPAKA_HAS_STD_SIMD)
-#        define ALPAKA_HAS_STD_SIMD 1
-#    endif
 #endif
 
 #include <cstdlib>

--- a/example/scan/src/scan_executors.hpp
+++ b/example/scan/src/scan_executors.hpp
@@ -197,7 +197,7 @@ namespace alpaka::example::scan
     }
 } // namespace alpaka::example::scan
 
-#if ALPAKA_HAS_CUB
+#ifdef ALPAKA_HAS_CUB
 // only do this when CUB is found
 
 #    include <cub/device/device_scan.cuh>
@@ -340,7 +340,7 @@ namespace alpaka::example::scan
 
 #endif
 
-#if ALPAKA_HAS_HIPCUB
+#ifdef ALPAKA_HAS_HIPCUB
 
 #    include <hipcub/device/device_scan.hpp>
 #    include <hipcub/util_allocator.hpp>

--- a/include/alpaka/api/api.hpp
+++ b/include/alpaka/api/api.hpp
@@ -25,7 +25,7 @@ namespace alpaka
      */
     constexpr auto thisApi()
     {
-#if ALPAKA_LANG_SYCL && ALPAKA_LANG_ONEAPI && __SYCL_DEVICE_ONLY__
+#if ALPAKA_LANG_SYCL && ALPAKA_LANG_ONEAPI && defined(__SYCL_DEVICE_ONLY__)
         return api::oneApi;
 #elif ALPAKA_LANG_CUDA && (ALPAKA_COMP_CLANG_CUDA || ALPAKA_COMP_NVCC) && __CUDA_ARCH__
         return api::cuda;

--- a/include/alpaka/api/host/block/mem/SharedStorage.hpp
+++ b/include/alpaka/api/host/block/mem/SharedStorage.hpp
@@ -73,12 +73,6 @@ namespace alpaka::onAcc::cpu::detail
             meta->offset = m_allocdBytes;
         }
 
-#if BOOST_COMP_GNUC
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored                                                                                    \
-        "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
-#endif
-
         //! Give the pointer to an exiting variable
         //!
         //! @tparam T type of the variable
@@ -117,9 +111,6 @@ namespace alpaka::onAcc::cpu::detail
         }
 
     private:
-#if BOOST_COMP_GNUC
-#    pragma GCC diagnostic pop
-#endif
         uint8_t* data() const
         {
             return m_data.data();

--- a/include/alpaka/api/host/cpuArchSize.hpp
+++ b/include/alpaka/api/host/cpuArchSize.hpp
@@ -21,7 +21,7 @@ namespace alpaka::onHost::internal
     {
         return 0;
     }
-#if (ALPAKA_HAS_STD_SIMD)
+#if ALPAKA_HAS_STD_SIMD
     template<typename T_Type>
     requires requires { alpakaStdSimd::native_simd<T_Type>::size(); }
     constexpr size_t stdSimdWidth()

--- a/include/alpaka/api/host/sysInfo.hpp
+++ b/include/alpaka/api/host/sysInfo.hpp
@@ -15,13 +15,13 @@
 #    endif
 // We could use some more macros to reduce the number of sub-headers included, but this would restrict user code.
 #    include <windows.h>
-#elif ALPAKA_OS_LINUX || ALPAKA_OS_MACOS
+#elif ALPAKA_OS_LINUX || ALPAKA_OS_IOS
 #    include <sys/param.h>
 #    include <sys/types.h>
 #    include <unistd.h>
 
 #    include <cstdint>
-#    if ALPAKA_OS_BSD || ALPAKA_OS_MACOS
+#    if ALPAKA_OS_IOS
 #        include <sys/sysctl.h>
 #    endif
 #endif
@@ -128,7 +128,7 @@ namespace alpaka::onHost
         SYSTEM_INFO si;
         GetSystemInfo(&si);
         return si.dwPageSize;
-#elif ALPAKA_OS_LINUX || ALPAKA_OS_MACOS
+#elif ALPAKA_OS_LINUX || ALPAKA_OS_IOS
 #    if defined(_SC_PAGESIZE)
         return static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
 #    else
@@ -159,7 +159,7 @@ namespace alpaka::onHost
         GlobalMemoryStatus(&status);
         return static_cast<std::size_t>(status.dwTotalPhys);
 
-#elif ALPAKA_OS_LINUX || ALPAKA_OS_MACOS
+#elif ALPAKA_OS_LINUX || ALPAKA_OS_IOS
         // Unix : Prefer sysctl() over sysconf() except sysctl() with HW_REALMEM and HW_PHYSMEM which are not
         // always reliable
 #    if defined(CTL_HW) && (defined(HW_MEMSIZE) || defined(HW_PHYSMEM64))
@@ -221,7 +221,7 @@ namespace alpaka::onHost
         // this is legacy and only used as fallback
         return static_cast<std::size_t>(get_avphys_pages()) * getPageSize();
 #    endif
-#elif ALPAKA_OS_MACOS
+#elif ALPAKA_OS_IOS
         int free_pages = 0;
         std::size_t len = sizeof(free_pages);
         if(sysctlbyname("vm.page_free_count", &free_pages, &len, nullptr, 0) < 0)

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -306,8 +306,8 @@ namespace alpaka::onHost::internal
             {
                 printf(
                     "Dynamic evaluated warp size on host does not match the compile time warp size ( macro "
-                    "SYCL_SUBGROUP_SIZE) evaluated in the "
-                    "kernel. Update the definition of SYCL_SUBGROUP_SIZE section and check the trait "
+                    "ALPAKA_SYCL_SUBGROUP_SIZE) evaluated in the "
+                    "kernel. Update the definition of ALPAKA_SYCL_SUBGROUP_SIZE section and check the trait "
                     "Warpsize::Dispatch<>.");
                 abort();
             }
@@ -360,7 +360,7 @@ namespace alpaka::onHost::internal
                             constexpr uint32_t syclDim = workerDesc.first.dimensions;
 
                             constexpr uint32_t w = ALPAKA_TYPEOF(warpSize)::value;
-                            detail::EnqueueKernelWithWarpSize<syclDim, w, SYCL_SUBGROUP_SIZE & w>::call(
+                            detail::EnqueueKernelWithWarpSize<syclDim, w, ALPAKA_SYCL_SUBGROUP_SIZE & w>::call(
                                 cgh,
                                 workerDesc.first,
                                 kernelBundle,
@@ -429,7 +429,7 @@ namespace alpaka::onHost::internal
 
                             constexpr uint32_t w = ALPAKA_TYPEOF(warpSize)::value;
 
-                            detail::EnqueueKernelWithWarpSize<syclDim, w, SYCL_SUBGROUP_SIZE & w>::call(
+                            detail::EnqueueKernelWithWarpSize<syclDim, w, ALPAKA_SYCL_SUBGROUP_SIZE & w>::call(
                                 cgh,
                                 workerDesc.first,
                                 kernelBundle,

--- a/include/alpaka/core/syclConfig.hpp
+++ b/include/alpaka/core/syclConfig.hpp
@@ -11,136 +11,237 @@
 // defines can be taken from
 // https://github.com/llvm/llvm-project/blob/3cfe6aa46e06a8caa3f07057838d31c6ce840076/clang/include/clang/Basic/OffloadArch.h#L18-L28
 
-/* Intel GPU and CPU subgroup size detection */
-#        if (/* Broadwell Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_BDW__)                               \
-            || (/* Skylake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_SKL__)                              \
-            || (/* Kaby Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_KBL__)                            \
-            || (/* Coffee Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_CFL__)                          \
-            || (/* Apollo Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_APL__)                          \
-            || (/* Gemini Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_GLK__)                          \
-            || (/* Whiskey Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_WHL__)                         \
-            || (/* Amber Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_AML__)                           \
-            || (/* Comet Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_CML__)                           \
-            || (/* Ice Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ICLLP__)                           \
-            || (/* Elkhart Lake or Jasper Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_EHL__)          \
-            || (/* Tiger Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_TGLLP__)                         \
-            || (/* Rocket Lake Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_RKL__)                          \
-            || (/* Alder Lake S or Raptor Lake S Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ADL_S__)      \
-            || (/* Alder Lake P Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ADL_P__)                       \
-            || (/* Alder Lake N Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ADL_N__)                       \
-            || (/* DG1 Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_DG1__)                                  \
-            || (/* Alchemist G10 Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ACM_G10__)                    \
-            || (/* Alchemist G11 Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ACM_G11__)                    \
-            || (/* Alchemist G12 Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ACM_G12__)                    \
-            || (/* Meteor Lake U/S or Arrow Lake U/S Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_MTL_U__)  \
-            || (/* Meteor Lake H Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_MTL_H__)                      \
-            || (/* Arrow Lake H Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_ARL_H__)                       \
-            || (/* Battlemage G21 Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_BMG_G21__)                   \
-            || (/* Lunar Lake M Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_LNL_M__)
-#            define SYCL_SUBGROUP_SIZE (8 | 16 | 32)
+#        if /* Broadwell Intel graphics architecture */                                                               \
+            (defined(__SYCL_TARGET_INTEL_GPU_BDW__) && __SYCL_TARGET_INTEL_GPU_BDW__)                                 \
+            || /* Skylake Intel graphics architecture */                                                              \
+            (defined(__SYCL_TARGET_INTEL_GPU_SKL__) && __SYCL_TARGET_INTEL_GPU_SKL__)                                 \
+            || /* Kaby Lake Intel graphics architecture */                                                            \
+            (defined(__SYCL_TARGET_INTEL_GPU_KBL__) && __SYCL_TARGET_INTEL_GPU_KBL__)                                 \
+            || /* Coffee Lake Intel graphics architecture */                                                          \
+            (defined(__SYCL_TARGET_INTEL_GPU_CFL__) && __SYCL_TARGET_INTEL_GPU_CFL__)                                 \
+            || /* Apollo Lake Intel graphics architecture */                                                          \
+            (defined(__SYCL_TARGET_INTEL_GPU_APL__) && __SYCL_TARGET_INTEL_GPU_APL__)                                 \
+            || /* Gemini Lake Intel graphics architecture */                                                          \
+            (defined(__SYCL_TARGET_INTEL_GPU_GLK__) && __SYCL_TARGET_INTEL_GPU_GLK__)                                 \
+            || /* Whiskey Lake Intel graphics architecture */                                                         \
+            (defined(__SYCL_TARGET_INTEL_GPU_WHL__) && __SYCL_TARGET_INTEL_GPU_WHL__)                                 \
+            || /* Amber Lake Intel graphics architecture */                                                           \
+            (defined(__SYCL_TARGET_INTEL_GPU_AML__) && __SYCL_TARGET_INTEL_GPU_AML__)                                 \
+            || /* Comet Lake Intel graphics architecture */                                                           \
+            (defined(__SYCL_TARGET_INTEL_GPU_CML__) && __SYCL_TARGET_INTEL_GPU_CML__)                                 \
+            || /* Ice Lake Intel graphics architecture */                                                             \
+            (defined(__SYCL_TARGET_INTEL_GPU_ICLLP__) && __SYCL_TARGET_INTEL_GPU_ICLLP__)                             \
+            || /* Elkhart Lake or Jasper Lake Intel graphics architecture */                                          \
+            (defined(__SYCL_TARGET_INTEL_GPU_EHL__) && __SYCL_TARGET_INTEL_GPU_EHL__)                                 \
+            || /* Tiger Lake Intel graphics architecture */                                                           \
+            (defined(__SYCL_TARGET_INTEL_GPU_TGLLP__) && __SYCL_TARGET_INTEL_GPU_TGLLP__)                             \
+            || /* Rocket Lake Intel graphics architecture */                                                          \
+            (defined(__SYCL_TARGET_INTEL_GPU_RKL__) && __SYCL_TARGET_INTEL_GPU_RKL__)                                 \
+            || /* Alder Lake S or Raptor Lake S Intel graphics architecture */                                        \
+            (defined(__SYCL_TARGET_INTEL_GPU_ADL_S__) && __SYCL_TARGET_INTEL_GPU_ADL_S__)                             \
+            || /* Alder Lake P Intel graphics architecture */                                                         \
+            (defined(__SYCL_TARGET_INTEL_GPU_ADL_P__) && __SYCL_TARGET_INTEL_GPU_ADL_P__)                             \
+            || /* Alder Lake N Intel graphics architecture */                                                         \
+            (defined(__SYCL_TARGET_INTEL_GPU_ADL_N__) && __SYCL_TARGET_INTEL_GPU_ADL_N__)                             \
+            || /* DG1 Intel graphics architecture */                                                                  \
+            (defined(__SYCL_TARGET_INTEL_GPU_DG1__) && __SYCL_TARGET_INTEL_GPU_DG1__)                                 \
+            || /* Alchemist G10 Intel graphics architecture */                                                        \
+            (defined(__SYCL_TARGET_INTEL_GPU_ACM_G10__) && __SYCL_TARGET_INTEL_GPU_ACM_G10__)                         \
+            || /* Alchemist G11 Intel graphics architecture */                                                        \
+            (defined(__SYCL_TARGET_INTEL_GPU_ACM_G11__) && __SYCL_TARGET_INTEL_GPU_ACM_G11__)                         \
+            || /* Alchemist G12 Intel graphics architecture */                                                        \
+            (defined(__SYCL_TARGET_INTEL_GPU_ACM_G12__) && __SYCL_TARGET_INTEL_GPU_ACM_G12__)                         \
+            || /* Meteor Lake U/S or Arrow Lake U/S Intel graphics architecture */                                    \
+            (defined(__SYCL_TARGET_INTEL_GPU_MTL_U__) && __SYCL_TARGET_INTEL_GPU_MTL_U__)                             \
+            || /* Meteor Lake H Intel graphics architecture */                                                        \
+            (defined(__SYCL_TARGET_INTEL_GPU_MTL_H__) && __SYCL_TARGET_INTEL_GPU_MTL_H__)                             \
+            || /* Arrow Lake H Intel graphics architecture */                                                         \
+            (defined(__SYCL_TARGET_INTEL_GPU_ARL_H__) && __SYCL_TARGET_INTEL_GPU_ARL_H__)                             \
+            || /* Battlemage G21 Intel graphics architecture */                                                       \
+            (defined(__SYCL_TARGET_INTEL_GPU_BMG_G21__) && __SYCL_TARGET_INTEL_GPU_BMG_G21__)                         \
+            || /* Lunar Lake Intel graphics architecture */                                                           \
+            (defined(__SYCL_TARGET_INTEL_GPU_LNL_M__) && __SYCL_TARGET_INTEL_GPU_LNL_M__)
 
-#        elif (/* Ponte Vecchio Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_PVC__)                         \
-            || (/* Ponte Vecchio VG Intel graphics architecture */ __SYCL_TARGET_INTEL_GPU_PVC_VG__)
-#            define SYCL_SUBGROUP_SIZE (16 | 32)
+#            define ALPAKA_SYCL_SUBGROUP_SIZE (8 | 16 | 32)
 
-#        elif (/* x86_64 CPUs */ __SYCL_TARGET_INTEL_X86_64__)
+#        elif /* Ponte Vecchio Intel graphics architecture */                                                         \
+            (defined(__SYCL_TARGET_INTEL_GPU_PVC__) && __SYCL_TARGET_INTEL_GPU_PVC__)                                 \
+            || /* Ponte Vecchio VG Intel graphics architecture */                                                     \
+            (defined(__SYCL_TARGET_INTEL_GPU_PVC_VG__) && __SYCL_TARGET_INTEL_GPU_PVC_VG__)
+
+#            define ALPAKA_SYCL_SUBGROUP_SIZE (16 | 32)
+
+#        elif(/* generate code ahead of time for x86_64 CPUs */                                                       \
+              defined(__SYCL_TARGET_INTEL_X86_64__) && __SYCL_TARGET_INTEL_X86_64__)
 // @attention ony CPU side detachment of SYCL kernel we limit the CPU currently to max warp group size of 32, therefore
 // 64 is removed from this list
-#            define SYCL_SUBGROUP_SIZE (1 | 2 | 4 | 8 | 16 | 32)
+#            define ALPAKA_SYCL_SUBGROUP_SIZE (1 | 2 | 4 | 8 | 16 | 32)
 
-#        elif (/* NVIDIA Maxwell architecture (compute capability 5.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_50__)           \
-            || (/* NVIDIA Maxwell architecture (compute capability 5.2) */ __SYCL_TARGET_NVIDIA_GPU_SM_52__)          \
-            || (/* NVIDIA Jetson TX1 / Nano (compute capability 5.3) */ __SYCL_TARGET_NVIDIA_GPU_SM_53__)             \
-            || (/* NVIDIA Pascal architecture (compute capability 6.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_60__)           \
-            || (/* NVIDIA Pascal architecture (compute capability 6.1) */ __SYCL_TARGET_NVIDIA_GPU_SM_61__)           \
-            || (/* NVIDIA Jetson TX2 (compute capability 6.2) */ __SYCL_TARGET_NVIDIA_GPU_SM_62__)                    \
-            || (/* NVIDIA Volta architecture (compute capability 7.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_70__)            \
-            || (/* NVIDIA Jetson AGX Xavier (compute capability 7.2) */ __SYCL_TARGET_NVIDIA_GPU_SM_72__)             \
-            || (/* NVIDIA Turing architecture (compute capability 7.5) */ __SYCL_TARGET_NVIDIA_GPU_SM_75__)           \
-            || (/* NVIDIA Ampere architecture (compute capability 8.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_80__)           \
-            || (/* NVIDIA Ampere architecture (compute capability 8.6) */ __SYCL_TARGET_NVIDIA_GPU_SM_86__)           \
-            || (/* NVIDIA Jetson/Drive AGX Orin (compute capability 8.7) */ __SYCL_TARGET_NVIDIA_GPU_SM_87__)         \
-            || (/* NVIDIA Ada Lovelace architecture (compute capability 8.9) */ __SYCL_TARGET_NVIDIA_GPU_SM_89__)     \
-            || (/* NVIDIA Hopper architecture (compute capability 9.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_90__)           \
-            || (/* NVIDIA Hopper architecture variant (compute capability 9.0a) */ __SYCL_TARGET_NVIDIA_GPU_SM_90a__) \
-            || (/* NVIDIA Blackwell architecture (compute capability 10.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_100__)      \
-            || (/* NVIDIA Blackwell architecture variant (compute capability 10.0a) */                                \
-                __SYCL_TARGET_NVIDIA_GPU_SM_100a__)                                                                   \
-            || (/* NVIDIA Blackwell Next architecture (compute capability 10.1) */ __SYCL_TARGET_NVIDIA_GPU_SM_101__) \
-            || (/* NVIDIA Blackwell Next architecture variant (compute capability 10.1a) */                           \
-                __SYCL_TARGET_NVIDIA_GPU_SM_101a__)                                                                   \
-            || (/* NVIDIA Next-generation architecture (compute capability 10.3) */                                   \
-                __SYCL_TARGET_NVIDIA_GPU_SM_103__)                                                                    \
-            || (/* NVIDIA Next-generation architecture variant (compute capability 10.3a) */                          \
-                __SYCL_TARGET_NVIDIA_GPU_SM_103a__)                                                                   \
-            || (/* NVIDIA Future architecture (compute capability 12.0) */ __SYCL_TARGET_NVIDIA_GPU_SM_120__)         \
-            || (/* NVIDIA Future architecture variant (compute capability 12.0a) */                                   \
-                __SYCL_TARGET_NVIDIA_GPU_SM_120a__)                                                                   \
-            || (/* NVIDIA Future architecture (compute capability 12.1) */ __SYCL_TARGET_NVIDIA_GPU_SM_121__)         \
-            || (/*NVIDIA Future architecture variant (compute capability 12.1a) */                                    \
-                __SYCL_TARGET_NVIDIA_GPU_SM_121a__)
+#        elif /* NVIDIA Maxwell architecture (compute capability 5.0) */                                              \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_50__) && __SYCL_TARGET_NVIDIA_GPU_SM_50__)                           \
+            || /* NVIDIA Maxwell architecture (compute capability 5.2) */                                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_52__) && __SYCL_TARGET_NVIDIA_GPU_SM_52__)                           \
+            || /* NVIDIA Jetson TX1 / Nano (compute capability 5.3) */                                                \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_53__) && __SYCL_TARGET_NVIDIA_GPU_SM_53__)                           \
+            || /* NVIDIA Pascal architecture (compute capability 6.0) */                                              \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_60__) && __SYCL_TARGET_NVIDIA_GPU_SM_60__)                           \
+            || /* NVIDIA Pascal architecture (compute capability 6.1) */                                              \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_61__) && __SYCL_TARGET_NVIDIA_GPU_SM_61__)                           \
+            || /* NVIDIA Jetson TX2 (compute capability 6.2) */                                                       \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_62__) && __SYCL_TARGET_NVIDIA_GPU_SM_62__)                           \
+            || /* NVIDIA Volta architecture (compute capability 7.0) */                                               \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_70__) && __SYCL_TARGET_NVIDIA_GPU_SM_70__)                           \
+            || /* NVIDIA Jetson AGX (compute capability 7.2) */                                                       \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_72__) && __SYCL_TARGET_NVIDIA_GPU_SM_72__)                           \
+            || /* NVIDIA Turing architecture (compute capability 7.5) */                                              \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_75__) && __SYCL_TARGET_NVIDIA_GPU_SM_75__)                           \
+            || /* NVIDIA Ampere architecture (compute capability 8.0) */                                              \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_80__) && __SYCL_TARGET_NVIDIA_GPU_SM_80__)                           \
+            || /* NVIDIA Ampere architecture (compute capability 8.6) */                                              \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_86__) && __SYCL_TARGET_NVIDIA_GPU_SM_86__)                           \
+            || /* NVIDIA Jetson/Drive AGX Orin (compute capability 8.7) */                                            \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_87__) && __SYCL_TARGET_NVIDIA_GPU_SM_87__)                           \
+            || /* NVIDIA Ada Lovelace arch. (compute capability 8.9) */                                               \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_89__) && __SYCL_TARGET_NVIDIA_GPU_SM_89__)                           \
+            || /* NVIDIA Hopper architecture (compute capability 9.0) */                                              \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_90__) && __SYCL_TARGET_NVIDIA_GPU_SM_90__)                           \
+            || /*NVIDIA Hopper architecture variant(compute capability 9.0a) */                                       \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_90a__) && __SYCL_TARGET_NVIDIA_GPU_SM_90a__)                         \
+            || /* NVIDIA Blackwell architecture (compute capability 10.0) */                                          \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_100__) && __SYCL_TARGET_NVIDIA_GPU_SM_100__)                         \
+            || /* NVIDIA Blackwell architecture variant (compute capability 10.0a) */                                 \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_100a__) && __SYCL_TARGET_NVIDIA_GPU_SM_100a__)                       \
+            || /* NVIDIA Blackwell Next architecture (compute capability 10.1) */                                     \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_101__) && __SYCL_TARGET_NVIDIA_GPU_SM_101__)                         \
+            || /* NVIDIA Blackwell Next architecture variant (compute capability 10.1a) */                            \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_101a__) && __SYCL_TARGET_NVIDIA_GPU_SM_101a__)                       \
+            || /* NVIDIA Next-generation architecture (compute capability 10.3) */                                    \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_103__) && __SYCL_TARGET_NVIDIA_GPU_SM_103__)                         \
+            || /* NVIDIA Next-generation architecture variant (compute capability 10.3a) */                           \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_103a__) && __SYCL_TARGET_NVIDIA_GPU_SM_103a__)                       \
+            || /* NVIDIA Future architecture (compute capability 12.0) */                                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_120__) && __SYCL_TARGET_NVIDIA_GPU_SM_120__)                         \
+            || /* NVIDIA Future architecture variant (compute capability 12.0a) */                                    \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_120a__) && __SYCL_TARGET_NVIDIA_GPU_SM_120a__)                       \
+            || /* NVIDIA Future architecture (compute capability 12.1) */                                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_121__) && __SYCL_TARGET_NVIDIA_GPU_SM_121__)                         \
+            || /* NVIDIA Future architecture variant (compute capability 12.1a) */                                    \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_121a__) && __SYCL_TARGET_NVIDIA_GPU_SM_121a__)
 
-#            define SYCL_SUBGROUP_SIZE (32) /* CUDA supports warp size 32 */
+#            define ALPAKA_SYCL_SUBGROUP_SIZE (32) /* CUDA supports warp size 32 */
 
-#        elif (/* AMD GCN 5.0 Vega architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX900__)                          \
-            || (/* AMD GCN 5.0 Vega architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX902__)                         \
-            || (/* AMD GCN 5.0 Vega architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX904__)                         \
-            || (/* AMD GCN 5.1 Vega II architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX906__)                      \
-            || (/* AMD CDNA 1.0 Arcturus architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX908__)                    \
-            || (/* AMD GCN 5.0 Raven 2 architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX909__)                      \
-            || (/* AMD CDNA 2.0 Aldebaran architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX90A__)                   \
-            || (/* AMD GCN 5.1 Renoir architecture (gfx 9.0) */ __SYCL_TARGET_AMD_GPU_GFX90C__)                       \
-            || (/* AMD CDNA 3.x generic architecture (gfx 9.4) */ __SYCL_TARGET_AMD_GPU_GFX9_4_GENERIC__)             \
-            || (/* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */ __SYCL_TARGET_AMD_GPU_GFX940__)               \
-            || (/* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */ __SYCL_TARGET_AMD_GPU_GFX941__)               \
-            || (/* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */ __SYCL_TARGET_AMD_GPU_GFX942__)               \
-            || (/* AMD CDNA 3.5 derivative architecture (gfx 9.5) */ __SYCL_TARGET_AMD_GPU_GFX950__)                  \
-            || (/* AMD GCN 5.x generic architecture (gfx 9.x) */ __SYCL_TARGET_AMD_GPU_GFX9_GENERIC__)
+#        elif /* AMD GCN 2.0 Sea Islands architecture (gfx 7.0) */                                                    \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX700__) && __SYCL_TARGET_AMD_GPU_GFX700__)                               \
+            || /* AMD GCN 2.0 Sea Islands architecture (gfx 7.0) */                                                   \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX701__) && __SYCL_TARGET_AMD_GPU_GFX701__)                               \
+            || /* AMD GCN 2.0 Sea Islands architecture (gfx 7.0) */                                                   \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX702__) && __SYCL_TARGET_AMD_GPU_GFX702__)                               \
+            || /* AMD GCN 3.0 Volcanic Islands architecture (gfx 8.0) */                                              \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX801__) && __SYCL_TARGET_AMD_GPU_GFX801__)                               \
+            || /* AMD GCN 3.0 Volcanic Islands architecture (gfx 8.0) */                                              \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX802__) && __SYCL_TARGET_AMD_GPU_GFX802__)                               \
+            || /* AMD GCN 4.0 Arctic Islands architecture (gfx 8.0) */                                                \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX803__) && __SYCL_TARGET_AMD_GPU_GFX803__)                               \
+            || /* AMD GCN 3.0 Volcanic Islands architecture (gfx 8.0) */                                              \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX805__) && __SYCL_TARGET_AMD_GPU_GFX805__)                               \
+            || /* AMD GCN 3.0 Volcanic Islands architecture (gfx 8.1) */                                              \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX810__) && __SYCL_TARGET_AMD_GPU_GFX810__)                               \
+            || /* AMD GCN 5.0 Vega architecture (gfx 9.0) */                                                          \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX900__) && __SYCL_TARGET_AMD_GPU_GFX900__)                               \
+            || /* AMD GCN 5.0 Vega architecture (gfx 9.0) */                                                          \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX902__) && __SYCL_TARGET_AMD_GPU_GFX902__)                               \
+            || /* AMD GCN 5.0 Vega architecture (gfx 9.0) */                                                          \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX904__) && __SYCL_TARGET_AMD_GPU_GFX904__)                               \
+            || /* AMD GCN 5.1 Vega II architecture (gfx 9.0) */                                                       \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX906__) && __SYCL_TARGET_AMD_GPU_GFX906__)                               \
+            || /* AMD CDNA 1.0 Arcturus architecture (gfx 9.0) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX908__) && __SYCL_TARGET_AMD_GPU_GFX908__)                               \
+            || /* AMD GCN 5.0 Raven 2 architecture (gfx 9.0) */                                                       \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX909__) && __SYCL_TARGET_AMD_GPU_GFX909__)                               \
+            || /* AMD CDNA 2.0 Aldebaran architecture (gfx 9.0) */                                                    \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX90A__) && __SYCL_TARGET_AMD_GPU_GFX90A__)                               \
+            || /* AMD GCN 5.1 Renoir architecture (gfx 9.0) */                                                        \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX90C__) && __SYCL_TARGET_AMD_GPU_GFX90C__)                               \
+            || /* AMD CDNA 3.x generic architecture (gfx 9.4) */                                                      \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX9_4_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX9_4_GENERIC__)               \
+            || /* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */                                                \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX940__) && __SYCL_TARGET_AMD_GPU_GFX940__)                               \
+            || /* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */                                                \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX941__) && __SYCL_TARGET_AMD_GPU_GFX941__)                               \
+            || /* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */                                                \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX942__) && __SYCL_TARGET_AMD_GPU_GFX942__)                               \
+            || /* AMD CDNA 3.5 derivative architecture (gfx 9.5) */                                                   \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX950__) && __SYCL_TARGET_AMD_GPU_GFX950__)                               \
+            || /* AMD GCN 5.x generic architecture (gfx 9.x) */                                                       \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX9_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX9_GENERIC__)
 
-#            define SYCL_SUBGROUP_SIZE (64) /* up to gfx9, HIP supports wavefront size 64 */
+#            define ALPAKA_SYCL_SUBGROUP_SIZE (64) /* up to gfx9, HIP supports wavefront size 64 */
 
-#        elif (/* AMD RDNA 1.0 Navi 10 architecture (gfx 10.1) */ __SYCL_TARGET_AMD_GPU_GFX1010__)                    \
-            || (/* AMD RDNA 1.0 Navi 12 architecture (gfx 10.1) */ __SYCL_TARGET_AMD_GPU_GFX1011__)                   \
-            || (/* AMD RDNA 1.0 Navi 14 architecture (gfx 10.1) */ __SYCL_TARGET_AMD_GPU_GFX1012__)                   \
-            || (/* AMD RDNA 2.0 Oberon architecture (gfx 10.1) */ __SYCL_TARGET_AMD_GPU_GFX1013__)                    \
-            || (/* AMD RDNA 1.x generic architecture (gfx 10.1) */ __SYCL_TARGET_AMD_GPU_GFX10_1_GENERIC__)           \
-            || (/* AMD RDNA 2.0 Navi 21 architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1030__)                   \
-            || (/* AMD RDNA 2.0 Navi 22 architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1031__)                   \
-            || (/* AMD RDNA 2.0 Navi 23 architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1032__)                   \
-            || (/* AMD RDNA 2.0 Van Gogh architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1033__)                  \
-            || (/* AMD RDNA 2.0 Navi 24 architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1034__)                   \
-            || (/* AMD RDNA 2.0 Rembrandt Mobile architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1035__)          \
-            || (/* AMD RDNA 2.0 Raphael architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX1036__)                   \
-            || (/* AMD RDNA 2.x generic architecture (gfx 10.3) */ __SYCL_TARGET_AMD_GPU_GFX10_3_GENERIC__)           \
-            || (/* AMD RDNA 3.0 Navi 31 architecture (gfx 11.0) */ __SYCL_TARGET_AMD_GPU_GFX1100__)                   \
-            || (/* AMD RDNA 3.0 Navi 32 architecture (gfx 11.0) */ __SYCL_TARGET_AMD_GPU_GFX1101__)                   \
-            || (/* AMD RDNA 3.0 Navi 33 architecture (gfx 11.0) */ __SYCL_TARGET_AMD_GPU_GFX1102__)                   \
-            || (/* AMD RDNA 3.0 Phoenix mobile architecture (gfx 11.0) */ __SYCL_TARGET_AMD_GPU_GFX1103__)            \
-            || (/* AMD RDNA 3.x generic architecture (gfx 11.x) */ __SYCL_TARGET_AMD_GPU_GFX11_GENERIC__)             \
-            || (/* AMD RDNA 3.5 Strix Point architecture (gfx 11.5) */ __SYCL_TARGET_AMD_GPU_GFX1150__)               \
-            || (/* AMD RDNA 3.5 Strix Halo architecture (gfx 11.5) */ __SYCL_TARGET_AMD_GPU_GFX1151__)                \
-            || (/* AMD RDNA 3.5 derivative architecture (gfx 11.5) */ __SYCL_TARGET_AMD_GPU_GFX1152__)                \
-            || (/* AMD RDNA 3.5 derivative architecture (gfx 11.5) */ __SYCL_TARGET_AMD_GPU_GFX1153__)                \
-            || (/* AMD RDNA 4.0 Navi 44 architecture (gfx 12.0) */ __SYCL_TARGET_AMD_GPU_GFX1200__)                   \
-            || (/* AMD RDNA 4.0 Navi 48 architecture (gfx 12.0) */ __SYCL_TARGET_AMD_GPU_GFX1201__)                   \
-            || (/* AMD RDNA 4.x generic architecture (gfx 12.x) */ __SYCL_TARGET_AMD_GPU_GFX12_GENERIC__)             \
-            || (/* AMD RDNA 4.5 derivative architecture (gfx 12.5) */ __SYCL_TARGET_AMD_GPU_GFX1250__)                \
-            || (/* AMD RDNA 4.5 derivative architecture (gfx 12.5) */ __SYCL_TARGET_AMD_GPU_GFX1251__)
+#        elif /* AMD RDNA 1.0 Navi 10 architecture (gfx 10.1) */                                                      \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1010__) && __SYCL_TARGET_AMD_GPU_GFX1010__)                             \
+            || /* AMD RDNA 1.0 Navi 12 architecture (gfx 10.1) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1011__) && __SYCL_TARGET_AMD_GPU_GFX1011__)                             \
+            || /* AMD RDNA 1.0 Navi 14 architecture (gfx 10.1) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1012__) && __SYCL_TARGET_AMD_GPU_GFX1012__)                             \
+            || /* AMD RDNA 2.0 Oberon architecture (gfx 10.1) */                                                      \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1013__) && __SYCL_TARGET_AMD_GPU_GFX1013__)                             \
+            || /* AMD RDNA 1.x generic architecture (gfx 10.1) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX10_1_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX10_1_GENERIC__)             \
+            || /* AMD RDNA 2.0 Navi 21 architecture (gfx 10.3) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1030__) && __SYCL_TARGET_AMD_GPU_GFX1030__)                             \
+            || /* AMD RDNA 2.0 Navi 22 architecture (gfx 10.3) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1031__) && __SYCL_TARGET_AMD_GPU_GFX1031__)                             \
+            || /* AMD RDNA 2.0 Navi 23 architecture (gfx 10.3) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1032__) && __SYCL_TARGET_AMD_GPU_GFX1032__)                             \
+            || /* AMD RDNA 2.0 Van Gogh architecture (gfx 10.3) */                                                    \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1033__) && __SYCL_TARGET_AMD_GPU_GFX1033__)                             \
+            || /* AMD RDNA 2.0 Navi 24 architecture (gfx 10.3) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1034__) && __SYCL_TARGET_AMD_GPU_GFX1034__)                             \
+            || /* AMD RDNA 2.0 Rembrandt Mobile architecture (gfx 10.3) */                                            \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1035__) && __SYCL_TARGET_AMD_GPU_GFX1035__)                             \
+            || /* AMD RDNA 2.0 Raphael architecture (gfx 10.3) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1036__) && __SYCL_TARGET_AMD_GPU_GFX1036__)                             \
+            || /* AMD RDNA 2.x generic architecture (gfx 10.3) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX10_3_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX10_3_GENERIC__)             \
+            || /* AMD RDNA 3.0 Navi 31 architecture (gfx 11.0) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1100__) && __SYCL_TARGET_AMD_GPU_GFX1100__)                             \
+            || /* AMD RDNA 3.0 Navi 32 architecture (gfx 11.0) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1101__) && __SYCL_TARGET_AMD_GPU_GFX1101__)                             \
+            || /* AMD RDNA 3.0 Navi 33 architecture (gfx 11.0) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1102__) && __SYCL_TARGET_AMD_GPU_GFX1102__)                             \
+            || /* AMD RDNA 3.0 Phoenix mobile architecture (gfx 11.0) */                                              \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1103__) && __SYCL_TARGET_AMD_GPU_GFX1103__)                             \
+            || /* AMD RDNA 3.x generic architecture (gfx 11.x) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX11_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX11_GENERIC__)                 \
+            || /* AMD RDNA 3.5 Strix Point architecture (gfx 11.5) */                                                 \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1150__) && __SYCL_TARGET_AMD_GPU_GFX1150__)                             \
+            || /* AMD RDNA 3.5 Strix Halo architecture (gfx 11.5) */                                                  \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1151__) && __SYCL_TARGET_AMD_GPU_GFX1151__)                             \
+            || /* AMD RDNA 4.0 Navi 44 architecture (gfx 12.0) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1200__) && __SYCL_TARGET_AMD_GPU_GFX1200__)                             \
+            || /* AMD RDNA 4.0 Navi 48 architecture (gfx 12.0) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1201__) && __SYCL_TARGET_AMD_GPU_GFX1201__)                             \
+            || /* AMD RDNA 4.x generic architecture (gfx 12.x) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX12_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX12_GENERIC__)                 \
+            || /* AMD RDNA 4.5 derivative architecture (gfx 12.5) */                                                  \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1250__) && __SYCL_TARGET_AMD_GPU_GFX1250__)                             \
+            || /* AMD RDNA 4.5 derivative architecture (gfx 12.5) */                                                  \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1251__) && __SYCL_TARGET_AMD_GPU_GFX1251__)
 
-#            define SYCL_SUBGROUP_SIZE (32) /* starting from gfx10, HIP supports wavefront size 32 */
+#            define ALPAKA_SYCL_SUBGROUP_SIZE (32) /* starting from gfx10, HIP supports wavefront size 32 */
 
 #        else // __SYCL_TARGET_*
 
 // if we do not compile ahead of time for a device and use e.g. -fsycl-targets=spir64 we need to accept all possible
 // variants
-#            define SYCL_SUBGROUP_SIZE (0xFFFF'FFFF) /* unknown target */
+#            define ALPAKA_SYCL_SUBGROUP_SIZE (0xFFFF'FFFF) /* unknown target */
 
 #        endif // __SYCL_TARGET_*
 
 #    else
 
 // ony the host side we need to allow all possible variants of a subgroup size else kernel will not be build
-#        define SYCL_SUBGROUP_SIZE (0xFFFF'FFFF) /* host compilation */
+#        define ALPAKA_SYCL_SUBGROUP_SIZE (0xFFFF'FFFF) /* host compilation */
 
 #    endif // __SYCL_DEVICE_ONLY__
 

--- a/include/alpaka/executor.hpp
+++ b/include/alpaka/executor.hpp
@@ -26,30 +26,32 @@ namespace alpaka::exec
      * - the second way to disable an executor is to define the preprocessor define ALPAKA_DISABLE_EXEC_<ExecutorName>,
      * if not the executor is enabled
      */
-    constexpr auto enabledExecutors = std::make_tuple(ALPAKA_PP_REMOVE_FIRST_COMMA(
+    constexpr auto enabledExecutors = std::tuple_cat(
+        // empty tuple to avoid issues with the first comma
+        std::tuple<>{}
 #ifndef ALPAKA_DISABLE_EXEC_CpuOmpBlocks
         ,
-        exec::cpuOmpBlocks
+        std::tuple{exec::cpuOmpBlocks}
 #endif
 #ifndef ALPAKA_DISABLE_EXEC_CpuTbbBlocks
         ,
-        exec::cpuTbbBlocks
+        std::tuple{exec::cpuTbbBlocks}
 #endif
 #ifndef ALPAKA_DISABLE_EXEC_CpuSerial
         ,
-        exec::cpuSerial
+        std::tuple{exec::cpuSerial}
 #endif
 #ifndef ALPAKA_DISABLE_EXEC_GpuCuda
         ,
-        exec::gpuCuda
+        std::tuple{exec::gpuCuda}
 #endif
 #ifndef ALPAKA_DISABLE_EXEC_GpuHip
         ,
-        exec::gpuHip
+        std::tuple{exec::gpuHip}
 #endif
 #ifndef ALPAKA_DISABLE_EXEC_OneApi
         ,
-        exec::oneApi
+        std::tuple{exec::oneApi}
 #endif
-        ));
+    );
 } // namespace alpaka::exec

--- a/include/alpaka/simd/internal/EmuSimd.hpp
+++ b/include/alpaka/simd/internal/EmuSimd.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include "SmartMaskValueRef.hpp"
 #include "alpaka/api/api.hpp"
 #include "alpaka/simd/concepts.hpp"
+#include "alpaka/simd/internal/SmartMaskValueRef.hpp"
 #include "alpaka/simd/internal/alignment.hpp"
 #include "alpaka/simd/internal/utility.hpp"
 #include "alpaka/simd/trait.hpp"

--- a/include/alpaka/simd/internal/StdSimdMask.hpp
+++ b/include/alpaka/simd/internal/StdSimdMask.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include "StdSimd.hpp"
 #include "alpaka/api/api.hpp"
 #include "alpaka/mem/Alignment.hpp"
+#include "alpaka/simd/internal/StdSimd.hpp"
 #include "alpaka/simd/simdConfig.hpp"
 #include "alpaka/simd/trait.hpp"
 

--- a/include/alpaka/simd/simdConfig.hpp
+++ b/include/alpaka/simd/simdConfig.hpp
@@ -29,3 +29,9 @@ namespace alpakaStdSimd = std::experimental;
 #    endif
 
 #endif
+
+// In case it is not already set, set it to disabled, to ensure that his header is includes whereever the macro is
+// used. If this header is not included compiler flag `-Wundef` will show an error.
+#if !defined(ALPAKA_HAS_STD_SIMD)
+#    define ALPAKA_HAS_STD_SIMD 0
+#endif


### PR DESCRIPTION
- fix usage of undefined macros
- fix warning ``` executor.hpp:30:1: warning: embedding a directive within macro arguments is not portable 30 | #ifndef ALPAKA_DISABLE_EXEC_CpuOmpBlocks ```