### PR TITLE
sphinx doc: on a local system, build doxygen only of a source file is changed

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -927,7 +927,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = NO
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, Doxygen will generate warnings for
 # potential errors in the documentation, such as documenting some parameters in
@@ -942,7 +942,7 @@ WARN_IF_DOC_ERROR      = YES
 # parameters have no documentation without warning.
 # The default value is: YES.
 
-WARN_IF_INCOMPLETE_DOC = YES
+WARN_IF_INCOMPLETE_DOC = NO
 
 # This WARN_NO_PARAMDOC option can be enabled to get warnings for functions that
 # are documented, but have no documentation for their parameters or return
@@ -952,7 +952,7 @@ WARN_IF_INCOMPLETE_DOC = YES
 # WARN_IF_INCOMPLETE_DOC
 # The default value is: NO.
 
-WARN_NO_PARAMDOC       = YES
+WARN_NO_PARAMDOC       = NO
 
 # If WARN_IF_UNDOC_ENUM_VAL option is set to YES, Doxygen will warn about
 # undocumented enumeration values. If set to NO, Doxygen will accept

--- a/docs/Doxyfile_dev
+++ b/docs/Doxyfile_dev
@@ -927,7 +927,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = NO
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, Doxygen will generate warnings for
 # potential errors in the documentation, such as documenting some parameters in
@@ -942,7 +942,7 @@ WARN_IF_DOC_ERROR      = YES
 # parameters have no documentation without warning.
 # The default value is: YES.
 
-WARN_IF_INCOMPLETE_DOC = YES
+WARN_IF_INCOMPLETE_DOC = NO
 
 # This WARN_NO_PARAMDOC option can be enabled to get warnings for functions that
 # are documented, but have no documentation for their parameters or return
@@ -952,7 +952,7 @@ WARN_IF_INCOMPLETE_DOC = YES
 # WARN_IF_INCOMPLETE_DOC
 # The default value is: NO.
 
-WARN_NO_PARAMDOC       = YES
+WARN_NO_PARAMDOC       = NO
 
 # If WARN_IF_UNDOC_ENUM_VAL option is set to YES, Doxygen will warn about
 # undocumented enumeration values. If set to NO, Doxygen will accept

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,53 +2,18 @@
 # Configuration file for the Sphinx documentation builder.
 
 import os
-import subprocess
-import shutil
 import sys
 
 # allows to import module `build_helper`
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 from sphinx_helper.single_header import generate_single_header
 from sphinx_helper.utils import on_rtd
-
-
-
-def build_doxygen():
-    subprocess.call("cd ..; doxygen", shell=True)
-    subprocess.call("cd ..; doxygen Doxyfile_dev", shell=True)
-
-def copy_doxygen(dst, src):
-    print("Copying from:", src)
-    print("Copying to:", dst)
-    if os.path.exists(src):
-        if os.path.exists(dst):
-            shutil.rmtree(dst)
-        shutil.copytree(src, dst)
-    else:
-        print("Doxygen HTML not found at:", src)
-
-def copy_doxygen_html(app, exception):
-    # confdir = …/repo-root/docs/source
-    confdir = os.path.dirname(app.confdir)
-
-    # --------------------------------------------------------------
-    # USER documentation (docs/doxygen/html)
-    # --------------------------------------------------------------
-    src = os.path.abspath(os.path.join(confdir, '..', 'docs/doxygen', 'html'))
-    dst = os.path.join(app.builder.outdir, 'doxygen')
-    copy_doxygen(dst, src)
-
-    # --------------------------------------------------------------
-    # DEVELOPER documentation (docs/doxygen_dev/html)
-    # --------------------------------------------------------------
-    src = os.path.abspath(os.path.join(confdir, '..', 'docs/doxygen_dev', 'html'))
-    dst = os.path.join(app.builder.outdir, 'doxygen_dev')
-    copy_doxygen(dst, src)
+from sphinx_helper.doxygen import generate_doxygen
 
 def setup(app):
     # Hook into the 'builder-inited' event to run the function before the build starts
     app.connect('build-finished', generate_single_header)
-    app.connect('build-finished', copy_doxygen_html)
+    app.connect('build-finished', generate_doxygen)
 
 # -- Project information -----------------------------------------------------
 
@@ -208,7 +173,7 @@ cpp_id_attributes = [
 # -- processing --
 
 if on_rtd():
-    build_doxygen()
+    pass
     #subprocess.call(
     #    "cd ../cheatsheet; rst2pdf -s cheatsheet.style ../source/basic/cheatsheet.rst -o cheatsheet.pdf", shell=True
     #)
@@ -221,11 +186,5 @@ else:
     html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
-    logger.info("single header build can be force build or skipped with the environment variable 'ALPAKA_SINGLE_HEADER=0|OFF|1|ON'")
-
-    if shutil.which("doxygen"):
-        if not "ALPAKA_NO_DOXYGEN" in os.environ:
-            build_doxygen()
-        logger.info("doxygen build can be skipped with the environment variable 'ALPAKA_NO_DOXYGEN=1'")
-    else:
-        logger.warning("could not find 'doxygen' executable. Skip building doxygen documentation.")
+    logger.info("single header build can be force build or skipped with the environment variable 'ALPAKA_DOC_SINGLE_HEADER=0|OFF|1|ON'")
+    logger.info("doxygen build can be force build or skipped with the environment variable 'ALPAKA_DOC_DOXYGEN=0|OFF|1|ON'")

--- a/docs/source/sphinx_helper/doxygen.py
+++ b/docs/source/sphinx_helper/doxygen.py
@@ -128,7 +128,7 @@ def build_doxygen(app):
             logger.warning(doxygen_process.stderr.strip())
         if doxygen_process.returncode != 0:
             logger.error(f"{cmd} failed")
-            sys.exit(0)
+            sys.exit(doxygen_process.returncode)
 
     # copy user and developer to sphinx doc html output
     for src, dest in get_src_dest_paths(app):

--- a/docs/source/sphinx_helper/doxygen.py
+++ b/docs/source/sphinx_helper/doxygen.py
@@ -1,0 +1,142 @@
+"""Build doxygen Documentation"""
+
+import os
+import shutil
+import subprocess
+import pathlib
+import sys
+from sphinx.util import logging
+
+from .utils import on_rtd
+from .file_cache import get_modified_files
+
+
+def generate_doxygen(app, exception):
+    """Build doxygen documentation.
+
+    Args:
+        app: Sphinx doc app object
+        exception: Sphinx doc exception object
+    """
+    if is_generate_doxygen(app):
+        build_doxygen(app)
+
+
+def get_src_dest_paths(app) -> list[tuple[pathlib.Path, pathlib.Path]]:
+    """Get the path, where doxygen build the doc (source) and the where it
+    needs to copy there (destination). The list contains the user and developer
+    build.
+
+    Args:
+        app: Sphinx doc app object
+
+    Returns:
+        list[tuple[pathlib.Path, pathlib.Path]]: Each entry of the list is a
+            (source, destination) tuple.
+    """
+    # confdir = …/repo-root/docs/source
+    conf_dir = pathlib.Path(app.confdir)
+    output_dir = pathlib.Path(app.builder.outdir)
+
+    return [
+        # USER documentation (docs/doxygen/html)
+        (
+            (conf_dir / "../doxygen/html")
+            .resolve()
+            .absolute(),
+            (output_dir / "doxygen").absolute(),
+        ),
+        # DEVELOPER documentation (docs/doxygen_dev/html)
+        (
+            (conf_dir / "../doxygen_dev/html")
+            .resolve()
+            .absolute(),
+            (output_dir / "doxygen_dev").absolute(),
+        ),
+    ]
+
+
+def is_generate_doxygen(app) -> bool:
+    """Check if doxygen should be build.
+
+    Args:
+        app: sphinx doc object
+
+    Returns:
+        bool: Return true, if doxygen should be build.
+    """
+    logger = logging.getLogger(__name__)
+
+    if on_rtd():
+        logger.info("Doxygen: create because we are on read the docs.")
+        return True
+
+    if not shutil.which("doxygen"):
+        logger.warning(
+            "Doxygen: could not find 'doxygen' executable. Skip building doxygen documentation."
+        )
+        return False
+
+    for _, dest in get_src_dest_paths(app):
+        if not dest.exists():
+            logger.info(f"Doxygen: build because {dest} does not exist.")
+            return True
+
+    if "ALPAKA_DOC_DOXYGEN" in os.environ:
+        env_value = os.environ["ALPAKA_DOC_DOXYGEN"]
+        if env_value in ("1", "ON"):
+            logger.info(
+                f"Doxygen: force build via environment variable ALPAKA_DOC_DOXYGEN={env_value}"
+            )
+            return True
+        if env_value in ("0", "OFF"):
+            logger.info(
+                f"Doxygen: disable build via environment variable ALPAKA_DOC_DOXYGEN={env_value}"
+            )
+            return False
+
+        logger.error(
+            f"Doxygen: unknown value for environment variable ALPAKA_DOC_DOXYGEN={env_value}"
+        )
+        sys.exit(1)
+
+    if not get_modified_files(
+        os.path.join(app.builder.outdir, ".doxygen_cache.json"), "^include"
+    ):
+        logger.info("Doxygen: skip build because no file was changed")
+        return False
+
+    return True
+
+
+def build_doxygen(app):
+    """Run the doxygen build process and copy the rendered doc to the correct position.
+
+    Args:
+        app: Sphinx doc app object
+    """
+    docs_dir = pathlib.Path(app.confdir).parent
+    print(docs_dir)
+
+    logger = logging.getLogger(__name__)
+    for cmd in (["doxygen"], ["doxygen", "Doxyfile_dev"]):
+        logger.info(f"Run {' '.join(cmd)}")
+        doxygen_process = subprocess.run(
+            cmd, cwd=docs_dir, stdout=subprocess.PIPE, text=True, check=True
+        )
+        if doxygen_process.stderr:
+            logger.warning(doxygen_process.stderr.strip())
+        if doxygen_process.returncode != 0:
+            logger.error(f"{cmd} failed")
+            sys.exit(0)
+
+    # copy user and developer to sphinx doc html output
+    for src, dest in get_src_dest_paths(app):
+        logger.info(f"copy from {src}\n       to {dest}")
+        if src.exists():
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.copytree(src, dest)
+        else:
+            logger.error(f"Doxygen HTML not found at: {src}")
+            sys.exit(1)

--- a/docs/source/sphinx_helper/single_header.py
+++ b/docs/source/sphinx_helper/single_header.py
@@ -30,26 +30,26 @@ def is_generate_single_header(app) -> bool:
         logger.info("Single Header: create because single header does not exist.")
         return True
 
-    if "ALPAKA_SINGLE_HEADER" in os.environ:
-        env_value = os.environ["ALPAKA_SINGLE_HEADER"]
+    if "ALPAKA_DOC_SINGLE_HEADER" in os.environ:
+        env_value = os.environ["ALPAKA_DOC_SINGLE_HEADER"]
         if env_value in ("1", "ON"):
             logger.info(
-                f"Single Header: force build via environment variable ALPAKA_SINGLE_HEADER={env_value}"
+                f"Single Header: force build via environment variable ALPAKA_DOC_SINGLE_HEADER={env_value}"
             )
             return True
         if env_value in ("0", "OFF"):
             logger.info(
-                f"Single Header: disable build via environment variable ALPAKA_SINGLE_HEADER={env_value}"
+                f"Single Header: disable build via environment variable ALPAKA_DOC_SINGLE_HEADER={env_value}"
             )
             return False
 
         logger.error(
-            f"Single Header: unknown value for environment variable ALPAKA_SINGLE_HEADER={env_value}"
+            f"Single Header: unknown value for environment variable ALPAKA_DOC_SINGLE_HEADER={env_value}"
         )
         sys.exit(1)
 
     if not get_modified_files(
-        os.path.join(app.builder.outdir, ".include_diff_cache"), "^include"
+        os.path.join(app.builder.outdir, ".single_header_cache.json"), "^include"
     ):
         logger.info("Single Header: skip build because no file was changed")
         return False


### PR DESCRIPTION
Same functionality like in PR #499 but for the Doxygen build instead the single header build

- behavior can be overwritten with the environment variable  ALPAKA_DOC_DOXYGEN
- changed environment variable `ALPAKA_SINGLE_HEADER` to `ALPAKA_DOC_SINGLE_HEADER`
- disable some Doxygen warnings because we agreed that not every trivial function needs to be documented and also some functions can be documented with a single line instead whole parameter documentation.