### PR TITLE
CI: add cuda 13.1 and 13.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
           - { compiler: nvcc, version: "", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04" }
           - { compiler: nvcc, version: "", cuda: "12.9", hip: "no", container: "nvidia/cuda:12.9.1-devel-ubuntu24.04" }
           - { compiler: nvcc, version: "", cuda: "13.0", hip: "no", container: "nvidia/cuda:13.0.0-devel-ubuntu24.04" }
+          - { compiler: nvcc, version: "", cuda: "13.1", hip: "no", container: "nvidia/cuda:13.1.0-devel-ubuntu24.04" }
+          - { compiler: nvcc, version: "", cuda: "13.2", hip: "no", container: "nvidia/cuda:13.2.0-devel-ubuntu24.04" }
           # clang-cuda (device compile with clang)
           - { compiler: clang, version: "20", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04" }
           - { compiler: clang, version: "21", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04" }

--- a/example/heatEquation2D/src/StencilKernel.hpp
+++ b/example/heatEquation2D/src/StencilKernel.hpp
@@ -39,17 +39,20 @@ struct StencilKernel
     {
         using namespace alpaka;
 
-        for(concepts::Dim<2u> auto blockStartIdx :
+        for(auto blockStartIdx :
             onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec{0u, 0u}, numNodes, chunkSize}))
         {
+            // CUDA 13.1/13.2 bug workaround: concepts can not be used in a range based for loop
+            static_assert(concepts::Dim<ALPAKA_TYPEOF(blockStartIdx), 2u>);
             auto sdata = onAcc::declareSharedMdArray<double, uniqueId()>(acc, sharedMemExtents);
 
             // avoid data race with the stencil calculation at the end
             onAcc::syncBlockThreads(acc);
 
-            for(concepts::Dim<2u> auto idx2d :
-                onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{sharedMemExtents}))
+            for(auto idx2d : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{sharedMemExtents}))
             {
+                // CUDA 13.1/13.2 bug workaround: concepts can not be used in a range based for loop
+                static_assert(concepts::Dim<ALPAKA_TYPEOF(idx2d), 2u>);
                 auto bufIdx = idx2d + blockStartIdx;
                 sdata[idx2d] = uCurrBuf[bufIdx];
             }
@@ -65,12 +68,14 @@ struct StencilKernel
 
             // go over only core cells
             // Vec{1, 1}; offset for halo above and to the left
-            for(concepts::Dim<2u> auto idx2D : onAcc::makeIdxMap(
+            for(auto idx2D : onAcc::makeIdxMap(
                     acc,
                     onAcc::worker::threadsInBlock,
                     IdxRange{chunkSize} >> 1u,
                     onAcc::traverse::tiled))
             {
+                // CUDA 13.1/13.2 bug workaround: concepts can not be used in a range based for loop
+                static_assert(concepts::Dim<ALPAKA_TYPEOF(idx2D), 2u>);
                 auto bufIdx = idx2D + blockStartIdx;
 
                 uNextBuf[bufIdx] = sdata[idx2D] * (1.0 - 2.0 * rX - 2.0 * rY) + sdata[idx2D - xDir] * rX

--- a/example/nBody/src/Kernels.hpp
+++ b/example/nBody/src/Kernels.hpp
@@ -35,11 +35,13 @@ namespace alpaka::example::nBody
             auto const extents = particleData.getExtents();
 
             // loop through blocks in the grid
-            for(concepts::Dim<1_idx> auto blockStartIdx : onAcc::makeIdxMap(
+            for(auto blockStartIdx : onAcc::makeIdxMap(
                     acc,
                     onAcc::worker::blocksInGrid,
                     IdxRange{CVec<IdxType, 0_idx>{}, extents, chunkSize}))
             {
+                // CUDA 13.1/13.2 bug workaround: concepts can not be used in a range based for loop
+                static_assert(concepts::Dim<ALPAKA_TYPEOF(blockStartIdx), 1u>);
                 // each block updates its particles with all other particles (3-dimensional positions)
                 auto particlePositions = onAcc::declareSharedMdArray<Simd<BaseType, 3u>, uniqueId()>(acc, chunkSize);
 
@@ -53,9 +55,10 @@ namespace alpaka::example::nBody
                 auto masses = onAcc::declareSharedMdArray<BaseType, uniqueId()>(acc, chunkSize);
 
                 // == load the particles for this block into shared memory and initialize accelerations ==
-                for(concepts::Dim<1_idx> auto particleIdx :
-                    onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
+                for(auto particleIdx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
                 {
+                    // CUDA 13.1/13.2 bug workaround: concepts can not be used in a range based for loop
+                    static_assert(concepts::Dim<ALPAKA_TYPEOF(particleIdx), 1u>);
                     auto const globalIdx = blockStartIdx + particleIdx;
                     particlePositions[particleIdx] = Simd{
                         particleData.xPositions[globalIdx],
@@ -69,9 +72,10 @@ namespace alpaka::example::nBody
                     otherBlockStartIdx += chunkSize.x())
                 {
                     // == load the particles for this block into shared memory and initialize accelerations ==
-                    for(concepts::Dim<1_idx> auto particleIdx :
-                        onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
+                    for(auto particleIdx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
                     {
+                        // CUDA 13.1/13.2 bug workaround: concepts can not be used in a range based for loop
+                        static_assert(concepts::Dim<ALPAKA_TYPEOF(particleIdx), 1u>);
                         auto const otherGlobalIdx = otherBlockStartIdx + particleIdx;
                         otherParticlePositions[particleIdx] = Simd{
                             particleData.xPositions[otherGlobalIdx],
@@ -83,9 +87,10 @@ namespace alpaka::example::nBody
                     onAcc::syncBlockThreads(acc);
 
                     // == iterate through every x,y pair of particles in this tile ==
-                    for(concepts::Dim<1_idx> auto particleIdx :
-                        onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
+                    for(auto particleIdx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
                     {
+                        // CUDA 13.1/13.2 bug workaround: concepts can not be used in a range based for loop
+                        static_assert(concepts::Dim<ALPAKA_TYPEOF(particleIdx), 1u>);
                         for(IdxType i = 0_idx; i < chunkSize; ++i)
                         {
                             auto const distanceVector = otherParticlePositions[i] - particlePositions[particleIdx];
@@ -105,9 +110,10 @@ namespace alpaka::example::nBody
                 onAcc::syncBlockThreads(acc);
 
                 // == calculate and save the particles' new velocities back into global memory ==
-                for(concepts::Dim<1_idx> auto particleIdx :
-                    onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
+                for(auto particleIdx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
                 {
+                    // CUDA 13.1/13.2 bug workaround: concepts can not be used in a range based for loop
+                    static_assert(concepts::Dim<ALPAKA_TYPEOF(particleIdx), 1u>);
                     auto const acceleration = accelerations[particleIdx] * dt;
                     particleData.xVelocities[blockStartIdx + particleIdx] += acceleration.x();
                     particleData.yVelocities[blockStartIdx + particleIdx] += acceleration.y();


### PR DESCRIPTION
Add CUDA 13.1/2 to the CI.
Workaround CUDA 13.1 and 13.2 bug that concepts can not be used to
Validate the return value in a range-based for loop.