### PR TITLE
fix `Simd` and `SimdMask`

### DIFF
--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -265,11 +265,11 @@ namespace alpaka
 #define ALPAKA_NAMED_ARRAY_ACCESS(functionName, laneIdx)                                                              \
     constexpr reference functionName() requires(T_width >= laneIdx + 1)                                               \
     {                                                                                                                 \
-        return (*this)[T_width - 1u - laneIdx];                                                                       \
+        return (*this)[laneIdx];                                                                                      \
     }                                                                                                                 \
     constexpr type functionName() const requires(T_width >= laneIdx + 1)                                              \
     {                                                                                                                 \
-        return (*this)[T_width - 1u - laneIdx];                                                                       \
+        return (*this)[laneIdx];                                                                                      \
     }
 
         /** @brief named lane access
@@ -522,27 +522,6 @@ namespace alpaka
     {
         return v[I];
     }
-
-    template<typename Type>
-    struct Simd<Type, 0>
-    {
-        using type = Type;
-        static constexpr uint32_t T_width = 0;
-
-        template<typename OtherType>
-        constexpr operator Simd<OtherType, 0>() const
-        {
-            return Simd<OtherType, 0>();
-        }
-
-        static constexpr Simd fill(Type)
-        {
-            /* this method should never be actually called,
-             * it exists only for Visual Studio to handle alpaka::Size_t< 0 >
-             */
-            static_assert(sizeof(Type) != 0 && false);
-        }
-    };
 
     template<typename Type, uint32_t T_width, typename T_Storage>
     std::ostream& operator<<(std::ostream& s, Simd<Type, T_width, T_Storage> const& vec)

--- a/include/alpaka/SimdMask.hpp
+++ b/include/alpaka/SimdMask.hpp
@@ -118,7 +118,7 @@ namespace alpaka
          */
         template<typename... T_Args>
         requires(
-            ((std::is_convertible_v<T_Args, T_Type> && !std::same_as<bool, T_Type>) && ...)
+            ((std::is_convertible_v<T_Args, T_Type> && !std::same_as<bool, T_Args>) && ...)
             && (sizeof...(T_Args) == T_width))
         ALPAKA_FN_HOST_ACC SimdMask(T_Args const&... args) : Storage(static_cast<T_Type>(args)...)
         {
@@ -176,10 +176,9 @@ namespace alpaka
          * @param value Value which is set for all lanes
          * @return new Simd<...>
          */
-        static constexpr auto fill(concepts::Convertible<T_Type> auto const& value)
+        static constexpr auto fill(bool value)
         {
-            SimdMask result([=](uint32_t const) { return static_cast<T_Type>(value); });
-            return result;
+            return SimdMask{Storage::fill(value)};
         }
 
         constexpr SimdMask toRT() const
@@ -251,34 +250,42 @@ namespace alpaka
             return static_cast<type>(Storage::operator[](idx));
         }
 
-        /** named member access
+        /** @brief named lane access
          *
-         * @attention The mapping from names x,y,z,w to memory indicies differ from the mapping of an alpaka vector @c
-         * Vec
+         * @attention The mapping from names x,y,z,w to memory indices differ from the mapping of an alpaka vector @c
+         * Vec. The availability of the naming methods depends on the SIMD width.
          *
-         * index -> name [0->x,1->y,2->z,3->w]
-         *               [0->r,1->g,2->b,3->a]
-         *               [0->s0,1->s1,2->s2,...,10->sA,...,15->sF]
+         * You can have access to the same lane index via different nonspecific naming.
+         *
+         * @code
+         * lane index   :  0,  1,  2,  3, ...,  9, 10, ... , 15
+         * hexadecimal  : s0, s1, s2, s3, ..., s9, SA, ... , SF
+         * coordinate   :  x,  y,  z,  w
+         * color channel:  r,  g,  b,  a
+         * @endcode
+         *
          * @{
          */
 #define ALPAKA_NAMED_ARRAY_ACCESS(functionName, laneIdx)                                                              \
     constexpr reference functionName() requires(T_width >= laneIdx + 1)                                               \
     {                                                                                                                 \
-        return (*this)[T_width - 1u - laneIdx];                                                                       \
+        return (*this)[laneIdx];                                                                                      \
     }                                                                                                                 \
     constexpr type functionName() const requires(T_width >= laneIdx + 1)                                              \
     {                                                                                                                 \
-        return (*this)[T_width - 1u - laneIdx];                                                                       \
+        return (*this)[laneIdx];                                                                                      \
     }
 
         ALPAKA_NAMED_ARRAY_ACCESS(x, 0u)
         ALPAKA_NAMED_ARRAY_ACCESS(y, 1u)
         ALPAKA_NAMED_ARRAY_ACCESS(z, 2u)
         ALPAKA_NAMED_ARRAY_ACCESS(w, 3u)
+
         ALPAKA_NAMED_ARRAY_ACCESS(r, 0u)
         ALPAKA_NAMED_ARRAY_ACCESS(g, 1u)
         ALPAKA_NAMED_ARRAY_ACCESS(b, 2u)
         ALPAKA_NAMED_ARRAY_ACCESS(a, 3u)
+
         ALPAKA_NAMED_ARRAY_ACCESS(s0, 0u)
         ALPAKA_NAMED_ARRAY_ACCESS(s1, 1u)
         ALPAKA_NAMED_ARRAY_ACCESS(s2, 2u)
@@ -407,27 +414,6 @@ namespace alpaka
         return v[I];
     }
 
-    template<typename Type>
-    struct SimdMask<Type, 0>
-    {
-        using type = Type;
-        static constexpr uint32_t T_width = 0;
-
-        template<typename OtherType>
-        constexpr operator SimdMask<OtherType, 0>() const
-        {
-            return SimdMask<OtherType, 0>();
-        }
-
-        static constexpr SimdMask fill(Type)
-        {
-            /* this method should never be actually called,
-             * it exists only for Visual Studio to handle alpaka::Size_t< 0 >
-             */
-            static_assert(sizeof(Type) != 0 && false);
-        }
-    };
-
     template<typename Type, uint32_t T_width, typename T_Storage>
     std::ostream& operator<<(std::ostream& s, SimdMask<Type, T_width, T_Storage> const& vec)
     {
@@ -444,6 +430,7 @@ namespace alpaka
      * @tparam T_Args arguments forwarded to the constructor of the mask
      */
     template<typename T, typename... T_Args>
+    requires((std::same_as<std::remove_cvref_t<T_Args>, bool>) && ...)
     constexpr auto makeSimdMask(T_Args... args)
     {
         using Storage =

--- a/include/alpaka/simd/internal/EmuSimdMask.hpp
+++ b/include/alpaka/simd/internal/EmuSimdMask.hpp
@@ -76,13 +76,13 @@ namespace alpaka
             // constructor is required because exposing the array constructors does not work
             template<typename... T_Args>
             requires(sizeof...(T_Args) == T_width && (std::same_as<T_Args, T_Type> && ...))
-            constexpr EmuSimdMask(T_Args&&... args) : BaseType{std::forward<T_Args>(args)...}
+            constexpr EmuSimdMask(T_Args const&... args) : BaseType{args...}
             {
             }
 
             template<typename... T_Args>
             requires(sizeof...(T_Args) == T_width && (std::same_as<T_Args, bool> && ...))
-            constexpr EmuSimdMask(T_Args&&... args) : BaseType{valueMaskCast<T_Type>(args)...}
+            constexpr EmuSimdMask(T_Args... args) : BaseType{valueMaskCast<T_Type>(args)...}
             {
             }
 
@@ -107,11 +107,12 @@ namespace alpaka
 
             /** @} */
 
-            static constexpr auto fill(T_Type const& value)
+            static constexpr auto fill(bool value)
             {
+                auto maskValue = valueMaskCast<T_Type>(value);
                 BaseType ret{};
                 for(uint32_t i = 0u; i < T_width; ++i)
-                    ret[i] = value;
+                    ret[i] = maskValue;
 
                 return EmuSimdMask(ret);
             }

--- a/include/alpaka/simd/internal/StdSimdMask.hpp
+++ b/include/alpaka/simd/internal/StdSimdMask.hpp
@@ -57,7 +57,7 @@ namespace alpaka
             // constructor is required because exposing the array constructors does not work
             template<typename... T_Args>
             requires(sizeof...(T_Args) == T_width && (std::same_as<T_Args, T_Type> && ...))
-            constexpr StdSimdMask(T_Args&&... args) : BaseType{}
+            constexpr StdSimdMask(T_Args const&... args) : BaseType{}
             {
                 std::array<T_Type, T_width> const initArgs{ALPAKA_FORWARD(args)...};
                 for(uint32_t i = 0u; i < T_width; ++i)
@@ -66,9 +66,9 @@ namespace alpaka
 
             template<typename... T_Args>
             requires(sizeof...(T_Args) == T_width && (std::same_as<T_Args, bool> && ...))
-            constexpr StdSimdMask(T_Args&&... args) : BaseType{}
+            constexpr StdSimdMask(T_Args... args) : BaseType{}
             {
-                std::array<bool, T_width> const initArgs{ALPAKA_FORWARD(args)...};
+                std::array<bool, T_width> const initArgs{args...};
                 for(uint32_t i = 0u; i < T_width; ++i)
                     this->asNativeType()[i] = initArgs[i];
             }
@@ -95,7 +95,7 @@ namespace alpaka
 
             /** @} */
 
-            static constexpr auto fill(T_Type const& value)
+            static constexpr auto fill(bool value)
             {
                 return StdSimdMask{BaseType(value)};
             }

--- a/test/unit/simd/simd.cpp
+++ b/test/unit/simd/simd.cpp
@@ -72,7 +72,10 @@ TEST_CASE("simd 2D", "[simd vector]")
 
     auto simd = Simd{3, 7};
     CHECK(simd.width() == 2);
-    CHECK((simd.y() == 3 && simd.x() == 7));
+    CHECK((simd.x() == 3 && simd.y() == 7));
+    CHECK((simd.r() == 3 && simd.g() == 7));
+    CHECK((simd.s0() == 3 && simd.s1() == 7));
+    CHECK((simd[0] == 3 && simd[1] == 7));
     CHECK((simd == Simd{3, 7}).reduce(std::logical_and{}));
     CHECK((simd != Simd{7, 3}).reduce(std::logical_and{}));
     CHECK((Simd{7} == Simd{7, 3}.eraseBack()).reduce(std::logical_and{}));

--- a/test/unit/simd/simdMask.cpp
+++ b/test/unit/simd/simdMask.cpp
@@ -22,55 +22,13 @@ TEST_CASE("simd mask 1D", "[simd mask vector]")
 {
     using namespace alpaka;
 
-    auto mask = makeSimdMask<int>(true);
+    auto mask = makeSimdMask<uint32_t>(true);
     CHECK(mask.width() == 1);
     CHECK(mask.x() == true);
-    CHECK((mask == makeSimdMask<int>(true)).reduce(std::logical_and{}));
+    CHECK(mask.r() == true);
+    CHECK(mask.s0() == true);
+    CHECK(mask[0] == true);
 
-
-    auto typeLambda = [](auto const typeDummy)
-    {
-        using type = std::decay_t<decltype(typeDummy)>;
-
-        constexpr type falseValue = type{0};
-        constexpr type trueValue = std::numeric_limits<type>::max();
-
-        auto inputData = std::make_tuple(
-            std::make_tuple(
-                std::logical_and{},
-                makeSimdMask<type>(true),
-                makeSimdMask<type>(true),
-                makeSimdMask<type>(true)),
-            std::make_tuple(
-                std::logical_and{},
-                makeSimdMask<type>(false),
-                makeSimdMask<type>(true),
-                makeSimdMask<type>(false)),
-            std::make_tuple(
-                std::logical_and{},
-                SimdMask(trueValue),
-                makeSimdMask<type>(true),
-                makeSimdMask<type>(true)),
-            std::make_tuple(
-                std::logical_and{},
-                SimdMask(falseValue),
-                makeSimdMask<type>(true),
-                makeSimdMask<type>(false)),
-            std::make_tuple(std::logical_and{}, SimdMask(falseValue), SimdMask(falseValue), SimdMask(falseValue)),
-            std::make_tuple(std::logical_and{}, SimdMask(trueValue), SimdMask(trueValue), SimdMask(trueValue)));
-        bool x = std::apply(
-            [&](auto... args)
-            {
-                return (
-                    (std::get<0>(args)(std::get<1>(args), std::get<2>(args)) == std::get<3>(args))
-                        .reduce(std::logical_and{})
-                    && ...);
-            },
-            inputData);
-        return x;
-    };
-
-    constexpr auto inputTypes = std::tuple<uint32_t, uint64_t>{};
-    bool x = std::apply([&](auto... args) { return (typeLambda(args) && ...); }, inputTypes);
-    CHECK(x);
+    auto maskTrue = SimdMask<uint32_t, 1u>::fill(true);
+    CHECK((maskTrue == SimdMask<uint32_t, 1u>(true)).reduce(std::logical_and{}));
 }


### PR DESCRIPTION
- the named access for `SimdMask` and `Simd` was using the wrong order of names (copy past issue from `Vec`
  - the `Simd` test for named access was wrong, implemented wrong name ordering
- fix `SimdMask::fill(bool)`, now only supports bool equal to the `std::simd` broatcast constructor
- fix constructors for internal simd masks and `SimdMask`
- add slidly more tests for `SimdMask`
- remove left over code for zero dimensional simd maks and data pack (we have a static assert in `Simd` to guard against zero) 