### PR TITLE
disable fast math in the CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,8 @@
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "alpaka_TESTS": "ON",
         "alpaka_EXAMPLES": "ON",
-        "alpaka_BENCHMARKS": "ON"
+        "alpaka_BENCHMARKS": "ON",
+        "alpaka_FAST_MATH": "OFF"
       }
     },
     {


### PR DESCRIPTION
- fast math let some tests fail