### PR TITLE
refactor internal SIMD configuration for algorithms

### DIFF
--- a/include/alpaka/onAcc/SimdAlgo.hpp
+++ b/include/alpaka/onAcc/SimdAlgo.hpp
@@ -10,6 +10,7 @@
 #include "alpaka/onAcc/internal/SimdConcurrent.hpp"
 #include "alpaka/onAcc/internal/SimdTransformReduce.hpp"
 
+#include <bit>
 #include <cstdint>
 
 namespace alpaka::onAcc
@@ -296,6 +297,65 @@ namespace alpaka::onAcc
         {
             constexpr uint32_t maxSimdBytes = std::min(T_cacheLineInByte, T_maxConcurrencyInByte);
             return alpaka::divExZero(maxSimdBytes, static_cast<uint32_t>(sizeof(T_Type)));
+        }
+
+        template<typename T_Type>
+        struct SimdPackConfig
+        {
+            using value_type = T_Type;
+            uint32_t simdWidth;
+            uint32_t numSimdPacksPerFnCall;
+        };
+
+        /** Generate a SIMD config for the API and device kind.
+         *
+         * Produces an optimized SIMD configuration based on technical constrained.
+         * The SIMD is set to a power of two.
+         * If possible, the SIMD configuration is aligned to the cacheline size for the given device kind.
+         *
+         * @maxConcurrencyInByte The upper limit in bytes a SIMD configuration must not exceed, except a single value
+         * is larger. This parameter is used to control the register pressure.
+         *
+         * @return a configuration with the number of SIMD pack which should be used in parallel for a single
+         * invocation. And the width of a single SIMD pack.
+         */
+        template<typename T_ValueType>
+        [[nodiscard]] static consteval SimdPackConfig<T_ValueType> calcSimdPackConfig(
+            alpaka::concepts::Api auto api,
+            alpaka::concepts::DeviceKind auto deviceKind,
+            uint32_t maxConcurrencyInByte)
+        {
+            constexpr uint32_t maxArchSimdWidth = getArchSimdWidth<T_ValueType>(api, deviceKind);
+            constexpr uint32_t cachelineBytes = getCachelineSize(api, deviceKind);
+            uint32_t simdWidth = maxArchSimdWidth;
+
+            // Maximum SIMD width allowed by the byte concurrency budget.
+            uint32_t maxWidthAllowed = maxConcurrencyInByte / sizeof(T_ValueType);
+
+            // Clamp max hardware SIMD width and ensure at least 1.
+            uint32_t clampedWidth = std::max(std::min(simdWidth, maxWidthAllowed), 1u);
+
+            // Round down to the nearest power of two.
+            simdWidth = std::bit_floor(clampedWidth);
+
+            uint32_t const simdWidthInByte = simdWidth * sizeof(T_ValueType);
+
+            // Number of SIMD packs that fit into the concurrency budget.
+            uint32_t const numSimdPacksToUtilizeConcurrency = alpaka::divExZero(maxConcurrencyInByte, simdWidthInByte);
+
+            // Number of SIMD packs required to cover one cache line
+            uint32_t const numSimdPacksPerCacheLine = alpaka::divExZero(cachelineBytes, simdWidthInByte);
+
+            // Prefer the largest cache-line multiple that fits into the budget.
+            uint32_t numSimdPacksPerFnCall = numSimdPacksToUtilizeConcurrency;
+            if(numSimdPacksToUtilizeConcurrency >= numSimdPacksPerCacheLine)
+            {
+                uint32_t const cachelineMultiple
+                    = (numSimdPacksToUtilizeConcurrency / numSimdPacksPerCacheLine) * numSimdPacksPerCacheLine;
+                numSimdPacksPerFnCall = std::max(cachelineMultiple, 1u);
+            }
+
+            return {simdWidth, numSimdPacksPerFnCall};
         }
 
         T_WorkGroup m_workGroup;

--- a/include/alpaka/onAcc/internal/SimdConcurrent.hpp
+++ b/include/alpaka/onAcc/internal/SimdConcurrent.hpp
@@ -37,18 +37,17 @@ namespace alpaka::onAcc::internal
             auto numElements = typename ALPAKA_TYPEOF(extents)::UniVec{extents};
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
 
-            constexpr uint32_t maxArchSimdWidth
-                = getArchSimdWidth<ValueType>(ALPAKA_TYPEOF(acc.getApi()){}, ALPAKA_TYPEOF(acc.getDeviceKind()){});
-            constexpr uint32_t cachelineBytes
-                = getCachelineSize(ALPAKA_TYPEOF(acc.getApi()){}, ALPAKA_TYPEOF(acc.getDeviceKind()){});
+            constexpr auto simdCfg = T_Parent::template calcSimdPackConfig<ValueType>(
+                ALPAKA_TYPEOF(acc.getApi()){},
+                ALPAKA_TYPEOF(acc.getDeviceKind()){},
+                T_maxConcurrencyInByte);
 
-            constexpr uint32_t width = std::min(
-                maxArchSimdWidth,
-                T_Parent::template calcSimdWidth<ValueType, T_maxConcurrencyInByte, cachelineBytes>());
+            constexpr uint32_t simdWidth = simdCfg.simdWidth;
 
-            if constexpr(width != 1u)
+            if constexpr(simdWidth != 1u)
             {
-                concurrentSimdPackExecution<T_maxConcurrencyInByte, width, T_MemAlignment>(
+                constexpr uint32_t numSimdPerFnCall = simdCfg.numSimdPacksPerFnCall;
+                concurrentSimdPackExecution<simdWidth, numSimdPerFnCall, T_MemAlignment>(
                     acc,
                     numElements,
                     ALPAKA_FORWARD(func),
@@ -119,7 +118,7 @@ namespace alpaka::onAcc::internal
                 ids);
         }
 
-        template<uint32_t T_maxConcurrencyInByte, uint32_t T_simdWidth, alpaka::concepts::Alignment T_MemAlignment>
+        template<uint32_t T_simdWidth, uint32_t T_numSimdPerFnCall, alpaka::concepts::Alignment T_MemAlignment>
         ALPAKA_FN_INLINE ALPAKA_FN_ACC constexpr auto concurrentSimdPackExecution(
             auto const& acc,
             alpaka::concepts::Vector auto numElements,
@@ -127,31 +126,13 @@ namespace alpaka::onAcc::internal
             alpaka::concepts::IDataSource auto&& data0,
             alpaka::concepts::IDataSource auto&&... dataN) const
         {
-            using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
-            constexpr uint32_t simdWidthInByte = T_simdWidth * sizeof(ValueType);
-            // number of simd packs fitting into the maxConcurrencyInByte
-            constexpr uint32_t numSimdPacksToUtilizeConcurrency
-                = alpaka::divExZero(T_maxConcurrencyInByte, simdWidthInByte);
-
-            constexpr uint32_t cachelineBytes
-                = getCachelineSize(ALPAKA_TYPEOF(acc.getApi()){}, ALPAKA_TYPEOF(acc.getDeviceKind()){});
-            // number of simd packs fitting into the cacheline
-            constexpr uint32_t numSimdPacksPerCacheLine = std::max(cachelineBytes / simdWidthInByte, 1u);
-            /* number of simd packs used per functor call
-             * - the number of simd packs per functor call should be a multiple of the number of simd packs per
-             * cacheline
-             */
-            constexpr uint32_t numSimdPacksPerFnCall
-                = alpaka::divExZero(numSimdPacksToUtilizeConcurrency, numSimdPacksPerCacheLine)
-                  * numSimdPacksPerCacheLine;
-
             auto const workGroup = asParent().getWorkGroup();
 
             // we SIMDfy only over the fast moving dimension (columns of memory)
             auto const wSize = workGroup.size(acc).back();
 
             /* Number of data elements process per functor call. */
-            auto const numElementsPerFnCall = T_simdWidth * numSimdPacksPerFnCall;
+            auto const numElementsPerFnCall = T_simdWidth * T_numSimdPerFnCall;
             /** To avoid a overflow in the index range we device first by the number of elements per
              * function call and than by the number of workers.
              */
@@ -208,7 +189,7 @@ namespace alpaka::onAcc::internal
                         execute<T_MemAlignment, T_simdWidth>(
                             acc,
                             iter,
-                            std::make_integer_sequence<uint32_t, numSimdPacksPerFnCall>{},
+                            std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
                             ALPAKA_FORWARD(func),
                             ALPAKA_FORWARD(data0),
                             ALPAKA_FORWARD(dataN)...);
@@ -229,7 +210,7 @@ namespace alpaka::onAcc::internal
                     execute<T_MemAlignment, T_simdWidth>(
                         acc,
                         iter,
-                        std::make_integer_sequence<uint32_t, numSimdPacksPerFnCall>{},
+                        std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
                         ALPAKA_FORWARD(func),
                         ALPAKA_FORWARD(data0),
                         ALPAKA_FORWARD(dataN)...);

--- a/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
+++ b/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
@@ -42,20 +42,17 @@ namespace alpaka::onAcc::internal
             auto numElements = typename ALPAKA_TYPEOF(extents)::UniVec{extents};
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
 
-            constexpr uint32_t maxArchSimdWidth
-                = getArchSimdWidth<ValueType>(ALPAKA_TYPEOF(acc.getApi()){}, ALPAKA_TYPEOF(acc.getDeviceKind()){});
-            constexpr uint32_t cachlineBytes
-                = getCachelineSize(ALPAKA_TYPEOF(acc.getApi()){}, ALPAKA_TYPEOF(acc.getDeviceKind()){});
+            constexpr auto simdCfg = T_Parent::template calcSimdPackConfig<ValueType>(
+                ALPAKA_TYPEOF(acc.getApi()){},
+                ALPAKA_TYPEOF(acc.getDeviceKind()){},
+                T_maxConcurrencyInByte);
 
-            constexpr uint32_t width = std::min(
-                maxArchSimdWidth,
-                T_Parent::template calcSimdWidth<ValueType, T_maxConcurrencyInByte, cachlineBytes>());
+            constexpr uint32_t simdWidth = simdCfg.simdWidth;
 
-            auto const workGroup = asParent().getWorkGroup();
-
-            if constexpr(width != 1u)
+            if constexpr(simdWidth != 1u)
             {
-                return reduceSimdPackExecution<T_maxConcurrencyInByte, width, T_MemAlignment>(
+                constexpr uint32_t numSimdPerFnCall = simdCfg.numSimdPacksPerFnCall;
+                return reduceSimdPackExecution<simdWidth, numSimdPerFnCall, T_MemAlignment>(
                     acc,
                     numElements,
                     neutralElement,
@@ -65,6 +62,7 @@ namespace alpaka::onAcc::internal
                     ALPAKA_FORWARD(dataN)...);
             }
 
+            auto const workGroup = asParent().getWorkGroup();
             // execute the algorithm with SIMD width one
             auto traverse = onAcc::makeIdxMap(
                 acc,
@@ -225,7 +223,7 @@ namespace alpaka::onAcc::internal
             return static_cast<T_Parent const&>(*this);
         }
 
-        template<uint32_t T_maxConcurrencyInByte, uint32_t T_simdWidth, alpaka::concepts::Alignment T_MemAlignment>
+        template<uint32_t T_simdWidth, uint32_t T_numSimdPerFnCall, alpaka::concepts::Alignment T_MemAlignment>
         ALPAKA_FN_INLINE ALPAKA_FN_ACC constexpr auto reduceSimdPackExecution(
             auto const& acc,
             alpaka::concepts::Vector auto numElements,
@@ -237,31 +235,13 @@ namespace alpaka::onAcc::internal
         {
             auto reduceFunc = getReducer(acc, userReduceFunc);
 
-            using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
-            constexpr uint32_t simdWidthInByte = T_simdWidth * sizeof(ValueType);
-            // number of simd packs fitting into the maxConcurrencyInByte
-            constexpr uint32_t numSimdPacksToUtilizeConcurrency
-                = alpaka::divExZero(T_maxConcurrencyInByte, simdWidthInByte);
-
-            constexpr uint32_t cachlineBytes
-                = getCachelineSize(ALPAKA_TYPEOF(acc.getApi()){}, ALPAKA_TYPEOF(acc.getDeviceKind()){});
-            // number of simd packs fitting into the cacheline
-            constexpr uint32_t numSimdPacksPerCacheLine = alpaka::divExZero(cachlineBytes, simdWidthInByte);
-            /* number of simd packs used per functor call
-             * - the number of simd packs per functor call should be a multiple of the number of simd packs per
-             * cacheline
-             */
-            constexpr uint32_t numSimdPacksPerFnCall
-                = alpaka::divExZero(numSimdPacksToUtilizeConcurrency, numSimdPacksPerCacheLine)
-                  * numSimdPacksPerCacheLine;
-
             auto const workGroup = asParent().getWorkGroup();
 
             // we SIMDfy only over the fast moving dimension (columns of memory)
             auto const wSize = workGroup.size(acc).back();
 
             /* Number of data elements process per functor call. */
-            auto const numElementsPerFnCall = T_simdWidth * numSimdPacksPerFnCall;
+            auto const numElementsPerFnCall = T_simdWidth * T_numSimdPerFnCall;
             /** To avoid a overflow in the index range we device first by the number of elements per
              * function call and than by the number of workers.
              */
@@ -286,7 +266,7 @@ namespace alpaka::onAcc::internal
             using SimdReturn = decltype(executeReduce<T_MemAlignment, T_simdWidth>(
                 acc,
                 iter,
-                std::make_integer_sequence<uint32_t, numSimdPacksPerFnCall>{},
+                std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
                 ALPAKA_FORWARD(reduceFunc),
                 ALPAKA_FORWARD(func),
                 ALPAKA_FORWARD(data0),
@@ -339,7 +319,7 @@ namespace alpaka::onAcc::internal
                             executeReduce<T_MemAlignment, T_simdWidth>(
                                 acc,
                                 iter,
-                                std::make_integer_sequence<uint32_t, numSimdPacksPerFnCall>{},
+                                std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
                                 ALPAKA_FORWARD(reduceFunc),
                                 ALPAKA_FORWARD(func),
                                 ALPAKA_FORWARD(data0),
@@ -356,7 +336,7 @@ namespace alpaka::onAcc::internal
                         executeReduce<T_MemAlignment, T_simdWidth>(
                             acc,
                             iter,
-                            std::make_integer_sequence<uint32_t, numSimdPacksPerFnCall>{},
+                            std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
                             ALPAKA_FORWARD(reduceFunc),
                             ALPAKA_FORWARD(func),
                             ALPAKA_FORWARD(data0),


### PR DESCRIPTION
The internal SIMD configuration, which calculates the SIMD width and the number of SIMD packages used for instruction-level parallelism, was scattered across two classes.
This PR is unifying the calculation within a single function. This makes it a little bit better understandable and fixes an issue that the maximum concurrency byte limit was violated because the previous implementation always rounded up to a full cacheline.