### PR TITLE
fix example scan improved

### DIFF
--- a/example/scan/src/scan_improved.hpp
+++ b/example/scan/src/scan_improved.hpp
@@ -269,7 +269,7 @@ namespace alpaka::example::scan
                     for(auto miniBlockOffset = 0_idx; miniBlockOffset < elsPerThread; miniBlockOffset += miniBlockSize)
                     {
                         // load block sum from shared memory
-                        Data blockSum;
+                        Data blockSum{0};
                         if(frameOffset + frameElem + miniBlockOffset < numElements)
                         {
                             blockSum = tmp[conflictFreeAccess<DeviceType>(


### PR DESCRIPTION
```
scan_improved.hpp:99:22: error: 'blockSum' may be used uninitialized [-Werror=maybe-uninitialized]
   99 |             block[i] += blockSum;
```