### PR TITLE
sphinx doc: on local system, build single header only of a source file is changed

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -221,7 +221,7 @@ else:
     html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
-    logger.info("single header build can be force build or skipped with the environment variable 'ALPAKA_SINGLE_HEADER=ON|OFF'")
+    logger.info("single header build can be force build or skipped with the environment variable 'ALPAKA_SINGLE_HEADER=0|OFF|1|ON'")
 
     if shutil.which("doxygen"):
         if not "ALPAKA_NO_DOXYGEN" in os.environ:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,18 +4,14 @@
 import os
 import subprocess
 import shutil
+import sys
 
-def generate_single_header(app, exception):
-    # Destination folder relative to conf.py
-    single_header_path = os.path.abspath(os.path.join(app.builder.outdir))
-    os.makedirs(single_header_path, exist_ok=True)
+# allows to import module `build_helper`
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+from sphinx_helper.single_header import generate_single_header
+from sphinx_helper.utils import on_rtd
 
-    # Path to your script
-    script_path = os.path.abspath(os.path.join(app.srcdir, '..', '..', 'script', 'create-single-header.sh'))
 
-    # Call the script with the destination folder as argument
-    subprocess.run([script_path, single_header_path], check=True)
-    print(f"Generated single header in {single_header_path}")
 
 def build_doxygen():
     subprocess.call("cd ..; doxygen", shell=True)
@@ -51,8 +47,7 @@ def copy_doxygen_html(app, exception):
 
 def setup(app):
     # Hook into the 'builder-inited' event to run the function before the build starts
-    if not "ALPAKA_NO_SINGLE_HEADER" in os.environ:
-        app.connect('build-finished', generate_single_header)
+    app.connect('build-finished', generate_single_header)
     app.connect('build-finished', copy_doxygen_html)
 
 # -- Project information -----------------------------------------------------
@@ -71,7 +66,6 @@ master_doc = "index"
 # -- General configuration ---------------------------------------------------
 
 highlight_language = 'c++'
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 show_authors = True
 
@@ -213,7 +207,7 @@ cpp_id_attributes = [
 
 # -- processing --
 
-if on_rtd:
+if on_rtd():
     build_doxygen()
     #subprocess.call(
     #    "cd ../cheatsheet; rst2pdf -s cheatsheet.style ../source/basic/cheatsheet.rst -o cheatsheet.pdf", shell=True
@@ -227,7 +221,7 @@ else:
     html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
-    logger.info("single header build can be skipped with the environment variable 'ALPAKA_NO_SINGLE_HEADER=1'")
+    logger.info("single header build can be force build or skipped with the environment variable 'ALPAKA_SINGLE_HEADER=ON|OFF'")
 
     if shutil.which("doxygen"):
         if not "ALPAKA_NO_DOXYGEN" in os.environ:

--- a/docs/source/sphinx_helper/file_cache.py
+++ b/docs/source/sphinx_helper/file_cache.py
@@ -24,12 +24,18 @@ def get_modified_files(
     """
     cache_file_path_obj = pathlib.Path(cache_file_path)
 
+    git_get_commit_hash_process = subprocess.run(
+        ["git", "rev-parse", "HEAD"], stdout=subprocess.PIPE, text=True, check=True
+    )
+    current_git_commit_hash = git_get_commit_hash_process.stdout.strip()
+
     old_changes: dict[str, str] = {}
     if cache_file_path_obj.exists():
         with open(cache_file_path_obj, "r", encoding="UTF-8") as f:
             old_changes: dict[str, str] = json.load(f)
 
     current_changes = get_hashed_files(path_filter_regex)
+    current_changes["commit"] = current_git_commit_hash
 
     def dict_diffs(A: dict, B: dict) -> dict:
         _sentinel = object()

--- a/docs/source/sphinx_helper/file_cache.py
+++ b/docs/source/sphinx_helper/file_cache.py
@@ -1,0 +1,97 @@
+"""Provied functionally to check if a file was changed since last doc build process."""
+
+import re
+import hashlib
+import json
+import pathlib
+import subprocess
+
+
+def get_modified_files(
+    cache_file_path: str, path_filter_regex: str = ""
+) -> dict[str, str]:
+    """Return all files, which changed since last documentation build. If empty, nothing changed.
+
+    Args:
+        cache_file_path (str): Name of the cache file.
+        path_filter_regex (str, optional): Filter which file paths should be included.
+            The paths are relative to the Git project root.
+            Defaults to "", which means all files in the repostiory.
+
+    Returns:
+        dict[str, str]: Dictionary of files, which changed since last time.
+        Key is the relative path to git project root. The value is the sha256 hash of the file.
+    """
+    cache_file_path_obj = pathlib.Path(cache_file_path)
+
+    old_changes: dict[str, str] = {}
+    if cache_file_path_obj.exists():
+        with open(cache_file_path_obj, "r", encoding="UTF-8") as f:
+            old_changes: dict[str, str] = json.load(f)
+
+    current_changes = get_hashed_files(path_filter_regex)
+
+    def dict_diffs(A: dict, B: dict) -> dict:
+        _sentinel = object()
+
+        diffs = {}
+        for k in set(A) | set(B):
+            a = A.get(k, _sentinel)
+            b = B.get(k, _sentinel)
+            if a is _sentinel or b is _sentinel or a != b:
+                diffs[k] = (
+                    None if a is _sentinel else a,
+                    None if b is _sentinel else b,
+                )
+        return diffs
+
+    diff = dict_diffs(old_changes, current_changes)
+
+    with open(cache_file_path_obj, "w", encoding="UTF-8") as f:
+        json.dump(current_changes, f, indent=4)
+
+    return diff
+
+
+def get_hashed_files(path_filter_regex: str = "") -> dict[str, str]:
+    """Search for all files which are new or modified basing on git status in the repository.
+
+    Args:
+        path_filter_regex (str, optional): Filter which file paths should be included.
+            The paths are relative to the Git project root.
+            Defaults to "", which means all files in the repostiory.
+
+    Returns:
+        dict[str, str]: Dictionary of files.
+        Key is the relative path to git project root. The value is the sha256 hash of the file.
+    """
+    compiled_regex = re.compile(path_filter_regex)
+
+    show_git_toplevel = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    project_root = pathlib.Path(show_git_toplevel.stdout.strip())
+
+    git_status = subprocess.run(
+        ["git", "status", "--porcelain"], stdout=subprocess.PIPE, text=True, check=True
+    )
+
+    modified_files = []
+    for line in git_status.stdout.strip().split("\n"):
+        path = line.strip().split(" ")[1]
+        if compiled_regex.match(path):
+            if (project_root / pathlib.Path(path)).is_file():
+                modified_files.append(path)
+
+    hash_files: dict[str, str] = {}
+
+    for path in modified_files:
+        p = project_root / pathlib.Path(path)
+        with open(p, "rb") as f:
+            digest = hashlib.file_digest(f, "sha256")
+        hash_files[path] = digest.hexdigest()
+
+    return hash_files

--- a/docs/source/sphinx_helper/file_cache.py
+++ b/docs/source/sphinx_helper/file_cache.py
@@ -1,4 +1,4 @@
-"""Provied functionally to check if a file was changed since last doc build process."""
+"""Provide functionally to check if a file was changed since last doc build process."""
 
 import re
 import hashlib
@@ -16,7 +16,7 @@ def get_modified_files(
         cache_file_path (str): Name of the cache file.
         path_filter_regex (str, optional): Filter which file paths should be included.
             The paths are relative to the Git project root.
-            Defaults to "", which means all files in the repostiory.
+            Defaults to "", which means all files in the repository.
 
     Returns:
         dict[str, str]: Dictionary of files, which changed since last time.
@@ -60,7 +60,7 @@ def get_modified_files(
 
 
 def get_hashed_files(path_filter_regex: str = "") -> dict[str, str]:
-    """Search for all files which are new or modified basing on git status in the repository.
+    """Search for all files which are new or modified based on git status in the repository.
 
     Args:
         path_filter_regex (str, optional): Filter which file paths should be included.

--- a/docs/source/sphinx_helper/single_header.py
+++ b/docs/source/sphinx_helper/single_header.py
@@ -32,14 +32,14 @@ def is_generate_single_header(app) -> bool:
 
     if "ALPAKA_SINGLE_HEADER" in os.environ:
         env_value = os.environ["ALPAKA_SINGLE_HEADER"]
-        if env_value == "ON":
+        if env_value in ("1", "ON"):
             logger.info(
-                "Single Header: force build via environment variable ALPAKA_SINGLE_HEADER=ON"
+                f"Single Header: force build via environment variable ALPAKA_SINGLE_HEADER={env_value}"
             )
             return True
-        if env_value == "OFF":
+        if env_value in ("0", "OFF"):
             logger.info(
-                "Single Header: disable build via environment variable ALPAKA_SINGLE_HEADER=OFF"
+                f"Single Header: disable build via environment variable ALPAKA_SINGLE_HEADER={env_value}"
             )
             return False
 

--- a/docs/source/sphinx_helper/single_header.py
+++ b/docs/source/sphinx_helper/single_header.py
@@ -1,0 +1,81 @@
+"""Build alpaka single header."""
+
+import os
+import sys
+import pathlib
+import subprocess
+from sphinx.util import logging
+
+from .utils import on_rtd
+from .file_cache import get_modified_files
+
+
+def is_generate_single_header(app) -> bool:
+    """Check if single header should be build.
+
+    Args:
+        app: sphinx doc object
+
+    Returns:
+        bool: Return true, if single header should be build.
+    """
+    logger = logging.getLogger(__name__)
+
+    if on_rtd():
+        logger.info("Single Header: create because we are on read the docs.")
+        return True
+
+    single_header_path = os.path.abspath(os.path.join(app.builder.outdir))
+    if not pathlib.Path(single_header_path).exists():
+        logger.info("Single Header: create because single header does not exist.")
+        return True
+
+    if "ALPAKA_SINGLE_HEADER" in os.environ:
+        env_value = os.environ["ALPAKA_SINGLE_HEADER"]
+        if env_value == "ON":
+            logger.info(
+                "Single Header: force build via environment variable ALPAKA_SINGLE_HEADER=ON"
+            )
+            return True
+        if env_value == "OFF":
+            logger.info(
+                "Single Header: disable build via environment variable ALPAKA_SINGLE_HEADER=OFF"
+            )
+            return False
+
+        logger.error(
+            f"Single Header: unknown value for environment variable ALPAKA_SINGLE_HEADER={env_value}"
+        )
+        sys.exit(1)
+
+    if not get_modified_files(
+        os.path.join(app.builder.outdir, ".include_diff_cache"), "^include"
+    ):
+        return False
+
+    return True
+
+
+def generate_single_header(app, exception):
+    """Build single header.
+
+    Args:
+        app: Sphinx doc app object
+        exception: Sphinx doc exception object
+    """
+    if not is_generate_single_header(app):
+        return
+    # Destination folder relative to conf.py
+    single_header_path = os.path.abspath(os.path.join(app.builder.outdir))
+    os.makedirs(single_header_path, exist_ok=True)
+
+    # Path to your script
+    script_path = os.path.abspath(
+        os.path.join(app.srcdir, "..", "..", "script", "create-single-header.sh")
+    )
+
+    logger = logging.getLogger(__name__)
+
+    # Call the script with the destination folder as argument
+    subprocess.run([script_path, single_header_path], check=True)
+    logger.info(f"Generated single header in {single_header_path}")

--- a/docs/source/sphinx_helper/single_header.py
+++ b/docs/source/sphinx_helper/single_header.py
@@ -51,6 +51,7 @@ def is_generate_single_header(app) -> bool:
     if not get_modified_files(
         os.path.join(app.builder.outdir, ".include_diff_cache"), "^include"
     ):
+        logger.info("Single Header: skip build because no file was changed")
         return False
 
     return True
@@ -76,6 +77,11 @@ def generate_single_header(app, exception):
 
     logger = logging.getLogger(__name__)
 
+    logger.info(f"Generate single header in {single_header_path} (takes some time)")
     # Call the script with the destination folder as argument
-    subprocess.run([script_path, single_header_path], check=True)
-    logger.info(f"Generated single header in {single_header_path}")
+    single_header_build = subprocess.run(
+        [script_path, single_header_path], stdout=subprocess.PIPE, text=True, check=True
+    )
+
+    if single_header_build.returncode != 0:
+        logger.error(single_header_build.stderr.strip())

--- a/docs/source/sphinx_helper/utils.py
+++ b/docs/source/sphinx_helper/utils.py
@@ -1,0 +1,7 @@
+"""Utility functions for documentation build."""
+
+import os
+
+def on_rtd() -> bool:
+    """Return true, if build is executed on readthedocs.io"""
+    return os.environ.get("READTHEDOCS", None) == "True"

--- a/script/create-single-header.sh
+++ b/script/create-single-header.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+set -e
+
 workingcopy_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )/.."
 dst=${1:-$workingcopy_dir/single-header/include/alpaka/}
 mkdir -p $dst
 tmp_dir=$(mktemp -d)
-git clone https://github.com/shrpnsld/amalgamate.git --depth 1 $tmp_dir/clone
+git clone https://github.com/shrpnsld/amalgamate.git --depth 1 $tmp_dir/clone &> /dev/null
 $tmp_dir/clone/amalgamate -o $tmp_dir -v -a -n 'alpaka' -I $workingcopy_dir/include -- $workingcopy_dir/include/alpaka/alpaka.hpp $workingcopy_dir/include/alpaka/onHost/example/executors.hpp
 mv $tmp_dir/alpaka-amalgamated/alpaka.hpp $dst/alpaka.hpp
 rm -rf $tmp_dir


### PR DESCRIPTION
Make much easier to use `make html` to build the documentation. The single header is automatically rebuild if required.

The rules for a build are:
- On readthedocs.io -> build all the time
- If single header is missing -> build all the time
- If environment variable `ALPAKA_SINGLE_HEADER` -> build depending on the value (`ON` -> force build, `OFF` -> force skip)
- Auto detection if a file is changed*

* The mechanism is the following. It takes `git status` to check which files was modified. The set can be filtered by a filter, e.g. only files from the `include` folder. Hash each file and store it in cache file. If a hash changed, a file was added or removed, trigger rebuild of the single header.

# TODO:

- [x] stop building documentation if single header build failes
- [x] Show only single header output in a case of an error

# Following up tasks

I will also use the same mechanism for the doxygen build. Therefore I open an extra PR.