### PR TITLE
fix function interface registration check

### DIFF
--- a/include/alpaka/fn.hpp
+++ b/include/alpaka/fn.hpp
@@ -176,7 +176,7 @@ namespace alpaka::fn
         /** Checks if a function overload is registered for the given device specification.
          *
          * You can use the result to optionally call the function overload and disable at compile time code sections
-         * similar to C** preprocessor guards.
+         * similar to C++ preprocessor guards.
          * @code
          * ALPAKA_FN_SYMBOL(Foo,alpaka::fn::Fallback::none, alpaka::fn::Registration::enforced);
          *
@@ -193,13 +193,36 @@ namespace alpaka::fn
          * @endcode
          *
          * @param any any type which is usable with alpaka::getApi() and alpaka::getDeviceKind()
-         * @return true if the function type T_FnClass is registered else false.
+         * @return true if the function overload T_FnClass is registered else false.
+         * It does not try to check if a fallback overload is dispatchable, to check fallback registrations use
+         * hasRegisteredFallback(alpaka::concepts::DeviceSpec auto const& any).
          */
         static constexpr bool isRegistered(alpaka::concepts::DeviceSpec auto const& any)
             requires(T_registrationPolicy != Registration::none)
         {
-            return T_registrationPolicy == Registration::alwaysTrue || concepts::FnRegistered<ALPAKA_TYPEOF(spec(any))>
-                   || ((T_fallbackPolicy != Fallback::none) && concepts::FnRegistered<ALPAKA_TYPEOF(spec(any))>);
+            return T_registrationPolicy == Registration::alwaysTrue
+                   || concepts::FnRegistered<ALPAKA_TYPEOF(spec(any))>;
+        }
+
+        /** Checks if the function overload fallback is registered.
+         *
+         * Similar to isRegistered(alpaka::concepts::DeviceSpec auto const& any) but it checks for the fallback
+         * overload only.
+         *
+         * @param any any type which is usable with alpaka::getApi() and alpaka::getDeviceKind()
+         * @return true if the function overload fallback for T_FnClass is registered else false.
+         */
+        static constexpr bool hasRegisteredFallback(alpaka::concepts::DeviceSpec auto const& any)
+            requires(T_registrationPolicy != Registration::none)
+        {
+            constexpr bool isFallbackAllowed = T_fallbackPolicy != Fallback::none;
+            constexpr bool hasAlpakaFallback
+                = ((T_fallbackPolicy == Fallback::toAlpaka)
+                   && concepts::FnRegistered<ALPAKA_TYPEOF(spec(api::Alpaka{}, getDeviceKind(any)))>);
+            constexpr bool hasGenericFallback
+                = ((T_fallbackPolicy == Fallback::toGeneric) && concepts::FnRegistered<T_FnClass>);
+            return T_registrationPolicy == Registration::alwaysTrue
+                   || (isFallbackAllowed && (hasAlpakaFallback || hasGenericFallback));
         }
 
         /** Call function overload if defined for the given device specification. */

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -142,6 +142,11 @@ namespace alpaka::onHost
         {
             return T_DeviceKind{};
         }
+
+        constexpr alpaka::concepts::Api auto getApi() const
+        {
+            return T_Api{};
+        }
     };
 
     namespace concepts

--- a/test/unit/fn/fn.cpp
+++ b/test/unit/fn/fn.cpp
@@ -1,0 +1,211 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <iostream>
+
+
+using namespace alpaka;
+
+ALPAKA_FN_SYMBOL(FnFallBackAlpakaRegisterEnforced, alpaka::fn::Fallback::toAlpaka, alpaka::fn::Registration::enforced);
+
+constexpr void fnRegister(FnFallBackAlpakaRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
+{
+}
+
+template<concepts::DeviceKind T_DeviceKind>
+constexpr void fnRegister(FnFallBackAlpakaRegisterEnforced::Spec<alpaka::fn::api::Alpaka, T_DeviceKind>)
+{
+}
+
+constexpr int fnDispatch(
+    FnFallBackAlpakaRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>,
+    auto const&)
+{
+    return 42;
+}
+
+template<concepts::DeviceKind T_DeviceKind>
+constexpr int fnDispatch(FnFallBackAlpakaRegisterEnforced::Spec<alpaka::fn::api::Alpaka, T_DeviceKind>, auto const&)
+{
+    return 43;
+}
+
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+
+TEMPLATE_LIST_TEST_CASE("fn with alpaka fallback", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+
+    if constexpr(device.getApi() == api::host && device.getDeviceKind() == deviceKind::cpu)
+    {
+        STATIC_CHECK(FnFallBackAlpakaRegisterEnforced::isRegistered(device));
+        STATIC_CHECK(FnFallBackAlpakaRegisterEnforced::hasRegisteredFallback(device));
+        CHECK(FnFallBackAlpakaRegisterEnforced::call(device) == 42);
+    }
+    else if constexpr(device.getApi() == api::host)
+    {
+        // fallback to alpaka overload
+        STATIC_CHECK_FALSE(FnFallBackAlpakaRegisterEnforced::isRegistered(device));
+        STATIC_CHECK(FnFallBackAlpakaRegisterEnforced::hasRegisteredFallback(device));
+        CHECK(FnFallBackAlpakaRegisterEnforced::call(device) == 43);
+    }
+    else
+    {
+        // for all non host apis we fallback to the alpaka overload
+        STATIC_CHECK_FALSE(FnFallBackAlpakaRegisterEnforced::isRegistered(device));
+        STATIC_CHECK(FnFallBackAlpakaRegisterEnforced::hasRegisteredFallback(device));
+        CHECK(FnFallBackAlpakaRegisterEnforced::call(device) == 43);
+    }
+}
+
+ALPAKA_FN_SYMBOL(
+    FnFallBackGenericRegisterEnforced,
+    alpaka::fn::Fallback::toGeneric,
+    alpaka::fn::Registration::enforced);
+
+constexpr void fnRegister(FnFallBackGenericRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
+{
+}
+
+constexpr void fnRegister(FnFallBackGenericRegisterEnforced)
+{
+}
+
+constexpr int fnDispatch(
+    FnFallBackGenericRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>,
+    auto const&)
+{
+    return 52;
+}
+
+constexpr int fnDispatch(FnFallBackGenericRegisterEnforced, auto const&)
+{
+    return 53;
+}
+
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+
+TEMPLATE_LIST_TEST_CASE("fn with generic fallback", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+
+    if constexpr(device.getApi() == api::host && device.getDeviceKind() == deviceKind::cpu)
+    {
+        STATIC_CHECK(FnFallBackGenericRegisterEnforced::isRegistered(device));
+        STATIC_CHECK(FnFallBackGenericRegisterEnforced::hasRegisteredFallback(device));
+        // we do not specialize the api::Alpaka overload
+        STATIC_CHECK_FALSE(
+            FnFallBackGenericRegisterEnforced::isRegistered(
+                onHost::DeviceSpec<alpaka::fn::api::Alpaka, deviceKind::Cpu>{}));
+        CHECK(FnFallBackGenericRegisterEnforced::call(device) == 52);
+    }
+    else if constexpr(device.getApi() == api::host)
+    {
+        // fallback to alpaka overload
+        STATIC_CHECK_FALSE(FnFallBackGenericRegisterEnforced::isRegistered(device));
+        STATIC_CHECK(FnFallBackGenericRegisterEnforced::hasRegisteredFallback(device));
+        // we do not specialize the api::Alpaka overload
+        STATIC_CHECK_FALSE(
+            FnFallBackGenericRegisterEnforced::isRegistered(
+                onHost::DeviceSpec<alpaka::fn::api::Alpaka, deviceKind::Cpu>{}));
+        CHECK(FnFallBackGenericRegisterEnforced::call(device) == 53);
+    }
+    else
+    {
+        // for all non host apis we fallback to the alpaka overload
+        STATIC_CHECK_FALSE(FnFallBackGenericRegisterEnforced::isRegistered(device));
+        STATIC_CHECK(FnFallBackGenericRegisterEnforced::hasRegisteredFallback(device));
+        // we do not specialize the api::Alpaka overload
+        STATIC_CHECK_FALSE(
+            FnFallBackGenericRegisterEnforced::isRegistered(
+                onHost::DeviceSpec<alpaka::fn::api::Alpaka, deviceKind::Cpu>{}));
+        CHECK(FnFallBackGenericRegisterEnforced::call(device) == 53);
+    }
+}
+
+/** For the next test the fallback overloads will be declared but since the function symbol definition is
+ * Fallback::none querries for the fallback status must return false.
+ */
+ALPAKA_FN_SYMBOL(FnFallBackNoRegisterEnforced, alpaka::fn::Fallback::none, alpaka::fn::Registration::enforced);
+
+constexpr void fnRegister(FnFallBackNoRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
+{
+}
+
+constexpr void fnRegister(FnFallBackNoRegisterEnforced)
+{
+}
+
+constexpr int fnDispatch(FnFallBackNoRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>, auto const&)
+{
+    return 62;
+}
+
+constexpr int fnDispatch(FnFallBackNoRegisterEnforced, auto const&)
+{
+    return 63;
+}
+
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, exec::enabledExecutors))>;
+
+TEMPLATE_LIST_TEST_CASE("fn without fallback", "", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+
+    if constexpr(device.getApi() == api::host && device.getDeviceKind() == deviceKind::cpu)
+    {
+        STATIC_CHECK(FnFallBackNoRegisterEnforced::isRegistered(device));
+        STATIC_CHECK_FALSE(FnFallBackNoRegisterEnforced::hasRegisteredFallback(device));
+        // we do not specialize the api::Alpaka overload
+        STATIC_CHECK_FALSE(
+            FnFallBackNoRegisterEnforced::isRegistered(
+                onHost::DeviceSpec<alpaka::fn::api::Alpaka, deviceKind::Cpu>{}));
+        CHECK(FnFallBackNoRegisterEnforced::call(device) == 62);
+    }
+    else
+    {
+        // we can not cal the symbol because we do not have a fallback
+        STATIC_CHECK_FALSE(FnFallBackNoRegisterEnforced::isRegistered(device));
+        STATIC_CHECK_FALSE(FnFallBackNoRegisterEnforced::hasRegisteredFallback(device));
+        // we do not specialize the api::Alpaka overload
+        STATIC_CHECK_FALSE(
+            FnFallBackNoRegisterEnforced::isRegistered(
+                onHost::DeviceSpec<alpaka::fn::api::Alpaka, deviceKind::Cpu>{}));
+    }
+}


### PR DESCRIPTION
Fix the wrong implementation of the function interface registration check.

- introduce `hasRegisteredFallback()` to check for the fallback
  registration only
- add test cases, to guard against wrong behaviour
- add `getApi()` to `onHost::Device`