### PR TITLE
add `alpaka::concepts::SpecializationOf<>`

### DIFF
--- a/include/alpaka/Tuple.hpp
+++ b/include/alpaka/Tuple.hpp
@@ -92,7 +92,7 @@ namespace alpaka
     Tuple(T_Args&&...) -> Tuple<T_Args...>;
 
     template<size_t T_idx>
-    constexpr decltype(auto) get(auto&& t) noexcept requires(alpaka::isSpecializationOf_v<ALPAKA_TYPEOF(t), Tuple>)
+    constexpr decltype(auto) get(concepts::SpecializationOf<Tuple> auto&& t) noexcept
     {
         return ALPAKA_FORWARD(t).template get<T_idx>();
     }

--- a/include/alpaka/core/Dict.hpp
+++ b/include/alpaka/core/Dict.hpp
@@ -148,13 +148,13 @@ namespace alpaka
     };
 
     template<size_t T_idx>
-    constexpr decltype(auto) get(auto& t) noexcept requires(alpaka::isSpecializationOf_v<ALPAKA_TYPEOF(t), Dict>)
+    constexpr decltype(auto) get(concepts::SpecializationOf<Dict> auto& t) noexcept
     {
         return t.template get<T_idx>();
     }
 
     template<size_t T_idx>
-    constexpr decltype(auto) get(auto const& t) noexcept requires(alpaka::isSpecializationOf_v<ALPAKA_TYPEOF(t), Dict>)
+    constexpr decltype(auto) get(concepts::SpecializationOf<Dict> auto const& t) noexcept
     {
         return t.template get<T_idx>();
     }

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -209,8 +209,7 @@ namespace alpaka
         {
         };
 
-        template<typename T>
-        requires(isSpecializationOf_v<std::remove_cvref_t<T>, IdxRange>)
+        template<concepts::SpecializationOf<IdxRange> T>
         struct IsIndexRange<T> : std::true_type
         {
         };

--- a/include/alpaka/onAcc/Acc.hpp
+++ b/include/alpaka/onAcc/Acc.hpp
@@ -93,7 +93,7 @@ namespace alpaka::onAcc
          * @tparam T_Api Enforce an API type, if not provided api type is not checked
          */
         template<typename T_Acc, typename T_Api = alpaka::NotRequired>
-        concept Acc = alpaka::isSpecializationOf_v<T_Acc, alpaka::onAcc::Acc>
+        concept Acc = alpaka::concepts::SpecializationOf<T_Acc, onAcc::Acc>
                       && (std::same_as<T_Api, ALPAKA_TYPEOF(std::declval<T_Acc>().getApi())>
                           || std::same_as<T_Api, alpaka::NotRequired>);
     } // namespace concepts

--- a/include/alpaka/onAcc/internal/IdxRange.hpp
+++ b/include/alpaka/onAcc/internal/IdxRange.hpp
@@ -79,14 +79,12 @@ namespace alpaka::onAcc::internal
 
 namespace alpaka::trait
 {
-    template<typename T>
-    requires(isSpecializationOf_v<std::remove_cvref_t<T>, onAcc::internal::IdxRangeLazy>)
+    template<concepts::SpecializationOf<onAcc::internal::IdxRangeLazy> T>
     struct IsLazyIndexRange<T> : std::true_type
     {
     };
 
-    template<typename T>
-    requires(isSpecializationOf_v<std::remove_cvref_t<T>, onAcc::internal::IdxRangeFn>)
+    template<concepts::SpecializationOf<onAcc::internal::IdxRangeFn> T>
     struct IsLazyIndexRange<T> : std::true_type
     {
     };

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -158,7 +158,7 @@ namespace alpaka::onHost
          * alpaka, refer to the class documentation.
          */
         template<typename T_Device>
-        concept Device = alpaka::isSpecializationOf_v<T_Device, onHost::Device>;
+        concept Device = alpaka::concepts::SpecializationOf<T_Device, onHost::Device>;
     } // namespace concepts
 
     template<typename T_Device>

--- a/include/alpaka/onHost/DeviceSpec.hpp
+++ b/include/alpaka/onHost/DeviceSpec.hpp
@@ -114,7 +114,7 @@ namespace alpaka::onHost
         /** Concept to check for specializations of alpaka::onHost::DeviceSpec
          */
         template<typename T>
-        concept DeviceSpec = isSpecializationOf_v<T, onHost::DeviceSpec>;
+        concept DeviceSpec = alpaka::concepts::SpecializationOf<T, onHost::DeviceSpec>;
     } // namespace concepts
 
 } // namespace alpaka::onHost

--- a/include/alpaka/utility.hpp
+++ b/include/alpaka/utility.hpp
@@ -107,6 +107,17 @@ namespace alpaka
 
     /** @} */
 
+    namespace concepts
+    {
+        /** Validates if T is a specialization of the unspecialized template type U.
+         *
+         * @tparam T full type specialization
+         * @tparam U unspecialized template type
+         */
+        template<typename T, template<typename...> typename U>
+        concept SpecializationOf = isSpecializationOf_v<std::remove_cvref_t<T>, U>;
+    } // namespace concepts
+
     /**
      * @brief Helper function calculating the integer power for the given base and exponent.
      */


### PR DESCRIPTION
- add concepts to simplify usage without using `requires{}`
- use new concept where it is usefull to simplify the code