### PR TITLE
fix missing data source assign check

### DIFF
--- a/include/alpaka/concepts.hpp
+++ b/include/alpaka/concepts.hpp
@@ -6,6 +6,7 @@
 
 #include "alpaka/api/concepts/api.hpp"
 #include "alpaka/concepts/hasName.hpp"
+#include "alpaka/mem/concepts/AssignableFrom.hpp"
 #include "alpaka/mem/concepts/ExpectedValueType.hpp"
 #include "alpaka/mem/concepts/IBuffer.hpp"
 #include "alpaka/mem/concepts/IMdSpan.hpp"

--- a/include/alpaka/mem/MdSpan.hpp
+++ b/include/alpaka/mem/MdSpan.hpp
@@ -161,13 +161,23 @@ namespace alpaka
         {
         }
 
+        template<typename T_Type_Other>
+        requires alpaka::internal::concepts::InnerTypeAllowedCast<T_Type, T_Type_Other>
+        constexpr MdSpan(MdSpan<T_Type_Other, T_Extents, T_Pitches, T_MemAlignment>&& other)
+            : m_ptr(std::move(other.data()))
+            , m_extent(std::move(other.getExtents()))
+            , m_pitch(std::move(other.getPitches()))
+        {
+        }
+
         constexpr MdSpan(MdSpan const&) = default;
+        constexpr MdSpan(MdSpan&&) = default;
 
-        // causes a compiler error with nvcc
-        // error: static assertion failed with "All kernel arguments must be trivially copyable or specialize
-        // trait::IsKernelArgumentTriviallyCopyable<>!"
-        // constexpr MdSpan& operator=(MdSpan&) = default;
-
+        /** Assignment operator keeping const-ness
+         *
+         * @attention the assign operator is not removing inner const-ness because the type signature is not changed.
+         */
+        constexpr MdSpan& operator=(MdSpan const&) = default;
 
         constexpr MdSpan& operator=(MdSpan&&) = default;
 

--- a/include/alpaka/mem/MdSpanArray.hpp
+++ b/include/alpaka/mem/MdSpanArray.hpp
@@ -152,6 +152,16 @@ namespace alpaka
 
         constexpr MdSpanArray(MdSpanArray const&) = default;
 
+        /** Assignment operator keeping const-ness
+         *
+         * alpaka keeps track that const references to a span can not be cast to non const.
+         * If the inner value type is not const the second assignment operator with non const will be used.
+         */
+        constexpr MdSpanArray& operator=(MdSpanArray const& other)
+            requires(std::is_const_v<typename ALPAKA_TYPEOF(other)::value_type>)
+            = default;
+        constexpr MdSpanArray& operator=(MdSpanArray&) = default;
+
         constexpr MdSpanArray(MdSpanArray&&) = default;
 
         template<alpaka::concepts::CStaticArray T_OtherArrayType>

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -123,7 +123,12 @@ namespace alpaka
 
         constexpr View(View&&) = default;
 
+        /** Assignment operator keeping const-ness
+         *
+         * @attention the assign operator is not removing inner const-ness because the type signature is not changed.
+         */
         constexpr View& operator=(View const&) = default;
+
         constexpr View& operator=(View&&) = default;
 
         static consteval T_Api getApi()

--- a/include/alpaka/mem/concepts/AssignableFrom.hpp
+++ b/include/alpaka/mem/concepts/AssignableFrom.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Simeon Ehrig
+/* Copyright 2026 René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/include/alpaka/mem/concepts/AssignableFrom.hpp
+++ b/include/alpaka/mem/concepts/AssignableFrom.hpp
@@ -1,0 +1,30 @@
+/* Copyright 2025 Simeon Ehrig
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/trait.hpp"
+#include "alpaka/unused.hpp"
+
+#include <concepts>
+
+namespace alpaka::concepts
+{
+    /** Check whether the specified data type T_To can be assigned to T_From
+     *
+     * Read the check as a variable of the type T_From is assigned to a variable of the type T_To.
+     *
+     * @attention it is not equal to std::is_assignable
+     *
+     * Equivalent to execute:
+     *
+     * @code
+     *      T_To to;
+     *      T_From from;
+     *      to = foo;
+     * @endcode
+     */
+    template<typename T_To, typename T_From>
+    concept AssignableFrom = requires(T_To to, T_From from) { to = from; };
+} // namespace alpaka::concepts

--- a/include/alpaka/mem/concepts/IDataSource.hpp
+++ b/include/alpaka/mem/concepts/IDataSource.hpp
@@ -6,6 +6,7 @@
 
 #include "alpaka/Vec.hpp"
 #include "alpaka/mem/Alignment.hpp"
+#include "alpaka/mem/concepts/AssignableFrom.hpp"
 #include "alpaka/mem/concepts/ExpectedValueType.hpp"
 #include "alpaka/trait.hpp"
 
@@ -42,6 +43,11 @@ namespace alpaka::concepts
         concept IDataSource = requires(T t, alpaka::Vec<typename T::index_type, T::dim()> vec) {
             typename T::value_type;
             typename T::index_type;
+
+            /* Non const data sources must be assignable.
+             * You can NOT assign const data sources to non const dta sources because this will remove the const-ness.
+             */
+            requires concepts::AssignableFrom<std::decay_t<T>, std::decay_t<T>>;
 
             // only the non-const type is moveable
             requires std::movable<std::remove_const_t<T>>;

--- a/include/alpaka/onHost/mem/SharedBuffer.hpp
+++ b/include/alpaka/onHost/mem/SharedBuffer.hpp
@@ -101,11 +101,11 @@ namespace alpaka::onHost
 
         SharedBuffer(SharedBuffer const&) = default;
 
-        SharedBuffer& operator=(SharedBuffer const& otherSharedBuffer)
-        {
-            *this = otherSharedBuffer.getConstSharedBuffer();
-            return *this;
-        }
+        /** Assignment operator keeping const-ness
+         *
+         * @attention the assign operator is not removing inner const-ness because the type signature is not changed.
+         */
+        SharedBuffer& operator=(SharedBuffer const& otherSharedBuffer) = default;
 
         template<typename T_Type_Other>
         requires alpaka::internal::concepts::InnerTypeAllowedCast<T_Type, T_Type_Other>

--- a/test/unit/concepts/assignableFrom.cpp
+++ b/test/unit/concepts/assignableFrom.cpp
@@ -1,0 +1,44 @@
+/* Copyright 2025 Anton Reinhard
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/mem/concepts/AssignableFrom.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace alpaka;
+
+struct Dummy
+{
+    Dummy& operator=(Dummy const&) = delete;
+    Dummy& operator=(Dummy&) = default;
+    float foo;
+};
+
+TEST_CASE("sharedBuffer inner const assignment operator", "[mem][concepts][AssignableFrom]")
+{
+    using namespace alpaka;
+
+    STATIC_REQUIRE(concepts::AssignableFrom<int, int>);
+    STATIC_REQUIRE(concepts::AssignableFrom<int&, int>);
+    STATIC_REQUIRE(concepts::AssignableFrom<int&&, int>);
+    STATIC_REQUIRE(concepts::AssignableFrom<int&, int const>);
+    STATIC_REQUIRE(concepts::AssignableFrom<int, int&>);
+    STATIC_REQUIRE(concepts::AssignableFrom<int, int&&>);
+    STATIC_REQUIRE(concepts::AssignableFrom<int, int const&>);
+    STATIC_REQUIRE(concepts::AssignableFrom<int&, int&>);
+    STATIC_REQUIRE(concepts::AssignableFrom<int&, int&&>);
+    STATIC_REQUIRE(concepts::AssignableFrom<int&, int const&>);
+
+    STATIC_REQUIRE_FALSE(concepts::AssignableFrom<int const&, int>);
+    STATIC_REQUIRE_FALSE(concepts::AssignableFrom<int const&, int&>);
+    STATIC_REQUIRE_FALSE(concepts::AssignableFrom<int const, int>);
+    STATIC_REQUIRE_FALSE(concepts::AssignableFrom<int const, int&>);
+
+    // check few non build in types
+    STATIC_REQUIRE(concepts::AssignableFrom<Dummy, Dummy>);
+    STATIC_REQUIRE(concepts::AssignableFrom<Dummy, Dummy&>);
+
+    STATIC_REQUIRE_FALSE(concepts::AssignableFrom<Dummy, Dummy const>);
+    STATIC_REQUIRE_FALSE(concepts::AssignableFrom<Dummy, Dummy const&>);
+}

--- a/test/unit/mem/constCorrectness.cpp
+++ b/test/unit/mem/constCorrectness.cpp
@@ -78,14 +78,19 @@ TEST_CASE("mdspan inner const assignment operator", "[mem][mdspan][correctness][
     MutMdSpan mut_mdspan(ptr, extents, pitches);
     ConstMdSpan const_mdspan(const_ptr, extents, pitches);
 
-    STATIC_REQUIRE(std::assignable_from<MutMdSpan&, MutMdSpan>);
+    STATIC_REQUIRE(concepts::AssignableFrom<MutMdSpan&, MutMdSpan>);
     [[maybe_unused]] MutMdSpan mut_mdspan2 = mut_mdspan;
-    STATIC_REQUIRE(std::assignable_from<ConstMdSpan&, ConstMdSpan>);
+    mut_mdspan2 = mut_mdspan;
+    STATIC_REQUIRE(concepts::AssignableFrom<ConstMdSpan&, ConstMdSpan>);
     [[maybe_unused]] ConstMdSpan const_mdspan2 = const_mdspan;
-    STATIC_REQUIRE(std::assignable_from<ConstMdSpan&, MutMdSpan>);
+    const_mdspan2 = const_mdspan;
+    STATIC_REQUIRE(concepts::AssignableFrom<ConstMdSpan&, MutMdSpan>);
     [[maybe_unused]] ConstMdSpan const_mdspan3 = mut_mdspan;
-    STATIC_REQUIRE_FALSE(std::assignable_from<MutMdSpan&, ConstMdSpan>);
+    const_mdspan3 = mut_mdspan;
+    STATIC_REQUIRE_FALSE(concepts::AssignableFrom<MutMdSpan&, ConstMdSpan>);
+    // Not allowed cases, remove inner const via copy construction or assignment
     // MutMdSpan mut_mdspan3 = const_mdspan;
+    // mut_mdspan3 = const_mdspan;
 }
 
 TEST_CASE("mdspan inner const move operator", "[mem][mdspan][correctness][moveConstruct]")
@@ -228,14 +233,19 @@ TEST_CASE("MdSpanArray inner const assignment operator", "[mem][mdspanarray][cor
     MutMdSpanArray mut_md_span_array(static_data);
     ConstMdSpanArray const_md_span_array(const_static_data);
 
-    STATIC_REQUIRE(std::assignable_from<MutMdSpanArray&, MutMdSpanArray>);
+    STATIC_REQUIRE(concepts::AssignableFrom<MutMdSpanArray&, MutMdSpanArray>);
     [[maybe_unused]] MutMdSpanArray mut_md_span_arra2 = mut_md_span_array;
-    STATIC_REQUIRE(std::assignable_from<ConstMdSpanArray&, ConstMdSpanArray>);
+    mut_md_span_arra2 = mut_md_span_array;
+    STATIC_REQUIRE(concepts::AssignableFrom<ConstMdSpanArray&, ConstMdSpanArray>);
     [[maybe_unused]] ConstMdSpanArray const_md_span_array2 = const_md_span_array;
-    STATIC_REQUIRE(std::assignable_from<ConstMdSpanArray&, MutMdSpanArray>);
+    const_md_span_array2 = const_md_span_array;
+    STATIC_REQUIRE(concepts::AssignableFrom<ConstMdSpanArray&, MutMdSpanArray>);
     [[maybe_unused]] ConstMdSpanArray const_md_span_array3 = mut_md_span_array;
-    STATIC_REQUIRE_FALSE(std::assignable_from<MutMdSpanArray&, ConstMdSpanArray>);
+    const_md_span_array3 = mut_md_span_array;
+    STATIC_REQUIRE_FALSE(concepts::AssignableFrom<MutMdSpanArray&, ConstMdSpanArray>);
+    // Not allowed cases, remove inner const via copy construction or assignment
     // MutMdSpanArray mut_view3 = const_md_span_array;
+    // mut_view3 = const_md_span_array;
 }
 
 TEST_CASE(
@@ -313,14 +323,19 @@ TEST_CASE("View inner const assignment operator", "[mem][view][correctness][copy
     MutView mut_view(api::host, ptr, extents, pitches);
     ConstView const_view(api::host, const_ptr, extents, pitches);
 
-    STATIC_REQUIRE(std::assignable_from<MutView&, MutView>);
+    STATIC_REQUIRE(concepts::AssignableFrom<MutView&, MutView>);
     [[maybe_unused]] MutView mut_view2 = mut_view;
-    STATIC_REQUIRE(std::assignable_from<ConstView&, ConstView>);
+    mut_view2 = mut_view;
+    STATIC_REQUIRE(concepts::AssignableFrom<ConstView&, ConstView>);
     [[maybe_unused]] ConstView const_view2 = const_view;
-    STATIC_REQUIRE(std::assignable_from<ConstView&, MutView>);
+    const_view2 = const_view;
+    STATIC_REQUIRE(concepts::AssignableFrom<ConstView&, MutView>);
     [[maybe_unused]] ConstView const_view3 = mut_view;
-    STATIC_REQUIRE_FALSE(std::assignable_from<MutView&, ConstView>);
+    const_view3 = mut_view;
+    STATIC_REQUIRE_FALSE(concepts::AssignableFrom<MutView&, ConstView>);
+    // Not allowed cases, remove inner const via copy construction or assignment
     // MutView mut_view3 = const_view;
+    // mut_view3 = const_view;
 }
 
 TEST_CASE("View inner const move constructor and move assignment operator", "[mem][view][correctness][moveConstruct]")
@@ -400,14 +415,19 @@ TEST_CASE("sharedBuffer inner const assignment operator", "[mem][sharedBuffer][c
     MutSharedBuffer mut_shared_buffer(api::host, ptr, extents, pitches, [] {});
     ConstSharedBuffer const_shared_buffer(api::host, const_ptr, extents, pitches, [] {});
 
-    STATIC_REQUIRE(std::assignable_from<MutSharedBuffer&, MutSharedBuffer>);
+    STATIC_REQUIRE(concepts::AssignableFrom<MutSharedBuffer&, MutSharedBuffer>);
     [[maybe_unused]] MutSharedBuffer mut_shared_buffer2 = mut_shared_buffer;
-    STATIC_REQUIRE(std::assignable_from<ConstSharedBuffer&, ConstSharedBuffer>);
+    mut_shared_buffer2 = mut_shared_buffer;
+    STATIC_REQUIRE(concepts::AssignableFrom<ConstSharedBuffer&, ConstSharedBuffer>);
     [[maybe_unused]] ConstSharedBuffer const_shared_buffer2 = const_shared_buffer;
-    STATIC_REQUIRE(std::assignable_from<ConstSharedBuffer&, MutSharedBuffer>);
+    const_shared_buffer2 = const_shared_buffer;
+    STATIC_REQUIRE(concepts::AssignableFrom<ConstSharedBuffer&, MutSharedBuffer>);
     [[maybe_unused]] ConstSharedBuffer const_shared_buffer3 = mut_shared_buffer;
-    STATIC_REQUIRE_FALSE(std::assignable_from<MutSharedBuffer&, ConstSharedBuffer>);
+    const_shared_buffer3 = mut_shared_buffer;
+    STATIC_REQUIRE_FALSE(concepts::AssignableFrom<MutSharedBuffer&, ConstSharedBuffer>);
+    // Not allowed cases, remove inner const via copy construction or assignment
     // MutSharedBuffer mut_shared_buffer3 = const_shared_buffer;
+    // mut_shared_buffer3 = const_shared_buffer;
 }
 
 TEST_CASE("sharedBuffer inner const move operator", "[mem][sharedBuffer][correctness][moveConstruct]")


### PR DESCRIPTION
- add assignment check to `IDataSource`
- add concepts `alpaka::concepts::AssinableFrom<>`
- fix `SharedBuffer`, `MdSpan`, `MdSpanArray` and `View` assign operator