### PR TITLE
use Catch2 macros for IO

### DIFF
--- a/test/unit/algorithm/concurrent.cpp
+++ b/test/unit/algorithm/concurrent.cpp
@@ -10,7 +10,6 @@
 
 #include <chrono>
 #include <functional>
-#include <iostream>
 #include <type_traits>
 
 using namespace alpaka;
@@ -64,7 +63,7 @@ struct TestWithMdSpan
         auto const setup,
         concepts::Vector auto extentMd)
     {
-        std::cout << "run func : " << onHost::demangledName(std::get<1>(setup)) << std::endl;
+        INFO("run func : " << onHost::demangledName(std::get<1>(setup)));
 
         auto computeDev = computeQueue.getDevice();
         using DataType = T_DataType;
@@ -97,8 +96,9 @@ struct TestWithMdSpan
 
         onHost::wait(computeQueue);
         auto const endT = std::chrono::high_resolution_clock::now();
-        std::cout << "Time for concurrent: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-                  << " data size: " << extentMd << std::endl;
+        UNSCOPED_INFO(
+            "Time for concurrent: " << std::chrono::duration<double>(endT - beginT).count()
+                                    << "s data size: " << extentMd);
 
         onHost::memcpy(computeQueue, hostBufferOut, computeBufferIn0);
         onHost::wait(computeQueue);
@@ -126,15 +126,15 @@ void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTupl
     auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!computeDevSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
 
-    std::cout << "device spec: " << getName(deviceSpec) << std::endl;
-    std::cout << "device name: " << computeDev.getName() << std::endl;
-    std::cout << "executor   : " << exec.getName() << std::endl;
+    INFO("device spec: " << getName(deviceSpec));
+    INFO("device name: " << computeDev.getName());
+    INFO("executor   : " << exec.getName());
 
     onHost::Queue computeQueue = computeDev.makeQueue();
 
@@ -178,7 +178,7 @@ struct TestWithGenerator
         auto const setup,
         concepts::Vector auto extentMd)
     {
-        std::cout << "run func : " << onHost::demangledName(std::get<1>(setup)) << std::endl;
+        INFO("run func : " << onHost::demangledName(std::get<1>(setup)));
 
         auto computeDev = computeQueue.getDevice();
         using DataType = T_DataType;
@@ -205,8 +205,9 @@ struct TestWithGenerator
 
         onHost::wait(computeQueue);
         auto const endT = std::chrono::high_resolution_clock::now();
-        std::cout << "Time for concurrent: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-                  << " data size: " << extentMd << std::endl;
+        UNSCOPED_INFO(
+            "Time for concurrent: " << std::chrono::duration<double>(endT - beginT).count()
+                                    << "s data size: " << extentMd);
 
         onHost::memcpy(computeQueue, hostBufferOut, computeBufferIn0);
         onHost::wait(computeQueue);

--- a/test/unit/algorithm/iota.cpp
+++ b/test/unit/algorithm/iota.cpp
@@ -10,7 +10,6 @@
 
 #include <chrono>
 #include <functional>
-#include <iostream>
 #include <type_traits>
 
 using namespace alpaka;
@@ -36,8 +35,8 @@ void executeTest(concepts::Executor auto exec, auto const& computeQueue, concept
             onHost::wait(computeQueue);
         }
         auto const endT = std::chrono::high_resolution_clock::now();
-        std::cout << "Time for iota: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-                  << " data size: " << extentMd << std::endl;
+        UNSCOPED_INFO(
+            "Time for iota: " << std::chrono::duration<double>(endT - beginT).count() << "s data size: " << extentMd);
 
         onHost::memcpy(computeQueue, hostBufferOut0, computeBufferIn0);
         onHost::wait(computeQueue);
@@ -68,8 +67,9 @@ void executeTest(concepts::Executor auto exec, auto const& computeQueue, concept
             onHost::wait(computeQueue);
         }
         auto const endT = std::chrono::high_resolution_clock::now();
-        std::cout << "Time for iota two inputs: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-                  << " data size: " << extentMd << std::endl;
+        UNSCOPED_INFO(
+            "Time for iota two inputs: " << std::chrono::duration<double>(endT - beginT).count()
+                                         << "s data size: " << extentMd);
 
         onHost::memcpy(computeQueue, hostBufferOut0, computeBufferIn0);
         onHost::memcpy(computeQueue, hostBufferOut1, computeBufferIn1);
@@ -99,15 +99,15 @@ void prepareTest(auto cfg, concepts::Vector auto extentMd)
     auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!computeDevSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
 
-    std::cout << "device spec: " << getName(deviceSpec) << std::endl;
-    std::cout << "device name: " << computeDev.getName() << std::endl;
-    std::cout << "executor   : " << exec.getName() << std::endl;
+    INFO("device spec: " << getName(deviceSpec));
+    INFO("device name: " << computeDev.getName());
+    INFO("executor   : " << exec.getName());
 
     onHost::Queue computeQueue = computeDev.makeQueue();
     executeTest<DataType>(exec, computeQueue, extentMd);

--- a/test/unit/algorithm/reduce.cpp
+++ b/test/unit/algorithm/reduce.cpp
@@ -10,7 +10,6 @@
 
 #include <chrono>
 #include <functional>
-#include <iostream>
 #include <type_traits>
 
 using namespace alpaka;
@@ -56,7 +55,7 @@ struct TestWithMdSpan
         auto const setup,
         concepts::Vector auto extentMd)
     {
-        std::cout << "run func : " << onHost::demangledName(std::get<2>(setup)) << std::endl;
+        INFO("run func : " << onHost::demangledName(std::get<2>(setup)));
 
         auto computeDev = computeQueue.getDevice();
         using DataType = T_DataType;
@@ -83,8 +82,9 @@ struct TestWithMdSpan
 
         onHost::wait(computeQueue);
         auto const endT = std::chrono::high_resolution_clock::now();
-        std::cout << "Time for reduction: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-                  << " data size: " << hostBufferIota.getExtents() << std::endl;
+        UNSCOPED_INFO(
+            "Time for reduction: " << std::chrono::duration<double>(endT - beginT).count()
+                                   << "s data size: " << hostBufferIota.getExtents());
 
         onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
         onHost::wait(computeQueue);
@@ -116,15 +116,15 @@ void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTupl
     auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!computeDevSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
 
-    std::cout << "device spec: " << getName(deviceSpec) << std::endl;
-    std::cout << "device name: " << computeDev.getName() << std::endl;
-    std::cout << "executor   : " << exec.getName() << std::endl;
+    INFO("device spec: " << getName(deviceSpec));
+    INFO("device name: " << computeDev.getName());
+    INFO("executor   : " << exec.getName());
 
     onHost::Queue computeQueue = computeDev.makeQueue();
 
@@ -163,7 +163,7 @@ struct TestWithGenerator
         auto const functorPair,
         concepts::Vector auto extentMd)
     {
-        std::cout << "run func : " << onHost::demangledName(std::get<2>(functorPair)) << std::endl;
+        INFO("run func : " << onHost::demangledName(std::get<2>(functorPair)));
 
         auto computeDev = computeQueue.getDevice();
         using OutDataType = ALPAKA_TYPEOF(std::get<0>(functorPair));
@@ -185,8 +185,9 @@ struct TestWithGenerator
 
         onHost::wait(computeQueue);
         auto const endT = std::chrono::high_resolution_clock::now();
-        std::cout << "Time for reduction: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-                  << " data size: " << generator.getExtents() << std::endl;
+        UNSCOPED_INFO(
+            "Time for reduction: " << std::chrono::duration<double>(endT - beginT).count()
+                                   << "s data size: " << generator.getExtents());
 
         onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
         onHost::wait(computeQueue);

--- a/test/unit/algorithm/scan.cpp
+++ b/test/unit/algorithm/scan.cpp
@@ -10,7 +10,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <functional>
-#include <iostream>
 #include <type_traits>
 
 using namespace alpaka;
@@ -55,7 +54,7 @@ int validateResult(
         if(computedY != correctResult)
         {
             if(falseResults < MAX_PRINT_FALSE_RESULTS)
-                std::cerr << "bufY[" << i << "] == " << computedY << " != " << correctResult << std::endl;
+                UNSCOPED_INFO("bufY[" << i << "] == " << computedY << " != " << correctResult);
             ++falseResults;
         }
     }
@@ -65,8 +64,9 @@ int validateResult(
         return EXIT_SUCCESS;
     }
 
-    std::cout << "Found " << falseResults << " false results, printed no more than " << MAX_PRINT_FALSE_RESULTS << "\n"
-              << "Execution results incorrect!" << std::endl;
+    UNSCOPED_INFO(
+        "Found " << falseResults << " false results, printed no more than " << MAX_PRINT_FALSE_RESULTS
+                 << ". Execution results incorrect!");
     return EXIT_FAILURE;
 }
 
@@ -82,14 +82,14 @@ void testExclusiveScan(
     auto numEl = hostIn.getExtents().x();
 
     // exclusive scan, no buffer
-    std::cout << "exclusive scan, no buffer" << std::endl;
+    INFO("exclusive scan, no buffer");
     onHost::memcpy(computeQueue, inBuf, hostIn);
     onHost::exclusiveScan(computeQueue, exec, outBuf, inBuf);
     auto res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // exclusive scan, in-place
-    std::cout << "exclusive scan, no buffer, in-place" << std::endl;
+    INFO("exclusive scan, no buffer, in-place");
     onHost::exclusiveScanInPlace(computeQueue, exec, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
@@ -99,14 +99,14 @@ void testExclusiveScan(
         = onHost::alloc<std::byte>(computeDev, onHost::getScanBufferSize<T_Data>(inBuf.getExtents()));
 
     // exclusive scan, with buffer
-    std::cout << "exclusive scan, with buffer" << std::endl;
+    INFO("exclusive scan, with buffer");
     onHost::memcpy(computeQueue, inBuf, hostIn);
     onHost::exclusiveScan(computeQueue, exec, intermediateBuffer, outBuf, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // exclusive scan, in-place with buffer
-    std::cout << "exclusive scan, with buffer, in-place" << std::endl;
+    INFO("exclusive scan, with buffer, in-place");
     onHost::exclusiveScanInPlace(computeQueue, exec, intermediateBuffer, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::EXCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
@@ -124,14 +124,14 @@ void testInclusiveScan(
     auto numEl = hostIn.getExtents().x();
 
     // inclusive scan, no buffer
-    std::cout << "inclusive scan, no buffer" << std::endl;
+    INFO("inclusive scan, no buffer");
     onHost::memcpy(computeQueue, inBuf, hostIn);
     onHost::inclusiveScan(computeQueue, exec, outBuf, inBuf);
     auto res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // inclusive scan, in-place
-    std::cout << "inclusive scan, no buffer, in-place" << std::endl;
+    INFO("inclusive scan, no buffer, in-place");
     onHost::inclusiveScanInPlace(computeQueue, exec, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
@@ -141,14 +141,14 @@ void testInclusiveScan(
         = onHost::alloc<std::byte>(computeDev, onHost::getScanBufferSize<T_Data>(inBuf.getExtents()));
 
     // inclusive scan, with buffer
-    std::cout << "inclusive scan, with buffer" << std::endl;
+    INFO("inclusive scan, with buffer");
     onHost::memcpy(computeQueue, inBuf, hostIn);
     onHost::inclusiveScan(computeQueue, exec, intermediateBuffer, outBuf, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, outBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
 
     // inclusive scan, in-place with buffer
-    std::cout << "inclusive scan, with buffer, in-place" << std::endl;
+    INFO("inclusive scan, with buffer, in-place");
     onHost::inclusiveScanInPlace(computeQueue, exec, intermediateBuffer, inBuf);
     res = validateResult<T_Data>(computeQueue, hostIn, inBuf, numEl, onHost::internal::INCLUSIVE_SCAN);
     CHECK(res == EXIT_SUCCESS);
@@ -165,15 +165,15 @@ void prepareTest(auto cfg, concepts::Vector auto extents)
     auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!computeDevSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
 
-    std::cout << "device spec: " << getName(deviceSpec) << std::endl;
-    std::cout << "device name: " << computeDev.getName() << std::endl;
-    std::cout << "executor   : " << exec.getName() << std::endl;
+    INFO("device spec: " << getName(deviceSpec));
+    INFO("device name: " << computeDev.getName());
+    INFO("executor   : " << exec.getName());
 
     onHost::Queue computeQueue = computeDev.makeQueue();
 

--- a/test/unit/algorithm/transform.cpp
+++ b/test/unit/algorithm/transform.cpp
@@ -10,7 +10,6 @@
 
 #include <chrono>
 #include <functional>
-#include <iostream>
 #include <type_traits>
 
 using namespace alpaka;
@@ -73,7 +72,7 @@ struct TestWithMdSpan
         auto const setup,
         concepts::Vector auto extentMd)
     {
-        std::cout << "run func : " << onHost::demangledName(std::get<1>(setup)) << std::endl;
+        INFO("run func : " << onHost::demangledName(std::get<1>(setup)));
 
         auto computeDev = computeQueue.getDevice();
         using DataType = T_DataType;
@@ -108,8 +107,9 @@ struct TestWithMdSpan
 
         onHost::wait(computeQueue);
         auto const endT = std::chrono::high_resolution_clock::now();
-        std::cout << "Time for transform: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-                  << " data size: " << computeBufferOut.getExtents() << std::endl;
+        UNSCOPED_INFO(
+            "Time for transform: " << std::chrono::duration<double>(endT - beginT).count()
+                                   << "s data size: " << computeBufferOut.getExtents());
 
         onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
         onHost::wait(computeQueue);
@@ -137,15 +137,15 @@ void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTupl
     auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!computeDevSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
 
-    std::cout << "device spec: " << getName(deviceSpec) << std::endl;
-    std::cout << "device name: " << computeDev.getName() << std::endl;
-    std::cout << "executor   : " << exec.getName() << std::endl;
+    INFO("device spec: " << getName(deviceSpec));
+    INFO("device name: " << computeDev.getName());
+    INFO("executor   : " << exec.getName());
 
     onHost::Queue computeQueue = computeDev.makeQueue();
 
@@ -206,7 +206,7 @@ struct TestWithGenerator
         auto const setup,
         concepts::Vector auto extentMd)
     {
-        std::cout << "run func : " << onHost::demangledName(std::get<1>(setup)) << std::endl;
+        INFO("run func : " << onHost::demangledName(std::get<1>(setup)));
 
         auto computeDev = computeQueue.getDevice();
         using DataType = T_DataType;
@@ -234,8 +234,9 @@ struct TestWithGenerator
 
         onHost::wait(computeQueue);
         auto const endT = std::chrono::high_resolution_clock::now();
-        std::cout << "Time for transform: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-                  << " data size: " << computeBufferOut.getExtents() << std::endl;
+        UNSCOPED_INFO(
+            "Time for transform: " << std::chrono::duration<double>(endT - beginT).count()
+                                   << "s data size: " << computeBufferOut.getExtents());
 
         onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
         onHost::wait(computeQueue);

--- a/test/unit/algorithm/transformReduce.cpp
+++ b/test/unit/algorithm/transformReduce.cpp
@@ -10,7 +10,6 @@
 
 #include <chrono>
 #include <functional>
-#include <iostream>
 #include <type_traits>
 
 using namespace alpaka;
@@ -86,8 +85,9 @@ struct TestWithMdSpan
         auto const setup,
         concepts::Vector auto extentMd)
     {
-        std::cout << "run reduce(func) : " << onHost::demangledName(std::get<1>(setup).second) << "("
-                  << onHost::demangledName(std::get<2>(setup).second) << ")" << std::endl;
+        INFO(
+            "run reduce(func) : " << onHost::demangledName(std::get<1>(setup).second) << "("
+                                  << onHost::demangledName(std::get<2>(setup).second) << ")");
 
         auto computeDev = computeQueue.getDevice();
         using DataType = T_DataType;
@@ -124,8 +124,9 @@ struct TestWithMdSpan
 
         onHost::wait(computeQueue);
         auto const endT = std::chrono::high_resolution_clock::now();
-        std::cout << "Time for transform reduce: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-                  << " data size: " << hostBufferIota.getExtents() << std::endl;
+        UNSCOPED_INFO(
+            "Time for transform reduce: " << std::chrono::duration<double>(endT - beginT).count()
+                                          << "s data size: " << hostBufferIota.getExtents());
 
         onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
         onHost::wait(computeQueue);
@@ -156,15 +157,15 @@ void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTupl
     auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!computeDevSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device computeDev = computeDevSelector.makeDevice(0);
 
-    std::cout << "device spec: " << getName(deviceSpec) << std::endl;
-    std::cout << "device name: " << computeDev.getName() << std::endl;
-    std::cout << "executor   : " << exec.getName() << std::endl;
+    INFO("device spec: " << getName(deviceSpec));
+    INFO("device name: " << computeDev.getName());
+    INFO("executor   : " << exec.getName());
 
     onHost::Queue computeQueue = computeDev.makeQueue();
 
@@ -244,8 +245,9 @@ struct TestWithGenerator
         auto const setup,
         concepts::Vector auto extentMd)
     {
-        std::cout << "run reduce(func) : " << onHost::demangledName(std::get<1>(setup).second) << "("
-                  << onHost::demangledName(std::get<2>(setup).second) << ")" << std::endl;
+        INFO(
+            "run reduce(func) : " << onHost::demangledName(std::get<1>(setup).second) << "("
+                                  << onHost::demangledName(std::get<2>(setup).second) << ")");
 
         auto computeDev = computeQueue.getDevice();
         using DataType = T_DataType;
@@ -281,8 +283,9 @@ struct TestWithGenerator
 
         onHost::wait(computeQueue);
         auto const endT = std::chrono::high_resolution_clock::now();
-        std::cout << "Time for transform reduce: " << std::chrono::duration<double>(endT - beginT).count() << 's'
-                  << " data size: " << hostBufferIota.getExtents() << std::endl;
+        UNSCOPED_INFO(
+            "Time for transform reduce: " << std::chrono::duration<double>(endT - beginT).count()
+                                          << "s data size: " << hostBufferIota.getExtents());
 
         onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
         onHost::wait(computeQueue);

--- a/test/unit/atomic/atomic.cpp
+++ b/test/unit/atomic/atomic.cpp
@@ -206,7 +206,7 @@ struct TestAtomicOperations
         {
             if(device.getNativeHandle().first.template get_info<sycl::info::device::double_fp_config>().size() == 0)
             {
-                WARN(
+                SUCCEED(
                     onHost::getName(device)
                     << " does not support double precision.\n Skip benchmark.\n"
                        "For Intel Arc GPUs, use the environment variables `IGC_EnableDPEmulation=1 "
@@ -249,7 +249,7 @@ TEMPLATE_LIST_TEST_CASE("atomicOperationsWorking", "[atomic]", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/atomic/atomicAdd.cpp
+++ b/test/unit/atomic/atomicAdd.cpp
@@ -45,7 +45,7 @@ TEMPLATE_LIST_TEST_CASE("cpu atomic add increments", "[executor][atomic]", TestA
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/block/block.cpp
+++ b/test/unit/block/block.cpp
@@ -9,7 +9,6 @@
 
 #include <chrono>
 #include <functional>
-#include <iostream>
 #include <thread>
 
 using namespace alpaka;
@@ -51,20 +50,19 @@ TEMPLATE_LIST_TEST_CASE("block iota", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getDeviceProperties() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device properties=" << device.getDeviceProperties());
 
     Queue queue = device.makeQueue();
     constexpr Vec numBlocks = Vec{9u};
     constexpr Vec blockExtent = Vec{4u};
     constexpr Vec dataExtent = numBlocks * blockExtent;
-    std::cout << "block iota exec=" << onHost::demangledName(exec) << std::endl;
+    INFO("block iota exec=" << onHost::demangledName(exec));
     auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
 
     auto hBuff = onHost::allocHostLike(dBuff);

--- a/test/unit/cvecKernelCall/cvecKernelCall.cpp
+++ b/test/unit/cvecKernelCall/cvecKernelCall.cpp
@@ -9,7 +9,6 @@
 
 #include <chrono>
 #include <functional>
-#include <iostream>
 #include <thread>
 
 /** @file In this file we test if the a compile time thread extent for number of threads within a block is forwarded
@@ -52,14 +51,13 @@ TEMPLATE_LIST_TEST_CASE("CVec frame extent kernel call", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     Queue queue = device.makeQueue();
 
@@ -106,14 +104,13 @@ TEMPLATE_LIST_TEST_CASE("CVec thread extent kernel call", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
-    std::cout << deviceSpec.getApi().getName() << std::endl;
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     Queue queue = device.makeQueue();
 

--- a/test/unit/device/deviceProperties.cpp
+++ b/test/unit/device/deviceProperties.cpp
@@ -22,7 +22,8 @@ TEMPLATE_LIST_TEST_CASE("deviceProperties", "[device][property]", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SKIP("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
+        return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);

--- a/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -7,8 +7,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <iostream>
-
 using namespace alpaka;
 using namespace alpaka::onHost;
 
@@ -79,19 +77,17 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
     auto deviceSpec = cfg[object::deviceSpec];
     auto exec = cfg[object::exec];
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
-
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << "device name: " << device.getName() << "\n";
-    std::cout << "executor   : " << exec.getName() << std::endl;
+    INFO("api        :" << deviceSpec.getApi().getName());
+    INFO("device name: " << device.getName());
+    INFO("executor   : " << exec.getName());
 
     Queue queue = device.makeQueue();
     constexpr Vec numBlocks = Vec{1u};
@@ -200,25 +196,23 @@ TEMPLATE_LIST_TEST_CASE("device global mem copy", "", TestApis)
     auto deviceSpec = cfg[object::deviceSpec];
     auto exec = cfg[object::exec];
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
-
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     Queue queue = device.makeQueue();
     constexpr Vec numBlocks = Vec{1u};
     constexpr Vec blockExtent = Vec{4u};
     constexpr Vec dataExtent = 13u;
-    std::cout << "device name: " << device.getName() << "\n";
-    std::cout << "executor   : " << exec.getName() << std::endl;
+    INFO("device name: " << device.getName());
+    INFO("executor   : " << exec.getName());
 
     auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
     auto hBuff = onHost::allocHostLike(dBuff);

--- a/test/unit/event/event.cpp
+++ b/test/unit/event/event.cpp
@@ -9,8 +9,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <iostream>
-
 /** @file
  *
  * This tests evaluated if events in a queue follows a defined behaviour. Events used to describe dependencies
@@ -47,18 +45,18 @@ TEMPLATE_LIST_TEST_CASE("device analysis", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     bool hasCQueue = detectConcurrentQueue(device);
-    std::cout << "Concurrent kernel queue detected: " << (hasCQueue ? "yes" : "no") << std::endl;
+    INFO("Concurrent kernel queue detected: " << (hasCQueue ? "yes" : "no"));
 
     bool supportMappedMemTrigger = mappedMemTriggerDetection(device);
-    std::cout << "Can trigger via mapped memory: " << (supportMappedMemTrigger ? "yes" : "no") << std::endl;
+    INFO("Can trigger via mapped memory: " << (supportMappedMemTrigger ? "yes" : "no"));
 }
 
 TEMPLATE_LIST_TEST_CASE("event creation and enqueue", "", TestApis)
@@ -69,12 +67,12 @@ TEMPLATE_LIST_TEST_CASE("event creation and enqueue", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     onHost::Queue queue = device.makeQueue();
     onHost::Event ev = device.makeEvent();
@@ -91,12 +89,12 @@ TEMPLATE_LIST_TEST_CASE("basic queue wait for event", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     onHost::Queue queue0 = device.makeQueue();
     onHost::Queue queue1 = device.makeQueue();
@@ -120,12 +118,12 @@ TEMPLATE_LIST_TEST_CASE("test trigger event", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
     if(!hasConcurrentKernelQueues)
@@ -134,8 +132,9 @@ TEMPLATE_LIST_TEST_CASE("test trigger event", "", TestApis)
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
-                  << " because the device does not support concurrent queues." << std::endl;
+        SUCCEED(
+            "Event tests can not be executed with " << deviceSpec.getName()
+                                                    << " because the device does not support concurrent queues.");
         return;
     }
 
@@ -156,12 +155,12 @@ TEMPLATE_LIST_TEST_CASE("eventTestShouldBeFalseWhileInQueueAndTrueAfterBeingProc
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
     if(!hasConcurrentKernelQueues)
@@ -170,8 +169,9 @@ TEMPLATE_LIST_TEST_CASE("eventTestShouldBeFalseWhileInQueueAndTrueAfterBeingProc
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
-                  << " because the device does not support concurrent queues." << std::endl;
+        SUCCEED(
+            "Event tests can not be executed with " << deviceSpec.getName()
+                                                    << " because the device does not support concurrent queues.");
         return;
     }
 
@@ -194,12 +194,12 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfNobodyWaitsFor", "", Te
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
     if(!hasConcurrentKernelQueues)
@@ -208,14 +208,14 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfNobodyWaitsFor", "", Te
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
-                  << " because the device does not support concurrent queues." << std::endl;
+        SUCCEED(
+            "Event tests can not be executed with " << deviceSpec.getName()
+                                                    << " because the device does not support concurrent queues.");
         return;
     }
     if(deviceSpec.getApi() == api::oneApi && deviceSpec.getDeviceKind() == deviceKind::intelGpu)
     {
-        std::cout << "Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking."
-                  << std::endl;
+        SUCCEED("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
         return;
     }
 
@@ -270,12 +270,12 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "", T
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
     if(!hasConcurrentKernelQueues)
@@ -284,14 +284,14 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "", T
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
-                  << " because the device does not support concurrent queues." << std::endl;
+        SUCCEED(
+            "Event tests can not be executed with " << deviceSpec.getName()
+                                                    << " because the device does not support concurrent queues.");
         return;
     }
     if(deviceSpec.getApi() == api::oneApi && deviceSpec.getDeviceKind() == deviceKind::intelGpu)
     {
-        std::cout << "Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking."
-                  << std::endl;
+        SUCCEED("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
         return;
     }
 
@@ -360,12 +360,12 @@ TEMPLATE_LIST_TEST_CASE("waitForEventThatAlreadyFinishedShouldBeSkipped", "", Te
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
     if(!hasConcurrentKernelQueues)
@@ -374,14 +374,14 @@ TEMPLATE_LIST_TEST_CASE("waitForEventThatAlreadyFinishedShouldBeSkipped", "", Te
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
-                  << " because the device does not support concurrent queues." << std::endl;
+        SUCCEED(
+            "Event tests can not be executed with " << deviceSpec.getName()
+                                                    << " because the device does not support concurrent queues.");
         return;
     }
     if(deviceSpec.getApi() == api::oneApi && deviceSpec.getDeviceKind() == deviceKind::intelGpu)
     {
-        std::cout << "Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking."
-                  << std::endl;
+        SUCCEED("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
         return;
     }
 
@@ -447,12 +447,12 @@ TEMPLATE_LIST_TEST_CASE("evReEnqueueWithSomeoneWaitsForEventInOrderLifetimeRelea
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
     if(!hasConcurrentKernelQueues)
@@ -461,14 +461,14 @@ TEMPLATE_LIST_TEST_CASE("evReEnqueueWithSomeoneWaitsForEventInOrderLifetimeRelea
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
-                  << " because the device does not support concurrent queues." << std::endl;
+        SUCCEED(
+            "Event tests can not be executed with " << deviceSpec.getName()
+                                                    << " because the device does not support concurrent queues.");
         return;
     }
     if(deviceSpec.getApi() == api::oneApi && deviceSpec.getDeviceKind() == deviceKind::intelGpu)
     {
-        std::cout << "Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking."
-                  << std::endl;
+        SUCCEED("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
         return;
     }
 
@@ -574,12 +574,12 @@ TEMPLATE_LIST_TEST_CASE("EventOutOfOrderLifetimeRelease", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
     if(!hasConcurrentKernelQueues)
@@ -588,14 +588,14 @@ TEMPLATE_LIST_TEST_CASE("EventOutOfOrderLifetimeRelease", "", TestApis)
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        std::cout << "Event tests can not be executed with " << deviceSpec.getName()
-                  << " because the device does not support concurrent queues." << std::endl;
+        SUCCEED(
+            "Event tests can not be executed with " << deviceSpec.getName()
+                                                    << " because the device does not support concurrent queues.");
         return;
     }
     if(deviceSpec.getApi() == api::oneApi && deviceSpec.getDeviceKind() == deviceKind::intelGpu)
     {
-        std::cout << "Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking."
-                  << std::endl;
+        SUCCEED("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
         return;
     }
 

--- a/test/unit/event/eventHelper.hpp
+++ b/test/unit/event/eventHelper.hpp
@@ -4,7 +4,7 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include <iostream>
+#include <catch2/catch_test_macros.hpp>
 
 namespace alpaka::test::event
 {
@@ -237,7 +237,7 @@ namespace alpaka::test::event
         }
 
         // set event to ready state
-        constexpr void trigger()
+        void trigger()
         {
             for(int i = 0; i < 10; ++i)
             {
@@ -248,7 +248,7 @@ namespace alpaka::test::event
                     break;
                 else
                 {
-                    std::cout << "warning: trigger had no effect, re-trigger " << i + 1 << " of " << 10 << std::endl;
+                    WARN("trigger had no effect, re-trigger " << i + 1 << " of " << 10);
                 }
             }
         }

--- a/test/unit/fn/fn.cpp
+++ b/test/unit/fn/fn.cpp
@@ -7,8 +7,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <iostream>
-
 
 using namespace alpaka;
 
@@ -46,7 +44,7 @@ TEMPLATE_LIST_TEST_CASE("fn with alpaka fallback", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -109,7 +107,7 @@ TEMPLATE_LIST_TEST_CASE("fn with generic fallback", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -182,7 +180,7 @@ TEMPLATE_LIST_TEST_CASE("fn without fallback", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/math/TestTemplate.hpp
+++ b/test/unit/math/TestTemplate.hpp
@@ -12,7 +12,6 @@
 #include "alpakaTest/mathHelper.hpp"
 
 #include <catch2/catch_approx.hpp>
-#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <cmath>
@@ -122,7 +121,7 @@ namespace mathtest
             auto devSelector = onHost::makeDeviceSelector(deviceSpec);
             if(!devSelector.isAvailable())
             {
-                std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+                SUCCEED("No device available for " << deviceSpec.getName());
                 return;
             }
 
@@ -137,7 +136,7 @@ namespace mathtest
                 if(device.getNativeHandle().first.template get_info<sycl::info::device::double_fp_config>().size()
                    == 0)
                 {
-                    WARN(
+                    SUCCEED(
                         onHost::getName(device)
                         << " does not support double precision.\n Skip benchmark.\n"
                            "For Intel Arc GPUs, use the environment variables `IGC_EnableDPEmulation=1 "
@@ -197,8 +196,6 @@ namespace mathtest
             // Copy back the results (encapsulated in the buffer class).
             results.copyFromDevice(queue);
             alpaka::onHost::wait(queue);
-            std::cout.precision(std::numeric_limits<Underlying>::digits10 + 1);
-
 
             INFO("Operator: " << functor);
             INFO("Type: " << alpaka::onHost::demangledName<TData>()); // Compiler specific.
@@ -226,8 +223,7 @@ namespace mathtest
 
                 if(!test::isApproxEqual(results(i), stdExpectedResult))
                 {
-                    std::cerr << "Idx i: " << i << " computed : " << results(i)
-                              << " vs expected: " << stdExpectedResult << " arguments:" << args(i) << std::endl;
+                    CAPTURE(i, results(i), stdExpectedResult, args(i));
                 }
                 // Validate
                 REQUIRE(test::isApproxEqual(results(i), stdExpectedResult));

--- a/test/unit/math/executeOnComputeDevice.hpp
+++ b/test/unit/math/executeOnComputeDevice.hpp
@@ -8,7 +8,6 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <utility>
@@ -34,7 +33,7 @@ namespace alpaka::test
         auto devSelector = onHost::makeDeviceSelector(deviceSpec);
         if(!devSelector.isAvailable())
         {
-            std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+            SUCCEED("No device available for " << deviceSpec.getName());
             return false;
         }
 
@@ -48,7 +47,7 @@ namespace alpaka::test
         {
             if(device.getNativeHandle().first.template get_info<sycl::info::device::double_fp_config>().size() == 0)
             {
-                WARN(
+                SUCCEED(
                     onHost::getName(device)
                     << " does not support double precision.\n Skip benchmark.\n"
                        "For Intel Arc GPUs, use the environment variables `IGC_EnableDPEmulation=1 "

--- a/test/unit/mem/alloc.cpp
+++ b/test/unit/mem/alloc.cpp
@@ -7,8 +7,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <iostream>
-
 using namespace alpaka;
 
 using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
@@ -111,13 +109,12 @@ TEMPLATE_LIST_TEST_CASE("alloc", "", TestBackends)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     allocDeferredImplicitWait(device, exec);
 }
@@ -131,13 +128,12 @@ TEMPLATE_LIST_TEST_CASE("alloc zero bytes", "", TestDeviceSpecs)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     auto hostDevice = onHost::makeHostDevice();
 
@@ -201,13 +197,12 @@ TEMPLATE_LIST_TEST_CASE("alloc alignment", "", TestDeviceSpecs)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     using DataType = int;
 
@@ -236,13 +231,12 @@ TEMPLATE_LIST_TEST_CASE("alloc volatile memory", "", TestDeviceSpecs)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     using DataType = int;
 

--- a/test/unit/mem/allocDeferred.cpp
+++ b/test/unit/mem/allocDeferred.cpp
@@ -7,8 +7,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <iostream>
-
 using namespace alpaka;
 
 using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
@@ -103,13 +101,12 @@ TEMPLATE_LIST_TEST_CASE("allocDeferred", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << deviceSpec.getApi().getName() << "on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     // repeat the test multiple times to increase the change to trigger data races
     constexpr int testRounds = 10;

--- a/test/unit/mem/keepAlive.cpp
+++ b/test/unit/mem/keepAlive.cpp
@@ -8,8 +8,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <future>
-#include <iostream>
-
 using namespace alpaka;
 
 using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
@@ -40,13 +38,12 @@ TEMPLATE_LIST_TEST_CASE("keep alive", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     onHost::Queue queue = device.makeQueue();
 

--- a/test/unit/mem/memFenceBasic.cpp
+++ b/test/unit/mem/memFenceBasic.cpp
@@ -50,7 +50,7 @@ TEMPLATE_LIST_TEST_CASE("thread fence operations", "[memFence][basic]", TestApis
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        WARN("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
     auto device = selector.makeDevice(0);

--- a/test/unit/mem/memFenceProducerConsumer.cpp
+++ b/test/unit/mem/memFenceProducerConsumer.cpp
@@ -97,7 +97,7 @@ TEMPLATE_LIST_TEST_CASE("memFence producer-consumer publication", "[memFence][pr
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        WARN("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
     auto device = selector.makeDevice(0);
@@ -278,7 +278,7 @@ TEMPLATE_LIST_TEST_CASE("memFence block shared-memory ordering", "[memFence][blo
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        WARN("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
     auto device = selector.makeDevice(0);

--- a/test/unit/mem/memcpy.cpp
+++ b/test/unit/mem/memcpy.cpp
@@ -7,8 +7,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <iostream>
-
 /** @file test if memcpy is working into all direction in a device queue
  *   host -> host (even a GPU device should be able to copy host memory to host memory)
  *   device -> host
@@ -144,13 +142,12 @@ TEMPLATE_LIST_TEST_CASE("memcopy test", "", DeviceSpecs)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << deviceSpec.getApi().getName() << " on " << device.getName() << std::endl;
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
 
     using DataType = int;
 

--- a/test/unit/platform/platform.cpp
+++ b/test/unit/platform/platform.cpp
@@ -17,7 +17,7 @@ TEST_CASE("host api creation", "")
 
     Device device = hostSelector.makeDevice(0);
     Device device2 = hostSelector.makeDevice(0);
-    std::cout << device.getName() << " == " << device2.getName() << std::endl;
+    INFO(device.getName() << " == " << device2.getName());
     // api::host has only one device therefore the device must be equal
     CHECK(device.getNativeHandle() == device2.getNativeHandle());
 }
@@ -32,7 +32,7 @@ TEST_CASE("api creation", "")
             for(uint32_t i = 0; i < numDevices; ++i)
             {
                 Device device = devSelector.makeDevice(i);
-                std::cout << "api=" << deviceSpec.getApi().getName() << "device=" << device.getName() << std::endl;
+                INFO("api=" << deviceSpec.getApi().getName() << " device=" << device.getName());
             }
 
             return 0;

--- a/test/unit/precision/precision.cpp
+++ b/test/unit/precision/precision.cpp
@@ -73,7 +73,7 @@ void callTests(auto cfg)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        WARN("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -230,7 +230,7 @@ void callForceCastTests(auto cfg)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        WARN("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/queue/blockingQueue.cpp
+++ b/test/unit/queue/blockingQueue.cpp
@@ -16,7 +16,6 @@
 
 #include <atomic>
 #include <barrier>
-#include <iostream>
 #include <thread>
 #include <vector>
 
@@ -48,14 +47,14 @@ TEMPLATE_LIST_TEST_CASE("blocking queue memory operations", "[bq][memory]", Test
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     onHost::Device device = devSelector.makeDevice(0);
-    std::cout << "device spec: " << getName(deviceSpec) << "\n";
-    std::cout << "device name: " << device.getName() << "\n";
-    std::cout << "executor   : " << exec.getName() << std::endl;
+    INFO("device spec: " << getName(deviceSpec));
+    INFO("device name: " << device.getName());
+    INFO("executor   : " << exec.getName());
 
     auto blockingQueue0 = device.makeQueue(queueKind::blocking);
     auto blockingQueue1 = device.makeQueue(queueKind::blocking);
@@ -132,13 +131,13 @@ TEMPLATE_LIST_TEST_CASE("blocking queue chained operations", "[bq][chain]", Test
     auto sel = onHost::makeDeviceSelector(deviceSpec);
     if(!sel.isAvailable())
     {
-        // backend not available
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
     onHost::Device device = sel.makeDevice(0);
-    std::cout << "device spec: " << getName(deviceSpec) << "\n";
-    std::cout << "device name: " << device.getName() << "\n";
-    std::cout << "executor   : " << exec.getName() << std::endl;
+    INFO("device spec: " << getName(deviceSpec));
+    INFO("device name: " << device.getName());
+    INFO("executor   : " << exec.getName());
     auto qBlocking0 = device.makeQueue(queueKind::blocking);
     auto qBlocking1 = device.makeQueue(queueKind::blocking);
     auto qBlocking2 = device.makeQueue(queueKind::blocking);
@@ -178,7 +177,10 @@ TEMPLATE_LIST_TEST_CASE("mixed queues independence", "[bq][mixed]", TestApis)
     auto exec = cfg[object::exec];
     auto sel = onHost::makeDeviceSelector(deviceSpec);
     if(!sel.isAvailable())
+    {
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
+    }
     onHost::Device device = sel.makeDevice(0);
 
     constexpr Vec extent = Vec{8u};
@@ -208,7 +210,10 @@ TEMPLATE_LIST_TEST_CASE("blocking queue event semantics", "[bq][event]", TestApi
 
     auto sel = onHost::makeDeviceSelector(deviceSpec);
     if(!sel.isAvailable())
+    {
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
+    }
     onHost::Device device = sel.makeDevice(0);
 
     // Blocking producer queue, non-blocking consumer queue
@@ -296,7 +301,10 @@ TEMPLATE_LIST_TEST_CASE("blocking queue event cache functionality", "[event][blo
 
     auto sel = onHost::makeDeviceSelector(deviceSpec);
     if(!sel.isAvailable())
+    {
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
+    }
 
     onHost::Device device = sel.makeDevice(0);
 
@@ -369,7 +377,10 @@ TEMPLATE_LIST_TEST_CASE("blocking queue event race condition", "[bq][event][race
 
     auto sel = onHost::makeDeviceSelector(deviceSpec);
     if(!sel.isAvailable())
+    {
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
+    }
     onHost::Device device = sel.makeDevice(0);
     auto blockingQueue = device.makeQueue(queueKind::blocking);
 

--- a/test/unit/queue/kernelMD.cpp
+++ b/test/unit/queue/kernelMD.cpp
@@ -13,8 +13,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <iostream>
-
 using namespace alpaka;
 
 using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
@@ -47,8 +45,9 @@ struct Case
 void validate(auto& queue, auto& device, auto exec, auto testCase)
 {
     Vec extentMd = testCase.m_extents;
-    std::cout << " exec=" << onHost::demangledName(exec) << " extents=" << testCase.m_extents
-              << " frame size=" << testCase.m_frameSize << std::endl;
+    INFO(
+        "exec=" << onHost::demangledName(exec) << " extents=" << testCase.m_extents
+                << " frame size=" << testCase.m_frameSize);
     auto dBuff = onHost::alloc<Vec<uint32_t, extentMd.dim()>>(device, extentMd);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -84,14 +83,13 @@ TEMPLATE_LIST_TEST_CASE("kernelCallMD", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     onHost::Queue queue = device.makeQueue();
 

--- a/test/unit/queue/queue.cpp
+++ b/test/unit/queue/queue.cpp
@@ -7,8 +7,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <iostream>
-
 using namespace alpaka;
 
 using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
@@ -33,19 +31,18 @@ TEMPLATE_LIST_TEST_CASE("kernel no arguments", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
-    std::cout << deviceSpec.getApi().getName() << std::endl;
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
-    std::cout << "mem     :" << device.getDeviceProperties().globalMemCapacityBytes << std::endl;
-    std::cout << "free mem:" << device.getFreeGlobalMemBytes() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
+    INFO("mem=" << device.getDeviceProperties().globalMemCapacityBytes);
+    INFO("free mem=" << device.getFreeGlobalMemBytes());
 
     onHost::Queue queue = device.makeQueue(queueKind::blocking);
-    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
+    INFO("exec=" << onHost::demangledName(exec));
 
     queue.enqueue(exec, onHost::FrameSpec{1, 1}, KernelBundle{NoArgumentsKernel{}});
 }
@@ -58,7 +55,7 @@ struct IotaKernel
         static_assert(alpaka::concepts::CVector<ALPAKA_TYPEOF(acc[frame::extent])>);
         for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, onAcc::range::totalFrameSpecExtent))
         {
-            //            std::cout<<i<<std::endl;
+            // Debug-only trace removed in favor of Catch2 diagnostics.
             out[i.x()] = i.x();
         }
     }
@@ -73,18 +70,17 @@ TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
-    std::cout << deviceSpec.getApi().getName() << std::endl;
 
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec extent = Vec{12u};
-    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
+    INFO("exec=" << onHost::demangledName(exec));
     auto dBuff = onHost::alloc<uint32_t>(device, extent);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -116,18 +112,17 @@ TEMPLATE_LIST_TEST_CASE("iota2D", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec extent = Vec{8u, 16u};
-    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
+    INFO("exec=" << onHost::demangledName(exec));
     auto dBuff = onHost::alloc<Vec<uint32_t, 2u>>(device, extent);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -149,18 +144,17 @@ TEMPLATE_LIST_TEST_CASE("iota3D", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec extent = Vec{4u, 8u, 16u};
-    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
+    INFO("exec=" << onHost::demangledName(exec));
     auto dBuff = onHost::alloc<Vec<uint32_t, 3u>>(device, extent);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -182,18 +176,17 @@ TEMPLATE_LIST_TEST_CASE("iota4D", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec extent = Vec{4u, 8u, 16, 32};
-    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
+    INFO("exec=" << onHost::demangledName(exec));
     auto dBuff = onHost::alloc<Vec<uint32_t, 4u>>(device, extent);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -242,22 +235,21 @@ TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec numBlocks = Vec{4u, 8u, 16u};
     auto numBlocksReduced = numBlocks;
     numBlocksReduced.ref(CVec<uint32_t, 2u, 1u>{}) = 1u;
 
-    std::cout << numBlocksReduced << std::endl;
-    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
+    INFO("numBlocksReduced=" << numBlocksReduced);
+    INFO("exec=" << onHost::demangledName(exec));
     auto dBuff = onHost::alloc<Vec<uint32_t, 3u>>(device, numBlocks);
 
     auto hBuff = onHost::allocHostLike(dBuff);
@@ -334,14 +326,13 @@ TEMPLATE_LIST_TEST_CASE("memcpy", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec problemSize = Vec{16u};
@@ -405,26 +396,21 @@ TEMPLATE_LIST_TEST_CASE("host task callback", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     onHost::Queue queue = device.makeQueue();
 
     std::promise<bool> promise;
 
-    queue.enqueueHostFn(
-        [&]()
-        {
-            std::cout << "Host Callback executed!" << std::endl;
-            promise.set_value(true);
-        });
+    queue.enqueueHostFn([&]() { promise.set_value(true); });
 
+    INFO("Host callback enqueued");
     CHECK(promise.get_future().get());
 }
 
@@ -436,14 +422,13 @@ TEMPLATE_LIST_TEST_CASE("host task", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     onHost::Queue queue = device.makeQueue();
 
@@ -472,14 +457,13 @@ TEMPLATE_LIST_TEST_CASE("queue wait should work", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     onHost::Queue queue = device.makeQueue();
 
@@ -503,14 +487,13 @@ TEMPLATE_LIST_TEST_CASE("task is destroyed after execution", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     onHost::Queue queue = device.makeQueue();
 

--- a/test/unit/rand/uniformReal.cpp
+++ b/test/unit/rand/uniformReal.cpp
@@ -137,7 +137,7 @@ void testCase(HelperPack<T_Engine, T_FP, T_Interval>, uint64_t seed, T_FP minF, 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/sharedMem/sharedMem.cpp
+++ b/test/unit/sharedMem/sharedMem.cpp
@@ -50,7 +50,7 @@ TEMPLATE_LIST_TEST_CASE("block shared iota", "[sharedMem]", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        WARN("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -187,7 +187,7 @@ TEMPLATE_LIST_TEST_CASE("block shared alias", "[SharedMem]", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        WARN("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -262,7 +262,7 @@ TEMPLATE_LIST_TEST_CASE("test shared memory index type", "[sharedMem]", TestApis
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        WARN("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/wait/device.cpp
+++ b/test/unit/wait/device.cpp
@@ -105,8 +105,9 @@ void executeWaitTest(auto& device, auto const& exec)
         REQUIRE(singleQueueHostBufs[i][0] == testValue);
     }
 
-    std::cout << "✓ wait(device) verified with " << numQueues << " concurrent queues + " << numOpsPerQueue
-              << " ops on single queue" << std::endl;
+    UNSCOPED_INFO(
+        "wait(device) verified with " << numQueues << " concurrent queues + " << numOpsPerQueue
+                                      << " ops on single queue");
 }
 
 void prepareAndExecuteWaitTest(auto cfg)
@@ -117,19 +118,19 @@ void prepareAndExecuteWaitTest(auto cfg)
     auto deviceSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!deviceSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
     auto deviceCount = deviceSelector.getDeviceCount();
-    std::cout << "device spec: " << deviceSpec.getName() << std::endl;
-    std::cout << "executor   : " << exec.getName() << std::endl;
+    INFO("device spec: " << deviceSpec.getName());
+    INFO("executor   : " << exec.getName());
 
     // Test wait(device) on all available devices
     for(uint32_t deviceIdx = 0; deviceIdx < deviceCount; ++deviceIdx)
     {
         auto device = deviceSelector.makeDevice(deviceIdx);
-        std::cout << "device name: " << device.getName() << " (idx=" << deviceIdx << ")" << std::endl;
+        INFO("device name: " << device.getName() << " (idx=" << deviceIdx << ")");
 
         executeWaitTest<uint32_t>(device, exec);
     }

--- a/test/unit/warp/activemask.cpp
+++ b/test/unit/warp/activemask.cpp
@@ -70,7 +70,7 @@ TEMPLATE_LIST_TEST_CASE("warp activemask reflects participating lanes", "[warp][
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/warp/all.cpp
+++ b/test/unit/warp/all.cpp
@@ -76,7 +76,7 @@ TEMPLATE_LIST_TEST_CASE("warp all vote honours only active lanes", "[warp][all]"
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/warp/any.cpp
+++ b/test/unit/warp/any.cpp
@@ -76,7 +76,7 @@ TEMPLATE_LIST_TEST_CASE("warp any vote observes active lanes", "[warp][any]", Wa
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/warp/ballot.cpp
+++ b/test/unit/warp/ballot.cpp
@@ -86,7 +86,7 @@ TEMPLATE_LIST_TEST_CASE("warp ballot captures predicate lanes", "[warp][ballot]"
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/warp/getSize.cpp
+++ b/test/unit/warp/getSize.cpp
@@ -81,7 +81,7 @@ TEMPLATE_LIST_TEST_CASE("warp size trait matches runtime size", "[warp][getSize]
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/warp/iota.cpp
+++ b/test/unit/warp/iota.cpp
@@ -7,8 +7,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-#include <iostream>
-
 using namespace alpaka;
 
 using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
@@ -47,21 +45,20 @@ TEMPLATE_LIST_TEST_CASE("warp iota1D", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        std::cout << "No device available for " << deviceSpec.getName() << std::endl;
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 
-    std::cout << deviceSpec.getApi().getName() << std::endl;
     onHost::Device device = devSelector.makeDevice(0);
-
-    std::cout << device.getName() << std::endl;
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
 
     auto deviceProperties = devSelector.getDeviceProperties(0);
     uint32_t warpSize = deviceProperties.warpSize;
 
     onHost::Queue queue = device.makeQueue();
     Vec extent = Vec{warpSize * 123u};
-    std::cout << "exec=" << onHost::demangledName(exec) << std::endl;
+    INFO("exec=" << onHost::demangledName(exec));
     auto dBuff = onHost::alloc<Vec<uint32_t, 1u>>(device, extent);
 
     auto hBuff = onHost::allocHostLike(dBuff);

--- a/test/unit/warp/shfl.cpp
+++ b/test/unit/warp/shfl.cpp
@@ -106,7 +106,7 @@ TEMPLATE_LIST_TEST_CASE("warp shfl moves values between lanes", "[warp][shfl]", 
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/warp/shfl_down.cpp
+++ b/test/unit/warp/shfl_down.cpp
@@ -116,7 +116,7 @@ TEMPLATE_LIST_TEST_CASE("warp shflDown shifts toward higher lanes", "[warp][shfl
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/warp/shfl_up.cpp
+++ b/test/unit/warp/shfl_up.cpp
@@ -106,7 +106,7 @@ TEMPLATE_LIST_TEST_CASE("warp shflUp shifts toward lower lanes", "[warp][shfl_up
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/warp/shfl_xor.cpp
+++ b/test/unit/warp/shfl_xor.cpp
@@ -104,7 +104,7 @@ TEMPLATE_LIST_TEST_CASE("warp shflXor exchanges partner lanes", "[warp][shfl_xor
     auto selector = onHost::makeDeviceSelector(deviceSpec);
     if(!selector.isAvailable())
     {
-        INFO("No device available for " << deviceSpec.getName());
+        SUCCEED("No device available for " << deviceSpec.getName());
         return;
     }
 


### PR DESCRIPTION
Instead of using `std::cout` and `std::cerr` use Catch2 macro's for screen IO.
If a test is skipped because of a missing device, it will use `SUCCEED("No device available for ...")`.
This PR is, in principle, an automatic search and replace.
Change two tests, they worked over all APIs instead of available backends, which avoids SYCL issues (see second commit).

A [review comment](https://github.com/alpaka-group/alpaka3/pull/513#discussion_r3166706425) by @SimeonEhrig said we should use CATCH macros instead `cout`, so this PR is changing the already implemented tests.