### PR TITLE
Add SIMD feature `simdize` and benchmark HACCmk

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -15,3 +15,4 @@ project("alpakaBenchmarks" LANGUAGES CXX)
 alpaka_install_catch2()
 
 add_subdirectory("babelstream/")
+add_subdirectory("HACCmk")

--- a/benchmark/HACCmk/CMakeLists.txt
+++ b/benchmark/HACCmk/CMakeLists.txt
@@ -1,0 +1,41 @@
+#
+# Copyright 2025 René Widera
+# SPDX-License-Identifier: ISC
+#
+cmake_minimum_required(VERSION 3.25)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+project(HACCmk LANGUAGES CXX)
+
+if(NOT TARGET alpaka::alpaka)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    if(alpaka_USE_SOURCE_TREE)
+        # Don't build the benchmarks recursively
+        set(alpaka_BUILD_BENCHMARKS OFF)
+        add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")
+    else()
+        find_package(alpaka REQUIRED)
+    endif()
+endif()
+
+# original version of HACCmk
+add_executable(HACCmk_orig "src/main_orig.cpp")
+target_include_directories(HACCmk_orig PRIVATE "src")
+# alpaka is taking care that Catch2 is available, so we can link it directly here.
+target_link_libraries(HACCmk_orig PRIVATE Catch2::Catch2WithMain)
+
+# alpaka is searching for OpenMP, if the target is available use it, else build without OpenMP support.
+if(TARGET OpenMP::OpenMP_CXX)
+    target_link_libraries(HACCmk_orig PRIVATE OpenMP::OpenMP_CXX)
+else()
+    message(STATUS "HACCmk_orig is built without OpenMP support.")
+endif()
+add_test(NAME HACCmk_orig COMMAND "HACCmk_orig")
+
+# alpaka version of HACCmk
+add_executable(HACCmk_alpaka "src/main_alpaka.cpp")
+target_include_directories(HACCmk_alpaka PRIVATE "src")
+target_link_libraries(HACCmk_alpaka PUBLIC alpaka::alpaka)
+target_link_libraries(HACCmk_alpaka PRIVATE Catch2::Catch2WithMain Catch2::Catch2)
+alpaka_finalize(HACCmk_alpaka)
+
+add_test(NAME HACCmk_alpaka COMMAND "HACCmk_alpaka")

--- a/benchmark/HACCmk/README.md
+++ b/benchmark/HACCmk/README.md
@@ -1,0 +1,8 @@
+# HACCmk Benchmark
+
+The benchmark based on the HACCmk code, which is a cosmological N-body simulation code. 
+The benchmark is designed to evaluate the performance of the HACCmk code on different hardware platforms and configurations.
+
+You can find the original information [here](https://asc.llnl.gov/sites/asc/files/2020-06/HACCmk_Summary_v1.0.pdf).
+
+The benchmark version within this repository based on the [ORNL version of HACCmk](https://github.com/ORNL/HeCBench).

--- a/benchmark/HACCmk/src/helper.hpp
+++ b/benchmark/HACCmk/src/helper.hpp
@@ -67,26 +67,26 @@ namespace hacc
 
     int verify(int n2, auto vx2, auto vy2, auto vz2, auto vx2_hw, auto vy2_hw, auto vz2_hw)
     {
-        int error = 0;
+        int error = EXIT_SUCCESS;
         float const eps = 1.0f;
         for(int i = 0; i < n2; i++)
         {
             if(fabsf(vx2[i] - vx2_hw[i]) > eps)
             {
                 printf("error at vx2[%d] %f %f\n", i, vx2[i], vx2_hw[i]);
-                error = 1;
+                error = EXIT_FAILURE;
                 break;
             }
             if(fabsf(vy2[i] - vy2_hw[i]) > eps)
             {
                 printf("error at vy2[%d]: %f %f\n", i, vy2[i], vy2_hw[i]);
-                error = 1;
+                error = EXIT_FAILURE;
                 break;
             }
             if(fabsf(vz2[i] - vz2_hw[i]) > eps)
             {
                 printf("error at vz2[%d]: %f %f\n", i, vz2[i], vz2_hw[i]);
-                error = 1;
+                error = EXIT_FAILURE;
                 break;
             }
         }

--- a/benchmark/HACCmk/src/helper.hpp
+++ b/benchmark/HACCmk/src/helper.hpp
@@ -1,0 +1,97 @@
+/* Copyright (c) 2020 , Argonne National Laboratory   (Zheming Jin)
+ * Copyright (c) 2020-, Oak Ridge National Laboratory   (Zheming Jin)
+ * Copyright 2026 René Widera
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+/** @file The file is providing some helpers for the HACCmk implementation shared between the original and the alpaka
+ * implementation.
+ */
+
+#include <math.h>
+#include <stdio.h>
+
+namespace hacc
+{
+    void haccmk_gold(
+        int count1,
+        float xxi,
+        float yyi,
+        float zzi,
+        float fsrrmax2,
+        float mp_rsm2,
+        auto xx1,
+        auto yy1,
+        auto zz1,
+        auto mass1,
+        auto dxi,
+        auto dyi,
+        auto dzi)
+    {
+        float const ma0 = 0.269327f, ma1 = -0.0750978f, ma2 = 0.0114808f, ma3 = -0.00109313f, ma4 = 0.0000605491f,
+                    ma5 = -0.00000147177f;
+
+
+        float dxc, dyc, dzc, m, r2, f, xi, yi, zi;
+
+        xi = 0.f;
+        yi = 0.f;
+        zi = 0.f;
+
+        for(int j = 0; j < count1; j++)
+        {
+            dxc = xx1[j] - xxi;
+            dyc = yy1[j] - yyi;
+            dzc = zz1[j] - zzi;
+
+            r2 = dxc * dxc + dyc * dyc + dzc * dzc;
+
+            if(r2 < fsrrmax2)
+                m = mass1[j];
+            else
+                m = 0.f;
+
+            f = r2 + mp_rsm2;
+            f = m * (1.f / (f * sqrtf(f)) - (ma0 + r2 * (ma1 + r2 * (ma2 + r2 * (ma3 + r2 * (ma4 + r2 * ma5))))));
+
+            xi = xi + f * dxc;
+            yi = yi + f * dyc;
+            zi = zi + f * dzc;
+        }
+
+        *dxi = xi;
+        *dyi = yi;
+        *dzi = zi;
+    }
+
+    int verify(int n2, auto vx2, auto vy2, auto vz2, auto vx2_hw, auto vy2_hw, auto vz2_hw)
+    {
+        int error = 0;
+        float const eps = 1.0f;
+        for(int i = 0; i < n2; i++)
+        {
+            if(fabsf(vx2[i] - vx2_hw[i]) > eps)
+            {
+                printf("error at vx2[%d] %f %f\n", i, vx2[i], vx2_hw[i]);
+                error = 1;
+                break;
+            }
+            if(fabsf(vy2[i] - vy2_hw[i]) > eps)
+            {
+                printf("error at vy2[%d]: %f %f\n", i, vy2[i], vy2_hw[i]);
+                error = 1;
+                break;
+            }
+            if(fabsf(vz2[i] - vz2_hw[i]) > eps)
+            {
+                printf("error at vz2[%d]: %f %f\n", i, vz2[i], vz2_hw[i]);
+                error = 1;
+                break;
+            }
+        }
+        printf("%s\n", error ? "Verification FAILED" : "Verification PASSED");
+        return error;
+    }
+
+} // namespace hacc

--- a/benchmark/HACCmk/src/main_alpaka.cpp
+++ b/benchmark/HACCmk/src/main_alpaka.cpp
@@ -125,7 +125,6 @@ namespace haccmkAlpaka
         }
     };
 
-    template<typename Data>
     void haccmk(
         auto devAcc,
         auto exec,
@@ -148,13 +147,13 @@ namespace haccmkAlpaka
         // a blocking queue is used to reduce the starting overhead for CPU devices
         onHost::Queue queue = devAcc.makeQueue(queueKind::blocking);
 
-        auto d_xx = onHost::alloc<Data>(devAcc, n2);
-        auto d_yy = onHost::alloc<Data>(devAcc, n2);
-        auto d_zz = onHost::alloc<Data>(devAcc, n2);
-        auto d_mass = onHost::alloc<Data>(devAcc, n2);
-        auto d_vx2 = onHost::alloc<Data>(devAcc, n1);
-        auto d_vy2 = onHost::alloc<Data>(devAcc, n1);
-        auto d_vz2 = onHost::alloc<Data>(devAcc, n1);
+        auto d_xx = onHost::alloc<float>(devAcc, n2);
+        auto d_yy = onHost::alloc<float>(devAcc, n2);
+        auto d_zz = onHost::alloc<float>(devAcc, n2);
+        auto d_mass = onHost::alloc<float>(devAcc, n2);
+        auto d_vx2 = onHost::alloc<float>(devAcc, n1);
+        auto d_vy2 = onHost::alloc<float>(devAcc, n1);
+        auto d_vz2 = onHost::alloc<float>(devAcc, n1);
 
         onHost::memcpy(queue, d_xx, xx);
         onHost::memcpy(queue, d_yy, yy);
@@ -225,12 +224,9 @@ namespace haccmkAlpaka
         // Define problem size
         IdxVec const extent(n2);
 
-        // Define the buffer element type
-        using Data = float;
-
         std::cout << "Outer loop count is set " << n1 << std::endl;
         std::cout << "Inner loop count is set " << n2 << std::endl;
-        std::cout << "Element type " << onHost::demangledName<Data>() << std::endl;
+        std::cout << "Element type float" << std::endl;
         std::cout << "Using alpaka accelerator " << onHost::demangledName(exec) << " for "
                   << deviceSpec.getApi().getName() << " " << deviceSpec.getDeviceKind().getName() << std::endl;
 
@@ -238,16 +234,16 @@ namespace haccmkAlpaka
         onHost::Device devAcc = devSelector.makeDevice(0);
 
 
-        auto xx = onHost::allocHost<Data>(extent);
-        auto yy = onHost::allocHost<Data>(extent);
-        auto zz = onHost::allocHost<Data>(extent);
-        auto mass = onHost::allocHost<Data>(extent);
-        auto vx2 = onHost::allocHost<Data>(extent);
-        auto vy2 = onHost::allocHost<Data>(extent);
-        auto vz2 = onHost::allocHost<Data>(extent);
-        auto vx2_hw = onHost::allocHost<Data>(extent);
-        auto vy2_hw = onHost::allocHost<Data>(extent);
-        auto vz2_hw = onHost::allocHost<Data>(extent);
+        auto xx = onHost::allocHost<float>(extent);
+        auto yy = onHost::allocHost<float>(extent);
+        auto zz = onHost::allocHost<float>(extent);
+        auto mass = onHost::allocHost<float>(extent);
+        auto vx2 = onHost::allocHost<float>(extent);
+        auto vy2 = onHost::allocHost<float>(extent);
+        auto vz2 = onHost::allocHost<float>(extent);
+        auto vx2_hw = onHost::allocHost<float>(extent);
+        auto vy2_hw = onHost::allocHost<float>(extent);
+        auto vz2_hw = onHost::allocHost<float>(extent);
 
         float fsrrmax2, mp_rsm2, fcoeff, dx1, dy1, dz1, dx2, dy2, dz2;
         int i = 0;
@@ -257,9 +253,9 @@ namespace haccmkAlpaka
         fcoeff = 0.23f;
         fsrrmax2 = 0.5f;
         mp_rsm2 = 0.03f;
-        dx1 = 1.0f / (float) n2;
-        dy1 = 2.0f / (float) n2;
-        dz1 = 3.0f / (float) n2;
+        dx1 = 1.0f / static_cast<float>(n2);
+        dy1 = 2.0f / static_cast<float>(n2);
+        dz1 = 3.0f / static_cast<float>(n2);
         xx[0] = 0.f;
         yy[0] = 0.f;
         zz[0] = 0.f;
@@ -270,7 +266,7 @@ namespace haccmkAlpaka
             xx[i] = xx[i - 1] + dx1;
             yy[i] = yy[i - 1] + dy1;
             zz[i] = zz[i - 1] + dz1;
-            mass[i] = (float) i * 0.01f + xx[i];
+            mass[i] = static_cast<float>(i) * 0.01f + xx[i];
         }
 
         for(i = 0; i < n2; i++)
@@ -291,8 +287,7 @@ namespace haccmkAlpaka
             vz2[i] = vz2[i] + dz2 * fcoeff;
         }
 
-        haccmk<
-            Data>(devAcc, exec, repeat, n1, n2, xx, yy, zz, mass, vx2_hw, vy2_hw, vz2_hw, fsrrmax2, mp_rsm2, fcoeff);
+        haccmk(devAcc, exec, repeat, n1, n2, xx, yy, zz, mass, vx2_hw, vy2_hw, vz2_hw, fsrrmax2, mp_rsm2, fcoeff);
 
         return hacc::verify(n2, vx2, vy2, vz2, vx2_hw, vy2_hw, vz2_hw);
     }
@@ -316,7 +311,7 @@ auto main(int argc, char* argv[]) -> int
      *  @code{.cpp}
      *  auto deviceSpec = onHost::DeviceSpec{api::cuda, deviceKind::nvidiaGpu};
      *  auto executor = exec::gpuCuda;
-     *  return example(deviceSpec, executor, n2,n1,repeat);
+     *  return example(deviceSpec, executor, n2, n1, repeat);
      *  @endcode
      *
      * Some examples for device specifications (depending on the active dependencies).

--- a/benchmark/HACCmk/src/main_alpaka.cpp
+++ b/benchmark/HACCmk/src/main_alpaka.cpp
@@ -1,0 +1,345 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "helper.hpp"
+#include "misc.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <bit>
+#include <chrono>
+#include <iostream>
+
+namespace haccmkAlpaka
+{
+    template<typename T>
+    struct DeltaMove
+    {
+        T x;
+        T y;
+        T z;
+
+        constexpr DeltaMove operator+(DeltaMove const& other)
+        {
+            return DeltaMove{x + other.x, y + other.y, z + other.z};
+        }
+    };
+
+    constexpr void simdizedInvoke(auto&& f, alpaka::concepts::SpecializationOf<DeltaMove> auto&&... args)
+    {
+        simdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).x...);
+        simdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).y...);
+        simdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).z...);
+    }
+
+    template<uint32_t T_width, typename T>
+    constexpr auto makeSimdized(DeltaMove<T> const& value)
+    {
+        using SimdMemberType = ALPAKA_TYPEOF(alpaka::makeSimdized<T_width>(std::declval<T>()));
+        DeltaMove<SimdMemberType> result;
+        simdizedInvoke([](alpaka::concepts::Simd auto& lhs, auto const& rhs) { lhs = rhs; }, result, value);
+        return result;
+    }
+
+    struct Step10Kernel
+    {
+        ALPAKA_FN_ACC auto operator()(
+            auto const& acc,
+            int n1,
+            int n2,
+            alpaka::concepts::IMdSpan auto xx,
+            alpaka::concepts::IMdSpan auto yy,
+            alpaka::concepts::IMdSpan auto zz,
+            alpaka::concepts::IMdSpan auto mass,
+            alpaka::concepts::IMdSpan auto vx2,
+            alpaka::concepts::IMdSpan auto vy2,
+            alpaka::concepts::IMdSpan auto vz2,
+            float fsrrmax2,
+            float mp_rsm2,
+            float fcoeff) const
+        {
+            using namespace alpaka;
+
+            constexpr float const ma0 = 0.269327, ma1 = -0.0750978, ma2 = 0.0114808, ma3 = -0.00109313,
+                                  ma4 = 0.0000605491, ma5 = -0.00000147177;
+
+            for(auto i :
+                alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::linearThreadsInGrid, alpaka::IdxRange{n1}))
+            {
+                auto move = DeltaMove<float>{0, 0, 0};
+
+                float xxi = xx[i];
+                float yyi = yy[i];
+                float zzi = zz[i];
+
+                auto simdGrid = onAcc::SimdAlgo{onAcc::WorkerGroup{Vec{0}, Vec{1}}};
+                move = simdGrid.transformReduce(
+                    acc,
+                    Vec{n2},
+                    move,
+                    std::plus{},
+                    [&](auto const&,
+                        concepts::SimdPtr auto&& simd_xx1,
+                        concepts::SimdPtr auto&& simd_yy1,
+                        concepts::SimdPtr auto&& simd_zz1,
+                        concepts::SimdPtr auto&& simd_mass1) constexpr
+                    {
+                        concepts::Simd auto dxc = simd_xx1.load() - xxi;
+                        concepts::Simd auto dyc = simd_yy1.load() - yyi;
+                        concepts::Simd auto dzc = simd_zz1.load() - zzi;
+
+                        concepts::Simd auto r2 = dxc * dxc + dyc * dyc + dzc * dzc;
+
+                        using SimdType = ALPAKA_TYPEOF(simd_mass1.load());
+                        concepts::Simd auto m = SimdType::fill(0.f);
+
+                        where(r2 < fsrrmax2, m) = simd_mass1.load();
+
+                        alpaka::concepts::Simd auto tmp = r2 + mp_rsm2;
+                        concepts::Simd auto bar = alpaka::math::sqrt(tmp);
+
+                        concepts::Simd auto p = float{1.0} / (tmp * bar);
+
+                        concepts::Simd auto f
+                            = p - (ma0 + r2 * (ma1 + r2 * (ma2 + r2 * (ma3 + r2 * (ma4 + r2 * ma5)))));
+                        concepts::Simd auto fac = SimdType::fill(0.f);
+                        where(r2 > 0.0f, fac) = m * f;
+
+                        using SimdizedType = decltype(makeSimdized<SimdType::width()>(move));
+                        return SimdizedType{(fac * dxc), (fac * dyc), (fac * dzc)};
+                    },
+                    xx,
+                    yy,
+                    zz,
+                    mass);
+
+                /* No `+=` is used to be comparable with the original version.
+                 * This differs to the original publication but is necessary due to an OpenMP bug in the original
+                 * implementation.
+                 */
+                vx2[i] = move.x * fcoeff;
+                vy2[i] = move.y * fcoeff;
+                vz2[i] = move.z * fcoeff;
+            }
+        }
+    };
+
+    template<typename Data>
+    void haccmk(
+        auto devAcc,
+        auto exec,
+        int const repeat,
+        int const n1,
+        int const n2,
+        auto& xx,
+        auto& yy,
+        auto& zz,
+        auto& mass,
+        auto& vx2,
+        auto& vy2,
+        auto& vz2,
+        float const fsrmax,
+        float const mp_rsm,
+        float const fcoeff)
+    {
+        using namespace alpaka;
+
+        // a blocking queue is used to reduce the starting overhead for CPU devices
+        onHost::Queue queue = devAcc.makeQueue(queueKind::blocking);
+
+        auto d_xx = onHost::alloc<Data>(devAcc, n2);
+        auto d_yy = onHost::alloc<Data>(devAcc, n2);
+        auto d_zz = onHost::alloc<Data>(devAcc, n2);
+        auto d_mass = onHost::alloc<Data>(devAcc, n2);
+        auto d_vx2 = onHost::alloc<Data>(devAcc, n1);
+        auto d_vy2 = onHost::alloc<Data>(devAcc, n1);
+        auto d_vz2 = onHost::alloc<Data>(devAcc, n1);
+
+        onHost::memcpy(queue, d_xx, xx);
+        onHost::memcpy(queue, d_yy, yy);
+        onHost::memcpy(queue, d_zz, zz);
+        onHost::memcpy(queue, d_mass, mass);
+
+        auto devProps = devAcc.getDeviceProperties();
+        // 8 is used for GPUs to provide at least frames to each multiprocessor
+        uint32_t suggestedNumFrames = devProps.multiProcessorCount * 8u;
+        // crop to the outer loop count if needed
+        int numeFrames = std::min(n1, static_cast<int>(suggestedNumFrames));
+        uint32_t possibleChunkSize = std::bit_floor(static_cast<uint32_t>(alpaka::divExZero(n1, numeFrames)));
+        uint32_t numElementsPerThread = getNumElemPerThread<float>(devAcc.getApi(), devAcc.getDeviceKind());
+        uint32_t frameExtent = alpaka::divExZero(possibleChunkSize, numElementsPerThread);
+        frameExtent = std::bit_floor(frameExtent);
+        frameExtent = frameExtent < devProps.warpSize ? devProps.warpSize : frameExtent;
+        auto frameSpec = onHost::FrameSpec{numeFrames, static_cast<int>(frameExtent)};
+
+        std::cout << "FrameSpec " << frameSpec << std::endl;
+
+        float total_time = 0.f;
+
+        for(int i = 0; i < repeat; i++)
+        {
+            // reset output
+            onHost::memcpy(queue, d_vx2, vx2, n1);
+            onHost::memcpy(queue, d_vy2, vy2, n1);
+            onHost::memcpy(queue, d_vz2, vz2, n1);
+
+            onHost::wait(devAcc);
+            auto start = std::chrono::steady_clock::now();
+
+            auto const haccKernel = KernelBundle{
+                Step10Kernel{},
+                n1,
+                n2,
+                d_xx,
+                d_yy,
+                d_zz,
+                d_mass,
+                d_vx2,
+                d_vy2,
+                d_vz2,
+                fsrmax,
+                mp_rsm,
+                fcoeff};
+
+            queue.enqueue(exec, frameSpec, haccKernel);
+            onHost::wait(devAcc);
+            auto end = std::chrono::steady_clock::now();
+            auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+            total_time += time;
+        }
+
+        printf("Average kernel execution time %f (s)\n", (total_time * 1e-9f) / repeat);
+        onHost::memcpy(queue, vx2, d_vx2, n1);
+        onHost::memcpy(queue, vy2, d_vy2, n1);
+        onHost::memcpy(queue, vz2, d_vz2, n1);
+        onHost::wait(devAcc);
+    }
+
+    auto example(auto const deviceSpec, auto const exec, int n2, int n1, int repeat) -> int
+    {
+        using namespace alpaka;
+
+        using IdxVec = Vec<int, 1u>;
+
+        // Define problem size
+        IdxVec const extent(n2);
+
+        // Define the buffer element type
+        using Data = float;
+
+        std::cout << "Outer loop count is set " << n1 << std::endl;
+        std::cout << "Inner loop count is set " << n2 << std::endl;
+        std::cout << "Element type " << onHost::demangledName<Data>() << std::endl;
+        std::cout << "Using alpaka accelerator " << onHost::demangledName(exec) << " for "
+                  << deviceSpec.getApi().getName() << " " << deviceSpec.getDeviceKind().getName() << std::endl;
+
+        auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+        onHost::Device devAcc = devSelector.makeDevice(0);
+
+
+        auto xx = onHost::allocHost<Data>(extent);
+        auto yy = onHost::allocHost<Data>(extent);
+        auto zz = onHost::allocHost<Data>(extent);
+        auto mass = onHost::allocHost<Data>(extent);
+        auto vx2 = onHost::allocHost<Data>(extent);
+        auto vy2 = onHost::allocHost<Data>(extent);
+        auto vz2 = onHost::allocHost<Data>(extent);
+        auto vx2_hw = onHost::allocHost<Data>(extent);
+        auto vy2_hw = onHost::allocHost<Data>(extent);
+        auto vz2_hw = onHost::allocHost<Data>(extent);
+
+        float fsrrmax2, mp_rsm2, fcoeff, dx1, dy1, dz1, dx2, dy2, dz2;
+        int i = 0;
+
+
+        /* Initial data preparation */
+        fcoeff = 0.23f;
+        fsrrmax2 = 0.5f;
+        mp_rsm2 = 0.03f;
+        dx1 = 1.0f / (float) n2;
+        dy1 = 2.0f / (float) n2;
+        dz1 = 3.0f / (float) n2;
+        xx[0] = 0.f;
+        yy[0] = 0.f;
+        zz[0] = 0.f;
+        mass[0] = 2.f;
+
+        for(i = 1; i < n2; i++)
+        {
+            xx[i] = xx[i - 1] + dx1;
+            yy[i] = yy[i - 1] + dy1;
+            zz[i] = zz[i - 1] + dz1;
+            mass[i] = (float) i * 0.01f + xx[i];
+        }
+
+        for(i = 0; i < n2; i++)
+        {
+            vx2[i] = 0.f;
+            vy2[i] = 0.f;
+            vz2[i] = 0.f;
+            vx2_hw[i] = 0.f;
+            vy2_hw[i] = 0.f;
+            vz2_hw[i] = 0.f;
+        }
+
+        for(i = 0; i < n1; ++i)
+        {
+            hacc::haccmk_gold(n2, xx[i], yy[i], zz[i], fsrrmax2, mp_rsm2, xx, yy, zz, mass, &dx2, &dy2, &dz2);
+            vx2[i] = vx2[i] + dx2 * fcoeff;
+            vy2[i] = vy2[i] + dy2 * fcoeff;
+            vz2[i] = vz2[i] + dz2 * fcoeff;
+        }
+
+        haccmk<
+            Data>(devAcc, exec, repeat, n1, n2, xx, yy, zz, mass, vx2_hw, vy2_hw, vz2_hw, fsrrmax2, mp_rsm2, fcoeff);
+
+        return hacc::verify(n2, vx2, vy2, vz2, vx2_hw, vy2_hw, vz2_hw);
+    }
+} // namespace haccmkAlpaka
+
+auto main(int argc, char* argv[]) -> int
+{
+    // naming is taken from the original code
+    int n2 = 1;
+    int n1 = 1;
+    int repeat = 1;
+
+    if(int const ret = hacc::parseCmd(argc, argv, n2, n1, repeat))
+        return ret;
+
+    using namespace alpaka;
+
+    /* Execute the example once for each backend (device specification + executor)
+     *
+     * If you would like to execute it for a single accelerator only you can use the following code.
+     *  @code{.cpp}
+     *  auto deviceSpec = onHost::DeviceSpec{api::cuda, deviceKind::nvidiaGpu};
+     *  auto executor = exec::gpuCuda;
+     *  return example(deviceSpec, executor, n2,n1,repeat);
+     *  @endcode
+     *
+     * Some examples for device specifications (depending on the active dependencies).
+     *
+     *   onHost::DeviceSpec{api::host, deviceKind::cpu}
+     *   onHost::DeviceSpec{api::cuda, deviceKind::nvidiaGpu}
+     *   onHost::DeviceSpec{api::hip, deviceKind::amdGpu}
+     *   onHost::DeviceSpec{api::oneApi, deviceKind::intelGpu}
+     *
+     * A list of api's and device kinds can be found
+     * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#available-apis
+     * A list of executors can be found
+     * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
+     */
+    return onHost::executeForEachIfHasDevice(
+        [=](auto const& backend)
+        {
+            return haccmkAlpaka::example(
+                backend[alpaka::object::deviceSpec],
+                backend[alpaka::object::exec],
+                n2,
+                n1,
+                repeat);
+        },
+        onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
+}

--- a/benchmark/HACCmk/src/main_orig.cpp
+++ b/benchmark/HACCmk/src/main_orig.cpp
@@ -142,9 +142,9 @@ int main(int argc, char* argv[])
     fcoeff = 0.23f;
     fsrrmax2 = 0.5f;
     mp_rsm2 = 0.03f;
-    dx1 = 1.0f / (float) n2;
-    dy1 = 2.0f / (float) n2;
-    dz1 = 3.0f / (float) n2;
+    dx1 = 1.0f / static_cast<float>(n2);
+    dy1 = 2.0f / static_cast<float>(n2);
+    dz1 = 3.0f / static_cast<float>(n2);
     xx[0] = 0.f;
     yy[0] = 0.f;
     zz[0] = 0.f;
@@ -155,7 +155,7 @@ int main(int argc, char* argv[])
         xx[i] = xx[i - 1] + dx1;
         yy[i] = yy[i - 1] + dy1;
         zz[i] = zz[i - 1] + dz1;
-        mass[i] = (float) i * 0.01f + xx[i];
+        mass[i] = static_cast<float>(i) * 0.01f + xx[i];
     }
 
     for(i = 0; i < n2; i++)

--- a/benchmark/HACCmk/src/main_orig.cpp
+++ b/benchmark/HACCmk/src/main_orig.cpp
@@ -1,0 +1,195 @@
+/* Copyright (c) 2020 , Argonne National Laboratory   (Zheming Jin)
+ * Copyright (c) 2020-, Oak Ridge National Laboratory   (Zheming Jin)
+ * Copyright 2026 René Widera
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "helper.hpp"
+#include "misc.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+
+#if defined(_OPENMP)
+#    include <omp.h>
+#endif
+
+
+template<typename T>
+void haccmk(
+    int const repeat,
+    size_t const n, // global size
+    int const ilp, // inner loop count
+    T const fsrrmax,
+    T const mp_rsm,
+    T const fcoeff,
+    T const* __restrict xx,
+    T const* __restrict yy,
+    T const* __restrict zz,
+    T const* __restrict mass,
+    T* __restrict vx2,
+    T* __restrict vy2,
+    T* __restrict vz2)
+{
+#if defined(_OPENMP)
+#    pragma omp target data map(to : xx[0 : ilp], yy[0 : ilp], zz[0 : ilp], mass[0 : ilp])                            \
+        map(tofrom : vx2[0 : n], vy2[0 : n], vz2[0 : n])
+#endif
+    {
+        float total_time = 0.f;
+
+        for(int r = 0; r < repeat; r++)
+        {
+#if defined(_OPENMP)
+            /* BUG This update is not working as expected, therefore the final values contains the changes from the
+             * device for each repetition. Therefore, vx2,vy2,vz2 in the kernel are assigned instead of using `+=`.
+             */
+#    pragma omp target update to(vx2[0 : n])
+#    pragma omp target update to(vy2[0 : n])
+#    pragma omp target update to(vz2[0 : n])
+#endif
+            auto start = std::chrono::steady_clock::now();
+
+#if defined(_OPENMP)
+#    pragma omp target teams distribute parallel for
+#endif
+            for(int i = 0; i < n; i++)
+            {
+                float const ma0 = 0.269327f;
+                float const ma1 = -0.0750978f;
+                float const ma2 = 0.0114808f;
+                float const ma3 = -0.00109313f;
+                float const ma4 = 0.0000605491f;
+                float const ma5 = -0.00000147177f;
+
+                float dxc, dyc, dzc, m, r2, f, xi, yi, zi;
+
+                xi = 0.f;
+                yi = 0.f;
+                zi = 0.f;
+
+                float xxi = xx[i];
+                float yyi = yy[i];
+                float zzi = zz[i];
+
+                for(int j = 0; j < ilp; j++)
+                {
+                    dxc = xx[j] - xxi;
+                    dyc = yy[j] - yyi;
+                    dzc = zz[j] - zzi;
+
+                    r2 = dxc * dxc + dyc * dyc + dzc * dzc;
+
+                    m = mass[j] * (r2 < fsrrmax);
+
+                    f = r2 + mp_rsm;
+                    f = m
+                        * (1.f / (f * sqrtf(f))
+                           - (ma0 + r2 * (ma1 + r2 * (ma2 + r2 * (ma3 + r2 * (ma4 + r2 * ma5))))));
+
+                    xi = xi + f * dxc;
+                    yi = yi + f * dyc;
+                    zi = zi + f * dzc;
+                }
+
+                /* No `+=` is used.
+                 * This differs to the original publication but is necessary due to the OpenMP bug.
+                 */
+                vx2[i] = xi * fcoeff;
+                vy2[i] = yi * fcoeff;
+                vz2[i] = zi * fcoeff;
+            }
+
+            auto end = std::chrono::steady_clock::now();
+            auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+            total_time += time;
+        }
+        printf("Average kernel execution time %f (s)\n", (total_time * 1e-9f) / repeat);
+#if defined(_OPENMP)
+#    pragma omp target update from(vx2[0 : n], vy2[0 : n], vz2[0 : n])
+#endif
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    int n2 = 1;
+    int n1 = 1;
+    int repeat = 1;
+
+    if(int const ret = hacc::parseCmd(argc, argv, n2, n1, repeat))
+        return ret;
+
+    float fsrrmax2, mp_rsm2, fcoeff, dx1, dy1, dz1, dx2, dy2, dz2;
+    int i;
+
+    printf("Outer loop count is set %d\n", n1);
+    printf("Inner loop count is set %d\n", n2);
+
+    float* xx = hacc::allocAligned<float>(n2);
+    float* yy = hacc::allocAligned<float>(n2);
+    float* zz = hacc::allocAligned<float>(n2);
+    float* mass = hacc::allocAligned<float>(n2);
+    float* vx2 = hacc::allocAligned<float>(n2);
+    float* vy2 = hacc::allocAligned<float>(n2);
+    float* vz2 = hacc::allocAligned<float>(n2);
+    float* vx2_hw = hacc::allocAligned<float>(n2);
+    float* vy2_hw = hacc::allocAligned<float>(n2);
+    float* vz2_hw = hacc::allocAligned<float>(n2);
+
+    /* Initial data preparation */
+    fcoeff = 0.23f;
+    fsrrmax2 = 0.5f;
+    mp_rsm2 = 0.03f;
+    dx1 = 1.0f / (float) n2;
+    dy1 = 2.0f / (float) n2;
+    dz1 = 3.0f / (float) n2;
+    xx[0] = 0.f;
+    yy[0] = 0.f;
+    zz[0] = 0.f;
+    mass[0] = 2.f;
+
+    for(i = 1; i < n2; i++)
+    {
+        xx[i] = xx[i - 1] + dx1;
+        yy[i] = yy[i - 1] + dy1;
+        zz[i] = zz[i - 1] + dz1;
+        mass[i] = (float) i * 0.01f + xx[i];
+    }
+
+    for(i = 0; i < n2; i++)
+    {
+        vx2[i] = 0.f;
+        vy2[i] = 0.f;
+        vz2[i] = 0.f;
+        vx2_hw[i] = 0.f;
+        vy2_hw[i] = 0.f;
+        vz2_hw[i] = 0.f;
+    }
+
+    for(i = 0; i < n1; ++i)
+    {
+        hacc::haccmk_gold(n2, xx[i], yy[i], zz[i], fsrrmax2, mp_rsm2, xx, yy, zz, mass, &dx2, &dy2, &dz2);
+        vx2[i] = vx2[i] + dx2 * fcoeff;
+        vy2[i] = vy2[i] + dy2 * fcoeff;
+        vz2[i] = vz2[i] + dz2 * fcoeff;
+    }
+
+    haccmk(repeat, n1, n2, fsrrmax2, mp_rsm2, fcoeff, xx, yy, zz, mass, vx2_hw, vy2_hw, vz2_hw);
+
+    int error = hacc::verify(n2, vx2, vy2, vz2, vx2_hw, vy2_hw, vz2_hw);
+
+    hacc::freeAligned(xx);
+    hacc::freeAligned(yy);
+    hacc::freeAligned(zz);
+    hacc::freeAligned(mass);
+    hacc::freeAligned(vx2);
+    hacc::freeAligned(vy2);
+    hacc::freeAligned(vz2);
+    hacc::freeAligned(vx2_hw);
+    hacc::freeAligned(vy2_hw);
+    hacc::freeAligned(vz2_hw);
+
+    return error;
+}

--- a/benchmark/HACCmk/src/misc.hpp
+++ b/benchmark/HACCmk/src/misc.hpp
@@ -1,0 +1,106 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file The file is providing some helpers for the HACCmk implementation shared between the original and the alpaka
+ * implementation.
+ * @attention The license differs compared to other files because it is not containing any parts from the ORNL code
+ * base.
+ */
+
+#include <catch2/catch_session.hpp>
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <new>
+#include <string>
+
+namespace hacc
+{
+    constexpr int defaultNumParticles = 15000;
+    constexpr int defaultNumActiveParticles = 784;
+    constexpr int defaultRepetitions = 64;
+
+    /** Parse cmd parameters and updates the parameters for HACC
+     */
+    inline int parseCmd(int argc, char* argv[], int& numParticles, int& numActiveParticles, int& numRepetitions)
+    {
+        /* Vector length, must be divisible by 4 */
+        numParticles = defaultNumParticles;
+        numActiveParticles = defaultNumActiveParticles;
+        numRepetitions = defaultRepetitions;
+
+        Catch::Session session;
+
+        using namespace Catch::Clara;
+
+        auto cli = session.cli()
+                   | Opt(numParticles, "numParticles")["--size"]("Number of particles (rounded up to a multiple of 4)")
+                   | Opt(numActiveParticles, "numberActivePArticles")["--particles"](
+                       "Number of active particles (particles where velocity is updated")
+                   | Opt(numRepetitions, "numRepetitions")["--repeat"]("Number repetitions of the benchmark");
+
+        session.cli(cli);
+
+        int const rc = session.applyCommandLine(argc, argv);
+        if(rc != 0)
+        {
+            return rc;
+        }
+
+        if(numParticles == 0)
+        {
+            std::cerr << "Error: number of elements must be greater than zero.\n";
+            return EXIT_FAILURE;
+        }
+
+        // round to a multiple of 4
+        numParticles = (numParticles + 3) / 4 * 4;
+
+        if(numActiveParticles == 0)
+        {
+            std::cerr << "Error: number of active particles must be greater than zero.\n";
+            return EXIT_FAILURE;
+        }
+
+        if(numRepetitions == 0)
+        {
+            std::cerr << "Error: number of runs must be greater than zero.\n";
+            return EXIT_FAILURE;
+        }
+
+        if(numActiveParticles > numParticles)
+        {
+            std::cerr << "Error: number of active particles must not exceed the number of elements.\n";
+            return EXIT_FAILURE;
+        }
+
+        return EXIT_SUCCESS;
+    }
+
+    /** allocated aligned memory
+     *
+     * @return a pointer to the memory section of the given type T. The pointer is aligned to 256 byte.
+     */
+    template<typename T>
+    inline auto* allocAligned(int numParticles)
+    {
+        constexpr uint32_t alignmentBytes = 256u;
+        return reinterpret_cast<T*>(
+            ::operator new(numParticles* static_cast<int>(sizeof(T)), std::align_val_t{alignmentBytes}));
+    }
+
+    /** free aligned memory
+     *
+     *  Free memory allocated with allocAligned.
+     */
+    inline void freeAligned(auto* ptr)
+    {
+        if(ptr != nullptr)
+        {
+            constexpr uint32_t alignmentBytes = 256u;
+            ::operator delete(ptr, std::align_val_t{alignmentBytes});
+        }
+    }
+} // namespace hacc

--- a/benchmark/HACCmk/src/misc.hpp
+++ b/benchmark/HACCmk/src/misc.hpp
@@ -84,7 +84,7 @@ namespace hacc
      * @return a pointer to the memory section of the given type T. The pointer is aligned to 256 byte.
      */
     template<typename T>
-    inline auto* allocAligned(int numParticles)
+    inline T* allocAligned(int numParticles)
     {
         constexpr uint32_t alignmentBytes = 256u;
         return reinterpret_cast<T*>(

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -62,6 +62,7 @@
 #include "alpaka/rand/distribution/UniformReal.hpp"
 #include "alpaka/rand/engine/philox/philox.hpp"
 #include "alpaka/simd/math.hpp"
+#include "alpaka/simd/simdized.hpp"
 #include "alpaka/tag.hpp"
 #include "alpaka/utility.hpp"
 

--- a/include/alpaka/onAcc/SimdAlgo.hpp
+++ b/include/alpaka/onAcc/SimdAlgo.hpp
@@ -222,12 +222,12 @@ namespace alpaka::onAcc
         /**
          * @copydoc transformReduce()
          *
-         * @param T_maxConcurrencyInByte
+         * @tparam T_maxConcurrencyInByte
          *    Maximum number of bytes to be used for concurrency.
          *    Concurrency bytes describe a virtual simd pack size which is not exceeded.
          *    Internally a best fitting SIMD width is calculated and instruction parallelism is exposed based on
          *    T_maxConcurrencyInByte.
-         * @param T_MemAlignment alignment of the memory, if no alignments is given the alignment will be derived from
+         * @tparam T_MemAlignment alignment of the memory, if no alignments is given the alignment will be derived from
          * the MdSpan data descriptions
          */
         template<uint32_t T_maxConcurrencyInByte, alpaka::concepts::Alignment T_MemAlignment = AutoAligned>
@@ -253,12 +253,12 @@ namespace alpaka::onAcc
          * @copydoc transformReduce()
          *
          * @param extents number of elements to process in each dimension
-         * @param T_maxConcurrencyInByte
+         * @tparam T_maxConcurrencyInByte
          *    Maximum number of bytes to be used for concurrency.
          *    Concurrency bytes describe a virtual simd pack size which is not exceeded.
          *    Internally a best fitting SIMD width is calculated and instruction parallelism is exposed based on
          *    T_maxConcurrencyInByte.
-         * @param T_MemAlignment alignment of the memory, if no alignments is given the alignment will be derived from
+         * @tparam T_MemAlignment alignment of the memory, if no alignments is given the alignment will be derived from
          * the MdSpan data descriptions
          */
         template<uint32_t T_maxConcurrencyInByte, alpaka::concepts::Alignment T_MemAlignment = AutoAligned>

--- a/include/alpaka/onAcc/SimdAlgo.hpp
+++ b/include/alpaka/onAcc/SimdAlgo.hpp
@@ -61,7 +61,7 @@ namespace alpaka::onAcc
         /** execute the functor concurrently over the given data.
          *
          * @attention The number of elements to process is derived from the first MdSpan object.
-         *            All other MdSpan objects must have hat least the same number of elements.
+         *            All other MdSpan objects must have at least the same number of elements.
          *            The optimal concurrency is also derived from the first MdSpan.
          *
          * @param func the functor to be executed
@@ -107,7 +107,7 @@ namespace alpaka::onAcc
         /** execute the functor concurrently over the given data.
          *
          * @attention The number of elements to process is derived from the first MdSpan object.
-         *            All other MdSpan objects must have hat least the same number of elements.
+         *            All other MdSpan objects must have at least the same number of elements.
          *
          * @param T_maxConcurrencyInByte
          *    Maximum number of bytes to be used for concurrency.
@@ -158,21 +158,21 @@ namespace alpaka::onAcc
 
         /** @} */
 
-        /** execute the functor concurrently over the given data.
+
+        /** @brief transform the input data and reduce is to a single value
          *
-         * @attention The number of elements to process is derived from the first MdSpan object.
-         *            All other MdSpan objects must have hat least the same number of elements.
+         * @attention If no extent is given the number of elements to process is derived from the first MdSpan object.
+         *            All other MdSpan objects must have at least the same number of elements.
          *
          * @param neutralElement the neutral element for the reduction operation
          * @param reduceFunc the binary reduction operation to be executed, e.g. std::plus
          * @param transformFunc n-nary functor to be executed, values of all containers will be passed to the functor
-         * as arguments
+         * as arguments. If the result of this functor is a structured value providing an overload to simdize the type
+         * can improve the performance see alpaka::makeSimdized.
          * @param data0 the first data to be processed
          * @param dataN the remaining data to be processed
-         *
-         * @{
+         * @return A single reduced value.
          */
-
         ALPAKA_FN_INLINE ALPAKA_FN_ACC constexpr auto transformReduce(
             auto const& acc,
             auto const& neutralElement,
@@ -192,6 +192,7 @@ namespace alpaka::onAcc
         }
 
         /**
+         * @copydoc transformReduce()
          * @param extents number of elements to process in each dimension
          */
         ALPAKA_FN_INLINE ALPAKA_FN_ACC constexpr auto transformReduce(
@@ -218,12 +219,8 @@ namespace alpaka::onAcc
                 ALPAKA_FORWARD(dataN)...);
         }
 
-        /** @} */
-
-        /** execute the transformFunctor concurrently over the given data.
-         *
-         * @attention The number of elements to process is derived from the first MdSpan object.
-         *            All other MdSpan objects must have hat least the same number of elements.
+        /**
+         * @copydoc transformReduce()
          *
          * @param T_maxConcurrencyInByte
          *    Maximum number of bytes to be used for concurrency.
@@ -232,14 +229,6 @@ namespace alpaka::onAcc
          *    T_maxConcurrencyInByte.
          * @param T_MemAlignment alignment of the memory, if no alignments is given the alignment will be derived from
          * the MdSpan data descriptions
-         * @param neutralElement the neutral element for the reduction operation
-         * @param reduceFunc the binary reduction operation to be executed, e.g. std::plus
-         * @param transformFunc n-nary functor to be executed, values of all containers will be passed to the functor
-         * as arguments
-         * @param T_data0 the first data to be processed
-         * @param T_dataN the remaining data to be processed
-         *
-         * @{
          */
         template<uint32_t T_maxConcurrencyInByte, alpaka::concepts::Alignment T_MemAlignment = AutoAligned>
         ALPAKA_FN_INLINE ALPAKA_FN_ACC constexpr auto transformReduce(
@@ -261,7 +250,16 @@ namespace alpaka::onAcc
         }
 
         /**
+         * @copydoc transformReduce()
+         *
          * @param extents number of elements to process in each dimension
+         * @param T_maxConcurrencyInByte
+         *    Maximum number of bytes to be used for concurrency.
+         *    Concurrency bytes describe a virtual simd pack size which is not exceeded.
+         *    Internally a best fitting SIMD width is calculated and instruction parallelism is exposed based on
+         *    T_maxConcurrencyInByte.
+         * @param T_MemAlignment alignment of the memory, if no alignments is given the alignment will be derived from
+         * the MdSpan data descriptions
          */
         template<uint32_t T_maxConcurrencyInByte, alpaka::concepts::Alignment T_MemAlignment = AutoAligned>
         ALPAKA_FN_INLINE ALPAKA_FN_ACC constexpr auto transformReduce(
@@ -282,8 +280,6 @@ namespace alpaka::onAcc
                 ALPAKA_FORWARD(data0),
                 ALPAKA_FORWARD(dataN)...);
         }
-
-        /** @} */
 
     private:
         using ConcurrentAlgo = internal::SimdConcurrent<SimdAlgo<T_WorkGroup, T_Traverse, T_IdxLayout>>;

--- a/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
+++ b/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
@@ -15,6 +15,7 @@
 #include "alpaka/onAcc/Acc.hpp"
 #include "alpaka/onAcc/WorkerGroup.hpp"
 #include "alpaka/onAcc/interface.hpp"
+#include "alpaka/simd/simdized.hpp"
 
 #include <cstdint>
 #include <new>
@@ -70,24 +71,26 @@ namespace alpaka::onAcc::internal
                 IdxRange{numElements},
                 asParent().getTraversePolicy(),
                 asParent().getIdxLayoutPolicy());
-            using ReturnType = decltype(func(
-                acc,
-                SimdPtr{data0, *(traverse.begin()), T_MemAlignment{}, CVec<uint32_t, 1u>{}},
-                SimdPtr{dataN, *(traverse.begin()), T_MemAlignment{}, CVec<uint32_t, 1u>{}}...));
 
-            auto retValue = ReturnType::fill(neutralElement);
+            using SimdOneReturnType = ALPAKA_TYPEOF(makeSimdized<1u>(neutralElement));
+            SimdOneReturnType simdizedReducedValue = makeSimdized<1u>(neutralElement);
+
             for(auto idx : traverse)
             {
-                retValue = reduceFunc(
-                    retValue,
+                simdizedReducedValue = reduceFunc(
+                    simdizedReducedValue,
                     func(
                         acc,
                         SimdPtr{data0, idx, T_MemAlignment{}, CVec<uint32_t, 1u>{}},
                         SimdPtr{dataN, idx, T_MemAlignment{}, CVec<uint32_t, 1u>{}}...));
             }
-            // std simd operator[] is returning a smart reference, therefore we need to std::as_const to enforce that
-            // the operator[] is returning the value_type
-            return std::as_const(retValue)[0];
+
+            auto result = neutralElement;
+            simdizedInvoke(
+                [](auto& lhs, alpaka::concepts::Simd auto const& rhs) { lhs = rhs[0]; },
+                result,
+                simdizedReducedValue);
+            return result;
         }
 
     private:
@@ -101,12 +104,33 @@ namespace alpaka::onAcc::internal
             return func(acc, SimdPtr{ALPAKA_FORWARD(data), dataIdx, T_MemAlignment{}, CVec<uint32_t, T_width>{}}...);
         }
 
-        /** calls the functor and forward the data T_repeat times
+        /** advance the iterator T_repeat times
+         *
+         * We do not check if the iterator points to a valid element, the caller must ensure that we can safely
+         * advance the iterator T_repeat time without jumping over iter.end().
+         *
+         * @tparam T_repeat Number of time sthe iterator should be advanced.
+         * @return Tuple with T_repeat times iterators.
+         */
+        template<uint32_t... T_repeat>
+        ALPAKA_FN_INLINE static constexpr auto makeAdvanceIterators(
+            auto& iter,
+            std::integer_sequence<uint32_t, T_repeat...>)
+        {
+            // The ternary operator is used to allow using the folding expression on iter.
+            return std::make_tuple(*(T_repeat + 1 != 0u ? iter++ : iter++)...);
+        }
+
+        /** Calls the transform functor T_repeat times and reduces the results with the given reduce function.
          *
          * The calls to the functor are independent and compile time unrolled to support instruction parallelism.
+         * In contrast to executeReduceInto() the register footprint is larger because T_repeat temporary results will
+         * be holt. This allows the compiler to use instruction level parallelism. Call this function if result of
+         * reduceFunc is a SIMD pack.
          *
          * @param iter the caller must ensure tha the interator can be increased T_repeat times without jumping over
          * iter.end()
+         * @return a single simdized pack
          */
         template<alpaka::concepts::Alignment T_MemAlignment, uint32_t T_width, uint32_t... T_repeat>
         ALPAKA_FN_INLINE static constexpr auto executeReduce(
@@ -117,12 +141,7 @@ namespace alpaka::onAcc::internal
             auto&& func,
             alpaka::concepts::IDataSource auto&&... data)
         {
-            /* We do not check if the iterator points to a valid element, the caller must ensure that we can safely
-             * increase the iterator without jumping over iter.end().
-             *
-             * The ternary operator is used to allow using the folding expression on iter.
-             */
-            auto ids = std::make_tuple(*(T_repeat + 1 != 0u ? iter++ : iter++)...);
+            auto ids = makeAdvanceIterators(iter, std::integer_sequence<uint32_t, T_repeat...>{});
             return std::apply(
                 [&](auto const&... dataIdx) constexpr
                 {
@@ -147,7 +166,81 @@ namespace alpaka::onAcc::internal
                 ids);
         }
 
-    private:
+        /** Reduce simdized packs into a single simdized pack with the given reduce function.
+         *
+         * In contrast to executeReduce() the register footprint is lower because all intermediate results are directly
+         * reduced into the result variable. Call this function if the type of result is a simdized pack is not a SIMD
+         * pack.
+         *
+         * @param result The results of reduceFn with the result of transformFn will be reduced into this simdized
+         * pack.
+         */
+        template<alpaka::concepts::Alignment T_MemAlignment, uint32_t T_width, uint32_t... T_repeat>
+        ALPAKA_FN_INLINE static constexpr void executeReduceInto(
+            concepts::Acc auto const& acc,
+            auto& iter,
+            std::integer_sequence<uint32_t, T_repeat...>,
+            auto& result,
+            auto&& reduceFn,
+            auto&& transformFn,
+            alpaka::concepts::IDataSource auto&&... data)
+        {
+            auto ids = makeAdvanceIterators(iter, std::integer_sequence<uint32_t, T_repeat...>{});
+            std::apply(
+                [&](auto const&... dataIdx) constexpr
+                {
+                    ((result = reduceFn(
+                          result,
+                          executeDoTransform<T_MemAlignment, T_width>(
+                              acc,
+                              dataIdx,
+                              ALPAKA_FORWARD(transformFn),
+                              ALPAKA_FORWARD(data)...))),
+                     ...);
+                },
+                ids);
+        }
+
+        /** Reduce T_numSimdPerFnCall simdized packs
+         *
+         */
+        template<uint32_t T_simdWidth, uint32_t T_numSimdPerFnCall, alpaka::concepts::Alignment T_MemAlignment>
+        ALPAKA_FN_INLINE static constexpr void reduceNextSimdized(
+            auto const& acc,
+            auto& iter,
+            auto& tmpReturn,
+            auto&& reduceFn,
+            auto&& transformFn,
+            alpaka::concepts::IDataSource auto&& data0,
+            alpaka::concepts::IDataSource auto&&... dataN)
+        {
+            if constexpr(alpaka::concepts::Simd<std::remove_cvref_t<decltype(tmpReturn)>>)
+            {
+                tmpReturn = reduceFn(
+                    tmpReturn,
+                    executeReduce<T_MemAlignment, T_simdWidth>(
+                        acc,
+                        iter,
+                        std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
+                        ALPAKA_FORWARD(reduceFn),
+                        ALPAKA_FORWARD(transformFn),
+                        ALPAKA_FORWARD(data0),
+                        ALPAKA_FORWARD(dataN)...));
+            }
+            else
+            {
+                executeReduceInto<T_MemAlignment, T_simdWidth>(
+                    acc,
+                    iter,
+                    std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
+                    tmpReturn,
+                    ALPAKA_FORWARD(reduceFn),
+                    ALPAKA_FORWARD(transformFn),
+                    ALPAKA_FORWARD(data0),
+                    ALPAKA_FORWARD(dataN)...);
+            }
+        }
+
         template<onAcc::concepts::Acc T_Acc, typename T_ReduceOp>
         struct ScalarReducer
         {
@@ -262,17 +355,8 @@ namespace alpaka::onAcc::internal
                 asParent().getTraversePolicy(),
                 asParent().getIdxLayoutPolicy());
 
-            auto iter = simdIdxContainer.begin();
-            using SimdReturn = decltype(executeReduce<T_MemAlignment, T_simdWidth>(
-                acc,
-                iter,
-                std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
-                ALPAKA_FORWARD(reduceFunc),
-                ALPAKA_FORWARD(func),
-                ALPAKA_FORWARD(data0),
-                ALPAKA_FORWARD(dataN)...));
-
-            alpaka::concepts::Simd auto tmpReturn = SimdReturn::fill(neutralElement);
+            using SimdReturn = ALPAKA_TYPEOF(makeSimdized<T_simdWidth>(neutralElement));
+            SimdReturn simdizedReducedValue = makeSimdized<T_simdWidth>(neutralElement);
 
             if constexpr(
                 domainSize.dim() > 1u && std::is_same_v<ALPAKA_TYPEOF(asParent().getTraversePolicy()), traverse::Flat>)
@@ -280,7 +364,7 @@ namespace alpaka::onAcc::internal
                 /* For cases where we traverse with the flat policy, we cannot assume that we can blindly increase the
                  * iterator later N times. This could happen in cases where we have enough concurrency. We evaluate for
                  * SIMD operations only the fast moving dimension but with the flat policy flattening the worker group
-                 * and use all workers on a linear domain. The loop must therefore be splited into iterating over all
+                 * and use all workers on a linear domain. The loop must therefore be split into iterating over all
                  * slow dimensions and an inner loop iterating over the fast moving dimension. For this we need to
                  * build our own groups out of the user-provided workgroup.
                  */
@@ -304,43 +388,39 @@ namespace alpaka::onAcc::internal
                     auto wSizeInner = ALPAKA_TYPEOF(domainSize)::fill(1).rAssign(workGroup.size(acc).back());
                     auto wInner = WorkerGroup{wIdxInner, wSizeInner};
 
-                    // iterate over the fast-moving dimension
-                    auto simdIdxContainer = onAcc::makeIdxMap(
+                    // iterate over the fast-moving dimension only
+                    auto simdIdxContainerFastDim = onAcc::makeIdxMap(
                         acc,
                         wInner,
                         IdxRange{rowIdx, domainSize, stride},
                         asParent().getTraversePolicy(),
                         asParent().getIdxLayoutPolicy())[CVec<uint32_t, ALPAKA_TYPEOF(domainSize)::dim() - 1u>{}];
 
-                    for(auto iter = simdIdxContainer.begin(); iter != simdIdxContainer.end();)
+                    for(auto iter = simdIdxContainerFastDim.begin(); iter != simdIdxContainerFastDim.end();)
                     {
-                        tmpReturn = reduceFunc(
-                            tmpReturn,
-                            executeReduce<T_MemAlignment, T_simdWidth>(
-                                acc,
-                                iter,
-                                std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
-                                ALPAKA_FORWARD(reduceFunc),
-                                ALPAKA_FORWARD(func),
-                                ALPAKA_FORWARD(data0),
-                                ALPAKA_FORWARD(dataN)...));
+                        reduceNextSimdized<T_simdWidth, T_numSimdPerFnCall, T_MemAlignment>(
+                            acc,
+                            iter,
+                            simdizedReducedValue,
+                            ALPAKA_FORWARD(reduceFunc),
+                            ALPAKA_FORWARD(func),
+                            ALPAKA_FORWARD(data0),
+                            ALPAKA_FORWARD(dataN)...);
                     }
                 }
             }
             else
             {
-                for(; iter != simdIdxContainer.end();)
+                for(auto iter = simdIdxContainer.begin(); iter != simdIdxContainer.end();)
                 {
-                    tmpReturn = reduceFunc(
-                        tmpReturn,
-                        executeReduce<T_MemAlignment, T_simdWidth>(
-                            acc,
-                            iter,
-                            std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
-                            ALPAKA_FORWARD(reduceFunc),
-                            ALPAKA_FORWARD(func),
-                            ALPAKA_FORWARD(data0),
-                            ALPAKA_FORWARD(dataN)...));
+                    reduceNextSimdized<T_simdWidth, T_numSimdPerFnCall, T_MemAlignment>(
+                        acc,
+                        iter,
+                        simdizedReducedValue,
+                        ALPAKA_FORWARD(reduceFunc),
+                        ALPAKA_FORWARD(func),
+                        ALPAKA_FORWARD(data0),
+                        ALPAKA_FORWARD(dataN)...);
                 }
             }
 
@@ -353,17 +433,28 @@ namespace alpaka::onAcc::internal
                     asParent().getTraversePolicy(),
                     asParent().getIdxLayoutPolicy()))
             {
-                // std simd non-const operator[] is returning a smart reference, therefore we need std::as_const to
-                // enforce returning a copy of the value.
-                alpaka::concepts::Simd auto funcResult = func(
+                auto transformResult = func(
                     acc,
                     SimdPtr{data0, idx, T_MemAlignment{}, CVec<uint32_t, 1u>{}},
                     SimdPtr{dataN, idx, T_MemAlignment{}, CVec<uint32_t, 1u>{}}...);
 
-                tmpReturn[0] = reduceFunc(std::as_const(tmpReturn)[0], std::as_const(funcResult)[0]);
+                simdizedInvoke(
+                    [reduceFunc](auto& lhs, alpaka::concepts::Simd auto const& rhs)
+                    {
+                        // std simd non-const operator[] is returning a smart reference, therefore we need
+                        // std::as_const to enforce returning a copy of the value.
+                        lhs[0] = reduceFunc(std::as_const(lhs)[0], rhs[0]);
+                    },
+                    simdizedReducedValue,
+                    transformResult);
             }
 
-            return tmpReturn.reduce(ALPAKA_FORWARD(reduceFunc));
+            ALPAKA_TYPEOF(neutralElement) result;
+            simdizedInvoke(
+                [reduceFunc](auto& lhs, alpaka::concepts::Simd auto const& rhs) { lhs = rhs.reduce(reduceFunc); },
+                result,
+                simdizedReducedValue);
+            return result;
         }
     };
 } // namespace alpaka::onAcc::internal

--- a/include/alpaka/simd/simdized.hpp
+++ b/include/alpaka/simd/simdized.hpp
@@ -1,0 +1,85 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file This file provides functionality to transform a type into a SIMD-optimized data structure.
+ *
+ * The implementation is motivated by https://ieeexplore.ieee.org/document/11207437
+ */
+
+#pragma once
+
+#include "alpaka/Simd.hpp"
+#include "alpaka/core/common.hpp"
+
+namespace alpaka
+{
+
+    /** Transform a type into a SIMD-optimized data structure.
+     *
+     * A simdized value is not necessarily a data type wrapped by alpaka::Simd, it can be a structured hierarchical
+     * type where each component is a SIMD pack. This function can be specialized within the namespace of the input
+     * type and will be found via ADL.
+     * @see simdizedInvoke should be specialized together with this function.
+     *
+     * Simdizing of structured types as shown in the code example often improves the performance compared to wrapping
+     * into a SIMD pack.
+     * @code{.cpp}
+     * // input type
+     * template<typename T>
+     * struct Pos
+     * {
+     *   T x = 0;
+     *   T y = 1;
+     * };
+     *
+     * // output could be
+     * template<typename T>
+     * struct Pos
+     * {
+     *   alpaka::Simd<T, width> x;
+     *   alpaka::Simd<T, width> y;
+     * };
+     * @endcode
+     *
+     * @tparam T_width the width of the used SIMD type
+     * @return A simdized data type where each lane replicates the given value. If `makeSimdized` is not specialized
+     * for the given type a SIMD pack wrapping the input value will be returned.
+     */
+    template<uint32_t T_width>
+    constexpr auto makeSimdized(auto&& value)
+    {
+        return Simd<ALPAKA_TYPEOF(value), T_width>::fill(value);
+    }
+
+    /** Invokes the callable object fn with the parameters args.
+     *
+     * For structured data where each component is a SIMD pack, the functor should be forwarded to the members while
+     * recursively calling simdizedInvoke.
+     * As soon as there is no use specialization available, the recursion is terminated by the invocation of the
+     * functor with the forwarded arguments. This function can be specialized within the namespace of the argument
+     * types and will be found via ADL.
+     * @see makeSimdized should be specialized together with this function.
+     *
+     * As shown in the code snippet, alpaka assumes at least a specialization where each argument can perform the same
+     * access used within the function. It is allowed to specialize more function signatures that do not follow the
+     * rule but are useful within the user code.
+     * @code{.cpp}
+     * // A typical case of how this specialization is called is
+     * // `simdizedInvoke(f, Pos<int>{}, Pos<alpaka::Simd<int,4>>{})`.
+     * constexpr void simdizedInvoke(auto&& f, alpaka::concepts::SpecializationOf<Pos> auto&&... args)
+     * {
+     *    // Accessing .x and .y must be supported by all arguments.
+     *    simdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).x...);
+     *    simdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).y...);
+     * }
+     * @endcode
+     *
+     * @param fn Callable object to which the arguments will be forwarded.
+     * @param args Arguments forwarded to fn.
+     */
+    constexpr void simdizedInvoke(auto&& fn, auto&&... args)
+    {
+        ALPAKA_FORWARD(fn)(ALPAKA_FORWARD(args)...);
+    }
+} // namespace alpaka


### PR DESCRIPTION
- introduce simdize motivated by https://ieeexplore.ieee.org/document/11207437
- add support for simdized data types to `SimdAlgo::transformReduce`
- add HACCmk benchmark basd on the ORNL HACCmk version