### PR TITLE
add `enabledDeviceSpecs`

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,6 +18,24 @@
       }
     },
     {
+      "name": "host-devices-base",
+      "hidden": true,
+      "cacheVariables": {
+        "alpaka_HOST_Cpu": "OFF",
+        "alpaka_DEP_HWLOC": "OFF"
+      }
+    },
+    {
+      "name": "oneapi-devices-base",
+      "hidden": true,
+      "cacheVariables": {
+        "alpaka_ONEAPI_Cpu": "OFF",
+        "alpaka_ONEAPI_IntelGpu": "OFF",
+        "alpaka_ONEAPI_NvidiaGpu": "OFF",
+        "alpaka_ONEAPI_AmdGpu": "OFF"
+      }
+    },
+    {
       "name": "release-base",
       "inherits": [
         "default"
@@ -68,12 +86,65 @@
     {
       "name": "cpu-base",
       "hidden": true,
+      "inherits": [
+        "host-devices-base"
+      ],
       "cacheVariables": {
-        "alpaka_DEP_OMP": "ON"
+        "alpaka_DEP_OMP": "ON",
+        "alpaka_HOST_Cpu": "ON"
       }
     },
     {
-      "name": "rel-host-gcc",
+      "name": "numacpu-base",
+      "hidden": true,
+      "inherits": [
+        "host-devices-base"
+      ],
+      "cacheVariables": {
+        "alpaka_DEP_OMP": "ON",
+        "alpaka_HOST_NumaCpu": "ON",
+        "alpaka_DEP_HWLOC": "ON"
+      }
+    },
+    {
+      "name": "cuda-base",
+      "hidden": true,
+      "inherits": [
+        "host-devices-base"
+      ],
+      "cacheVariables": {
+        "alpaka_DEP_CUDA": "ON",
+        "alpaka_DEP_OMP": "OFF",
+        "alpaka_CUDA_NvidiaGpu": "ON"
+      }
+    },
+    {
+      "name": "hip-base",
+      "hidden": true,
+      "inherits": [
+        "host-devices-base"
+      ],
+      "cacheVariables": {
+        "alpaka_DEP_HIP": "ON",
+        "alpaka_DEP_OMP": "OFF",
+        "alpaka_HIP_AmdGpu": "ON"
+      }
+    },
+    {
+      "name": "oneapi-base",
+      "hidden": true,
+      "inherits": [
+        "host-devices-base",
+        "oneapi-devices-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "icpx",
+        "alpaka_DEP_ONEAPI": "ON",
+        "alpaka_DEP_OMP": "OFF"
+      }
+    },
+    {
+      "name": "rel-host-cpu-gcc",
       "inherits": [
         "release-base",
         "cpu-base"
@@ -83,10 +154,30 @@
       }
     },
     {
-      "name": "rel-host-clang",
+      "name": "rel-host-cpu-clang",
       "inherits": [
         "release-base",
         "cpu-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
+    },
+    {
+      "name": "rel-host-numacpu-gcc",
+      "inherits": [
+        "release-base",
+        "numacpu-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    },
+    {
+      "name": "rel-host-numacpu-clang",
+      "inherits": [
+        "release-base",
+        "numacpu-base"
       ],
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "clang++"
@@ -96,79 +187,66 @@
       "name": "rel-cuda-nvcc-gcc",
       "inherits": [
         "release-base",
-        "cpu-base"
+        "cuda-base"
       ],
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "g++",
-        "alpaka_DEP_CUDA": "ON",
-        "alpaka_DEP_OMP": "OFF"
+        "CMAKE_CXX_COMPILER": "g++"
       }
     },
     {
       "name": "rel-cuda-nvcc-clang",
       "inherits": [
         "release-base",
-        "cpu-base"
+        "cuda-base"
       ],
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "clang++",
-        "alpaka_DEP_CUDA": "ON",
-        "alpaka_DEP_OMP": "OFF"
+        "CMAKE_CXX_COMPILER": "clang++"
       }
     },
     {
       "name": "rel-cuda-clangCuda",
       "inherits": [
         "release-base",
-        "cpu-base"
+        "cuda-base"
       ],
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "clang++",
         "CMAKE_CUDA_COMPILER": "clang++",
-        "CMAKE_CUDA_HOST_COMPILER": "clang++",
-        "alpaka_DEP_CUDA": "ON",
-        "alpaka_DEP_OMP": "OFF"
+        "CMAKE_CUDA_HOST_COMPILER": "clang++"
       }
     },
     {
       "name": "rel-hip",
       "inherits": [
-        "release-base"
+        "release-base",
+        "hip-base"
       ],
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "clang++",
-        "alpaka_DEP_HIP": "ON",
-        "alpaka_DEP_OMP": "OFF"
+        "CMAKE_CXX_COMPILER": "clang++"
       }
     },
     {
       "name": "rel-oneapi-cpu",
       "inherits": [
-        "release-base"
+        "release-base",
+        "oneapi-base"
       ],
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "icpx",
-        "alpaka_DEP_ONEAPI": "ON",
-        "alpaka_ONEAPI_Cpu": "ON",
-        "alpaka_ONEAPI_IntelGpu": "OFF",
-        "alpaka_DEP_OMP": "OFF"
+        "alpaka_ONEAPI_Cpu": "ON"
       }
     },
     {
       "name": "rel-oneapi-gpu",
       "inherits": [
-        "release-base"
+        "release-base",
+        "oneapi-base"
       ],
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "icpx",
-        "alpaka_DEP_ONEAPI": "ON",
-        "alpaka_ONEAPI_Cpu": "OFF",
-        "alpaka_ONEAPI_IntelGpu": "ON",
-        "alpaka_DEP_OMP": "OFF"
+        "alpaka_ONEAPI_IntelGpu": "ON"
       }
     },
     {
-      "name": "dbg-host-gcc",
+      "name": "dbg-host-cpu-gcc",
       "inherits": [
         "debug-base",
         "cpu-base"
@@ -178,7 +256,7 @@
       }
     },
     {
-      "name": "dbg-host-clang",
+      "name": "dbg-host-cpu-clang",
       "inherits": [
         "debug-base",
         "cpu-base"
@@ -188,82 +266,89 @@
       }
     },
     {
+      "name": "dbg-host-numacpu-gcc",
+      "inherits": [
+        "debug-base",
+        "numacpu-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    },
+    {
+      "name": "dbg-host-numacpu-clang",
+      "inherits": [
+        "debug-base",
+        "numacpu-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
+    },
+    {
       "name": "dbg-cuda-nvcc-gcc",
       "inherits": [
         "debug-base",
-        "cpu-base"
+        "cuda-base"
       ],
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "g++",
-        "alpaka_DEP_CUDA": "ON",
-        "alpaka_DEP_OMP": "OFF"
+        "CMAKE_CXX_COMPILER": "g++"
       }
     },
     {
       "name": "dbg-cuda-nvcc-clang",
       "inherits": [
         "debug-base",
-        "cpu-base"
+        "cuda-base"
       ],
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "clang++",
-        "alpaka_DEP_CUDA": "ON",
-        "alpaka_DEP_OMP": "OFF"
+        "CMAKE_CXX_COMPILER": "clang++"
       }
     },
     {
       "name": "dbg-cuda-clangCuda",
       "inherits": [
         "debug-base",
-        "cpu-base"
+        "cuda-base"
       ],
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "clang++",
         "CMAKE_CUDA_COMPILER": "clang++",
-        "CMAKE_CUDA_HOST_COMPILER": "clang++",
-        "alpaka_DEP_CUDA": "ON",
-        "alpaka_DEP_OMP": "OFF"
+        "CMAKE_CUDA_HOST_COMPILER": "clang++"
       }
     },
     {
       "name": "dbg-hip",
       "inherits": [
-        "debug-base"
+        "debug-base",
+        "hip-base"
       ],
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "clang++",
-        "alpaka_DEP_HIP": "ON",
-        "alpaka_DEP_OMP": "OFF"
+        "CMAKE_CXX_COMPILER": "clang++"
       }
     },
     {
       "name": "dbg-oneapi-cpu",
       "inherits": [
-        "debug-base"
+        "debug-base",
+        "oneapi-base"
       ],
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "icpx",
-        "alpaka_DEP_ONEAPI": "ON",
-        "alpaka_ONEAPI_Cpu": "ON",
-        "alpaka_ONEAPI_IntelGpu": "OFF",
-        "alpaka_DEP_OMP": "OFF"
+        "alpaka_ONEAPI_Cpu": "ON"
       }
     },
     {
       "name": "dbg-oneapi-gpu",
       "inherits": [
-        "debug-base"
+        "debug-base",
+        "oneapi-base"
       ],
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "icpx",
-        "alpaka_DEP_ONEAPI": "ON",
-        "alpaka_ONEAPI_Cpu": "OFF",
-        "alpaka_ONEAPI_IntelGpu": "ON",
-        "alpaka_DEP_OMP": "OFF"
+        "alpaka_ONEAPI_IntelGpu": "ON"
       }
     },
     {
-      "name": "rel-host-headercheck",
+      "name": "rel-host-cpu-headercheck",
       "inherits": [
         "release-base",
         "cpu-base"
@@ -273,7 +358,7 @@
       }
     },
     {
-      "name": "dbg-host-gcc-asan",
+      "name": "dbg-host-cpu-gcc-asan",
       "inherits": [
         "debug-base",
         "cpu-base",
@@ -284,7 +369,7 @@
       }
     },
     {
-      "name": "dbg-host-gcc-tsan",
+      "name": "dbg-host-cpu-gcc-tsan",
       "inherits": [
         "debug-base",
         "cpu-base",
@@ -295,7 +380,7 @@
       }
     },
     {
-      "name": "dbg-host-gcc-lsan",
+      "name": "dbg-host-cpu-gcc-lsan",
       "inherits": [
         "debug-base",
         "cpu-base",
@@ -306,7 +391,7 @@
       }
     },
     {
-      "name": "dbg-host-gcc-ubsan",
+      "name": "dbg-host-cpu-gcc-ubsan",
       "inherits": [
         "debug-base",
         "cpu-base",
@@ -317,7 +402,7 @@
       }
     },
     {
-      "name": "dbg-host-clang-asan",
+      "name": "dbg-host-cpu-clang-asan",
       "inherits": [
         "debug-base",
         "cpu-base",
@@ -328,7 +413,7 @@
       }
     },
     {
-      "name": "dbg-host-clang-tsan",
+      "name": "dbg-host-cpu-clang-tsan",
       "inherits": [
         "debug-base",
         "cpu-base",
@@ -339,7 +424,7 @@
       }
     },
     {
-      "name": "dbg-host-clang-lsan",
+      "name": "dbg-host-cpu-clang-lsan",
       "inherits": [
         "debug-base",
         "cpu-base",
@@ -350,10 +435,108 @@
       }
     },
     {
-      "name": "dbg-host-clang-ubsan",
+      "name": "dbg-host-cpu-clang-ubsan",
       "inherits": [
         "debug-base",
         "cpu-base",
+        "ubsan-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
+    },
+    {
+      "name": "rel-host-numacpu-headercheck",
+      "inherits": [
+        "release-base",
+        "numacpu-base"
+      ],
+      "cacheVariables": {
+        "alpaka_HEADERCHECKS": "ON"
+      }
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-asan",
+      "inherits": [
+        "debug-base",
+        "numacpu-base",
+        "asan-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-tsan",
+      "inherits": [
+        "debug-base",
+        "numacpu-base",
+        "tsan-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-lsan",
+      "inherits": [
+        "debug-base",
+        "numacpu-base",
+        "lsan-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-ubsan",
+      "inherits": [
+        "debug-base",
+        "numacpu-base",
+        "ubsan-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    },
+    {
+      "name": "dbg-host-numacpu-clang-asan",
+      "inherits": [
+        "debug-base",
+        "numacpu-base",
+        "asan-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
+    },
+    {
+      "name": "dbg-host-numacpu-clang-tsan",
+      "inherits": [
+        "debug-base",
+        "numacpu-base",
+        "tsan-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
+    },
+    {
+      "name": "dbg-host-numacpu-clang-lsan",
+      "inherits": [
+        "debug-base",
+        "numacpu-base",
+        "lsan-base"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
+    },
+    {
+      "name": "dbg-host-numacpu-clang-ubsan",
+      "inherits": [
+        "debug-base",
+        "numacpu-base",
         "ubsan-base"
       ],
       "cacheVariables": {
@@ -363,12 +546,20 @@
   ],
   "buildPresets": [
     {
-      "name": "rel-host-gcc",
-      "configurePreset": "rel-host-gcc"
+      "name": "rel-host-cpu-gcc",
+      "configurePreset": "rel-host-cpu-gcc"
     },
     {
-      "name": "rel-host-clang",
-      "configurePreset": "rel-host-clang"
+      "name": "rel-host-cpu-clang",
+      "configurePreset": "rel-host-cpu-clang"
+    },
+    {
+      "name": "rel-host-numacpu-gcc",
+      "configurePreset": "rel-host-numacpu-gcc"
+    },
+    {
+      "name": "rel-host-numacpu-clang",
+      "configurePreset": "rel-host-numacpu-clang"
     },
     {
       "name": "rel-cuda-nvcc-gcc",
@@ -395,12 +586,20 @@
       "configurePreset": "rel-oneapi-gpu"
     },
     {
-      "name": "dbg-host-gcc",
-      "configurePreset": "dbg-host-gcc"
+      "name": "dbg-host-cpu-gcc",
+      "configurePreset": "dbg-host-cpu-gcc"
     },
     {
-      "name": "dbg-host-clang",
-      "configurePreset": "dbg-host-clang"
+      "name": "dbg-host-cpu-clang",
+      "configurePreset": "dbg-host-cpu-clang"
+    },
+    {
+      "name": "dbg-host-numacpu-gcc",
+      "configurePreset": "dbg-host-numacpu-gcc"
+    },
+    {
+      "name": "dbg-host-numacpu-clang",
+      "configurePreset": "dbg-host-numacpu-clang"
     },
     {
       "name": "dbg-cuda-nvcc-gcc",
@@ -427,50 +626,94 @@
       "configurePreset": "dbg-oneapi-gpu"
     },
     {
-      "name": "rel-host-headercheck",
-      "configurePreset": "rel-host-headercheck"
+      "name": "rel-host-cpu-headercheck",
+      "configurePreset": "rel-host-cpu-headercheck"
     },
     {
-      "name": "dbg-host-gcc-asan",
-      "configurePreset": "dbg-host-gcc-asan"
+      "name": "dbg-host-cpu-gcc-asan",
+      "configurePreset": "dbg-host-cpu-gcc-asan"
     },
     {
-      "name": "dbg-host-gcc-tsan",
-      "configurePreset": "dbg-host-gcc-tsan"
+      "name": "dbg-host-cpu-gcc-tsan",
+      "configurePreset": "dbg-host-cpu-gcc-tsan"
     },
     {
-      "name": "dbg-host-gcc-lsan",
-      "configurePreset": "dbg-host-gcc-lsan"
+      "name": "dbg-host-cpu-gcc-lsan",
+      "configurePreset": "dbg-host-cpu-gcc-lsan"
     },
     {
-      "name": "dbg-host-gcc-ubsan",
-      "configurePreset": "dbg-host-gcc-ubsan"
+      "name": "dbg-host-cpu-gcc-ubsan",
+      "configurePreset": "dbg-host-cpu-gcc-ubsan"
     },
     {
-      "name": "dbg-host-clang-asan",
-      "configurePreset": "dbg-host-clang-asan"
+      "name": "dbg-host-cpu-clang-asan",
+      "configurePreset": "dbg-host-cpu-clang-asan"
     },
     {
-      "name": "dbg-host-clang-tsan",
-      "configurePreset": "dbg-host-clang-tsan"
+      "name": "dbg-host-cpu-clang-tsan",
+      "configurePreset": "dbg-host-cpu-clang-tsan"
     },
     {
-      "name": "dbg-host-clang-lsan",
-      "configurePreset": "dbg-host-clang-lsan"
+      "name": "dbg-host-cpu-clang-lsan",
+      "configurePreset": "dbg-host-cpu-clang-lsan"
     },
     {
-      "name": "dbg-host-clang-ubsan",
-      "configurePreset": "dbg-host-clang-ubsan"
+      "name": "dbg-host-cpu-clang-ubsan",
+      "configurePreset": "dbg-host-cpu-clang-ubsan"
+    },
+    {
+      "name": "rel-host-numacpu-headercheck",
+      "configurePreset": "rel-host-numacpu-headercheck"
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-asan",
+      "configurePreset": "dbg-host-numacpu-gcc-asan"
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-tsan",
+      "configurePreset": "dbg-host-numacpu-gcc-tsan"
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-lsan",
+      "configurePreset": "dbg-host-numacpu-gcc-lsan"
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-ubsan",
+      "configurePreset": "dbg-host-numacpu-gcc-ubsan"
+    },
+    {
+      "name": "dbg-host-numacpu-clang-asan",
+      "configurePreset": "dbg-host-numacpu-clang-asan"
+    },
+    {
+      "name": "dbg-host-numacpu-clang-tsan",
+      "configurePreset": "dbg-host-numacpu-clang-tsan"
+    },
+    {
+      "name": "dbg-host-numacpu-clang-lsan",
+      "configurePreset": "dbg-host-numacpu-clang-lsan"
+    },
+    {
+      "name": "dbg-host-numacpu-clang-ubsan",
+      "configurePreset": "dbg-host-numacpu-clang-ubsan"
     }
   ],
   "testPresets": [
     {
-      "name": "rel-host-gcc",
-      "configurePreset": "rel-host-gcc"
+      "name": "rel-host-cpu-gcc",
+      "configurePreset": "rel-host-cpu-gcc"
     },
     {
-      "name": "rel-host-clang",
-      "configurePreset": "rel-host-clang"
+      "name": "rel-host-cpu-clang",
+      "configurePreset": "rel-host-cpu-clang"
+    },
+    {
+      "name": "rel-host-numacpu-gcc",
+      "configurePreset": "rel-host-numacpu-gcc"
+    },
+    {
+      "name": "rel-host-numacpu-clang",
+      "configurePreset": "rel-host-numacpu-clang"
     },
     {
       "name": "rel-cuda-nvcc-gcc",
@@ -497,12 +740,20 @@
       "configurePreset": "rel-oneapi-gpu"
     },
     {
-      "name": "dbg-host-gcc",
-      "configurePreset": "dbg-host-gcc"
+      "name": "dbg-host-cpu-gcc",
+      "configurePreset": "dbg-host-cpu-gcc"
     },
     {
-      "name": "dbg-host-clang",
-      "configurePreset": "dbg-host-clang"
+      "name": "dbg-host-cpu-clang",
+      "configurePreset": "dbg-host-cpu-clang"
+    },
+    {
+      "name": "dbg-host-numacpu-gcc",
+      "configurePreset": "dbg-host-numacpu-gcc"
+    },
+    {
+      "name": "dbg-host-numacpu-clang",
+      "configurePreset": "dbg-host-numacpu-clang"
     },
     {
       "name": "dbg-cuda-nvcc-gcc",
@@ -529,40 +780,76 @@
       "configurePreset": "dbg-oneapi-gpu"
     },
     {
-      "name": "rel-host-headercheck",
-      "configurePreset": "rel-host-headercheck"
+      "name": "rel-host-cpu-headercheck",
+      "configurePreset": "rel-host-cpu-headercheck"
     },
     {
-      "name": "dbg-host-gcc-asan",
-      "configurePreset": "dbg-host-gcc-asan"
+      "name": "dbg-host-cpu-gcc-asan",
+      "configurePreset": "dbg-host-cpu-gcc-asan"
     },
     {
-      "name": "dbg-host-gcc-tsan",
-      "configurePreset": "dbg-host-gcc-tsan"
+      "name": "dbg-host-cpu-gcc-tsan",
+      "configurePreset": "dbg-host-cpu-gcc-tsan"
     },
     {
-      "name": "dbg-host-gcc-lsan",
-      "configurePreset": "dbg-host-gcc-lsan"
+      "name": "dbg-host-cpu-gcc-lsan",
+      "configurePreset": "dbg-host-cpu-gcc-lsan"
     },
     {
-      "name": "dbg-host-gcc-ubsan",
-      "configurePreset": "dbg-host-gcc-ubsan"
+      "name": "dbg-host-cpu-gcc-ubsan",
+      "configurePreset": "dbg-host-cpu-gcc-ubsan"
     },
     {
-      "name": "dbg-host-clang-asan",
-      "configurePreset": "dbg-host-clang-asan"
+      "name": "dbg-host-cpu-clang-asan",
+      "configurePreset": "dbg-host-cpu-clang-asan"
     },
     {
-      "name": "dbg-host-clang-tsan",
-      "configurePreset": "dbg-host-clang-tsan"
+      "name": "dbg-host-cpu-clang-tsan",
+      "configurePreset": "dbg-host-cpu-clang-tsan"
     },
     {
-      "name": "dbg-host-clang-lsan",
-      "configurePreset": "dbg-host-clang-lsan"
+      "name": "dbg-host-cpu-clang-lsan",
+      "configurePreset": "dbg-host-cpu-clang-lsan"
     },
     {
-      "name": "dbg-host-clang-ubsan",
-      "configurePreset": "dbg-host-clang-ubsan"
+      "name": "dbg-host-cpu-clang-ubsan",
+      "configurePreset": "dbg-host-cpu-clang-ubsan"
+    },
+    {
+      "name": "rel-host-numacpu-headercheck",
+      "configurePreset": "rel-host-numacpu-headercheck"
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-asan",
+      "configurePreset": "dbg-host-numacpu-gcc-asan"
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-tsan",
+      "configurePreset": "dbg-host-numacpu-gcc-tsan"
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-lsan",
+      "configurePreset": "dbg-host-numacpu-gcc-lsan"
+    },
+    {
+      "name": "dbg-host-numacpu-gcc-ubsan",
+      "configurePreset": "dbg-host-numacpu-gcc-ubsan"
+    },
+    {
+      "name": "dbg-host-numacpu-clang-asan",
+      "configurePreset": "dbg-host-numacpu-clang-asan"
+    },
+    {
+      "name": "dbg-host-numacpu-clang-tsan",
+      "configurePreset": "dbg-host-numacpu-clang-tsan"
+    },
+    {
+      "name": "dbg-host-numacpu-clang-lsan",
+      "configurePreset": "dbg-host-numacpu-clang-lsan"
+    },
+    {
+      "name": "dbg-host-numacpu-clang-ubsan",
+      "configurePreset": "dbg-host-numacpu-clang-ubsan"
     }
   ]
 }

--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -512,7 +512,7 @@ void testKernels(auto const deviceSpec, auto const exec)
     std::cout << metaData.serializeAsTable() << std::endl;
 }
 
-using Backends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using Backends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 // Run for all Accs given by the argument
 TEMPLATE_LIST_TEST_CASE("TEST: Babelstream Kernels<Float>", "[benchmark-test]", Backends)

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -157,6 +157,11 @@ if(NOT TARGET alpaka)
     target_compile_features(alpaka_target_headers INTERFACE cxx_std_${alpaka_CXX_STANDARD})
 
     target_link_libraries(alpaka INTERFACE alpaka_target_host)
+
+    option(alpaka_HOST_Cpu "Enable support for api::host and deviceKind::cpu in examples/benchmarks and tests" ON)
+    if(NOT alpaka_HOST_Cpu)
+        target_compile_definitions(alpaka_target_host INTERFACE ALPAKA_DISABLE_Host_Cpu)
+    endif()
 endif()
 
 set(alpaka_COUNT_API_DEPS 0)
@@ -218,9 +223,7 @@ if(NOT _alpaka_TARGETS_EXTENDED)
     set(_alpaka_TARGETS_EXTENDED ON ${_alpaka_EXPORT_SCOPE})
 
     ## HWLOC
-    if(alpaka_DEP_HWLOC)
-        include(${_alpaka_CMAKE_DIR}/alpakaHwloc.cmake)
-    endif()
+    include(${_alpaka_CMAKE_DIR}/alpakaHwloc.cmake)
 
     ## OpenMP
     # There is no way to get the correct flags for the language CUDA or HIP

--- a/cmake/alpakaCuda.cmake
+++ b/cmake/alpakaCuda.cmake
@@ -117,6 +117,15 @@ if(CMAKE_CUDA_COMPILER)
 
     target_compile_definitions(alpaka_target_cuda INTERFACE ALPAKA_CMAKE_TARGET_CUDA)
 
+    option(
+        alpaka_CUDA_NvidiaGpu
+        "Enable support for api::cuda and deviceKind::nvidiaGpu in examples/benchmarks and tests"
+        ON
+    )
+    if(NOT alpaka_CUDA_NvidiaGpu)
+        target_compile_definitions(alpaka_target_cuda INTERFACE ALPAKA_DISABLE_Cuda_NvidiaGpu)
+    endif()
+
     if(alpaka_COUNT_API_DEPS EQUAL 1)
         target_link_libraries(alpaka INTERFACE alpaka_target_cuda)
     endif()

--- a/cmake/alpakaHip.cmake
+++ b/cmake/alpakaHip.cmake
@@ -81,6 +81,11 @@ endif()
 target_compile_definitions(alpaka_target_hip INTERFACE ALPAKA_CMAKE_TARGET_HIP)
 target_link_libraries(alpaka_target_hip INTERFACE alpaka::headers)
 
+option(alpaka_HIP_AmdGpu "Enable support for api::hip and deviceKind::amdGpu in examples/benchmarks and tests" ON)
+if(NOT alpaka_HIP_AmdGpu)
+    target_compile_definitions(alpaka_target_hip INTERFACE ALPAKA_DISABLE_Hip_AmdGpu)
+endif()
+
 if(alpaka_COUNT_API_DEPS EQUAL 1)
     target_link_libraries(alpaka INTERFACE alpaka_target_hip)
 endif()

--- a/cmake/alpakaHwloc.cmake
+++ b/cmake/alpakaHwloc.cmake
@@ -47,7 +47,12 @@ endif()
 
 if(_alpaka_HAS_HWLOC)
     target_link_libraries(alpaka_target_host INTERFACE PkgConfig::HWLOC)
-    option(alpaka_HOST_NumaCpu "Enable host api numa cpu support for alpaka" ON)
+    option(
+        alpaka_HOST_NumaCpu
+        "Enable support for api::host and deviceKind::numaCpu in examples/benchmarks and tests"
+        ON
+    )
+
     option(
         alpaka_HOST_MemPinningCanFail
         "Allow that memory pinning with hwloc can fail, e.g. if not supported, no rights to pin memory."

--- a/docs/source/advanced/cmake.rst
+++ b/docs/source/advanced/cmake.rst
@@ -17,17 +17,17 @@ The `CMake Presets <https://cmake.org/cmake/help/latest/manual/cmake-presets.7.h
    cd <alpaka_project_root>
    cmake --list-presets
 
-To configure, build and run the tests of a specific preset, run the following commands (for the example, we use the ``rel-host-gcc`` preset):
+To configure, build and run the tests of a specific preset, run the following commands (for the example, we use the ``rel-host-cpu-gcc`` preset):
 
 .. code-block:: bash
 
    cd <alpaka_project_root>
    # configure a specific preset
-   cmake --preset rel-host-gcc
+   cmake --preset rel-host-cpu-gcc
    # build the preset
-   cmake --build --preset rel-host-gcc
+   cmake --build --preset rel-host-cpu-gcc
    # run test of the preset
-   ctest --preset rel-host-gcc
+   ctest --preset rel-host-cpu-gcc
 
 All presets are configure and build in a subfolder of the ``<alpaka_project_root>/build`` folder.
 
@@ -39,29 +39,29 @@ The easiest way to change a preset is to set CMake arguments during configuratio
 .. code-block:: bash
 
    cd <alpaka_project_root>
-   # configure the rel-host-gcc preset with clang++ as C++ compiler
-   cmake --preset rel-host-gcc -DCMAKE_CXX_COMPILER=clang++
+   # configure the rel-host-cpu-gcc preset with clang++ as C++ compiler
+   cmake --preset rel-host-cpu-gcc -DCMAKE_CXX_COMPILER=clang++
    # build the preset
-   cmake --build --preset rel-host-gcc
+   cmake --build --preset rel-host-cpu-gcc
    # run test of the preset
-   ctest --preset rel-host-gcc
+   ctest --preset rel-host-cpu-gcc
 
 It is also possible to configure the default setting first and then change the arguments with ``ccmake``:
 
 .. code-block:: bash
 
    cd <alpaka_project_root>
-   # configure the rel-host-gcc preset with clang++ as C++ compiler
-   cmake --preset rel-host-gcc
-   cd build/rel-host-gcc
+   # configure the rel-host-cpu-gcc preset with clang++ as C++ compiler
+   cmake --preset rel-host-cpu-gcc
+   cd build/rel-host-cpu-gcc
    ccmake .
    cd ../..
    # build the preset
-   cmake --build --preset rel-host-gcc
+   cmake --build --preset rel-host-cpu-gcc
    # run test of the preset
-   ctest --preset rel-host-gcc
+   ctest --preset rel-host-cpu-gcc
 
-CMake presets also offer the option of creating personal, user-specific configurations based on the predefined CMake presets. To do this, you can create the file ``CMakeUserPresets.json`` in the root directory of your project (the file is located directly next to ``CMakePresets.json``). You can then create your own configurations from the existing CMake presets. The following example takes the rel-host-gcc configuration, uses ``ninja`` as the generator instead of the standard generator and uses the build type ``RELEASE``.
+CMake presets also offer the option of creating personal, user-specific configurations based on the predefined CMake presets. To do this, you can create the file ``CMakeUserPresets.json`` in the root directory of your project (the file is located directly next to ``CMakePresets.json``). You can then create your own configurations from the existing CMake presets. The following example takes the rel-host-cpu-gcc configuration, uses ``ninja`` as the generator instead of the standard generator and uses the build type ``RELEASE``.
 
 .. code-block:: json
 
@@ -74,8 +74,8 @@ CMake presets also offer the option of creating personal, user-specific configur
       },
       "configurePresets": [
         {
-            "name": "rel-host-gcc-ninja-release",
-            "inherits": "rel-host-gcc",
+            "name": "rel-host-cpu-gcc-ninja-release",
+            "inherits": "rel-host-cpu-gcc",
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": {
@@ -158,6 +158,26 @@ Arguments
      - `STDSIMD`   - enforce that the CXX compiler supports `std::simd`, if not CMake will fail
      - `EMULATION` - disable the usage of `std::simd` even if supported by the CXX compiler
 
+Host
+^^^^
+
+``alpaka_HOST_Cpu``
+  .. code-block:: markdown
+
+     Enable/Disable the `api::host` device `deviceKind::cpu`.
+     This option effects the entries of the list `onHost::enabledDeviceSpecs` typically used in alpaka examples/benchmarks and tests.
+
+     **without CMake:** Define the preprocessor define `ALPAKA_DISABLE_Host_Cpu` to disable host CPU device support.
+
+``alpaka_HOST_NumaCpu``
+  .. code-block:: markdown
+
+     Enable/Disable the `api::host` device `deviceKind::numaCpu`.
+     Requires the dependency `hwloc`, can be enabled with the CMake option `-Dalpaka_DEP_HWLOC=ON`.
+     This option effects the entries of the list `onHost::enabledDeviceSpecs` typically used in alpaka examples/benchmarks and tests.
+
+     **without CMake:** Define the preprocessor define `ALPAKA_DISABLE_Host_NumaCpu` to disable host NUMA CPU device support.
+
 CUDA
 ^^^^
 
@@ -167,6 +187,15 @@ To enable the CUDA back-end please extend ``CMAKE_PREFIX_PATH`` with the path to
   .. code-block:: markdown
 
      Enable the CUDA API and the usage of the executor `exec::gpuCuda`.
+
+``alpaka_CUDA_NvidiaGpu``
+  .. code-block:: markdown
+
+     Enable/Disable the `api::cuda` device `deviceKind::nvidiaGpu`.
+     Requires the dependency `hwloc`.
+     This option effects the entries of the list `onHost::enabledDeviceSpecs` typically used in alpaka examples/benchmarks and tests.
+
+     **without CMake:** Define the preprocessor define `ALPAKA_DISABLE_Cuda_NvidiaGpu` to disable CUDA NVIDIA GPU device support.
 
 ``CMAKE_CUDA_ARCHITECTURES``
   .. code-block:: markdown
@@ -215,6 +244,15 @@ HIP
 
      Enable the HIP API and the usage of the executor `exec::gpuHip`.
 
+``alpaka_HIP_AmdGpu``
+  .. code-block:: markdown
+
+     Enable/Disable the `api::hip` device `deviceKind::amdGpu`.
+     Requires the dependency `hwloc`.
+     This option effects the entries of the list `onHost::enabledDeviceSpecs` typically used in alpaka examples/benchmarks and tests.
+
+     **without CMake:** Define the preprocessor define `ALPAKA_DISABLE_Hip_AmdGpu` to disable HIP AMD GPU device support.
+
 ``CMAKE_HIP_ARCHITECTURES``
   .. code-block:: markdown
 
@@ -241,23 +279,35 @@ oneAPI SYCL
   .. code-block:: markdown
 
      Enable SYCL oneAPI CPU device support.
+     This option effects the entries of the list `onHost::enabledDeviceSpecs` typically used in alpaka examples/benchmarks and tests.
+
+     **without CMake:** Define the preprocessor define `ALPAKA_DISABLE_OneApi_Cpu` to disable SYCL oneAPI CPU device support.
 
 ``alpaka_ONEAPI_IntelGpu``
   .. code-block:: markdown
 
      Enable SYCL oneAPI Intel GPU device support.
+     This option effects the entries of the list `onHost::enabledDeviceSpecs` typically used in alpaka examples/benchmarks and tests.
+
+     **without CMake:** Define the preprocessor define `ALPAKA_DISABLE_OneApi_IntelGpu` to disable SYCL oneAPI Intel GPU device support.
 
 ``alpaka_ONEAPI_NvidiaGpu``
   .. code-block:: markdown
 
      Enable SYCL oneAPI Nvidia GPU device support.
      Requires the oneAPI compiler extension for CUDA support.
+     This option effects the entries of the list `onHost::enabledDeviceSpecs` typically used in alpaka examples/benchmarks and tests.
+
+     **without CMake:** Define the preprocessor define `ALPAKA_DISABLE_OneApi_NvidiaGpu` to disable SYCL oneAPI NVIDIA GPU device support.
 
 ``alpaka_ONEAPI_AmdGpu``
   .. code-block:: markdown
 
      Enable SYCL oneAPI AMD GPU device support.
      Requires the oneAPI compiler extension for AMD ROCM support.
+     This option effects the entries of the list `onHost::enabledDeviceSpecs` typically used in alpaka examples/benchmarks and tests.
+
+     **without CMake:** Define the preprocessor define `ALPAKA_DISABLE_OneApi_AmdGpu` to disable SYCL oneAPI AMD GPU device support.
 
 OpenMP
 ^^^^^^
@@ -283,23 +333,16 @@ Numa Awareness
      You should utilize all NUMA devices to get the full performance of your CPU, this requires manual a domain decomposition of your problem to be able to run it on all NUMA devices.
      If you use a blocking host queue together with the serial executor the executing thread will only be pinned if it is not the thread of the process.
 
-    **attention** If `CMake` is not **NOT** and the header `hwloc.h` is found you need to link `-lhwloc` or disable `hwloc` support by defining the preprocessor define `ALPAKA_DISABLE_HWLOC`.
-
-``alpaka_HOST_NumaCpu``
-  .. code-block:: markdown
-
-     Enable/Disable the `host` device `numaCpu`.
-     Requires the dependency `hwloc`.
-     This option is currently affecting full alpaka and is disabling the support for the device kind `numaCPU` for the api `host`, the behaviour will be changed soon to effect examples, benchmarks and tests only.
+    **without CMake:** If the header `hwloc.h` is in the include path you should link `-lhwloc` or disable `hwloc` support by defining the preprocessor define `ALPAKA_DISABLE_HWLOC`.
 
 ``alpaka_HOST_MemPinningCanFail``
   .. code-block:: markdown
 
      Enable/Disable that the memory pinning via `hwloc` can fail.
+     On a system e.g. in container environments where it is not allowed to pin memory, this option can be enabled to allow that pinning can fail without an exception.
      Requires the dependency `hwloc`.
 
-    **attention** If `CMake` is not **NOT** defining the preprocessor define `ALPAKA_HOST_MEM_PINNING_CAN_FAIL` will allow that pinning can fail without an exception.
-
+    **without CMake:**  Defining the preprocessor define `ALPAKA_HOST_MEM_PINNING_CAN_FAIL` to allow that memory pinning can fail without an exception.
 
 Intel oneAPI Threading Building Blocks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -340,7 +383,7 @@ Executors
 
      Enable the HIP GPU executor `exec::gpuHip`.
 
-``alpaka_EXEC_OneApu``
+``alpaka_EXEC_OneApi``
   .. code-block:: markdown
 
      Enable the oneAPI SYCL executor `exec::oneApi`.

--- a/example/boundaryIter/src/boundaryIter.cpp
+++ b/example/boundaryIter/src/boundaryIter.cpp
@@ -173,5 +173,5 @@ auto main() -> int
      */
     return onHost::executeForEachIfHasDevice(
         [=](auto const& backend) { return example(backend[object::deviceSpec], backend[object::exec]); },
-        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/grayScale/src/grayScale.cpp
+++ b/example/grayScale/src/grayScale.cpp
@@ -352,5 +352,5 @@ auto main(int argc, char* argv[]) -> int
      */
     return onHost::executeForEachIfHasDevice(
         [=](auto const& tag) { return example(tag, numElements, numberOfRuns, enableStdForEach); },
-        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -355,5 +355,5 @@ auto main(int argc, char* argv[]) -> int
                 tMax,
                 enableCheck);
         },
-        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/nBody/src/nBody.cpp
+++ b/example/nBody/src/nBody.cpp
@@ -384,7 +384,7 @@ auto main(int argc, char* argv[]) -> int
         return onHost::executeForEachIfHasDevice(
             [=](auto const& backend)
             { return alpaka::example::nBody::benchmark(backend[object::deviceSpec], backend[object::exec], dt); },
-            onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+            onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
     }
     else
     {
@@ -400,6 +400,6 @@ auto main(int argc, char* argv[]) -> int
                     numTimeSteps,
                     dt);
             },
-            onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+            onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
     }
 }

--- a/example/randomInit/src/randomInit.cpp
+++ b/example/randomInit/src/randomInit.cpp
@@ -399,5 +399,5 @@ auto main(int argc, char* argv[]) -> int
             auto retVal = exampleUniformDist(tag, numElements) || exampleNormalDist(tag, numElementsNormal);
             return retVal;
         },
-        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/scan/src/scan_main.hpp
+++ b/example/scan/src/scan_main.hpp
@@ -210,7 +210,7 @@ auto main(int argc, char* argv[]) -> int
                 enableInPlace,
                 scanType);
         },
-        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 
     return result;
 }

--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -267,5 +267,5 @@ auto main() -> int
     return onHost::executeForEachIfHasDevice(
         [=](auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
-        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -285,5 +285,5 @@ auto main() -> int
     return onHost::executeForEachIfHasDevice(
         [=](auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
-        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -342,5 +342,5 @@ auto main() -> int
     return onHost::executeForEachIfHasDevice(
         [=](auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
-        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -277,5 +277,5 @@ auto main(int argc, char* argv[]) -> int
                 numElements,
                 numberOfRuns);
         },
-        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/vendorApi/src/main.cpp
+++ b/example/vendorApi/src/main.cpp
@@ -181,5 +181,5 @@ auto main(int argc, char* argv[]) -> int
     return onHost::executeForEachIfHasDevice(
         [=](auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec], numElements); },
-        onHost::allBackends(onHost::enabledApis, exec::enabledExecutors));
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/include/alpaka/api/host/Api.hpp
+++ b/include/alpaka/api/host/Api.hpp
@@ -52,14 +52,10 @@ namespace alpaka
         {
         };
 
-        /// @todo ALPAKA_DISABLE_OneApi_AmdGpu should not be used here, we should provide equal to executors a list of
-        /// enabled device kinds
-#if ALPAKA_HAS_HWLOC && !defined(ALPAKA_DISABLE_Host_NumaCpu)
         template<>
         struct IsDeviceSupportedBy::Op<deviceKind::NumaCpu, api::Host> : std::true_type
         {
         };
-#endif
     } // namespace onHost::trait
 
     namespace trait

--- a/include/alpaka/api/oneApi/Api.hpp
+++ b/include/alpaka/api/oneApi/Api.hpp
@@ -37,30 +37,26 @@ namespace alpaka
         struct IsPlatformAvailable::Op<api::OneApi> : std::true_type
         {
         };
-#    ifndef ALPAKA_DISABLE_OneApi_IntelGpu
+
         template<>
         struct IsDeviceSupportedBy::Op<deviceKind::IntelGpu, api::OneApi> : std::true_type
         {
         };
-#    endif
-#    ifndef ALPAKA_DISABLE_OneApi_NvidiaGpu
+
         template<>
         struct IsDeviceSupportedBy::Op<deviceKind::NvidiaGpu, api::OneApi> : std::true_type
         {
         };
-#    endif
-#    ifndef ALPAKA_DISABLE_OneApi_AmdGpu
+
         template<>
         struct IsDeviceSupportedBy::Op<deviceKind::AmdGpu, api::OneApi> : std::true_type
         {
         };
-#    endif
-#    ifndef ALPAKA_DISABLE_OneApi_Cpu
+
         template<>
         struct IsDeviceSupportedBy::Op<deviceKind::Cpu, api::OneApi> : std::true_type
         {
         };
-#    endif
     } // namespace onHost::trait
 
 #endif

--- a/include/alpaka/api/oneApi/Platform.hpp
+++ b/include/alpaka/api/oneApi/Platform.hpp
@@ -108,13 +108,23 @@ namespace alpaka::onHost::internal
     template<alpaka::concepts::DeviceKind T_DeviceKind, typename T_Any>
     struct IsDataAccessible::SecondPath<api::OneApi, T_DeviceKind, T_Any>
     {
-        static void getPtrType(auto const& platform, auto& sycl_data_alloc_type, auto const& view)
+        static void getPtrType(auto deviceKind, auto& sycl_data_alloc_type, auto const& view)
         {
-            auto sycl_context = platform->getContext();
-            auto sycl_alloc_type = get_pointer_type(Data::data(view), sycl_context);
+            try
+            {
+                auto platform
+                    = onHost::make_sharedSingleton<syclGeneric::Platform<api::OneApi, ALPAKA_TYPEOF(deviceKind)>>();
+                auto sycl_context = platform->getContext();
+                auto sycl_alloc_type = get_pointer_type(Data::data(view), sycl_context);
 
-            if(sycl_alloc_type != sycl::usm::alloc::unknown)
-                sycl_data_alloc_type = sycl_alloc_type;
+                if(sycl_alloc_type != sycl::usm::alloc::unknown)
+                    sycl_data_alloc_type = sycl_alloc_type;
+            }
+            catch(...)
+            {
+                // do to mising drivers or other issues we can not query the pointer type, in this case we assume that
+                // the memory is not accessible for the device
+            }
         }
 
         bool operator()(api::OneApi usedApi, T_DeviceKind deviceKind, T_Any const& view) const
@@ -123,13 +133,7 @@ namespace alpaka::onHost::internal
             auto sycl_data_alloc_type = sycl::usm::alloc::unknown;
             alpaka::apply(
                 [&sycl_data_alloc_type, &view](auto... devKind)
-                {
-                    (getPtrType(
-                         onHost::make_sharedSingleton<syclGeneric::Platform<api::OneApi, ALPAKA_TYPEOF(devKind)>>(),
-                         sycl_data_alloc_type,
-                         view),
-                     ...);
-                },
+                { (getPtrType(devKind, sycl_data_alloc_type, view), ...); },
                 deviceKindList);
 
             if(deviceKind == deviceKind::cpu || deviceKind == deviceKind::numaCpu)

--- a/include/alpaka/onHost/DeviceSelector.hpp
+++ b/include/alpaka/onHost/DeviceSelector.hpp
@@ -4,65 +4,12 @@
 
 #pragma once
 
-#include "alpaka/api/host/Api.hpp"
 #include "alpaka/onHost/Device.hpp"
-#include "alpaka/tag.hpp"
+#include "alpaka/onHost/DeviceSpec.hpp"
 #include "alpaka/utility.hpp"
 
 namespace alpaka::onHost
 {
-    /** @brief Concept for a combination of an API and device kind
-     *
-     * @details
-     * A device specification means the combination of an API and a device kind. Multiple instances of
-     * alpaka::onHost::Device can exist for the same device specification, for example in the form of multiple GPUs of
-     * the same type in one system.
-     *
-     * To check whether a specific combination is valid, i.e., whether an API can target a device kind, the static
-     * isValid() method can be used.
-     */
-    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
-    struct DeviceSpec
-    {
-    public:
-        constexpr DeviceSpec(T_Api api, T_DeviceKind deviceType) : m_api(api), m_deviceType(deviceType)
-        {
-        }
-
-        constexpr DeviceSpec() = default;
-
-        constexpr T_DeviceKind getDeviceKind() const
-        {
-            return m_deviceType;
-        }
-
-        constexpr T_Api getApi() const
-        {
-            return m_api;
-        }
-
-        std::string getName() const
-        {
-            return m_api.getName() + " " + m_deviceType.getName();
-        }
-
-        /** Checks if the device kind and api combination is valid
-         *
-         * Reasons why a combination is valid can be that the api does not know how to talk to a device or that the
-         * required dependencies e.g. CUDA, HIP, or OneApi are not fulfilled.
-         *
-         * @return true if the device kind and api combination is valid, else false
-         */
-        static constexpr bool isValid()
-        {
-            return trait::IsDeviceSupportedBy::Op<T_DeviceKind, T_Api>::value;
-        }
-
-    private:
-        T_Api m_api;
-        T_DeviceKind m_deviceType;
-    };
-
     template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     struct DeviceSelector
     {
@@ -132,13 +79,4 @@ namespace alpaka::onHost
             deviceKind::cpu}
             .makeDevice(0);
     }
-
-    namespace concepts
-    {
-        /** Concept to check for specializations of alpaka::onHost::DeviceSpec
-         */
-        template<typename T>
-        concept DeviceSpec = isSpecializationOf_v<T, onHost::DeviceSpec>;
-    } // namespace concepts
-
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/DeviceSpec.hpp
+++ b/include/alpaka/onHost/DeviceSpec.hpp
@@ -1,0 +1,120 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/api.hpp"
+#include "alpaka/core/config.hpp"
+#include "alpaka/tag.hpp"
+
+#include <tuple>
+
+namespace alpaka::onHost
+{
+    /** @brief Concept for a combination of an API and device kind
+     *
+     * @details
+     * A device specification means the combination of an API and a device kind. Multiple instances of
+     * alpaka::onHost::Device can exist for the same device specification, for example in the form of multiple GPUs of
+     * the same type in one system.
+     *
+     * To check whether a specific combination is valid, i.e., whether an API can target a device kind, the static
+     * isValid() method can be used.
+     */
+    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
+    struct DeviceSpec
+    {
+    public:
+        constexpr DeviceSpec(T_Api api, T_DeviceKind deviceType) : m_api(api), m_deviceType(deviceType)
+        {
+        }
+
+        constexpr DeviceSpec() = default;
+
+        constexpr T_DeviceKind getDeviceKind() const
+        {
+            return m_deviceType;
+        }
+
+        constexpr T_Api getApi() const
+        {
+            return m_api;
+        }
+
+        std::string getName() const
+        {
+            return m_api.getName() + " " + m_deviceType.getName();
+        }
+
+        /** Checks if the device kind and api combination is valid
+         *
+         * Reasons why a combination is valid can be that the api does not know how to talk to a device or that the
+         * required dependencies e.g. CUDA, HIP, or OneApi are not fulfilled.
+         *
+         * @return true if the device kind and api combination is valid, else false
+         */
+        static constexpr bool isValid()
+        {
+            if constexpr(requires { trait::IsDeviceSupportedBy::Op<T_DeviceKind, T_Api>::value; })
+                return trait::IsDeviceSupportedBy::Op<T_DeviceKind, T_Api>::value;
+            else
+                return false;
+        }
+
+    private:
+        T_Api m_api;
+        T_DeviceKind m_deviceType;
+    };
+
+    /** list of enabled device specifications
+     *
+     * - device specifications can be dis-/enabled by the CMake options alpaka_<API>_<DeviceKindType>
+     * - the second way to disable a device specifications is to define the preprocessor define
+     * ALPAKA_DISABLE_<ApiType>_<DeviceKindType>, else the device specification is enabled
+     */
+    constexpr auto enabledDeviceSpecs = std::tuple_cat(
+        std::tuple<>{}
+#if !defined(ALPAKA_DISABLE_Host_Cpu)
+        ,
+        std::tuple{DeviceSpec{api::host, deviceKind::cpu}}
+#endif
+#if !defined(ALPAKA_DISABLE_Host_NumaCpu) && ALPAKA_HAS_HWLOC
+        ,
+        std::tuple{DeviceSpec{api::host, deviceKind::numaCpu}}
+#endif
+#if !defined(ALPAKA_DISABLE_OneApi_IntelGpu) && ALPAKA_LANG_ONEAPI
+        ,
+        std::tuple{DeviceSpec{api::oneApi, deviceKind::intelGpu}}
+#endif
+#if !defined(ALPAKA_DISABLE_OneApi_NvidiaGpu) && ALPAKA_LANG_ONEAPI
+        ,
+        std::tuple{DeviceSpec{api::oneApi, deviceKind::nvidiaGpu}}
+#endif
+#if !defined(ALPAKA_DISABLE_OneApi_AmdGpu) && ALPAKA_LANG_ONEAPI
+        ,
+        std::tuple{DeviceSpec{api::oneApi, deviceKind::amdGpu}}
+#endif
+#if !defined(ALPAKA_DISABLE_OneApi_Cpu) && ALPAKA_LANG_ONEAPI
+        ,
+        std::tuple{DeviceSpec{api::oneApi, deviceKind::cpu}}
+#endif
+#if !defined(ALPAKA_DISABLE_Cuda_NvidiaGpu) && ALPAKA_LANG_CUDA
+        ,
+        std::tuple{DeviceSpec{api::cuda, deviceKind::nvidiaGpu}}
+#endif
+#if !defined(ALPAKA_DISABLE_Hip_AmdGpu) && ALPAKA_LANG_HIP
+        ,
+        std::tuple{DeviceSpec{api::hip, deviceKind::amdGpu}}
+#endif
+    );
+
+    namespace concepts
+    {
+        /** Concept to check for specializations of alpaka::onHost::DeviceSpec
+         */
+        template<typename T>
+        concept DeviceSpec = isSpecializationOf_v<T, onHost::DeviceSpec>;
+    } // namespace concepts
+
+} // namespace alpaka::onHost

--- a/include/alpaka/onHost/interface.hpp
+++ b/include/alpaka/onHost/interface.hpp
@@ -213,14 +213,25 @@ namespace alpaka::onHost
      * @param deviceSpec      device specification to be used
      * @param listOfExecutors tuple of executor types to be filtered
      * @return a tuple containing the supported executor types
+     *
+     * @{
      */
     constexpr auto getExecutorsList(auto const deviceSpec, auto const listOfExecutors)
+        requires(ALPAKA_TYPEOF(deviceSpec)::isValid())
     {
         using DevSelectorType = decltype(makeDeviceSelector(deviceSpec));
         using DeviceType = decltype(std::declval<DevSelectorType>().makeDevice(0));
         using ExecutorListType = decltype(supportedExecutors(std::declval<DeviceType>(), listOfExecutors));
         return ExecutorListType{};
     }
+
+    constexpr auto getExecutorsList(auto const deviceSpec, auto const listOfExecutors)
+    {
+        alpaka::unused(deviceSpec, listOfExecutors);
+        return std::tuple<>{};
+    }
+
+    /**@} */
 
     /** Create a tuple of device specifications for a single API.
      *
@@ -292,7 +303,8 @@ namespace alpaka::onHost
      * @param listOfExecutors tuple of executor types
      * @return a tuple of backend dictionaries covering all APIs and executors
      */
-    consteval auto allBackends(auto const usedApis, auto const listOfExecutors)
+    template<alpaka::concepts::Api... T_Apis>
+    consteval auto allBackends(std::tuple<T_Apis...> const& usedApis, auto const listOfExecutors)
     {
         return std::apply(
             [listOfExecutors](auto... api) constexpr
@@ -300,5 +312,18 @@ namespace alpaka::onHost
             usedApis);
     }
 
-    /** @} */
+    /** Generate the full set of backend dictionaries for a set of device kinds.
+     *
+     * The result contains a backend entry for each combination of supported device
+     * specification and executors.
+     *
+     * @param usedDeviceSpecs tuple of alpaka device kinds
+     * @param listOfExecutors tuple of executor types
+     * @return a tuple of backend dictionaries covering all device kinds and executors
+     */
+    template<concepts::DeviceSpec... T_DevicesSpecs>
+    consteval auto allBackends(std::tuple<T_DevicesSpecs...> const& usedDeviceSpecs, auto const& listOfExecutors)
+    {
+        return std::tuple_cat(createBackendList(usedDeviceSpecs, listOfExecutors));
+    }
 } // namespace alpaka::onHost

--- a/test/unit/algorithm/concurrent.cpp
+++ b/test/unit/algorithm/concurrent.cpp
@@ -15,7 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 /** Stencil SIMD functor
  *

--- a/test/unit/algorithm/iota.cpp
+++ b/test/unit/algorithm/iota.cpp
@@ -15,7 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 template<typename T_DataType>
 void executeTest(concepts::Executor auto exec, auto const& computeQueue, concepts::Vector auto extentMd)

--- a/test/unit/algorithm/reduce.cpp
+++ b/test/unit/algorithm/reduce.cpp
@@ -15,7 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 // This functor des not support Simd and must be wrapped by @see ScalarFunc
 struct MinValue

--- a/test/unit/algorithm/scan.cpp
+++ b/test/unit/algorithm/scan.cpp
@@ -15,7 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 template<typename T_Data>
 int validateResult(

--- a/test/unit/algorithm/transform.cpp
+++ b/test/unit/algorithm/transform.cpp
@@ -15,7 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 /** Stencil SIMD functor
  *

--- a/test/unit/algorithm/transformReduce.cpp
+++ b/test/unit/algorithm/transformReduce.cpp
@@ -15,7 +15,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 /** Stencil SIMD functor
  *

--- a/test/unit/atomic/atomic.cpp
+++ b/test/unit/atomic/atomic.cpp
@@ -14,7 +14,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 using namespace alpaka::test::unit::atomic;
 

--- a/test/unit/atomic/atomicAdd.cpp
+++ b/test/unit/atomic/atomicAdd.cpp
@@ -11,7 +11,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 struct AtomicIncrementKernel
 {

--- a/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -12,7 +12,7 @@
 using namespace alpaka;
 using namespace alpaka::onHost;
 
-using TestApis = std::decay_t<decltype(allBackends(enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 /* We can not check passing the attributes 'const', 'static' or 'constexpr' because this is not supported by OneApi
  * 2025.2 with AMD gpus.

--- a/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -82,6 +82,12 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
     std::cout << deviceSpec.getApi().getName() << std::endl;
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
     onHost::Device device = devSelector.makeDevice(0);
 
     std::cout << "device name: " << device.getName() << "\n";
@@ -197,6 +203,12 @@ TEMPLATE_LIST_TEST_CASE("device global mem copy", "", TestApis)
     std::cout << deviceSpec.getApi().getName() << std::endl;
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
     onHost::Device device = devSelector.makeDevice(0);
 
     std::cout << device.getName() << std::endl;

--- a/test/unit/event/event.cpp
+++ b/test/unit/event/event.cpp
@@ -33,7 +33,7 @@
 using namespace alpaka;
 using namespace alpaka::test::event;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 /** This test takes care that kernel in different queues can run concurrent and if we can communicate between host and
  * the device via mapped memory. Even if the concurrent queue test says true it could be that kernels can run under the

--- a/test/unit/intrinsic/clz.cpp
+++ b/test/unit/intrinsic/clz.cpp
@@ -10,7 +10,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 struct PopcountKernel
 {

--- a/test/unit/intrinsic/ffs.cpp
+++ b/test/unit/intrinsic/ffs.cpp
@@ -10,7 +10,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 struct TestKernel
 {

--- a/test/unit/intrinsic/popc.cpp
+++ b/test/unit/intrinsic/popc.cpp
@@ -10,7 +10,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 struct TestKernel
 {

--- a/test/unit/math/ADL.cpp
+++ b/test/unit/math/ADL.cpp
@@ -18,7 +18,7 @@
 #include <cmath>
 
 using namespace alpaka;
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 namespace custom
 {

--- a/test/unit/math/ComplexDouble.cpp
+++ b/test/unit/math/ComplexDouble.cpp
@@ -16,7 +16,7 @@
 #include <tuple>
 #include <type_traits>
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 // This file only has unit tests for complex numbers in order to split the tests between object files and save compiler
 // memory. For the same reason single- and double-precision are done separately and not wrapped into a common template.

--- a/test/unit/math/ComplexFloat.cpp
+++ b/test/unit/math/ComplexFloat.cpp
@@ -16,7 +16,7 @@
 #include <tuple>
 #include <type_traits>
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 // This file only has unit tests for complex numbers in order to split the tests between object files and save compiler
 // memory. For the same reason single- and double-precision are done separately and not wrapped into a common template.

--- a/test/unit/math/Double.cpp
+++ b/test/unit/math/Double.cpp
@@ -14,7 +14,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 // This file only has unit tests for real numbers in order to split the tests between object files
 using FunctorsReal = alpaka::meta::

--- a/test/unit/math/Float.cpp
+++ b/test/unit/math/Float.cpp
@@ -14,7 +14,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 // This file only has unit tests for real numbers in order to split the tests between object files
 using FunctorsReal = alpaka::meta::

--- a/test/unit/math/powMixedTypes.cpp
+++ b/test/unit/math/powMixedTypes.cpp
@@ -66,7 +66,7 @@ struct PowMixedTypesTestKernel
     }
 };
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 TEMPLATE_LIST_TEST_CASE("powMixedTypes", "[powMixedTypes]", TestBackends)
 {

--- a/test/unit/math/sincos.cpp
+++ b/test/unit/math/sincos.cpp
@@ -16,7 +16,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 struct SinCosTestKernel
 {

--- a/test/unit/mem/alloc.cpp
+++ b/test/unit/mem/alloc.cpp
@@ -11,7 +11,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 struct IotaValidate
 {

--- a/test/unit/mem/allocDeferred.cpp
+++ b/test/unit/mem/allocDeferred.cpp
@@ -11,7 +11,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 struct RaceCheckKernel
 {

--- a/test/unit/mem/keepAlive.cpp
+++ b/test/unit/mem/keepAlive.cpp
@@ -12,7 +12,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 using IdxType = std::size_t;
 using ValType = int;
 

--- a/test/unit/mem/memFenceBasic.cpp
+++ b/test/unit/mem/memFenceBasic.cpp
@@ -15,7 +15,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 // Compilation and stability test kernel. Does not validate correctness of the fence implementations.
 struct MemoryFenceTestKernel

--- a/test/unit/mem/memFenceProducerConsumer.cpp
+++ b/test/unit/mem/memFenceProducerConsumer.cpp
@@ -17,7 +17,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 // Producer-Consumer kernel documentation:
 //  - Producer (thread 0) publishes a payload (value = iteration index) to global memory,

--- a/test/unit/queue/blockingQueue.cpp
+++ b/test/unit/queue/blockingQueue.cpp
@@ -22,7 +22,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 // Any value for testing
 constexpr uint32_t kTestFillValue = 49u;

--- a/test/unit/queue/kernelMD.cpp
+++ b/test/unit/queue/kernelMD.cpp
@@ -17,7 +17,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 struct LastSetDataBlockIdx
 {

--- a/test/unit/queue/queue.cpp
+++ b/test/unit/queue/queue.cpp
@@ -11,7 +11,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 struct NoArgumentsKernel
 {

--- a/test/unit/rand/uniformReal.cpp
+++ b/test/unit/rand/uniformReal.cpp
@@ -17,7 +17,7 @@
 
 using namespace alpaka;
 
-using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 template<
     rand::concepts::UniformRandomEngine T_Engine,

--- a/test/unit/sharedMem/sharedMem.cpp
+++ b/test/unit/sharedMem/sharedMem.cpp
@@ -12,7 +12,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 template<uint32_t T_blockSize>
 struct SharedBlockIotaKernel

--- a/test/unit/wait/device.cpp
+++ b/test/unit/wait/device.cpp
@@ -12,7 +12,7 @@ using namespace alpaka;
 // any value for testing
 int const testValue = 49;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 // Simple write kernel used to create actual device work for testing wait(device).
 struct WaitTestWriteKernel

--- a/test/unit/warp/iota.cpp
+++ b/test/unit/warp/iota.cpp
@@ -11,7 +11,7 @@
 
 using namespace alpaka;
 
-using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 struct IotaKernelND
 {

--- a/test/unit/warp/utils.hpp
+++ b/test/unit/warp/utils.hpp
@@ -12,7 +12,8 @@
 
 namespace alpaka::test::warp
 {
-    using WarpTestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+    using WarpTestBackends
+        = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
     template<typename SuccessView>
     // Marks the shared success flag false when a lane detects a failure without aborting execution.


### PR DESCRIPTION
- add list `enabledDeviceSpecs` containing all device specs enabled based on CMake options or macro defines
- add generator `enabledBackends` which takes a device specification list e.g.i pre defined `enabledDeviceSpecs`
- add CMake options to control device specification as we had already for oneApi
  - `alpaka_HOST_Cpu`, `alpaka_HOST_NumaCpu`, `alpaka_CUDA_NvidiaGpu` and `alpaka_HIP_AmdGpu`
- update documentation
- update presets to build only for the combination the name suggests
- use `onHost::allBackends(onHost::enabledDeviceSpecs,exec::enabledExecutors)` for examples, tests and benchmarks

This PR solves an issue that oneApi devices were disabled by CMake options (e.g. `alpaka-ONEAPI_NvidiaGpu`) completely in alpaka instead of only for examples, tests, and benchmarks.