### PR TITLE
extent device properties

### DIFF
--- a/include/alpaka/api/host/Platform.hpp
+++ b/include/alpaka/api/host/Platform.hpp
@@ -142,7 +142,6 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(alpaka::onHost::logger::device);
                 auto prop = DeviceProperties{};
                 prop.name = getCpuName();
-                prop.maxThreadsPerBlock = std::numeric_limits<uint32_t>::max();
                 prop.warpSize = 1u;
                 prop.multiProcessorCount = hwloc::getNumCores(hwloc::allNumaDomains);
                 prop.globalMemCapacityBytes = hwloc::getMemCapacityBytes(hwloc::allNumaDomains);
@@ -156,6 +155,20 @@ namespace alpaka::onHost
                 }
                 else
                     alpaka::unused(deviceIdx);
+
+                prop.maxThreadsPerBlock = std::numeric_limits<uint32_t>::max();
+                prop.fnMaxThreadsPerBlock = [](uint32_t* data, uint32_t numDims)
+                {
+                    for(uint32_t d = 0u; d < numDims; ++d)
+                        data[d] = std::numeric_limits<uint32_t>::max();
+                };
+
+                prop.maxBlocksPerGrid = std::numeric_limits<uint32_t>::max();
+                prop.fnMaxBlocksPerGrid = [](uint32_t* data, uint32_t numDims)
+                {
+                    for(uint32_t d = 0u; d < numDims; ++d)
+                        data[d] = std::numeric_limits<uint32_t>::max();
+                };
 
                 return prop;
             }

--- a/include/alpaka/api/syclGeneric/Platform.hpp
+++ b/include/alpaka/api/syclGeneric/Platform.hpp
@@ -228,7 +228,6 @@ namespace alpaka
 
                     auto prop = DeviceProperties{};
                     prop.name = dev.get_info<sycl::info::device::name>();
-                    prop.maxThreadsPerBlock = dev.get_info<sycl::info::device::max_work_group_size>();
                     std::vector<std::size_t> wrap_sizes = dev.get_info<sycl::info::device::sub_group_sizes>();
                     // @todo do not reduce wrap size to a single value, return all values
                     prop.warpSize = static_cast<uint32_t>(std::reduce(
@@ -247,6 +246,35 @@ namespace alpaka
                     prop.multiProcessorCount = dev.get_info<sycl::info::device::max_compute_units>();
                     prop.globalMemCapacityBytes = dev.get_info<sycl::info::device::global_mem_size>();
                     prop.sharedMemPerBlockBytes = dev.get_info<sycl::info::device::local_mem_size>();
+
+                    prop.maxThreadsPerBlock = dev.get_info<sycl::info::device::max_work_group_size>();
+                    // will be copied into the lampda
+                    auto syclMaxThreadsPerBlock = dev.get_info<sycl::info::device::max_work_item_sizes<3>>();
+                    // in sycl index order == alpaka index order
+                    prop.fnMaxThreadsPerBlock = [maxThreadsPerBlock = prop.maxThreadsPerBlock,
+                                                 syclMaxThreadsPerBlock](uint32_t* data, uint32_t numDims)
+                    {
+                        if(numDims <= 3u)
+                        {
+                            for(uint32_t d = 0u; d < numDims; ++d)
+                                data[numDims - 1u - d] = syclMaxThreadsPerBlock[3u - 1u - d];
+                        }
+                        else
+                        {
+                            /* For more than 3 dimensions alpaka is linearizing to one dimension, therefore we use the
+                             * maximum for each dimension. */
+                            for(uint32_t d = 0u; d < numDims; ++d)
+                                data[d] = maxThreadsPerBlock;
+                        }
+                    };
+
+                    prop.maxBlocksPerGrid = std::numeric_limits<uint32_t>::max();
+                    prop.fnMaxBlocksPerGrid = [](uint32_t* data, uint32_t numDims)
+                    {
+                        for(uint32_t d = 0u; d < numDims; ++d)
+                            data[d] = std::numeric_limits<uint32_t>::max();
+                    };
+
 
                     return prop;
                 }

--- a/include/alpaka/api/unifiedCudaHip/Platform.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Platform.hpp
@@ -136,11 +136,56 @@ namespace alpaka::onHost
 
                 auto prop = DeviceProperties{};
                 prop.name = devProp.name;
-                prop.maxThreadsPerBlock = devProp.maxThreadsPerBlock;
                 prop.warpSize = devProp.warpSize;
                 prop.multiProcessorCount = devProp.multiProcessorCount;
                 prop.globalMemCapacityBytes = globalMemCapacityBytes;
                 prop.sharedMemPerBlockBytes = devProp.sharedMemPerBlock;
+
+                prop.maxThreadsPerBlock = devProp.maxThreadsPerBlock;
+                // will be copied into the lampda and follows cuda index order
+                Vec<uint32_t, 3u> cudaMaxThreadsPerBlock{
+                    devProp.maxThreadsDim[0u],
+                    devProp.maxThreadsDim[1u],
+                    devProp.maxThreadsDim[2u]};
+                prop.fnMaxThreadsPerBlock = [maxThreadsPerBlock = prop.maxThreadsPerBlock,
+                                             cudaMaxThreadsPerBlock](uint32_t* data, uint32_t numDims)
+                {
+                    if(numDims <= 3u)
+                    {
+                        for(uint32_t d = 0u; d < numDims; ++d)
+                            data[numDims - 1u - d] = cudaMaxThreadsPerBlock[d];
+                    }
+                    else
+                    {
+                        /* For more than 3 dimensions alpaka is linearizing to one dimension, therefore we use the
+                         * maximum for each dimension. */
+                        for(uint32_t d = 0u; d < numDims; ++d)
+                            data[d] = maxThreadsPerBlock;
+                    }
+                };
+
+                prop.maxBlocksPerGrid = std::numeric_limits<uint32_t>::max();
+                // will be copied into the lampda and follows cuda index order
+                Vec<uint32_t, 3u> cudaMaxBlocksPerGrid{
+                    devProp.maxGridSize[0u],
+                    devProp.maxGridSize[1u],
+                    devProp.maxGridSize[2u]};
+                prop.fnMaxBlocksPerGrid =
+                    [maxBlocksPerGrid = prop.maxBlocksPerGrid, cudaMaxBlocksPerGrid](uint32_t* data, uint32_t numDims)
+                {
+                    if(numDims <= 3u)
+                    {
+                        for(uint32_t d = 0u; d < numDims; ++d)
+                            data[numDims - 1u - d] = cudaMaxBlocksPerGrid[d];
+                    }
+                    else
+                    {
+                        /* For more than 3 dimensions alpaka is linearizing to one dimension, therefore we use the
+                         * maximum for each dimension. */
+                        for(uint32_t d = 0u; d < numDims; ++d)
+                            data[d] = maxBlocksPerGrid;
+                    }
+                };
 
                 return prop;
             }

--- a/include/alpaka/onHost/DeviceProperties.hpp
+++ b/include/alpaka/onHost/DeviceProperties.hpp
@@ -5,12 +5,22 @@
 
 #pragma once
 
+#include "alpaka/Vec.hpp"
+
+#include <array>
 #include <cstdint>
+#include <functional>
 #include <ostream>
 #include <string>
 
 namespace alpaka::onHost
 {
+    namespace internal
+    {
+        // forward declaration
+        struct GetDeviceProperties;
+    } // namespace internal
+
     /** Properties of a device
      *
      * Collection of static properties of a device.
@@ -44,6 +54,60 @@ namespace alpaka::onHost
         uint32_t warpSize;
         /** The maximum total number of threads per thread block. */
         uint32_t maxThreadsPerBlock;
+
+        /** Maximum number of threads within a thread block.
+         *
+         * @attention Do not assume that the limits are equal for any dimension.
+         * The product of the result is not allowed to exceed @see maxThreadsPerBlock, but the individual entries
+         * may be larger. All values are 32-bit indexes, take care of overflows.
+         *
+         *  @tparam T_dim Number of dimension used for a kernel call.
+         *  @return Maximum number of threads within a block usable for @see ThreadSpec.
+         */
+        template<uint32_t T_dim>
+        Vec<uint32_t, T_dim> getMaxThreadsPerBlock() const
+        {
+            std::array<uint32_t, T_dim> res;
+            fnMaxThreadsPerBlock(res.data(), T_dim);
+            return {res};
+        }
+
+        /** The maximum total number of blocks within a grid. */
+        uint32_t maxBlocksPerGrid;
+
+        /** Maximum number of blocks within a grid.
+         *
+         * @attention Do not assume that the limits are equal for any dimension.
+         * The product of the result is not allowed to exceed @see maxBlocksPerGrid, but the individual entries
+         * may be larger. All values are 32-bit indexes, take care of overflows.
+         *
+         *  @tparam T_dim Number of dimension used for a kernel call.
+         *  @return Maximum number of blocks usable for @see ThreadSpec.
+         */
+        template<uint32_t T_dim>
+        Vec<uint32_t, T_dim> getMaxBlocksPerGrid() const
+        {
+            std::array<uint32_t, T_dim> res;
+            fnMaxBlocksPerGrid(res.data(), T_dim);
+            return {res};
+        }
+
+    private:
+        friend internal::GetDeviceProperties;
+
+        /** function to fill maximum number of threads per block
+         *
+         * result: pointer to vector data, follows alpaka index order
+         * numDims: number of dimensions of the result, elements in result
+         */
+        std::function<void(uint32_t* result, uint32_t numDims)> fnMaxThreadsPerBlock;
+
+        /** function to fill maximum number of blocks within a grid
+         *
+         * result: pointer to vector data, follows alpaka index order
+         * numDims: number of dimensions of the result, elements in result
+         */
+        std::function<void(uint32_t* result, uint32_t numDims)> fnMaxBlocksPerGrid;
     };
 
     inline std::ostream& operator<<(std::ostream& s, DeviceProperties const& p)
@@ -52,6 +116,7 @@ namespace alpaka::onHost
         s << "multiProcessorCount: " << p.multiProcessorCount << "\n";
         s << "warpSize: " << p.warpSize << "\n";
         s << "maxThreadsPerBlock: " << p.maxThreadsPerBlock << "\n";
+        s << "maxBlocksPerGrid: " << p.maxBlocksPerGrid << "\n";
         s << "globalMemCapacityBytes: " << p.globalMemCapacityBytes << "\n";
         s << "sharedMemPerBlockBytes: " << p.sharedMemPerBlockBytes << "\n";
         return s;

--- a/include/alpaka/onHost/DeviceProperties.hpp
+++ b/include/alpaka/onHost/DeviceProperties.hpp
@@ -55,14 +55,14 @@ namespace alpaka::onHost
         /** The maximum total number of threads per thread block. */
         uint32_t maxThreadsPerBlock;
 
-        /** Maximum number of threads within a thread block.
+        /** Maximum number of threads within a thread block for each dimension.
          *
          * @attention Do not assume that the limits are equal for any dimension.
-         * The product of the result is not allowed to exceed @see maxThreadsPerBlock, but the individual entries
-         * may be larger. All values are 32-bit indexes, take care of overflows.
+         * The product of two or more dimensions can exceed maxThreadsPerBlock, this will result in an invalid
+         * configuration when used for kernel execution. All values are 32-bit indexes, take care of overflows.
          *
-         *  @tparam T_dim Number of dimension used for a kernel call.
-         *  @return Maximum number of threads within a block usable for @see ThreadSpec.
+         *  @tparam T_dim Number of dimensions used for a kernel call.
+         *  @return Maximum number of threads within a block, usable for @see ThreadSpec.
          */
         template<uint32_t T_dim>
         Vec<uint32_t, T_dim> getMaxThreadsPerBlock() const
@@ -75,14 +75,14 @@ namespace alpaka::onHost
         /** The maximum total number of blocks within a grid. */
         uint32_t maxBlocksPerGrid;
 
-        /** Maximum number of blocks within a grid.
+        /** Maximum number of blocks within a grid for each dimension.
          *
          * @attention Do not assume that the limits are equal for any dimension.
-         * The product of the result is not allowed to exceed @see maxBlocksPerGrid, but the individual entries
-         * may be larger. All values are 32-bit indexes, take care of overflows.
+         * The product of two or more dimensions can exceed maxBlocksPerGrid, this will result in an invalid
+         * configuration when used for kernel execution. All values are 32-bit indexes, take care of overflows.
          *
-         *  @tparam T_dim Number of dimension used for a kernel call.
-         *  @return Maximum number of blocks usable for @see ThreadSpec.
+         *  @tparam T_dim Number of dimensions used for a kernel call.
+         *  @return Maximum number of blocks, usable for @see ThreadSpec.
          */
         template<uint32_t T_dim>
         Vec<uint32_t, T_dim> getMaxBlocksPerGrid() const
@@ -95,14 +95,14 @@ namespace alpaka::onHost
     private:
         friend internal::GetDeviceProperties;
 
-        /** function to fill maximum number of threads per block
+        /** function to fill maximum number of threads per block per dimension
          *
          * result: pointer to vector data, follows alpaka index order
          * numDims: number of dimensions of the result, elements in result
          */
         std::function<void(uint32_t* result, uint32_t numDims)> fnMaxThreadsPerBlock;
 
-        /** function to fill maximum number of blocks within a grid
+        /** function to fill maximum number of blocks within a grid per dimension
          *
          * result: pointer to vector data, follows alpaka index order
          * numDims: number of dimensions of the result, elements in result

--- a/include/alpaka/onHost/DeviceProperties.hpp
+++ b/include/alpaka/onHost/DeviceProperties.hpp
@@ -62,7 +62,7 @@ namespace alpaka::onHost
          * configuration when used for kernel execution. All values are 32-bit indexes, take care of overflows.
          *
          *  @tparam T_dim Number of dimensions used for a kernel call.
-         *  @return Maximum number of threads within a block, usable for @see ThreadSpec.
+         *  @return Maximum number of threads within a block, usable for ThreadSpec.
          */
         template<uint32_t T_dim>
         Vec<uint32_t, T_dim> getMaxThreadsPerBlock() const
@@ -82,7 +82,7 @@ namespace alpaka::onHost
          * configuration when used for kernel execution. All values are 32-bit indexes, take care of overflows.
          *
          *  @tparam T_dim Number of dimensions used for a kernel call.
-         *  @return Maximum number of blocks, usable for @see ThreadSpec.
+         *  @return Maximum number of blocks, usable for ThreadSpec.
          */
         template<uint32_t T_dim>
         Vec<uint32_t, T_dim> getMaxBlocksPerGrid() const

--- a/test/unit/device/deviceProperties.cpp
+++ b/test/unit/device/deviceProperties.cpp
@@ -1,0 +1,46 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <iostream>
+
+using namespace alpaka;
+
+using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
+
+/* The test is not verifying any numbers because the device properties are device specific.
+ * We only ensure that all properties can be queried.
+ */
+TEMPLATE_LIST_TEST_CASE("deviceProperties", "[device][property]", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    onHost::DeviceProperties deviceProperties = device.getDeviceProperties();
+    std::cout << deviceProperties << "\n";
+    std::cout << "dim = 1 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<1>() << "\n";
+    std::cout << "dim = 2 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<2>() << "\n";
+    std::cout << "dim = 3 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<3>() << "\n";
+    std::cout << "dim = 4 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<4>() << "\n";
+    std::cout << "dim = 5 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<5>() << "\n";
+
+    std::cout << "dim = 1 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<1>() << "\n";
+    std::cout << "dim = 2 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<2>() << "\n";
+    std::cout << "dim = 3 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<3>() << "\n";
+    std::cout << "dim = 4 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<4>() << "\n";
+    std::cout << "dim = 5 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<5>() << "\n";
+    std::cout << "-----------------------------" << std::endl;
+}

--- a/test/unit/device/deviceProperties.cpp
+++ b/test/unit/device/deviceProperties.cpp
@@ -7,8 +7,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <iostream>
-
 using namespace alpaka;
 
 using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
@@ -24,23 +22,23 @@ TEMPLATE_LIST_TEST_CASE("deviceProperties", "[device][property]", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
-        return;
+        SKIP("No device available for " << deviceSpec.getName());
     }
 
     onHost::Device device = devSelector.makeDevice(0);
     onHost::DeviceProperties deviceProperties = device.getDeviceProperties();
-    std::cout << deviceProperties << "\n";
-    std::cout << "dim = 1 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<1>() << "\n";
-    std::cout << "dim = 2 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<2>() << "\n";
-    std::cout << "dim = 3 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<3>() << "\n";
-    std::cout << "dim = 4 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<4>() << "\n";
-    std::cout << "dim = 5 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<5>() << "\n";
+    INFO(deviceProperties);
+    INFO("dim = 1 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<1>());
+    INFO("dim = 2 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<2>());
+    INFO("dim = 3 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<3>());
+    INFO("dim = 4 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<4>());
+    INFO("dim = 5 threadsPerBlock = " << deviceProperties.getMaxThreadsPerBlock<5>());
 
-    std::cout << "dim = 1 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<1>() << "\n";
-    std::cout << "dim = 2 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<2>() << "\n";
-    std::cout << "dim = 3 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<3>() << "\n";
-    std::cout << "dim = 4 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<4>() << "\n";
-    std::cout << "dim = 5 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<5>() << "\n";
-    std::cout << "-----------------------------" << std::endl;
+    INFO("dim = 1 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<1>());
+    INFO("dim = 2 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<2>());
+    INFO("dim = 3 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<3>());
+    INFO("dim = 4 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<4>());
+    INFO("dim = 5 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<5>());
+    // This call is required else no information will be shown on the terminal.
+    SUCCEED("-----------------------------");
 }


### PR DESCRIPTION
Add missing device properties mentioned in #486.
To query the dimensional limits a method with compile tim dimensions must be used because alpaka is not limiting the number of dimension.

- add `getMaxThreadsPerBlock<dim>()`
- add `getMaxBlocksPerGrid<dim>()`
- add tests which validates the interfaces are callable