### PR TITLE
fix `icpx` bug

### DIFF
--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -270,13 +270,11 @@ namespace alpaka
         {
             if constexpr(requires { detail::TemplateSignatureStorage_v<T_Storage>; })
             {
-                UniVec result([=](uint32_t const) { return static_cast<T_Type>(value); });
-                return result;
+                return UniVec([=](uint32_t const) { return static_cast<T_Type>(value); });
             }
             else
             {
-                Vec result([=](uint32_t const) { return static_cast<T_Type>(value); });
-                return result;
+                return Vec([=](uint32_t const) { return static_cast<T_Type>(value); });
             }
         }
 

--- a/include/alpaka/simd/internal/EmuSimd.hpp
+++ b/include/alpaka/simd/internal/EmuSimd.hpp
@@ -96,8 +96,7 @@ namespace alpaka
 
             static constexpr auto fill(T_Type const& value)
             {
-                EmuSimd result([&value](uint32_t const) { return static_cast<T_Type>(value); });
-                return result;
+                return EmuSimd([&value](uint32_t const) { return value; });
             }
 
             template<typename F>

--- a/include/alpaka/simd/internal/StdSimd.hpp
+++ b/include/alpaka/simd/internal/StdSimd.hpp
@@ -94,8 +94,7 @@ namespace alpaka
 
             static constexpr auto fill(T_Type const& value)
             {
-                BaseType ret(value);
-                return StdSimd{ret};
+                return StdSimd{BaseType(value)};
             }
 
             constexpr void copyFrom(T_Type const* data, alpaka::concepts::Alignment auto alignment)

--- a/include/alpaka/simd/internal/StdSimdMask.hpp
+++ b/include/alpaka/simd/internal/StdSimdMask.hpp
@@ -97,8 +97,7 @@ namespace alpaka
 
             static constexpr auto fill(T_Type const& value)
             {
-                BaseType ret(value);
-                return StdSimdMask{ret};
+                return StdSimdMask{BaseType(value)};
             }
 
             constexpr void copyFrom(T_Type const* data, alpaka::concepts::Alignment auto alignment)


### PR DESCRIPTION
The warp iota test failed when using `icpx` as C++ compiler for code using the host executors.
The reason for the failing tests was that the buffer `fill()` was not working correctly. The issue is most likely triggered by an optimization bug:
  - `-O1` and `-O2` worked
  - `-O3` failed
  - Testing all with sanitizer is showing no issues and solves the issue too.
  - Adding mem fences in the generic fill kernel worked too; most likely, it breaks the optimizations.
  - Removing the copy constructor of `internal::EmuSimd` by the default constructor worked too, but resulted in `HACKmk` benchmark in worse performance. Changing `EmuSimd::fill()` fixes the bug too.

This PR fixes `fill()` implementation in `EmuSimd`, `EmuMask`, `StdMask`, `StdSimd`, and `Vec`. By removing the intermediate variable, the compiler can perform copy elision more effectively.

The bug shows up in #475 but the PR itself is not the trigger. The bug is reproducible with OneApi 2025.2 and 2025.3 on our development system. 
It is not clear why the CI did not trigger the bug before.