### PR TITLE
add `Queue::isEmpty()`

### DIFF
--- a/docs/snippets/cheatsheet/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet/cheatsheet.cpp
@@ -224,6 +224,11 @@ auto main() -> int
         queue.enqueueHostFnDeferred(task);
         // END-CHEATSHEET-enqueueHostTask
 
+        // BEGIN-CHEATSHEET-isQueueEmpty
+        bool isQueueEmpty = queue.isEmpty();
+        // END-CHEATSHEET-isQueueEmpty
+        alpaka::unused(isQueueEmpty);
+
         // BEGIN-CHEATSHEET-waitQueue
         onHost::wait(queue);
         // END-CHEATSHEET-waitQueue

--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -143,6 +143,14 @@ Wait for all operations in the queue
     :end-before: END-CHEATSHEET-waitQueue
     :dedent:
 
+Check if a queue is empty
+~~~~~~~~~~~~~~~~~~~~~~~~~
+  .. literalinclude:: ../../snippets/cheatsheet/cheatsheet.cpp
+    :language: cpp
+    :start-after: BEGIN-CHEATSHEET-isQueueEmpty
+    :end-before: END-CHEATSHEET-isQueueEmpty
+    :dedent:
+
 Create an event
 ~~~~~~~~~~~~~~~
   .. literalinclude:: ../../snippets/cheatsheet/cheatsheet.cpp

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -79,6 +79,14 @@ namespace alpaka::onHost
             uint32_t m_numaIdx = 0u;
             core::CallbackThread m_workerThread;
             bool m_isBlocking{false};
+            /** Flag to show if a blocking tasks is executed
+             *
+             * This variable is only used if m_isBlocking == true.
+             *
+             * state: If true a thread is executing a blocking tasks, else false.
+             */
+            std::atomic<bool> m_isBlockingTaskExecuted{false};
+
             /** Mutex to ensure sequential execution of tasks and operation if the queue is blocking.
              *
              * For non-blocking queue @c m_workerThread is taking care of the execution order
@@ -99,6 +107,7 @@ namespace alpaka::onHost
                 if(m_isBlocking)
                 {
                     std::lock_guard<std::mutex> lk(m_mutex);
+                    m_isBlockingTaskExecuted = true;
                     fn();
                     // silent tsan warnings: The promise is fulfilled directly and only a future which is true is
                     // returned, there can not be a data race in between.
@@ -113,6 +122,7 @@ namespace alpaka::onHost
 #if defined(__GNUC__) && !defined(__clang__)
 #    pragma GCC diagnostic pop
 #endif
+                    m_isBlockingTaskExecuted = false;
                     // to keep the uniform interface with the non-blocking case,
                     // return by moving the f since it is move-only
                     return f;
@@ -234,6 +244,30 @@ namespace alpaka::onHost
                 return this->shared_from_this();
             }
 
+            friend struct internal::IsQueueEmpty;
+
+            /** Checks if the queue is empty
+             *
+             * If m_isBlocking is true, only tasks will be taken into account, events will be ignored they could not
+             * influence the usage of isQueueEmpty. if m_isBlocking is false, events will be taken into account because
+             * they are handled as normal tasks.
+             *
+             * @return true if no tasks is executed else false
+             */
+            bool isQueueEmpty() const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                if(m_isBlocking)
+                {
+                    // check if the queue is currently executing a blocking task
+                    return !m_isBlockingTaskExecuted;
+                }
+                else
+                {
+                    return m_workerThread.isEmpty();
+                }
+            }
+
             friend struct onHost::internal::GetDevice;
 
             friend struct internal::Wait;
@@ -254,8 +288,13 @@ namespace alpaka::onHost
             void operator()(cpu::Queue<T_Device>& queue) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                // enqueue an empty task as marker and wait for the future
-                queue.submit([]() {}).wait();
+                /* If empty -> Enqueue an empty task as marker and wait for the future
+                 * else there is no need to wait
+                 */
+                if(queue.isQueueEmpty() == false)
+                {
+                    queue.submit([]() {}).wait();
+                }
             }
         };
 

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -41,7 +41,7 @@ namespace alpaka::onHost::internal
 
             constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
 
-            [[maybe_unused]] sycl::event ev;
+            sycl::event ev;
 
             if constexpr(dim == 2u)
             {
@@ -63,6 +63,7 @@ namespace alpaka::onHost::internal
                     dstExtentWithoutColumn.product());
             }
 
+            queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
         }
@@ -88,7 +89,7 @@ namespace alpaka::onHost::internal
 
             constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
 
-            [[maybe_unused]] sycl::event ev;
+            sycl::event ev;
 
             if constexpr(dim == 2u)
             {
@@ -112,6 +113,7 @@ namespace alpaka::onHost::internal
                     dstExtentWithoutColumn.product());
             }
 
+            queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
         }
@@ -134,8 +136,8 @@ namespace alpaka::onHost::internal
                 srcPtr = source;
             else
                 srcPtr = toVoidPtr(alpaka::onHost::data(source));
-            [[maybe_unused]] sycl::event ev = sycl_queue.memcpy(dest.getHandle(alpaka::api::oneApi), srcPtr);
-
+            sycl::event ev = sycl_queue.memcpy(dest.getHandle(alpaka::api::oneApi), srcPtr);
+            queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
         }
@@ -158,8 +160,8 @@ namespace alpaka::onHost::internal
                 destPtr = dest;
             else
                 destPtr = toVoidPtr(alpaka::onHost::data(dest));
-            [[maybe_unused]] sycl::event ev = sycl_queue.memcpy(destPtr, source.getHandle(alpaka::api::oneApi));
-
+            sycl::event ev = sycl_queue.memcpy(destPtr, source.getHandle(alpaka::api::oneApi));
+            queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
         }
@@ -336,7 +338,7 @@ namespace alpaka::onHost::internal
                 st_shared_mem_bytes + blockDynSharedMemBytes
                 <= queue.m_device->getNativeHandle().first.template get_info<sycl::info::device::local_mem_size>());
 
-            [[maybe_unused]] sycl::event ev = queue.dispatchWarpSize(
+            sycl::event ev = queue.dispatchWarpSize(
                 [&](auto warpSize) requires std::same_as<
                     std::integral_constant<
                         typename ALPAKA_TYPEOF(warpSize)::value_type,
@@ -374,6 +376,7 @@ namespace alpaka::onHost::internal
                         });
                 });
 
+            queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
         }

--- a/include/alpaka/api/syclGeneric/Event.hpp
+++ b/include/alpaka/api/syclGeneric/Event.hpp
@@ -13,13 +13,13 @@
 #include "alpaka/onHost/internal/interface.hpp"
 #include "alpaka/onHost/logger/logger.hpp"
 
+#include <algorithm>
+#include <shared_mutex>
+#include <sstream>
 
 #if ALPAKA_LANG_SYCL
 
 #    include <sycl/sycl.hpp>
-
-#    include <algorithm>
-#    include <sstream>
 
 namespace alpaka::onHost
 {
@@ -50,7 +50,7 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(onHost::logger::event);
                 try
                 {
-                    m_event.wait_and_throw();
+                    getEvent().wait_and_throw();
                 }
                 catch(sycl::exception const& err)
                 {
@@ -71,13 +71,13 @@ namespace alpaka::onHost
 
             [[nodiscard]] auto getNativeHandle() const noexcept
             {
-                return m_event;
+                return getEvent();
             }
 
             void wait()
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::event);
-                m_event.wait_and_throw();
+                getEvent().wait_and_throw();
             }
 
             std::string getName() const
@@ -112,7 +112,7 @@ namespace alpaka::onHost
              */
             bool isEventComplete() noexcept
             {
-                auto const status = m_event.template get_info<sycl::info::event::command_execution_status>();
+                auto const status = getEvent().template get_info<sycl::info::event::command_execution_status>();
                 return (status == sycl::info::event_command_status::complete);
             }
 
@@ -121,10 +121,21 @@ namespace alpaka::onHost
 
             void setEvent(sycl::event const& event)
             {
+                std::unique_lock<std::shared_mutex> lock{m_eventGuard};
                 m_event = event;
             }
 
+            sycl::event getEvent() const
+            {
+                std::shared_lock<std::shared_mutex> lock{m_eventGuard};
+                return m_event;
+            }
+
             Handle<T_Device> m_device;
+            //! secure that two threads can change the event at the same time
+            mutable std::shared_mutex m_eventGuard;
+
+            //! You should not use the event directly, use always getEvent() or setEvent()
             sycl::event m_event{};
             uint32_t m_idx = 0u;
         };

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <future>
+#include <shared_mutex>
 #include <sstream>
 #include <type_traits>
 
@@ -262,15 +263,65 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::event + onHost::logger::queue);
                 sycl::event sycl_event = event.getNativeHandle();
-                [[maybe_unused]] sycl::event ev
-                    = m_queue.submit([sycl_event](sycl::handler& cgh) { cgh.depends_on(sycl_event); });
+                sycl::event ev = m_queue.submit([sycl_event](sycl::handler& cgh) { cgh.depends_on(sycl_event); });
+                setLastEvent(ev);
                 if(isBlocking())
                     ev.wait_and_throw();
             }
 
+            friend struct internal::IsQueueEmpty;
+
+            /** Test of all tasks in the queue are finished
+             *
+             * @attention We are testing for the last event of last enqueued alpaka event or action. The function
+             * cannot check events that were queued directly into the native queue, bypassing alpaka.
+             */
+            bool isQueueEmpty() const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+
+                auto const status = getLastEvent().template get_info<sycl::info::event::command_execution_status>();
+                return status == sycl::info::event_command_status::complete;
+            }
+
+            //! Thread safe getter for the last sycl event.
+            sycl::event getLastEvent() const
+            {
+                std::shared_lock<std::shared_mutex> lock{m_eventGuard};
+                return m_lastEvent;
+            }
+
+            /** Thread safe setter for the last sycl event
+             *
+             * To track dependencies this method must be called with any event returned by native sycl calls.
+             */
+            void setLastEvent(sycl::event const& ev) const
+            {
+                std::unique_lock<std::shared_mutex> lock{m_eventGuard};
+                m_lastEvent = ev;
+            }
+
+            friend struct alpaka::onHost::internal::Memset;
+            friend struct alpaka::onHost::internal::Memcpy;
+            friend struct alpaka::onHost::internal::MemcpyDeviceGlobal;
+            friend struct alpaka::onHost::internal::Alloc;
+            friend struct alpaka::onHost::internal::AllocDeferred;
+            friend struct alpaka::onHost::internal::AllocMapped;
+            friend struct alpaka::onHost::internal::Fill;
+
             Handle<T_Device> m_device;
             uint32_t m_idx = 0u;
             sycl::queue m_queue;
+            // secure that two threads can change the event at the same time
+            mutable std::shared_mutex m_eventGuard;
+            /** Event which is representing the last enqueued task/action by alpaka
+             *
+             * @attention You should not use the event directly, use always getLastEvent() or setLastEvent().
+             * Tasks enqueued via the native handle outside of alpaka, will not be tracked by this event, therefore it
+             * can be possible that the queue is not empty but the event is already marked as complete. If you need to
+             * track also tasks enqueued outside of alpaka you should use onHost::wait(auto&&).
+             */
+            mutable sycl::event m_lastEvent;
             core::CallbackThread m_callBackThread;
             bool m_isBlocking{false};
         };
@@ -289,7 +340,7 @@ namespace alpaka::onHost
              * time. Capturing the queue as handle (shared pointer) will result into a deadlock because the native sycl
              * host task is not allowed to destruct the alpaka3, we call in the destructor of the queue 'wait for the
              * native sycl queue' which is than producing the deadlock.*/
-            [[maybe_unused]] sycl::event ev = queue.m_queue.submit(
+            sycl::event ev = queue.m_queue.submit(
                 [&queue, task](sycl::handler& cgh)
                 {
                     cgh.host_task(
@@ -299,6 +350,7 @@ namespace alpaka::onHost
                             f.wait();
                         });
                 });
+            queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
         }
@@ -317,11 +369,12 @@ namespace alpaka::onHost
              * time. Capturing the queue as handle (shared pointer) will result into a deadlock because the native sycl
              * host task is not allowed to destruct the alpaka3, we call in the destructor of the queue 'wait for the
              * native sycl queue' which is than producing the deadlock.*/
-            [[maybe_unused]] sycl::event ev = queue.m_queue.submit(
+            sycl::event ev = queue.m_queue.submit(
                 [&queue, task](sycl::handler& cgh)
                 {
                     cgh.host_task([&queue, task]() { queue.m_callBackThread.submit([t = std::move(task)] { t(); }); });
                 });
+            queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
         }
@@ -333,9 +386,11 @@ namespace alpaka::onHost
         void operator()(syclGeneric::Queue<T_Device>& queue, T_Event& event) const
         {
             ALPAKA_LOG_FUNCTION(onHost::logger::event + onHost::logger::queue);
+
+            /* We do not use the last event of the queue itself because creating an emulated event allows to see newly
+             * submitted tasks add to the native sycl queue outside alpaka. */
             sycl::event emulatedEvent = queue.m_queue.submit([](sycl::handler& cgh) { cgh.single_task([]() {}); });
             event.setEvent(emulatedEvent);
-
             if(queue.isBlocking())
                 emulatedEvent.wait_and_throw();
         }
@@ -351,10 +406,11 @@ namespace alpaka::onHost
             ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
             // TODO: implement generic version for multidimensional memory
             sycl::queue sycl_queue = queue.getNativeHandle();
-            [[maybe_unused]] sycl::event ev = sycl_queue.memset(
+            sycl::event ev = sycl_queue.memset(
                 internal::Data::data(dest),
                 byteValue,
                 extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
+            queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
         }
@@ -373,10 +429,11 @@ namespace alpaka::onHost
             ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
             // TODO: implement generic version for multidimensional memory
             sycl::queue sycl_queue = queue.getNativeHandle();
-            [[maybe_unused]] sycl::event ev = sycl_queue.memcpy(
+            sycl::event ev = sycl_queue.memcpy(
                 toVoidPtr(internal::Data::data(dest)),
                 toVoidPtr(internal::Data::data(source)),
                 extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
+            queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
         }
@@ -396,7 +453,8 @@ namespace alpaka::onHost
         {
             ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
             sycl::queue sycl_queue = queue.getNativeHandle();
-            [[maybe_unused]] sycl::event ev = sycl_queue.fill(internal::Data::data(dest), elementValue, extents.x());
+            sycl::event ev = sycl_queue.fill(internal::Data::data(dest), elementValue, extents.x());
+            queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
         }

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -159,6 +159,20 @@ namespace alpaka::onHost
                 conditionalWait();
             }
 
+            friend struct internal::IsQueueEmpty;
+
+            bool isQueueEmpty() const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+
+                typename ApiInterface::Error_t ret = ApiInterface::success;
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
+                    ApiInterface,
+                    ret = ApiInterface::streamQuery(getNativeHandle()),
+                    ApiInterface::errorNotReady);
+                return (ret == ApiInterface::success);
+            }
+
             friend struct onHost::internal::GetDevice;
 
             friend struct alpaka::internal::GetApi;

--- a/include/alpaka/core/CallbackThread.hpp
+++ b/include/alpaka/core/CallbackThread.hpp
@@ -126,6 +126,12 @@ namespace alpaka::core
             return f;
         }
 
+        bool isEmpty() const
+        {
+            std::unique_lock<std::mutex> lock{m_state->m_mutex};
+            return m_state->m_tasks.empty();
+        }
+
     private:
         std::jthread m_thread;
         /** Hold data shared between this call and the thread processing the tasts. */

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -56,7 +56,7 @@ namespace alpaka::onHost
 
         constexpr alpaka::concepts::QueueKind auto getQueueKind() const
         {
-            return T_DeviceKind{};
+            return T_QueueKind{};
         }
 
         constexpr alpaka::concepts::DeviceKind auto getDeviceKind() const
@@ -222,6 +222,20 @@ namespace alpaka::onHost
         void waitFor(Event<Device<T_Api, T_DeviceKind>> const& event) const
         {
             internal::waitFor(*m_queue.get(), *event.get());
+        }
+
+        /** Checks if the queue does not have any enqueued work to process.
+         *
+         * @attention: If you enqueue work outside alpaka by using the native handle of the queue, this function is
+         * maybe not seeing this tasks and can return true even if there are unfinished tasks.
+         * If you need the guarantee that all tasks, even enqueued tasks outside alpaka are finished you should use
+         * onHost::wait(alpaka::concepts::HasGet auto&).
+         *
+         * @return true if there are no unfinished tasks in the queue, else false.
+         */
+        bool isEmpty() const
+        {
+            return internal::isQueueEmpty(*m_queue.get());
         }
     };
 

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -171,6 +171,23 @@ namespace alpaka::onHost
             return IsEventComplete::Op<ALPAKA_TYPEOF(any)>{}(any);
         }
 
+        struct IsQueueEmpty
+        {
+            template<typename T_Queue>
+            struct Op
+            {
+                bool operator()(T_Queue& queue)
+                {
+                    return queue.isQueueEmpty();
+                }
+            };
+        };
+
+        inline bool isQueueEmpty(auto& queue)
+        {
+            return IsQueueEmpty::Op<ALPAKA_TYPEOF(queue)>{}(queue);
+        }
+
         struct Enqueue
         {
             template<

--- a/test/unit/queue/isEmpty.cpp
+++ b/test/unit/queue/isEmpty.cpp
@@ -1,0 +1,70 @@
+/* Copyright 2023 Axel Hübl, Benjamin Worpitz, Bernhard Manfred Gruber, Jan Stephan, René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include "alpaka/meta/CartesianProduct.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <atomic>
+#include <iostream>
+
+using namespace alpaka;
+
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
+using TestSetup = alpaka::meta::
+    CartesianProduct<std::tuple, TestBackends, std::tuple<queueKind::Blocking, queueKind::NonBlocking>>;
+
+TEMPLATE_LIST_TEST_CASE("queue isEmpty", "[queue][isEmpty]", TestSetup)
+{
+    using Backend = std::tuple_element_t<0u, TestType>;
+    using QueueKind = std::tuple_element_t<1u, TestType>;
+    auto cfg = Backend::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto sel = onHost::makeDeviceSelector(deviceSpec);
+    if(!sel.isAvailable())
+    {
+        // backend not available
+        return;
+    }
+    onHost::Device device = sel.makeDevice(0);
+    INFO("device spec: " << getName(deviceSpec));
+    INFO("device name: " << device.getName());
+    INFO("executor   : " << exec.getName());
+    INFO("queue kind : " << QueueKind::getName());
+
+    auto queue = device.makeQueue(QueueKind{});
+
+    std::atomic<bool> callbackFinished{false};
+    std::atomic<bool> inKernelIsNotEmptyBeforeSleep{false};
+    std::atomic<bool> inKernelIsNotEmptyAfterSleep{false};
+
+    CHECK(queue.isEmpty() == true);
+
+    queue.enqueueHostFn(
+        [&]()
+        {
+            // This callback function is in the queue therefore the queue can not be empty.
+            inKernelIsNotEmptyBeforeSleep = !queue.isEmpty();
+            std::this_thread::sleep_for(std::chrono::milliseconds(100u));
+            // Check again, the queue must stay not empty.
+            inKernelIsNotEmptyAfterSleep = !queue.isEmpty();
+            callbackFinished = true;
+        });
+
+    // A non-blocking queue will always stay empty because the task has been executed immediately.
+    if(queue.getQueueKind() == queueKind::nonBlocking)
+        onHost::wait(queue);
+
+    CHECK(callbackFinished.load() == true);
+    CHECK(inKernelIsNotEmptyBeforeSleep.load() == true);
+    CHECK(inKernelIsNotEmptyAfterSleep.load() == true);
+
+    // after the task is executed the queue should be empty
+    CHECK(queue.isEmpty() == true);
+}


### PR DESCRIPTION
- introduce the queue method `isEmpty()` (was already present in alpaka mainline but missed in alpaka3)
- FIX: during the implementation I found out that our event implementation for `OneApi` was not thread safe. It was possible that two threads changed the internal state of an event without any mutex.
- add the queue empty test case from alpaka mainline

The Sycl queue is now holding an event to the last enqueued action/task, this is required because Sycl is not providing a way to querry if the queue is empty. This has the disadvantage that if alpaka and native code is mixed alpaka `isEmpty()` can return a false positive because we can not track the queue state outside of alpaka.