### PR TITLE
refactor tutorial documentation

### DIFF
--- a/docs/snippets/example/02_execution.cpp
+++ b/docs/snippets/example/02_execution.cpp
@@ -1,0 +1,62 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <iostream>
+
+using namespace alpaka;
+
+TEST_CASE("tutorial enumerate backends and executors", "[docs]")
+{
+    // BEGIN-TUTORIAL-enumerateDeviceSpec
+    // Numa aware CPU: onHost::DeviceSpec{api::host, deviceKind::numaCpu};
+    // Nvidia GPU: onHost::DeviceSpec{api::cuda, deviceKind::nvidiaGpu};
+    // Amd GPU: onHost::DeviceSpec{api::hip, deviceKind::amdGpu};
+    // Intel GPU: onHost::DeviceSpec{api::oneApi, deviceKind::intelGpu};
+    // this call selects the host Cpu
+    auto deviceSpec = onHost::DeviceSpec{api::host, deviceKind::cpu};
+    auto selector = onHost::makeDeviceSelector(deviceSpec);
+
+    auto numDevices = selector.getDeviceCount();
+    REQUIRE(numDevices >= 1u);
+
+    auto properties = selector.getDeviceProperties(0u);
+    onHost::concepts::Device auto device = selector.makeDevice(0u);
+    // END-TUTORIAL-enumerateDeviceSpec
+
+    CHECK(properties.warpSize >= 1u);
+    CHECK(!device.getName().empty());
+
+    size_t numVisitedBackends = 0u;
+    // BEGIN-TUTORIAL-enumerateBackends
+    onHost::executeForEachIfHasDevice(
+        [&](auto const& backend)
+        {
+            ++numVisitedBackends;
+
+            auto backendDeviceSpec = backend[object::deviceSpec];
+            auto backendExec = backend[object::exec];
+            auto backendSelector = onHost::makeDeviceSelector(backendDeviceSpec);
+            onHost::concepts::Device auto backendDevice = backendSelector.makeDevice(0u);
+            onHost::Queue backendQueue = backendDevice.makeQueue();
+
+            backendQueue.enqueueHostFn(
+                [=]() noexcept
+                {
+                    std::cout << "Run with device " << backendDevice.getName() << " and executor "
+                              << backendExec.getName() << std::endl;
+                });
+            onHost::wait(backendQueue);
+
+            alpaka::unused(backendExec);
+            return EXIT_SUCCESS;
+        },
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
+    // END-TUTORIAL-enumerateBackends
+
+    CHECK(numVisitedBackends >= 1u);
+}

--- a/docs/snippets/example/05_device.cpp
+++ b/docs/snippets/example/05_device.cpp
@@ -26,7 +26,7 @@ TEST_CASE("show host devices", "[docs]")
     // END-TUTORIAL-devCount
 
     // BEGIN-TUTORIAL-devHandleCount
-    // Always check the number of available compute devices! Alpaka always creates a valid DeviceSelector even for
+    // Always check the number of available compute devices! alpaka always creates a valid DeviceSelector even for
     // unsupported combinations of an api and deviceKind.
     if(numComputeDevs > 0)
     {
@@ -53,7 +53,7 @@ TEST_CASE("host device", "[docs]")
     // BEGIN-TUTORIAL-devHostDev
     // Get a device to perform work on the host.
     // It is a shortcut compared to using the makeDeviceSelector(...) to get a host device.
-    auto hostDevice = onHost::makeHostDevice();
+    onHost::concepts::Device auto hostDevice = onHost::makeHostDevice();
     // END-TUTORIAL-devHostDev
 
     // Getting a queue to enqueue asynchronous work

--- a/docs/snippets/example/06_queue.cpp
+++ b/docs/snippets/example/06_queue.cpp
@@ -2,17 +2,23 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include "docsTest.hpp"
+
 #include <alpaka/alpaka.hpp>
 
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
 
 using namespace alpaka;
 
-TEST_CASE("non blocking queue", "[docs]")
+TEMPLATE_LIST_TEST_CASE("non blocking queue", "[docs]", docs::test::TestBackends)
 {
-    auto device = onHost::makeHostDevice();
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
 
     // BEGIN-TUTORIAL-nonBlockingQueue
     // Creating a non-blocking queue
@@ -24,16 +30,19 @@ TEST_CASE("non blocking queue", "[docs]")
     // END-TUTORIAL-nonBlockingQueue
 }
 
-TEST_CASE("blocking queue", "[docs]")
+TEMPLATE_LIST_TEST_CASE("blocking queue", "[docs]", docs::test::TestBackends)
 {
-    auto device = onHost::makeHostDevice();
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
 
     // BEGIN-TUTORIAL-blockingQueue
     // Creating a blocking queue
     onHost::Queue queue = device.makeQueue(queueKind::blocking);
     uint32_t value = 42u;
     queue.enqueueHostFn([&value]() { value = 23u; });
-    // no wait required, enqueue will wait untile the task is finished
+    // no wait required, enqueue will wait until the task is finished
     CHECK(value == 23u);
     // END-TUTORIAL-blockingQueue
 }

--- a/docs/snippets/example/08_events.cpp
+++ b/docs/snippets/example/08_events.cpp
@@ -1,0 +1,38 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include "docsTest.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+using namespace alpaka;
+
+TEMPLATE_LIST_TEST_CASE("tutorial events and synchronization", "[docs]", docs::test::TestBackends)
+{
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue0 = device.makeQueue();
+    onHost::Queue queue1 = device.makeQueue();
+    auto event = device.makeEvent();
+    int value = 0;
+
+    // BEGIN-TUTORIAL-eventCreation
+    queue0.enqueueHostFn([&value]() { value = 41; });
+    queue0.enqueue(event);
+    // END-TUTORIAL-eventCreation
+
+    // BEGIN-TUTORIAL-eventWait
+    queue1.waitFor(event);
+    queue1.enqueueHostFn([&value]() { value += 1; });
+    onHost::wait(queue1);
+    // END-TUTORIAL-eventWait
+
+    CHECK(event.isComplete());
+    CHECK(value == 42);
+}

--- a/docs/snippets/example/10_memory.cpp
+++ b/docs/snippets/example/10_memory.cpp
@@ -2,8 +2,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include "docsTest.hpp"
+
 #include <alpaka/alpaka.hpp>
 
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
@@ -14,7 +17,7 @@ using namespace alpaka;
 
 TEST_CASE("memory allocations", "[docs]")
 {
-    auto device = onHost::makeHostDevice();
+    onHost::concepts::Device auto device = onHost::makeHostDevice();
     {
         // BEGIN-TUTORIAL-allocBufferDev
         concepts::Vector auto extents = Vec{2u, 3u};
@@ -49,8 +52,8 @@ void callKernel([[maybe_unused]] auto dummyMemory)
 
 TEST_CASE("memory allocations deferred", "[docs]")
 {
-    auto device = onHost::makeHostDevice();
-    auto queue = device.makeQueue();
+    onHost::concepts::Device auto device = onHost::makeHostDevice();
+    onHost::Queue queue = device.makeQueue();
     // BEGIN-TUTORIAL-allocBufferDeferred
     concepts::Vector auto extents = Vec{2u, 3u};
     {
@@ -68,7 +71,7 @@ TEST_CASE("memory allocations deferred", "[docs]")
 
 TEST_CASE("memory allocations like", "[docs]")
 {
-    auto computeDevice = onHost::makeHostDevice();
+    onHost::concepts::Device auto computeDevice = onHost::makeHostDevice();
     // BEGIN-TUTORIAL-allocLike
     concepts::Vector auto extents = Vec{2u, 3u};
     // short notation to allocate memory on the host without a host device as first argument
@@ -80,20 +83,12 @@ TEST_CASE("memory allocations like", "[docs]")
     alpaka::unused(devDoubleBuffer);
 }
 
-TEST_CASE("memory", "[docs]")
+TEMPLATE_LIST_TEST_CASE("memory", "[docs]", docs::test::TestBackends)
 {
-    // Nvidia GPU: onHost::DeviceSpec{api::cuda, deviceKind::nvidiaGpu};
-    // Amd GPU: onHost::DeviceSpec{api::hip, deviceKind::amdGpu};
-    // Intel GPU: onHost::DeviceSpec{api::oneApi, deviceKind::intelGpu};
-    // this call selects the host Cpu
-    auto computeDevSpec = onHost::DeviceSpec{api::host, deviceKind::cpu};
+    auto computeDevSpec = TestType::makeDict()[object::deviceSpec];
     auto computeDevSelector = alpaka::onHost::makeDeviceSelector(computeDevSpec);
-    auto numComputeDevs = computeDevSelector.getDeviceCount();
-
-    if(numComputeDevs == 0)
-    {
-        std::cout << "No device for " << onHost::getName(computeDevSpec) << " found." << std::endl;
-    }
+    if(!computeDevSelector.isAvailable())
+        return;
 
     // using the typed interface and not concept + auto
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
@@ -133,20 +128,12 @@ TEST_CASE("memory", "[docs]")
         CHECK(v == 42);
 }
 
-TEST_CASE("memory using std::vector", "[docs]")
+TEMPLATE_LIST_TEST_CASE("memory using std::vector", "[docs]", docs::test::TestBackends)
 {
-    // Nvidia GPU: onHost::DeviceSpec{api::cuda, deviceKind::nvidiaGpu};
-    // Amd GPU: onHost::DeviceSpec{api::hip, deviceKind::amdGpu};
-    // Intel GPU: onHost::DeviceSpec{api::oneApi, deviceKind::intelGpu};
-    // this call selects the host Cpu
-    auto computeDevSpec = onHost::DeviceSpec{api::host, deviceKind::cpu};
+    auto computeDevSpec = TestType::makeDict()[object::deviceSpec];
     auto computeDevSelector = alpaka::onHost::makeDeviceSelector(computeDevSpec);
-    auto numComputeDevs = computeDevSelector.getDeviceCount();
-
-    if(numComputeDevs == 0)
-    {
-        std::cout << "No device for " << onHost::getName(computeDevSpec) << " found." << std::endl;
-    }
+    if(!computeDevSelector.isAvailable())
+        return;
 
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
     onHost::Queue asyncComputeQueue = computeDev.makeQueue();

--- a/docs/snippets/example/11_views.cpp
+++ b/docs/snippets/example/11_views.cpp
@@ -1,0 +1,49 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include "docsTest.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <vector>
+
+using namespace alpaka;
+
+TEMPLATE_LIST_TEST_CASE("tutorial views and subviews", "[docs]", docs::test::TestBackends)
+{
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue();
+
+    std::vector<int> hostData{0, 1, 2, 3, 4, 5, 6, 7};
+
+    // BEGIN-TUTORIAL-viewCreation
+    auto hostView = makeView(hostData);
+    auto middleView = hostView.getSubView(size_t{2}, size_t{4});
+    // END-TUTORIAL-viewCreation
+
+    CHECK(hostView.getExtents().x() == 8u);
+    CHECK(middleView.getExtents().x() == 4u);
+    CHECK(middleView[Vec{size_t{0}}] == 2);
+    CHECK(middleView[Vec{size_t{3}}] == 5);
+
+    // BEGIN-TUTORIAL-viewCopy
+    auto deviceBuffer = onHost::allocLike(device, hostView);
+    onHost::memcpy(queue, deviceBuffer, hostView);
+
+    auto hostSlice = onHost::allocHost<int>(4u);
+    onHost::memcpy(queue, hostSlice, deviceBuffer.getSubView(Vec{size_t{2}}, Vec{size_t{4}}));
+    onHost::wait(queue);
+    // END-TUTORIAL-viewCopy
+
+    CHECK(hostSlice[Vec{0u}] == 2);
+    CHECK(hostSlice[Vec{1u}] == 3);
+    CHECK(hostSlice[Vec{2u}] == 4);
+    CHECK(hostSlice[Vec{3u}] == 5);
+}

--- a/docs/snippets/example/15_kernel.cpp
+++ b/docs/snippets/example/15_kernel.cpp
@@ -2,8 +2,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include "docsTest.hpp"
+
 #include <alpaka/alpaka.hpp>
 
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <chrono>
@@ -15,7 +18,7 @@ using namespace alpaka;
 
 struct AddOne
 {
-    ALPAKA_FN_ACC void operator()(auto const& acc, concepts::IMdSpan auto out) const
+    ALPAKA_FN_ACC void operator()(onAcc::concepts::Acc auto const& acc, concepts::IMdSpan auto out) const
     {
         for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
         {
@@ -24,20 +27,12 @@ struct AddOne
     }
 };
 
-TEST_CASE("first kernel", "[docs]")
+TEMPLATE_LIST_TEST_CASE("first kernel", "[docs]", docs::test::TestBackends)
 {
-    // Nvidia GPU: onHost::DeviceSpec{api::cuda, deviceKind::nvidiaGpu};
-    // Amd GPU: onHost::DeviceSpec{api::hip, deviceKind::amdGpu};
-    // Intel GPU: onHost::DeviceSpec{api::oneApi, deviceKind::intelGpu};
-    // this call selects the host Cpu
-    auto computeDevSpec = onHost::DeviceSpec{api::host, deviceKind::cpu};
+    auto computeDevSpec = TestType::makeDict()[object::deviceSpec];
     auto computeDevSelector = alpaka::onHost::makeDeviceSelector(computeDevSpec);
-    auto numComputeDevs = computeDevSelector.getDeviceCount();
-
-    if(numComputeDevs == 0)
-    {
-        std::cout << "No device for " << onHost::getName(computeDevSpec) << " found." << std::endl;
-    }
+    if(!computeDevSelector.isAvailable())
+        return;
 
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
     onHost::Queue computeQueue = computeDev.makeQueue();
@@ -53,7 +48,8 @@ TEST_CASE("first kernel", "[docs]")
 
     // The frame extent is randomly chosen
     constexpr auto frameExtents = Vec{256};
-    auto frameSpec = onHost::FrameSpec{divExZero(computeBuffer.getExtents(), frameExtents), frameExtents};
+    onHost::concepts::FrameSpec auto frameSpec
+        = onHost::FrameSpec{divExZero(computeBuffer.getExtents(), frameExtents), frameExtents};
     // If no executor is given as first argument to enqueue than the default executor is used.
     // The default is the fastest for the corresponding device.
     // For deviceKind::cpu the default is exec::cpuOmpBlocks if omp is enabled, else exec::cpuTbbBlocks if available
@@ -70,7 +66,7 @@ TEST_CASE("first kernel", "[docs]")
 struct MDVectorAdd
 {
     ALPAKA_FN_ACC void operator()(
-        auto const& acc,
+        onAcc::concepts::Acc auto const& acc,
         concepts::IMdSpan auto out,
         concepts::IDataSource auto const& in0,
         concepts::IDataSource auto const& in1) const
@@ -84,20 +80,13 @@ struct MDVectorAdd
     }
 };
 
-TEST_CASE("MD vector add kernel", "[docs]")
+TEMPLATE_LIST_TEST_CASE("MD vector add kernel", "[docs]", docs::test::TestBackends)
 {
-    // Nvidia GPU: onHost::DeviceSpec{api::cuda, deviceKind::nvidiaGpu};
-    // Amd GPU: onHost::DeviceSpec{api::hip, deviceKind::amdGpu};
-    // Intel GPU: onHost::DeviceSpec{api::oneApi, deviceKind::intelGpu};
-    // this call selects the host Cpu
-    auto computeDevSpec = onHost::DeviceSpec{api::host, deviceKind::cpu};
+    auto cfg = TestType::makeDict();
+    auto computeDevSpec = cfg[object::deviceSpec];
     auto computeDevSelector = alpaka::onHost::makeDeviceSelector(computeDevSpec);
-    auto numComputeDevs = computeDevSelector.getDeviceCount();
-
-    if(numComputeDevs == 0)
-    {
-        std::cout << "No device for " << onHost::getName(computeDevSpec) << " found." << std::endl;
-    }
+    if(!computeDevSelector.isAvailable())
+        return;
 
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
     onHost::Queue computeQueue = computeDev.makeQueue();
@@ -124,13 +113,12 @@ TEST_CASE("MD vector add kernel", "[docs]")
     // The frame extent is randomly chosen, the dimensionality of the kernel is defined by the FrameSpec dimsions.
     constexpr auto frameExtents = Vec{8, 8, 8};
     concepts::Vector auto numFrames = divExZero(computeBufferOut.getExtents(), frameExtents);
-    auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
+    onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
 
     onHost::wait(computeQueue);
     auto const beginT = std::chrono::high_resolution_clock::now();
-    // we enforce serial execution because this executor is always available deviceKind::cpu and api::host
     computeQueue.enqueue(
-        exec::cpuSerial,
+        cfg[object::exec],
         frameSpec,
         KernelBundle{MDVectorAdd{}, computeBufferOut, computeBufferIn0, computeBufferIn1});
     onHost::wait(computeQueue);

--- a/docs/snippets/example/20_simdKernel.cpp
+++ b/docs/snippets/example/20_simdKernel.cpp
@@ -2,8 +2,11 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include "docsTest.hpp"
+
 #include <alpaka/alpaka.hpp>
 
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <chrono>
@@ -16,7 +19,7 @@ using namespace alpaka;
 struct MDVectorSimdAdd
 {
     ALPAKA_FN_ACC void operator()(
-        auto const& acc,
+        onAcc::concepts::Acc auto const& acc,
         concepts::IMdSpan auto out,
         concepts::IDataSource auto const& in0,
         concepts::IDataSource auto const& in1) const
@@ -35,20 +38,13 @@ struct MDVectorSimdAdd
     }
 };
 
-TEST_CASE("MD vector simd add kernel", "[docs]")
+TEMPLATE_LIST_TEST_CASE("MD vector simd add kernel", "[docs]", docs::test::TestBackends)
 {
-    // Nvidia GPU: onHost::DeviceSpec{api::cuda, deviceKind::nvidiaGpu};
-    // Amd GPU: onHost::DeviceSpec{api::hip, deviceKind::amdGpu};
-    // Intel GPU: onHost::DeviceSpec{api::oneApi, deviceKind::intelGpu};
-    // this call selects the host Cpu
-    auto computeDevSpec = onHost::DeviceSpec{api::host, deviceKind::cpu};
+    auto cfg = TestType::makeDict();
+    auto computeDevSpec = cfg[object::deviceSpec];
     auto computeDevSelector = alpaka::onHost::makeDeviceSelector(computeDevSpec);
-    auto numComputeDevs = computeDevSelector.getDeviceCount();
-
-    if(numComputeDevs == 0)
-    {
-        std::cout << "No device for " << onHost::getName(computeDevSpec) << " found." << std::endl;
-    }
+    if(!computeDevSelector.isAvailable())
+        return;
 
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
     onHost::Queue computeQueue = computeDev.makeQueue();
@@ -83,13 +79,12 @@ TEST_CASE("MD vector simd add kernel", "[docs]")
     concepts::Vector auto numFrames
         = divExZero(computeBufferOut.getExtents(), frameExtents * frameExtents.fill(1).rAssign(elementsPerFrameItem));
     // The frame specification is not required to be a multiple of the extent, it can be smaller.
-    auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
+    onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
     std::cout << frameSpec << std::endl;
     onHost::wait(computeQueue);
     auto const beginT = std::chrono::high_resolution_clock::now();
-    // we enforce serial execution because this executor is always available deviceKind::cpu and api::host
     computeQueue.enqueue(
-        exec::cpuSerial,
+        cfg[object::exec],
         frameSpec,
         KernelBundle{MDVectorSimdAdd{}, computeBufferOut, computeBufferIn0, computeBufferIn1});
     onHost::wait(computeQueue);

--- a/docs/snippets/example/CMakeLists.txt
+++ b/docs/snippets/example/CMakeLists.txt
@@ -46,7 +46,6 @@ function(alpaka_add_docs_target target_prefix folder)
 
                     add_executable(${_test_target_name} ${source_file})
                     if(EXISTS "${test_folder}/include")
-                        message(STATUS "  add include folder: ${test_folder}/include")
                         target_include_directories(${_test_target_name} PRIVATE ${test_folder}/include)
                     endif()
 

--- a/docs/snippets/example/include/docsTest.hpp
+++ b/docs/snippets/example/include/docsTest.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <alpaka/alpaka.hpp>
+
+namespace docs::test
+{
+    using TestBackends = std::decay_t<
+        decltype(alpaka::onHost::allBackends(alpaka::onHost::enabledDeviceSpecs, alpaka::exec::enabledExecutors))>;
+} // namespace docs::test

--- a/docs/source/_ext/filtered_literalinclude.py
+++ b/docs/source/_ext/filtered_literalinclude.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+
+
+MARKER_RE = re.compile(r"^\s*//\s*(BEGIN|END)-TUTORIAL-[A-Za-z0-9_-]+\s*$")
+
+
+class FilteredLiteralInclude(Directive):
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+    has_content = False
+    option_spec = {
+        "language": directives.unchanged_required,
+        "linenos": directives.flag,
+    }
+
+    def run(self):
+        env = self.state.document.settings.env
+        _, filename = env.relfn2path(self.arguments[0])
+        env.note_dependency(filename)
+
+        path = Path(filename)
+        lines = path.read_text(encoding="utf-8").splitlines()
+        filtered = [line for line in lines if not MARKER_RE.match(line)]
+        text = "\n".join(filtered)
+
+        literal = nodes.literal_block(text, text, source=str(path))
+        literal["language"] = self.options.get("language", "text")
+        literal["linenos"] = "linenos" in self.options
+        return [literal]
+
+
+def setup(app):
+    app.add_directive("filteredliteralinclude", FilteredLiteralInclude)
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/source/advanced/cmake.rst
+++ b/docs/source/advanced/cmake.rst
@@ -1,7 +1,7 @@
 CMake
 =====
 
-Alpaka configures a large part of its functionality at compile time. Therefore, a lot of compiler and link flags are needed, which are set by CMake arguments. First, we show a simple way to build alpaka for different back-ends using `CMake Presets <https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html>`_. The second part of the documentation shows the general and back-end specific alpaka CMake flags.
+alpaka configures a large part of its functionality at compile time. Therefore, a lot of compiler and link flags are needed, which are set by CMake arguments. First, we show a simple way to build alpaka for different back-ends using `CMake Presets <https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html>`_. The second part of the documentation shows the general and back-end specific alpaka CMake flags.
 
 .. hint::
 
@@ -98,12 +98,10 @@ Arguments
 
     The executor ``exec::cpuSerial`` is always available and does not require any special CMake flags beside linking the taget ``alpaka::alpaka`` or ``alpaka::host``.
 
-
 ``alpaka_CXX_STANDARD``
   .. code-block:: markdown
 
      Set the C++ standard version.
-
 
 ``alpaka_TESTS``
   .. code-block:: markdown
@@ -333,7 +331,7 @@ Numa Awareness
      You should utilize all NUMA devices to get the full performance of your CPU, this requires manual a domain decomposition of your problem to be able to run it on all NUMA devices.
      If you use a blocking host queue together with the serial executor the executing thread will only be pinned if it is not the thread of the process.
 
-    **without CMake:** If the header `hwloc.h` is in the include path you should link `-lhwloc` or disable `hwloc` support by defining the preprocessor define `ALPAKA_DISABLE_HWLOC`.
+     **without CMake:** If the header `hwloc.h` is in the include path you should link `-lhwloc` or disable `hwloc` support by defining the preprocessor define `ALPAKA_DISABLE_HWLOC`.
 
 ``alpaka_HOST_MemPinningCanFail``
   .. code-block:: markdown
@@ -342,7 +340,7 @@ Numa Awareness
      On a system e.g. in container environments where it is not allowed to pin memory, this option can be enabled to allow that pinning can fail without an exception.
      Requires the dependency `hwloc`.
 
-    **without CMake:**  Defining the preprocessor define `ALPAKA_HOST_MEM_PINNING_CAN_FAIL` to allow that memory pinning can fail without an exception.
+     **without CMake:**  Defining the preprocessor define `ALPAKA_HOST_MEM_PINNING_CAN_FAIL` to allow that memory pinning can fail without an exception.
 
 Intel oneAPI Threading Building Blocks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -387,7 +385,6 @@ Executors
   .. code-block:: markdown
 
      Enable the oneAPI SYCL executor `exec::oneApi`.
-
 
 Available during the Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -500,10 +497,10 @@ alpaka is providing CMake targets based on the optional activated dependencies `
    Dependencies of ``alpaka_DEP_OMP`` and ``alpaka_DEP_TBB`` are linked into the target ``alpaka::host`` because they influence only host executors and do not provide additional alpaka API support.
    When enabling `alpaka_DEP_TBB`, make sure Intel oneTBB version 2021.10 or newer (including 2022.x releases) is available.
 
-After linking Alpaka targets to your application, you should call ``alpaka_finalize(targetName)`` for each target that uses Alpaka.
+After linking alpaka targets to your application, you should call ``alpaka_finalize(targetName)`` for each target that uses alpaka.
 ``alpaka_finalize()`` is a CMake function that ensures all necessary compile definitions and compiler options are set for the given target.
 Depending on the enabled dependencies (``alpaka_DEP_*``), this call may copy your source files to a temporary directory and compile them with the appropriate compiler.
-Linking non-Alpaka targets after calling ``alpaka_finalize()`` is allowed.
+Linking non-alpaka targets after calling ``alpaka_finalize()`` is allowed.
 You should not include header files using relative paths in your source files.
 These relative paths may become invalid after ``alpaka_finalize()`` is called, because the source files can be copied to a different location.
 

--- a/docs/source/advanced/datastorage.rst
+++ b/docs/source/advanced/datastorage.rst
@@ -46,7 +46,7 @@ Memory Layout of multidimensional Data Storage
 ----------------------------------------------
 
 There are several functions and parameters for improving the memory layout of multidimensional ``Data Storage`` to enhance application performance.
-Alpaka supports ``Pitches``, which optimize memory loads, and ``Alignment``, which is required for vector operations such as AVX on CPUs.
+alpaka supports ``Pitches``, which optimize memory loads, and ``Alignment``, which is required for vector operations such as AVX on CPUs.
 All alpaka functions automatically handle ``Pitches`` and ``Alignment`` during memory access.
 However, it is sometimes necessary to process raw memory, for example, when a memory pointer is passed from alpaka to non-alpaka code.
 The following section explains how alpaka implements ``Pitches`` and ``Alignment``.
@@ -83,7 +83,6 @@ Therefore, the size of a row is ``5 elements * 4 Byte/element + 2 Byte = 22 Byte
 
     Matrix with [3, 5] elements, each element has a size of 4 bytes and 2 bytes of padding per row.
 
-
 .. literalinclude:: ../../snippets/dataStorage/datastorage_pitch.cpp
   :language: cpp
   :start-after: BEGIN-DATASTORAGE-pitch2D-example
@@ -117,3 +116,45 @@ The following example shows 3D memory and the corresponding values for the ``Ext
 
 Alignment
 `````````
+
+Complete Source Files
+---------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>datastorage_interface.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/dataStorage/datastorage_interface.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>datastorage_writeable_datasource.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/dataStorage/datastorage_writeable_datasource.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>datastorage_pitch.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/dataStorage/datastorage_pitch.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>

--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -377,3 +377,19 @@ Math functions
     :dedent:
 
 Similar for other math functions.
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>cheatsheet.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/cheatsheet/cheatsheet.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>

--- a/docs/source/basic/example.rst
+++ b/docs/source/basic/example.rst
@@ -64,3 +64,19 @@ In the CMake configuration phase of the project, you must activate the accelerat
 .. A complete list of CMake flags for the  accelerator can be found :doc:`here </advanced/cmake>`.
 
 If the configuration was successful and CMake found the CUDA SDK, the C++ api `cuda` and the executor `gpuCuda` is available.
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>30_elementWiseMultiplication.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/30_elementWiseMultiplication.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>

--- a/docs/source/basic/install.rst
+++ b/docs/source/basic/install.rst
@@ -137,6 +137,7 @@ The following ``CMakeLists.txt`` demonstrates how to use ``FetchContent`` with *
 .. literalinclude:: ../../snippets/fetchContent/CMakeLists.txt
     :language: C++
     :caption: CMakeLists.txt
+
   
 Example Source Code
 ^^^^^^^^^^^^^^^^^^^
@@ -186,7 +187,6 @@ You can select different device specifications at CMake configuration time using
 .. warning::
     
     The CUDA, HIP, or Intel backends are only working if the CUDA SDK, HIP SDK, or OneAPI SDK are available respectively
-
 
 .. _tests-and-examples:
 

--- a/docs/source/basic/library.rst
+++ b/docs/source/basic/library.rst
@@ -38,7 +38,6 @@ The interaction of the main user facing concepts can be seen in the following fi
 .. image:: /images/structure_assoc.png
    :alt: user / alpaka code interaction
 
-
 For each type of ``Device`` there is a ``DeviceSelector`` for enumerating the available ``Device``s.
 A ``Device`` is the requirement for creating ``Queues`` and ``Events`` as it is for allocating ``SharedBuffers`` on the respective ``Device``.
 ``SharedBuffers`` can be copied, their memory be byte-wise set or filled with element-wise.
@@ -49,7 +48,6 @@ It is possible to wait for (synchronize with) a single ``Event``, a ``Queue`` or
 An ``Executor`` can be enqueued into a ``Queue`` and will execute the ``Kernel`` (after all previous tasks in the queue have been completed).
 The ``Kernel`` in turn has access to the ``Accelerator`` it is running on.
 The ``Accelerator`` provides the ``Kernel`` with its current index in the block or grid, their extents or other data as well as it allows to allocate shared memory, execute atomic operations and many more.
-
 
 Interface Usage
 ---------------
@@ -70,7 +68,6 @@ Therefore the accelerator has to be passed in as a templated constant reference 
    {
        //...
    }
-
 
 Kernel Definition
 `````````````````

--- a/docs/source/basic/terms.rst
+++ b/docs/source/basic/terms.rst
@@ -3,7 +3,6 @@ Terms & Structure
 
 .. sectionauthor:: Simeon Ehrig, René Widera
 
-
 Host and Accelerator
 --------------------
 
@@ -74,7 +73,7 @@ Each Data Storage object either points to physical memory and uses it to read an
 The physical memory used is usually the RAM of a CPU, the VRAM of a GPU, or the unified memory (RAM) of an APU.
 
 The properties of a Data Storage object are described by the interface concept that it fulfills.
-Alpaka offers 4 interface concepts that complement each other.
+alpaka offers 4 interface concepts that complement each other.
 A data storage object must fulfill at least the ``alpaka::concepts::impl::IDataSource``.
 The ordering is ``IDataSource -> IMdSpan -> IView -> IBuffer``.
 
@@ -121,7 +120,6 @@ The memory is row-oriented. The fastest index is the outer right one.
 
     Memory layout of a Data Storage object with the extents [3, 5]. Access to memory at position [1, 3]. For simplicity, pitches and alignment are not shown in the figure.
 
-
 IMdSpan
 ```````
 
@@ -148,3 +146,19 @@ An ``IBuffer`` Data Storage object is pointing to memory and manages its lifetim
 When all ``IBuffer`` Data Storage objects that are pointing to the same memory are deleted, the memory is freed.
 
 Go to the `IBuffer Interface definition <https://alpaka3.readthedocs.io/en/latest/doxygen/conceptalpaka_1_1concepts_1_1impl_1_1IBuffer.html>`_
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>terms_extents.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/dataStorage/terms_extents.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,6 +4,9 @@
 import os
 import subprocess
 import shutil
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "_ext")))
 
 def generate_single_header(app, exception):
     # Destination folder relative to conf.py
@@ -82,6 +85,7 @@ extensions = [
     "sphinx.ext.mathjax",
     #    'sphinx.ext.napoleon',
     "breathe",
+    "filtered_literalinclude",
     "sphinx_rtd_theme",
     "sphinxcontrib.programoutput",
     #    'matplotlib.sphinxext.plot_directive'
@@ -125,7 +129,11 @@ html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 
 html_logo = "../logo/alpaka.svg"
-html_theme_options = {"logo_only": True}
+html_theme_options = {
+    "logo_only": True,
+    "collapse_navigation": False,
+    "navigation_depth": 2,
+}
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/docs/source/contribution/sphinx.rst
+++ b/docs/source/contribution/sphinx.rst
@@ -70,7 +70,6 @@ Build documentation:
     # chromium and other browser also works
     firefox ./build/html/index.html
 
-
 Useful Links
 ------------
 

--- a/docs/source/contribution/tools.rst
+++ b/docs/source/contribution/tools.rst
@@ -68,7 +68,6 @@ Formatter versions
     :language: yaml
     :caption: .pre-commit-config.yaml
 
-
 Code Changes with Tools
 -----------------------
 

--- a/docs/source/dev/logging.rst
+++ b/docs/source/dev/logging.rst
@@ -63,7 +63,6 @@ CMake Logging Options
      // long signature
      [Memory]    SharedBuffer{ dim=1, api= Host, extents={123456}, pitches={4} , alignment=16 } auto alpaka::onHost::internal::Alloc::Op<T_Type, alpaka::onHost::cpu::Device<T_Platform>, T_Extents>::operator()(alpaka::onHost::cpu::Device<T_Platform>&, const T_Extents&) const [with T_Type = unsigned int; T_Platform = alpaka::onHost::cpu::Platform<alpaka::deviceKind::Cpu>; T_Extents = alpaka::Vec<long unsigned int, 1, alpaka::ArrayStorage<long unsigned int, 1> >] alpaka/api/host/Device.hpp:198
 
-
 * ``alpaka_LOG_INDENT=<X>`` - where ``X``  can be ``ON`` or ``OFF`` which will format the output from ``alpaka_LOG_FUNCTIONS`` and ``alpaka_LOG_INFO`` depending on the call stack depth.
 
   .. code:: c++
@@ -81,7 +80,6 @@ The following CMake options requires ``alpaka_LOG=static``
 * ``alpaka_LOG_STATIC_Memory`` - activate logging for static memory information
 * ``alpaka_LOG_STATIC_Queue`` - activate logging for static queue information
 * ``alpaka_LOG_STATIC_Kernel`` - activate logging for static kernel information
-
 
 C++ Code logging
 ----------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,6 +41,7 @@ Individual chapters are based on the information of the chapters before.
 .. toctree::
    :caption: Basic
    :maxdepth: 1
+   :titlesonly:
 
    basic/intro.rst
    basic/install.rst
@@ -52,17 +53,16 @@ Individual chapters are based on the information of the chapters before.
 
 .. toctree::
    :caption: Tutorial
-   :maxdepth: 1
+   :maxdepth: 2
+   :titlesonly:
 
    tutorial/intro.rst
-   tutorial/vector.rst
-   tutorial/device.rst
-   tutorial/queue.rst
-   tutorial/memory.rst
+   tutorial/foundations.rst
 
 .. toctree::
    :caption: Advanced
    :maxdepth: 1
+   :titlesonly:
 
    advanced/cmake.rst
    advanced/datastorage.rst
@@ -72,6 +72,7 @@ Individual chapters are based on the information of the chapters before.
 .. toctree::
    :caption: Developer
    :maxdepth: 1
+   :titlesonly:
 
    dev/logging.rst
    dev/online_tools.rst
@@ -79,6 +80,7 @@ Individual chapters are based on the information of the chapters before.
 .. toctree::
    :caption: Contribution
    :maxdepth: 1
+   :titlesonly:
 
    contribution/sphinx.rst
    contribution/tools.rst
@@ -86,6 +88,7 @@ Individual chapters are based on the information of the chapters before.
 .. toctree::
    :maxdepth: 2
    :caption: API Reference
+   :titlesonly:
 
    doxygen
    doxygen_dev

--- a/docs/source/tutorial/device.rst
+++ b/docs/source/tutorial/device.rst
@@ -55,3 +55,21 @@ The device with the api ``host`` and the device kind ``cpu`` which represents yo
     :start-after: BEGIN-TUTORIAL-devHostDev
     :end-before: END-TUTORIAL-devHostDev
     :dedent:
+
+If you want to see how to enumerate all enabled backends and executors instead of choosing one device manually, continue with :doc:`execution`.
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>05_device.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/05_device.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>

--- a/docs/source/tutorial/events.rst
+++ b/docs/source/tutorial/events.rst
@@ -1,0 +1,62 @@
+Events and Synchronization
+==========================
+
+As soon as you use more than one queue, or mix host tasks with device work, you need a clear model for synchronization.
+In *alpaka*, queues describe execution order, and events describe dependencies between queues.
+
+Basic Rules
+-----------
+
+- Operations inside one queue execute in FIFO order.
+- Different queues may run independently.
+- ``onHost::wait(queue)`` waits until all work in that queue is complete.
+- ``onHost::wait(event)`` waits until the event has been processed.
+- ``queue1.waitFor(event)`` inserts a dependency so work in ``queue1`` starts only after the event is reached.
+
+Creating an Event
+-----------------
+
+  .. literalinclude:: ../../snippets/example/08_events.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-eventCreation
+    :end-before: END-TUTORIAL-eventCreation
+    :dedent:
+
+This records a point in ``queue0`` after the earlier tasks in that queue.
+
+Waiting From Another Queue
+--------------------------
+
+  .. literalinclude:: ../../snippets/example/08_events.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-eventWait
+    :end-before: END-TUTORIAL-eventWait
+    :dedent:
+
+This is the standard way to connect two queues without forcing the host to block between them.
+
+When to Use Which Primitive
+---------------------------
+
+- Use ``onHost::wait(queue)`` when the host must read or modify results after queued work.
+- Use an event plus ``waitFor`` when one queue depends on another queue.
+- Use block-level synchronization such as ``onAcc::syncBlockThreads`` only inside kernels, never as a host-side substitute.
+
+For beginners, the most important habit is to be explicit about synchronization.
+Most bugs in parallel programs are not arithmetic mistakes but ordering mistakes.
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>08_events.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/08_events.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>

--- a/docs/source/tutorial/execution.rst
+++ b/docs/source/tutorial/execution.rst
@@ -1,0 +1,64 @@
+Enumerating Devices and Executors
+=================================
+
+One of the first things new alpaka users notice is that execution configuration is explicit.
+You do not just "run on the GPU" or "run on the CPU". You choose a device specification, and you can also iterate over all enabled backend combinations.
+That may feel more verbose at first, but it becomes useful very quickly in real work.
+For example, if you write a small vector-add test, an image blur, or a heat-equation step, you can run exactly the same example once on the host backend and once on every available GPU backend without rewriting the code around the kernel.
+
+Device Specifications
+---------------------
+
+A ``DeviceSpec`` combines an API and a device kind, for example host CPU, CUDA NVIDIA GPU, HIP AMD GPU, or oneAPI Intel GPU.
+
+  .. literalinclude:: ../../snippets/example/02_execution.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-enumerateDeviceSpec
+    :end-before: END-TUTORIAL-enumerateDeviceSpec
+    :dedent:
+
+From that selector you can get:
+
+- the number of visible devices for that backend,
+- device properties such as the reported warp size,
+- and a concrete ``onHost::Device`` handle for allocation and queue creation.
+
+Running Over All Enabled Backends
+---------------------------------
+
+Many alpaka examples are written so they run once for every enabled backend that is actually available on the current machine.
+
+  .. literalinclude:: ../../snippets/example/02_execution.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-enumerateBackends
+    :end-before: END-TUTORIAL-enumerateBackends
+    :dedent:
+
+This pattern is especially useful when:
+
+- you want one example or test to exercise every enabled backend,
+- you want to compare behavior across executors,
+- or you want to keep tutorial code backend-neutral.
+
+The important part is that a backend entry bundles both the ``deviceSpec`` and the ``exec`` object.
+That is how many alpaka examples stay generic without branching into separate CUDA, HIP, SYCL, and host code paths by hand.
+
+The easiest way to think about this is:
+"I have one calculation, and I want to ask alpaka where that calculation can run on this machine."
+That is a better starting point than hard-coding CUDA or HIP first and only later trying to recover portability.
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>02_execution.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/02_execution.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>

--- a/docs/source/tutorial/foundations.rst
+++ b/docs/source/tutorial/foundations.rst
@@ -1,0 +1,20 @@
+Foundations
+===========
+
+This section covers the basic building blocks you need before writing real kernels:
+vector types, device selection, queues, events, memory allocation and copies, views, and execution setup.
+
+Read these pages in order if you are new to alpaka.
+
+.. toctree::
+   :maxdepth: 1
+
+   vector.rst
+   device.rst
+   queue.rst
+   events.rst
+   memory.rst
+   memoryOperations.rst
+   views.rst
+   execution.rst
+   mentalModel.rst

--- a/docs/source/tutorial/intro.rst
+++ b/docs/source/tutorial/intro.rst
@@ -1,6 +1,32 @@
 Motivation
 ==========
 
-The *alpaka* tutorial will go step-by-step through the most important objects and show, with small examples, how to use them.
-During the tutorial we will explain some of the design decisions and link to similar concepts in other languages, e.g. CUDA/HIP or SYCL, to aid understanding.
-The tutorial will use ``using namespace alpaka;`` to reduce the amount of code.
+The *alpaka* tutorial is meant to be worked through, not skimmed like a reference manual.
+Each section introduces one or two new ideas, uses a small example, and then builds on the pages before it.
+Where it helps, we point out the rough equivalent in CUDA/HIP, SYCL, or other parallel frameworks, but the examples stay written in alpaka style.
+
+Two small problem families appear again and again on purpose:
+
+- image-style workloads such as crops, stencils, blur-like kernels, and histograms,
+- and Monte Carlo style workloads such as random sampling, reduction, and pi estimation.
+
+Those recurring examples make it easier to connect the pages.
+You are not just learning isolated interfaces.
+You are learning how the same kinds of programs grow from memory and views into kernels, synchronization, atomics, randomness, and tuning.
+
+To keep the code readable, the tutorial uses ``using namespace alpaka;`` in the examples.
+
+Recommended Reading Order
+-------------------------
+
+The tutorial is intended to be read in roughly this order:
+
+1. :doc:`foundations`
+2. :doc:`kernels`
+3. :doc:`numerics`
+4. :doc:`migration`
+
+If you want one page that clarifies the central concepts before the first kernel, read :doc:`mentalModel` near the end of the foundations section.
+
+If you are new to parallel programming, treat the early chapters as the core path and the later ones as tools you add when the algorithm actually needs them.
+You do not need warp functions, shared-memory tiles, or custom atomics to write your first correct alpaka kernel.

--- a/docs/source/tutorial/memory.rst
+++ b/docs/source/tutorial/memory.rst
@@ -3,6 +3,7 @@ Allocate Memory
 
 Now that we know how to :ref:`get a device <device-selection>` and create :ref:`a queue <queue_creation>`, we can move on to memory allocation.
 To allocate memory, you need a *device* and sometimes a *queue*.
+See :ref:`memory-operations` for copy, fill, and memset details once the buffers exist.
 alpaka's memory allocation methods return a ``alpaka::onHost::SharedBuffer`` handle that tracks the lifetime of the memory and frees memory when the last instance goes out of scope, similar to ``std::shared_ptr<>`` in the STL.
 
 - Copying a ``alpaka::onHost::SharedBuffer`` handle is a shallow copy of the buffer handle and does not duplicate the data.
@@ -10,9 +11,9 @@ alpaka's memory allocation methods return a ``alpaka::onHost::SharedBuffer`` han
 - A buffer is **not** initialized with default values.
 - The *extents*, which describe the number of elements per dimension, should be ``>=1``. The *extents* can have any dimensionality.
 - If the extent requires the ``alpaka::concepts::VectorOrScalar`` concept, it is permissible to use a scalar instead of an alpaka vector type to allocate a one-dimensional buffer.
-- Each buffer uses the data type of the *extent* object as value type for internal index calculation.
+- The extent object also determines the internal index type used for addressing the buffer.
 
-The following examples show how to create memory which is **only** visible on the device.
+The following examples show how to create memory which is **only** accessible on the device.
 
   .. literalinclude:: ../../snippets/example/10_memory.cpp
     :language: cpp
@@ -31,7 +32,7 @@ Accessing this type of memory from the device is usually associated with high la
     :end-before: END-TUTORIAL-allocBufferMapped
     :dedent:
 
-Unified memory largely equal to the mapped memory and does not require explicit memory copies.
+Unified memory is similar to mapped memory in that it does not require explicit memory copies.
 Depending on the API used, it is located on the host or device.
 It is transparently migrated page by page to the location from which it is accessed.
 You should not access unified memory in parallel from the host and the device.
@@ -58,40 +59,26 @@ Sometimes you want to allocate memory that is only used as a temporary buffer an
 Since memory allocations are costly, you generally avoid allocating memory, for example, in a loop.
 Depending on the device or queue API, ``alpaka::onHost::allocDeferred()`` automatically uses an internal caching allocator to keep allocation as cost-effective as possible.
 
+That kind of temporary buffer shows up naturally later for things such as scan scratch storage, intermediate image tiles, or one stage of a multi-step numerical pipeline.
+
   .. literalinclude:: ../../snippets/example/10_memory.cpp
     :language: cpp
     :start-after: BEGIN-TUTORIAL-allocBufferDeferred
     :end-before: END-TUTORIAL-allocBufferDeferred
     :dedent:
 
-Memory Operations
-=================
+Complete Source File
+--------------------
 
-One of the most commonly used memory operations is the copy operation, which copies data from one buffer to another.
-All memory operations support any dimension ``>=1``.
+.. raw:: html
 
-- ``alpaka::onHost::memcpy()`` always works with the entire buffer unless you specify the extent. The extent defines the number of elements, **not** the size in bytes.
+   <details class="full-source">
+   <summary>10_memory.cpp</summary>
 
-  .. literalinclude:: ../../snippets/example/10_memory.cpp
-    :language: cpp
-    :start-after: BEGIN-TUTORIAL-memcpy
-    :end-before: END-TUTORIAL-memcpy
-    :dedent:
+.. filteredliteralinclude:: ../../snippets/example/10_memory.cpp
+   :language: cpp
+   :linenos:
 
-- You can also set all values of a buffer to a specific value using ``alpaka::onHost::fill()``.
+.. raw:: html
 
-  .. literalinclude:: ../../snippets/example/10_memory.cpp
-    :language: cpp
-    :start-after: BEGIN-TUTORIAL-fill
-    :end-before: END-TUTORIAL-fill
-    :dedent:
-
-- With ``alpaka::onHost::memset()``, all bytes of a buffer can be set to a specific byte value.
-  This is typically used to set all bytes to zero.
-  **Attention:** The optional extent still defines the number of elements and **not** the size in bytes.
-
-  .. literalinclude:: ../../snippets/example/10_memory.cpp
-    :language: cpp
-    :start-after: BEGIN-TUTORIAL-memset
-    :end-before: END-TUTORIAL-memset
-    :dedent:
+   </details>

--- a/docs/source/tutorial/memoryOperations.rst
+++ b/docs/source/tutorial/memoryOperations.rst
@@ -1,0 +1,53 @@
+.. _memory-operations:
+
+Memory Operations
+=================
+
+After allocating buffers, the next step is moving or initializing data inside them.
+One of the most commonly used memory operations is the copy operation, which copies data from one buffer to another.
+All memory operations support any dimension ``>=1``.
+
+In practice, these operations are the "plumbing" around nearly every example in this tutorial:
+copy an image to the device, clear a histogram buffer, move results back to the host, or prepare a Monte Carlo input/output pair before launching a kernel.
+
+- ``alpaka::onHost::memcpy()`` always works with the entire buffer unless you specify the extent. The extent defines the number of elements, **not** the size in bytes.
+
+  .. literalinclude:: ../../snippets/example/10_memory.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-memcpy
+    :end-before: END-TUTORIAL-memcpy
+    :dedent:
+
+- You can also set all values of a buffer to a specific value using ``alpaka::onHost::fill()``.
+
+  .. literalinclude:: ../../snippets/example/10_memory.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-fill
+    :end-before: END-TUTORIAL-fill
+    :dedent:
+
+- With ``alpaka::onHost::memset()``, all bytes of a buffer can be set to a specific byte value.
+  This is typically used to set all bytes to zero.
+  **Attention:** The optional extent still defines the number of elements and **not** the size in bytes.
+
+  .. literalinclude:: ../../snippets/example/10_memory.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-memset
+    :end-before: END-TUTORIAL-memset
+    :dedent:
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>10_memory.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/10_memory.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>

--- a/docs/source/tutorial/mentalModel.rst
+++ b/docs/source/tutorial/mentalModel.rst
@@ -1,0 +1,75 @@
+Core Mental Model
+=================
+
+Many beginner questions in *alpaka* become easier once three ideas are kept separate:
+
+- ``IdxRange`` describes the logical work that must be completed,
+- ``FrameSpec`` describes the available parallel structure for one launch,
+- ``makeIdxMap`` maps that parallel structure onto the logical work.
+
+Those three ideas show up again and again in the tutorial.
+If they stay clear in your head, most kernel code stops feeling mysterious.
+
+Logical Work: ``IdxRange``
+--------------------------
+
+``IdxRange`` describes the valid data domain.
+
+- for a vector, that is the full one-dimensional element range,
+- for an image, that is the two-dimensional domain of valid pixel coordinates,
+- for a volume, that is the full three-dimensional coordinate domain.
+- for higher-dimensional problems, that is the full n-dimensional coordinate domain.
+
+This is the answer to the question:
+"What work actually needs to be done?"
+
+Available Parallelism: ``FrameSpec``
+------------------------------------
+
+``FrameSpec`` describes the launch-side structure.
+It tells alpaka how many frames are available and how large one frame is.
+It describes the logical parallelism exposed to the kernel, not an exact backend block/thread configuration.
+
+This is the answer to the question:
+"How much parallel structure do I want to make available in this launch?"
+
+That is why the frame shape often follows the problem:
+
+- a 1D frame for a vector transform,
+- a 2D frame for an image or stencil,
+- a 3D frame only when the data is truly volumetric.
+- a ND frame only when the data is truly N-dimensional.
+
+Mapping Both Together: ``makeIdxMap``
+-------------------------------------
+
+``makeIdxMap`` is the bridge between the two.
+It takes the currently available workers and yields valid indices from the logical range.
+
+This is the answer to the question:
+"Which valid data items should this worker process?"
+
+For beginners, that is usually the right level of abstraction.
+You think in terms of output elements, pixels, samples, or cells, not in terms of manually computed global thread ids.
+
+One Short Example
+-----------------
+
+If you have a ``1024 x 1024`` grayscale image:
+
+- ``IdxRange`` is the full ``1024 x 1024`` image domain,
+- for ``FrameSpec`` a smaller 2D tile/frame shape such as ``16 x 16`` and ``2`` frames can be chosen,
+- and ``makeIdxMap`` lets the running workers cover the full image one valid pixel index at a time.
+
+So the important distinction is:
+
+- ``IdxRange`` is about the whole problem,
+- ``FrameSpec`` is about the launch shape,
+- ``makeIdxMap`` is how the kernel walks the problem with that launch shape.
+
+Where To Go Next
+----------------
+
+- :doc:`kernel` introduces the first real kernel with these concepts.
+- :doc:`multidim` shows how the same model extends naturally to images and stencils.
+- :doc:`chunked` shows how frames become reusable tiles of work.

--- a/docs/source/tutorial/queue.rst
+++ b/docs/source/tutorial/queue.rst
@@ -4,7 +4,7 @@ Queue
 A queue provides the ability to describe the order in which tasks such as kernel, memory operations, etc. are executed.
 If you are familiar with CUDA/HIP, a queue is comparable to a *Stream*.
 Everything that is placed in a queue is executed according to the FIFO principle (first in, first out).
-Different queues run parallel to each other.
+Different queues may run independently.
 There are two types of queues: *non-blocking* and *blocking* queues.
 If a task is placed in a *non-blocking* queue with the ``enqueue()`` call, the calling host thread does not wait until the task is started.
 It is not defined whether the queued task is started immediately or with a delay.
@@ -36,4 +36,20 @@ If you do not pass ``queueKind`` as an argument, you will get a *non-blocking* q
     :dedent:
 
 We will learn more about queue functions in later chapters.
-Before that, we need to deal with memory allocation, kernel writing, and events.
+Before that, we continue with events and memory management.
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>06_queue.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/06_queue.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>

--- a/docs/source/tutorial/vector.rst
+++ b/docs/source/tutorial/vector.rst
@@ -126,3 +126,19 @@ In this example it can only be validated with ``static_assert()`` because the op
     :start-after: BEGIN-TUTORIAL-CVecOp
     :end-before: END-TUTORIAL-CVecOp
     :dedent:
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>00_vector.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/00_vector.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>

--- a/docs/source/tutorial/views.rst
+++ b/docs/source/tutorial/views.rst
@@ -1,0 +1,68 @@
+Views and Subviews
+==================
+
+Buffers own memory.
+Views do not.
+A view is the right tool when you want to describe existing data without copying or reallocating it.
+
+This matters in two common beginner situations:
+
+- you already have a host container such as ``std::vector`` and want to use it with *alpaka*,
+- or you want to work on only part of a buffer, for example a slice, halo region, or tile.
+
+A good mental picture is image processing.
+The full image may live in one owning buffer, but many operations only touch a crop, one color plane, or the interior pixels without the boundary.
+Those smaller regions are natural views.
+
+Creating a View
+---------------
+
+You can create a non-owning view from a host container and then derive a subview from it.
+
+  .. literalinclude:: ../../snippets/example/11_views.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-viewCreation
+    :end-before: END-TUTORIAL-viewCreation
+    :dedent:
+
+This is useful when the data already exists and you want to keep using the original storage.
+It also makes function interfaces simpler because kernels and helper functions can accept views without caring who owns the memory.
+For example, a stencil update often wants the interior cells only, while a boundary kernel wants a narrow halo view around the edge.
+
+Copying Through a View
+----------------------
+
+Views work with the usual memory operations.
+That means you can allocate device memory based on a view and copy only the relevant slice back.
+
+  .. literalinclude:: ../../snippets/example/11_views.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-viewCopy
+    :end-before: END-TUTORIAL-viewCopy
+    :dedent:
+
+Typical use cases:
+
+- copying a subrange of a 1D vector,
+- copying only the active interior of a 2D grid,
+- passing a tile into a helper function,
+- and reusing kernel code with both owning buffers and non-owning views.
+
+For beginners, the main rule is simple: own data with buffers, describe data with views.
+If you imagine "crop this image" or "ignore the outer ghost cells", you are already thinking in the right direction.
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>11_views.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/11_views.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>


### PR DESCRIPTION
split PR from #492

- Refactor tutorial structure to an exploding side bar.
- Rename alpaka to always lower case
- add helper include command `filteredliteralinclude` for full source code files while excluding labels used to mark sections to reference parts of the code in rst files.
- add section for views, execution, events, and mental models

Note: There are 4 dead links in the doc, but I do not want to remove them, else it will be hard to partially fix it with the follow-up. They will become valid with the next PRs.


rendered view of the PR: https://alpaka3--495.org.readthedocs.build/en/495/