### PR TITLE
permit scalar extent for `getFrameSpec` 

### DIFF
--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -329,7 +329,9 @@ namespace alpaka::onHost
      * @return frame specification
      */
     template<typename T_DataType, typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
-    inline constexpr auto getFrameSpec(onHost::Device<T_Api, T_DeviceKind> const& device, auto&& extents)
+    inline constexpr auto getFrameSpec(
+        Device<T_Api, T_DeviceKind> const& device,
+        alpaka::concepts::VectorOrScalar auto const& extents)
     {
         return internal::getFrameSpec<T_DataType>(*device.get(), extents);
     }

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -1,11 +1,11 @@
-/* Copyright 2024 René Widera
+/* Copyright 2024 René Widera, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
-
 #include "alpaka/KernelBundle.hpp"
 #include "alpaka/api/trait.hpp"
+#include "alpaka/core/Assert.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/onHost/DeviceProperties.hpp"
 #include "alpaka/onHost/FrameSpec.hpp"
@@ -495,23 +495,28 @@ namespace alpaka::onHost
             return GetPitches::Op<ALPAKA_TYPEOF(*any.get())>{}(*any.get());
         }
 
-        /** get a SIMD optimized frame spec
+        /** implementation to get a SIMD optimized frame spec
          *
          * @param internalDevice must be a alpaka internal device implementation
          */
         template<typename T_DataType>
-        inline constexpr auto getFrameSpec(auto const& internalDevice, auto&& extents)
+        inline constexpr auto getFrameSpec(
+            auto const& internalDevice,
+            alpaka::concepts::VectorOrScalar auto const& extents)
         {
+            Vec extentMd = extents;
             auto deviceKind = alpaka::internal::getDeviceKind(internalDevice);
             auto deviceApi = alpaka::internal::getApi(internalDevice);
-            using ExtentVecType = ALPAKA_TYPEOF(extents);
+            using ExtentVecType = ALPAKA_TYPEOF(extentMd);
+            // check that all extent dimensions are greater than zero
+            ALPAKA_ASSERT((extentMd > ExtentVecType::fill(0u)).reduce(std::logical_and{}));
             using IndexType = alpaka::trait::GetValueType_t<ExtentVecType>;
             auto props = internal::GetDeviceProperties::Op<ALPAKA_TYPEOF(internalDevice)>{}(internalDevice);
             IndexType warpSize = static_cast<IndexType>(props.warpSize);
             // try to create a specification with a frame size of 512 elements
             IndexType numFrameElements = 512;
             // avoid non-power of two values
-            auto fastDimensionValue = roundDownToPowerOfTwo(std::min(warpSize, extents.x()));
+            auto fastDimensionValue = roundDownToPowerOfTwo(std::min(warpSize, extentMd.x()));
             auto frameExtents = ExtentVecType::fill(1).rAssign(fastDimensionValue);
             numFrameElements /= frameExtents.x();
             // distribute remainder frame elements
@@ -521,7 +526,7 @@ namespace alpaka::onHost
                 IndexType maxValue = 0;
                 for(auto i = 0u; i < ExtentVecType::dim(); ++i)
                 {
-                    auto v = extents[i] / frameExtents[i] / IndexType{2};
+                    auto v = extentMd[i] / frameExtents[i] / IndexType{2};
                     if(maxValue < v)
                     {
                         maxIdx = i;
@@ -529,7 +534,7 @@ namespace alpaka::onHost
                     }
                 }
                 // apply the change only if we not oversubscribe the extents
-                auto v = extents[maxIdx] / frameExtents[maxIdx] / IndexType{2};
+                auto v = extentMd[maxIdx] / frameExtents[maxIdx] / IndexType{2};
                 if(v >= IndexType{1})
                     frameExtents[maxIdx] *= IndexType{2};
                 else
@@ -539,9 +544,9 @@ namespace alpaka::onHost
             IndexType elementsPerFrameItem
                 = static_cast<IndexType>(getNumElemPerThread<T_DataType>(deviceApi, deviceKind));
             alpaka::concepts::Vector auto numFrames
-                = divExZero(extents, frameExtents * frameExtents.fill(1).rAssign(elementsPerFrameItem));
+                = divExZero(extentMd, frameExtents * frameExtents.fill(1).rAssign(elementsPerFrameItem));
             // The frame specification is not required to be a multiple of the extent, it can be smaller.
-            auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
+            auto frameSpec = FrameSpec{numFrames, frameExtents};
             return frameSpec;
         }
     } // namespace internal

--- a/test/unit/frame/getFrameSpec.cpp
+++ b/test/unit/frame/getFrameSpec.cpp
@@ -1,0 +1,101 @@
+
+/* Copyright 2026 Tim Hanel
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+
+using namespace alpaka;
+
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
+
+using TestBufferElemTypes = std::tuple<float, double, int, unsigned, uint32_t, uint64_t>;
+
+void checkFrameSpec(onHost::concepts::FrameSpec auto const& frameSpec, concepts::VectorOrScalar auto const& extent)
+{
+    Vec extentMd = extent;
+    using VecType = ALPAKA_TYPEOF(extentMd);
+    using ElemType = VecType::type;
+    auto const& numFrames = frameSpec.getNumFrames();
+    auto const& frameExtents = frameSpec.getFrameExtents();
+    CHECK(ALPAKA_TYPEOF(numFrames)::dim() == VecType::dim());
+    CHECK(ALPAKA_TYPEOF(frameExtents)::dim() == VecType::dim());
+
+    for(uint32_t d = 0u; d < VecType::dim(); ++d)
+    {
+        CHECK(numFrames[d] > ElemType{0});
+        CHECK(frameExtents[d] > ElemType{0});
+        CHECK(numFrames[d] * frameExtents[d] <= extentMd[d]);
+    }
+}
+
+template<typename T>
+void testScalar(auto const& computeDev)
+{
+    auto testValues = GENERATE(1, 2, 31, 128, 129, 257, 513, 10000, 100000);
+
+
+    // test lvalue
+    auto const frameSpec = alpaka::onHost::getFrameSpec<T>(computeDev, testValues);
+
+    checkFrameSpec(frameSpec, testValues);
+}
+
+template<typename T>
+void testVector(auto const& computeDev)
+{
+    auto test = [&](auto vec)
+    {
+        {
+            // test lvalue
+            auto const frameSpec = alpaka::onHost::getFrameSpec<T>(computeDev, vec);
+
+            checkFrameSpec(frameSpec, vec);
+        }
+    };
+
+    // 1D
+    test(Vec{1u});
+    test(Vec{10000u});
+
+    // 2D
+    test(Vec{3u, 4u});
+    test(Vec{128u, 129u});
+
+    // 3D
+    test(Vec{3u, 4u, 5u});
+    test(Vec{17u, 19u, 23u});
+}
+
+TEMPLATE_LIST_TEST_CASE("getFrameSpec scalar", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    auto deviceSpec = cfg[alpaka::object::deviceSpec];
+    auto devSelector = alpaka::onHost::makeDeviceSelector(deviceSpec);
+
+    onHost::Device computeDev = devSelector.makeDevice(0);
+    std::apply([&]<typename... T>(T...) { (testScalar<T>(computeDev), ...); }, TestBufferElemTypes{});
+}
+
+TEMPLATE_LIST_TEST_CASE("getFrameSpec vector", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    auto deviceSpec = cfg[alpaka::object::deviceSpec];
+    auto devSelector = alpaka::onHost::makeDeviceSelector(deviceSpec);
+
+    onHost::Device computeDev = devSelector.makeDevice(0);
+    std::apply([&]<typename... T>(T...) { (testVector<T>(computeDev), ...); }, TestBufferElemTypes{});
+}


### PR DESCRIPTION
The current `getFrameSpec` implementation should accept scalar extents, since the manual construction of scalar `FrameSpec`s is already permitted. 

The PR introduces thin wrapper functions for dispatching vector and scalar extents - minimizing code duplication at the cost of two copy operation in the case a scalar extent was used. 

Since both the `alpaka::Vector`  and `std::integral` concepts do not permit `lvalues` aka references -  I opted to use this pattern: 

`typename T_Extent, std::integral  = std::decay_t<T_Extent>` to apply constraints to the bare type - as I did not want to use `requires`.

This way both lvalue and rvalue extents inputs remain possible. 

Please flag this, if you have a cleaner alternative in mind or if you think I should rather use a different Implementation for scalar types - and scrap this naive copy-wrapper/`Vector`-cast approach. 