### PR TITLE
tutorial: add synchronization and shared memory

### DIFF
--- a/docs/snippets/example/110_synchronization.cpp
+++ b/docs/snippets/example/110_synchronization.cpp
@@ -1,0 +1,89 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: ISC
+ */
+
+#include "docsTest.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <numeric>
+#include <vector>
+
+using namespace alpaka;
+
+// BEGIN-TUTORIAL-syncKernel
+struct NeighborReuseKernel
+{
+    ALPAKA_FN_ACC void operator()(
+        onAcc::concepts::Acc auto const& acc,
+        concepts::IMdSpan auto out,
+        concepts::IDataSource auto const& in) const
+    {
+        auto const chunkExtent = acc[frame::extent];
+        auto chunk = onAcc::declareSharedMdArray<int, uniqueId()>(acc, acc[frame::extent]);
+
+        /* Iterate in chunks over the output data.
+         * It is assumed that the input data have at least the extents of the output.
+         */
+        for(auto chunkOffset : onAcc::makeIdxMap(
+                acc,
+                onAcc::worker::blocksInGrid,
+                IdxRange{Vec{0u}, static_cast<uint32_t>(out.getExtents().x()), chunkExtent}))
+        {
+            // fill the shared data chunk
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+                chunk[idx] = in[chunkOffset + idx];
+
+            onAcc::syncBlockThreads(acc);
+
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+            {
+                auto neighborIdx = (idx.x() + 1u) % chunkExtent;
+                out[chunkOffset + idx] = chunk[idx] + chunk[neighborIdx];
+            }
+
+            // avoid data race with the next loop iteration
+            onAcc::syncBlockThreads(acc);
+        }
+    }
+};
+
+// END-TUTORIAL-syncKernel
+
+TEMPLATE_LIST_TEST_CASE("tutorial in-kernel synchronization", "[docs]", docs::test::TestBackends)
+{
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+
+    uint32_t dataExtent = 16u;
+    std::vector<int> hostInput(dataExtent);
+    std::iota(hostInput.begin(), hostInput.end(), 0);
+    std::vector<int> hostOutput(dataExtent);
+
+    auto inputBuffer = onHost::allocLike(device, hostInput);
+    auto outputBuffer = onHost::allocLike(device, hostInput);
+
+    onHost::memcpy(queue, inputBuffer, hostInput);
+
+    // BEGIN-TUTORIAL-syncLaunch
+    constexpr uint32_t chunkSize = 8u;
+    onHost::concepts::FrameSpec auto frameSpec
+        = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), CVec<uint32_t, chunkSize>{}};
+    queue.enqueue(frameSpec, KernelBundle{NeighborReuseKernel{}, outputBuffer, inputBuffer});
+    // END-TUTORIAL-syncLaunch
+
+    onHost::memcpy(queue, hostOutput, outputBuffer);
+    onHost::wait(queue);
+
+    for(size_t i = 0; i < dataExtent; ++i)
+    {
+        uint32_t blockOffset = i / chunkSize * chunkSize;
+        CHECK(hostOutput[i] == static_cast<int>(blockOffset + i + ((i + 1) % chunkSize)));
+    }
+}

--- a/docs/snippets/example/120_sharedMemory.cpp
+++ b/docs/snippets/example/120_sharedMemory.cpp
@@ -22,8 +22,10 @@ struct BlockSumKernel
         concepts::IMdSpan auto out,
         concepts::IDataSource auto const& in) const
     {
+        /* Each shared memory declaration is required to have a unique id.
+         * Use the preprocessor macro `__COUNTER__` or `alpaka::uniqueId()`.
+         */
         auto& blockSum = onAcc::declareSharedVar<int, uniqueId()>(acc);
-        auto const chunkExtent = acc[frame::extent];
 
         // initialize the shared variable
         for([[maybe_unused]] auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{1u}))
@@ -31,15 +33,11 @@ struct BlockSumKernel
 
         onAcc::syncBlockThreads(acc);
 
-        // iterate chunked over the input data
-        for(auto chunkOffset : onAcc::makeIdxMap(
-                acc,
-                onAcc::worker::blocksInGrid,
-                IdxRange{Vec{0u}, static_cast<uint32_t>(in.getExtents().x()), chunkExtent}))
+        // iterate over the full input data
+        for(auto inputIdx :
+            onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{static_cast<uint32_t>(in.getExtents().x())}))
         {
-            // each thread in the block atomic increment to avoid data races
-            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
-                onAcc::atomicAdd(acc, &blockSum, in[chunkOffset + idx]);
+            onAcc::atomicAdd(acc, &blockSum, in[inputIdx]);
         }
 
         // wait that all threads wrote there changes
@@ -62,6 +60,9 @@ struct ReverseFrameKernel
         concepts::IDataSource auto const& in) const
     {
         auto const chunkExtent = acc[frame::extent];
+        /* Each shared memory declaration is required to have a unique id.
+         * Use the preprocessor macro `__COUNTER__` or `alpaka::uniqueId()`.
+         */
         auto chunk = onAcc::declareSharedMdArray<int, uniqueId()>(acc, chunkExtent);
 
         /* Iterate in chunks over the output data.
@@ -276,15 +277,11 @@ TEMPLATE_LIST_TEST_CASE("tutorial dynamic shared memory via member", "[docs]", d
     onHost::memcpy(queue, inputBuffer, hostInput);
 
     // BEGIN-TUTORIAL-dynSharedMemberLaunch
-    constexpr uint32_t chunkSize = 8u;
-    onHost::concepts::FrameSpec auto frameSpec
-        = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), CVec<uint32_t, chunkSize>{}};
+    uint32_t chunkSize = 8u;
+    onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), chunkSize};
     queue.enqueue(
         frameSpec,
-        KernelBundle{
-            DynamicReverseKernel{static_cast<uint32_t>(hostInput.size() * sizeof(int))},
-            outputBuffer,
-            inputBuffer});
+        KernelBundle{DynamicReverseKernel{static_cast<uint32_t>(chunkSize * sizeof(int))}, outputBuffer, inputBuffer});
     // END-TUTORIAL-dynSharedMemberLaunch
 
     onHost::memcpy(queue, hostOutput, outputBuffer);
@@ -316,7 +313,7 @@ TEMPLATE_LIST_TEST_CASE("tutorial dynamic shared memory via trait", "[docs]", do
 
     // BEGIN-TUTORIAL-dynSharedTraitKernelChunked
     int factor = 3;
-    constexpr uint32_t chunkSize = 8u;
+    uint32_t chunkSize = 8u;
     onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{1u, chunkSize};
     queue.enqueue(frameSpec, KernelBundle{DynamicScaleKernel{}, outputBuffer, inputBuffer, factor, chunkSize});
     // END-TUTORIAL-dynSharedTraitKernelChunked

--- a/docs/snippets/example/120_sharedMemory.cpp
+++ b/docs/snippets/example/120_sharedMemory.cpp
@@ -1,0 +1,329 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: ISC
+ */
+
+#include "docsTest.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cassert>
+#include <vector>
+
+using namespace alpaka;
+
+// BEGIN-TUTORIAL-sharedScalarKernel
+struct BlockSumKernel
+{
+    ALPAKA_FN_ACC void operator()(
+        onAcc::concepts::Acc auto const& acc,
+        concepts::IMdSpan auto out,
+        concepts::IDataSource auto const& in) const
+    {
+        auto& blockSum = onAcc::declareSharedVar<int, uniqueId()>(acc);
+        auto const chunkExtent = acc[frame::extent];
+
+        // initialize the shared variable
+        for([[maybe_unused]] auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{1u}))
+            blockSum = 0;
+
+        onAcc::syncBlockThreads(acc);
+
+        // iterate chunked over the input data
+        for(auto chunkOffset : onAcc::makeIdxMap(
+                acc,
+                onAcc::worker::blocksInGrid,
+                IdxRange{Vec{0u}, static_cast<uint32_t>(in.getExtents().x()), chunkExtent}))
+        {
+            // each thread in the block atomic increment to avoid data races
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+                onAcc::atomicAdd(acc, &blockSum, in[chunkOffset + idx]);
+        }
+
+        // wait that all threads wrote there changes
+        onAcc::syncBlockThreads(acc);
+
+        // A single thread is flushing the data to the output
+        for([[maybe_unused]] auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{1u}))
+            onAcc::atomicAdd(acc, &out[0u], blockSum);
+    }
+};
+
+// END-TUTORIAL-sharedScalarKernel
+
+// BEGIN-TUTORIAL-sharedKernel
+struct ReverseFrameKernel
+{
+    ALPAKA_FN_ACC void operator()(
+        onAcc::concepts::Acc auto const& acc,
+        concepts::IMdSpan auto out,
+        concepts::IDataSource auto const& in) const
+    {
+        auto const chunkExtent = acc[frame::extent];
+        auto chunk = onAcc::declareSharedMdArray<int, uniqueId()>(acc, chunkExtent);
+
+        /* Iterate in chunks over the output data.
+         * It is assumed that the input data have at least the extents of the output.
+         */
+        for(auto chunkOffset : onAcc::makeIdxMap(
+                acc,
+                onAcc::worker::blocksInGrid,
+                IdxRange{Vec{0u}, static_cast<uint32_t>(out.getExtents().x()), chunkExtent}))
+        {
+            // initialize the shared chunk
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+                chunk[idx] = in[chunkOffset + idx];
+
+            onAcc::syncBlockThreads(acc);
+
+            // each thread is flushing to the output
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+            {
+                auto reverseIdx = Vec{chunkExtent - 1u - idx.x()};
+                out[chunkOffset + idx] = chunk[reverseIdx];
+            }
+
+            // avoid data race with the next loop iteration
+            onAcc::syncBlockThreads(acc);
+        }
+    }
+};
+
+// END-TUTORIAL-sharedKernel
+
+// BEGIN-TUTORIAL-dynSharedMemberKernel
+struct DynamicReverseKernel
+{
+    uint32_t dynSharedMemBytes;
+
+    ALPAKA_FN_ACC void operator()(
+        onAcc::concepts::Acc auto const& acc,
+        concepts::IMdSpan auto out,
+        concepts::IDataSource auto const& in) const
+    {
+        auto* chunk = onAcc::getDynSharedMem<int>(acc);
+        auto const chunkExtent = acc[frame::extent];
+
+        /* Iterate in chunks over the output data.
+         * It is assumed that the input data have at least the extents of the output.
+         */
+        for(auto chunkOffset : onAcc::makeIdxMap(
+                acc,
+                onAcc::worker::blocksInGrid,
+                IdxRange{Vec{0u}, static_cast<uint32_t>(out.getExtents().x()), chunkExtent}))
+        {
+            // initialize the shared chunk
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+                chunk[idx.x()] = in[chunkOffset + idx];
+
+            onAcc::syncBlockThreads(acc);
+
+            // each thread is flushing to the output
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+            {
+                auto reverseIdx = acc[frame::extent].x() - 1u - idx.x();
+                out[chunkOffset + idx] = chunk[reverseIdx];
+            }
+
+            // avoid data race with the next loop iteration
+            onAcc::syncBlockThreads(acc);
+        }
+    }
+};
+
+// END-TUTORIAL-dynSharedMemberKernel
+
+// BEGIN-TUTORIAL-dynSharedTraitKernel
+struct DynamicScaleKernel
+{
+    ALPAKA_FN_ACC void operator()(
+        onAcc::concepts::Acc auto const& acc,
+        concepts::IMdSpan auto out,
+        concepts::IDataSource auto const& in,
+        int factor,
+        uint32_t chunkSize) const
+    {
+        auto* cache = onAcc::getDynSharedMem<int>(acc);
+
+        /* Iterate in chunks over the output data.
+         * It is assumed that the input data have at least the extents of the output.
+         */
+        for(auto chunkOffset : onAcc::makeIdxMap(
+                acc,
+                onAcc::worker::blocksInGrid,
+                IdxRange{Vec{0u}, static_cast<uint32_t>(out.getExtents().x()), Vec{chunkSize}}))
+        {
+            // initialize the shared chunk
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
+                cache[idx.x()] = in[chunkOffset + idx] * factor;
+
+            onAcc::syncBlockThreads(acc);
+
+            // each thread is flushing to the output
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
+                out[chunkOffset + idx] = cache[idx.x()];
+
+            // avoid data race with the next loop iteration
+            onAcc::syncBlockThreads(acc);
+        }
+    }
+};
+
+// END-TUTORIAL-dynSharedTraitKernel
+
+// BEGIN-TUTORIAL-dynSharedTraitSpec
+namespace alpaka::onHost::trait
+{
+    template<typename T_Spec>
+    struct BlockDynSharedMemBytes<DynamicScaleKernel, T_Spec>
+    {
+        BlockDynSharedMemBytes(DynamicScaleKernel const&, T_Spec const& spec) : m_spec(spec)
+        {
+        }
+
+        uint32_t operator()(auto const executor, auto const& out, auto const& in, int factor, uint32_t chunkSize) const
+        {
+            alpaka::unused(executor, out, in, factor);
+            return static_cast<uint32_t>(chunkSize * sizeof(int));
+        }
+
+    private:
+        T_Spec m_spec;
+    };
+} // namespace alpaka::onHost::trait
+
+// END-TUTORIAL-dynSharedTraitSpec
+
+TEMPLATE_LIST_TEST_CASE("tutorial shared memory chunk", "[docs]", docs::test::TestBackends)
+{
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+
+    uint32_t dataExtent = 16u;
+    std::vector<int> hostInput(dataExtent);
+    std::iota(hostInput.begin(), hostInput.end(), 0);
+    std::vector<int> hostOutput(dataExtent);
+
+    auto inputBuffer = onHost::allocLike(device, hostInput);
+    auto outputBuffer = onHost::allocLike(device, hostInput);
+
+    onHost::memcpy(queue, inputBuffer, hostInput);
+
+    // BEGIN-TUTORIAL-sharedLaunch
+    constexpr uint32_t chunkSize = 8u;
+    onHost::concepts::FrameSpec auto frameSpec
+        = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), CVec<uint32_t, chunkSize>{}};
+    queue.enqueue(frameSpec, KernelBundle{ReverseFrameKernel{}, outputBuffer, inputBuffer});
+    // END-TUTORIAL-sharedLaunch
+
+    onHost::memcpy(queue, hostOutput, outputBuffer);
+    onHost::wait(queue);
+
+    for(size_t i = 0; i < dataExtent; ++i)
+        CHECK(hostOutput[i] == static_cast<int>((i / chunkSize * chunkSize) + (chunkSize - 1 - (i % chunkSize))));
+}
+
+TEMPLATE_LIST_TEST_CASE("tutorial shared memory scalar value", "[docs]", docs::test::TestBackends)
+{
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+
+    uint32_t dataExtent = 16u;
+    std::vector<int> hostInput(dataExtent);
+    std::iota(hostInput.begin(), hostInput.end(), 1);
+
+    auto inputBuffer = onHost::allocLike(device, hostInput);
+    auto outputBuffer = onHost::allocUnified<int>(device, 1);
+    outputBuffer[0] = 0;
+
+    onHost::memcpy(queue, inputBuffer, hostInput);
+
+    constexpr uint32_t chunkSize = 8u;
+    onHost::concepts::FrameSpec auto frameSpec
+        = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), CVec<uint32_t, chunkSize>{}};
+    queue.enqueue(frameSpec, KernelBundle{BlockSumKernel{}, outputBuffer, inputBuffer});
+
+    onHost::wait(queue);
+
+    // Gauss's summation formula
+    CHECK(outputBuffer[0] == static_cast<int>(((dataExtent + 1) * dataExtent) / 2));
+}
+
+TEMPLATE_LIST_TEST_CASE("tutorial dynamic shared memory via member", "[docs]", docs::test::TestBackends)
+{
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+
+    uint32_t dataExtent = 16u;
+    std::vector<int> hostInput(dataExtent);
+    std::iota(hostInput.begin(), hostInput.end(), 0);
+    std::vector<int> hostOutput(dataExtent);
+
+    auto inputBuffer = onHost::allocLike(device, hostInput);
+    auto outputBuffer = onHost::allocLike(device, hostInput);
+
+    onHost::memcpy(queue, inputBuffer, hostInput);
+
+    // BEGIN-TUTORIAL-dynSharedMemberLaunch
+    constexpr uint32_t chunkSize = 8u;
+    onHost::concepts::FrameSpec auto frameSpec
+        = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), CVec<uint32_t, chunkSize>{}};
+    queue.enqueue(
+        frameSpec,
+        KernelBundle{
+            DynamicReverseKernel{static_cast<uint32_t>(hostInput.size() * sizeof(int))},
+            outputBuffer,
+            inputBuffer});
+    // END-TUTORIAL-dynSharedMemberLaunch
+
+    onHost::memcpy(queue, hostOutput, outputBuffer);
+    onHost::wait(queue);
+
+    for(uint32_t i = 0u; i < dataExtent; ++i)
+    {
+        CHECK(hostOutput[i] == static_cast<int>((i / chunkSize * chunkSize) + (chunkSize - 1 - (i % chunkSize))));
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("tutorial dynamic shared memory via trait", "[docs]", docs::test::TestBackends)
+{
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+
+    uint32_t dataExtent = 16u;
+    std::vector<int> hostInput(dataExtent);
+    std::iota(hostInput.begin(), hostInput.end(), 0);
+    std::vector<int> hostOutput(dataExtent);
+
+    auto inputBuffer = onHost::alloc<int>(device, dataExtent);
+    auto outputBuffer = onHost::alloc<int>(device, dataExtent);
+
+    onHost::memcpy(queue, inputBuffer, hostInput);
+
+    // BEGIN-TUTORIAL-dynSharedTraitKernelChunked
+    int factor = 3;
+    constexpr uint32_t chunkSize = 8u;
+    onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{1u, chunkSize};
+    queue.enqueue(frameSpec, KernelBundle{DynamicScaleKernel{}, outputBuffer, inputBuffer, factor, chunkSize});
+    // END-TUTORIAL-dynSharedTraitKernelChunked
+
+    onHost::memcpy(queue, hostOutput, outputBuffer);
+    onHost::wait(queue);
+
+    for(uint32_t i = 0u; i < dataExtent; ++i)
+        CHECK(hostOutput[i] == static_cast<int>(i) * factor);
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,8 +66,10 @@ Individual chapters are based on the information of the chapters before.
    :titlesonly:
 
    tutorial/views.rst
-   tutorial/kernelParallelism.rst
    tutorial/multidim.rst
+   tutorial/kernelParallelism.rst
+   tutorial/synchronization.rst
+   tutorial/sharedMemory.rst
 
 .. toctree::
    :caption: Advanced

--- a/docs/source/tutorial/sharedMemory.rst
+++ b/docs/source/tutorial/sharedMemory.rst
@@ -3,21 +3,23 @@
 Shared Memory
 =============
 
-Shared memory is memory local to a thread block within a kernel.
+Shared memory is a scratchpad memory accessible only by threads within thread block in a kernel.
 It is useful when several threads in the same block need to reuse the same data or communicate through a fast local data chunk.
 Typical use cases are, chunked stencil kernels, block-local reductions and scans, transposes, and small reusable data sets loaded once and consumed many times.
 The amount of shared memory per thread block depends on the device and is usually limited to around 64 KiB, so it is not a good choice for large data sets.
 In alpaka there are three common ways to declare shared memory:
 
 - Declare a single shared value with ``declareSharedVar()``.
-- Declare fixed-size shared multi dimensional array or chunk with compile-time known extents with ``declareSharedMdArray()``.
+- Declare fixed-size shared multidimensional array or chunk with compile-time known extents with ``declareSharedMdArray()``.
 - And dynamic shared memory with ``getDynSharedMem()`` when the size is only known at launch time.
 
 A Single Shared Value
 ---------------------
 
-Not every shared-memory kernel needs a chunk. Sometimes one shared scalar is enough.
-The next example computes one block-local sum in a shared variable.
+Not every shared-memory kernel needs a shared data chunk. Sometimes one shared scalar is enough.
+The next example is a very simple form of a global reduction with atomics.
+All threads within a thread block accumulate into a shared memory thread block partial result.
+After all threads in the thread block finished a single thread is accumulating the partial result into the output.
 
   .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp
     :language: cpp
@@ -27,13 +29,20 @@ The next example computes one block-local sum in a shared variable.
 
 This pattern is useful for block-local counters, flags, or partial reductions.
 The important detail is that the scalar still belongs to the whole thread block, not to a single thread.
-Do **not** forget to store the return type explicit as reference, in this case ``auto&``, otherwise you will get a **thread local copy** instead of the shared one.
 
-A Small Tiled Example
----------------------
+.. attention::
 
-The following kernel loads one frame-shaped chunk into shared memory, synchronizes the block, and then writes that chunk in
-reverse order.
+  Do **not** forget to store the return type explicitly as reference, in this case ``auto&``, otherwise you will get a **thread local copy** instead of the shared one.
+
+Static Shared Memory Array
+--------------------------
+
+The next example is showing a chunk-wise permutation of the indices.
+For each chunk the id's should be stored in reverse order into the output.
+The frame extent from the kernel launch parameters will be re-used as chunk extents.
+The frame extent is a `CVec` and therefore known at compile time, this allows its usage as extents to declare static shared memory.
+Static shared memory compared to dynamic shared memory, shown in the next example,
+has the benefits that the developer is not required to manage the shared memory chunk by hand and in case it is multidimensional it provides address calculations optimizations.
 
   .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp
     :language: cpp
@@ -41,19 +50,12 @@ reverse order.
     :end-before: END-TUTORIAL-sharedKernel
     :dedent:
 
-The important steps are:
-
-1. declare block-local shared memory,
-2. cooperatively fill it,
-3. synchronize the block,
-4. read from the shared chunk.
-
 The "reverse order" work is only there to keep the example small.
 The same structure is what you would use in more realistic kernels:
 
-- load a small image chunk before applying a blur or stencil,
-- stage a matrix chunk before a transpose or matrix multiply step,
-- or cache a short chunk of data before several neighboring threads reuse it.
+- Load a small image chunk before applying a blur or stencil.
+- Stage a matrix chunk before a transpose or matrix multiply step.
+- Cache a short chunk of data before several neighboring threads reuse it.
 
 Launching a Shared-Memory Kernel
 --------------------------------
@@ -64,13 +66,17 @@ Launching a Shared-Memory Kernel
     :end-before: END-TUTORIAL-sharedLaunch
     :dedent:
 
-This example uses ``CVec`` for the frame extent because compile-time-known extents are the simplest way to express a fixed shared-memory chunk.
+As mentioned before ``CVec`` for the frame extent is required to allow the reuse of the frame extents within the kernel to allocate the static shared memory chunk.
 
 Dynamic Shared Memory
 ---------------------
 
-Dynamic shared memory is useful when the amount of temporary storage depends on the launch configuration or the kernel arguments.
-In alpaka you allocate it indirectly: the runtime reserves a byte buffer for each block, and the kernel accesses it through ``onAcc::getDynSharedMem<T>(acc)``.
+Dynamic shared memory is useful when the amount of shared memory depends on kernel launch parameters or the kernel arguments.
+In alpaka it will be automatically allocated indirectly for each thread block before kernel invocation.
+Again the chunk-wise index reverse example is used.
+The difference to the example before is that the frame extent is now a runtime value and to get the shared memory within the kernel ``onAcc::getDynSharedMem<T>(acc)`` is used.
+You will only get a flat pointer to the allocated data without any information about how many values are valid.
+The developer is responsible that the number of allocated bytes at kernel launch time and used within a kernel match.
 
 There are two supported ways to tell alpaka how many bytes to reserve.
 
@@ -100,8 +106,8 @@ Dynamic Size Through ``BlockDynSharedMemBytes`` Trait
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When the size should depend on the executor or the kernel arguments, alpaka uses a trait specialization.
-It is not possible to access the frame specification in the trait, therefor this examples is using a user defined data chunk size passed through the kernel arguments.
-If you provide neither a ``dynSharedMemBytes`` member nor a ``BlockDynSharedMemBytes`` specialization, alpaka reserves no dynamic shared memory for that kernel.
+It is not possible to access the frame specification in the trait, therefore this example is using a user-defined data chunk size passed through the kernel arguments.
+If you provide neither a ``dynSharedMemBytes`` member nor a trait implementation ``alpaka::onHost::trait::BlockDynSharedMemBytes`` specialization, alpaka reserves no dynamic shared memory for that kernel.
 
   .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp
     :language: cpp
@@ -129,7 +135,7 @@ The difference when launching the kernel in comparison to the previous example i
 Practical Advice
 ----------------
 
-- Shared memory is local to one block. Different blocks cannot see each other's shared data.
+- Shared memory is local to the thread block. Different blocks cannot see each other's shared data.
 - Shared memory is not initialized automatically.
 - Every thread that reads shared data written by other threads usually needs a block synchronization first.
 - Reusing the same shared-memory id returns the same storage again; a different id gives you different storage.
@@ -161,3 +167,4 @@ Complete Source File
 .. raw:: html
 
    </details>
+   <br/>

--- a/docs/source/tutorial/sharedMemory.rst
+++ b/docs/source/tutorial/sharedMemory.rst
@@ -1,0 +1,163 @@
+.. _shared-memory:
+
+Shared Memory
+=============
+
+Shared memory is memory local to a thread block within a kernel.
+It is useful when several threads in the same block need to reuse the same data or communicate through a fast local data chunk.
+Typical use cases are, chunked stencil kernels, block-local reductions and scans, transposes, and small reusable data sets loaded once and consumed many times.
+The amount of shared memory per thread block depends on the device and is usually limited to around 64 KiB, so it is not a good choice for large data sets.
+In alpaka there are three common ways to declare shared memory:
+
+- Declare a single shared value with ``declareSharedVar()``.
+- Declare fixed-size shared multi dimensional array or chunk with compile-time known extents with ``declareSharedMdArray()``.
+- And dynamic shared memory with ``getDynSharedMem()`` when the size is only known at launch time.
+
+A Single Shared Value
+---------------------
+
+Not every shared-memory kernel needs a chunk. Sometimes one shared scalar is enough.
+The next example computes one block-local sum in a shared variable.
+
+  .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-sharedScalarKernel
+    :end-before: END-TUTORIAL-sharedScalarKernel
+    :dedent:
+
+This pattern is useful for block-local counters, flags, or partial reductions.
+The important detail is that the scalar still belongs to the whole thread block, not to a single thread.
+Do **not** forget to store the return type explicit as reference, in this case ``auto&``, otherwise you will get a **thread local copy** instead of the shared one.
+
+A Small Tiled Example
+---------------------
+
+The following kernel loads one frame-shaped chunk into shared memory, synchronizes the block, and then writes that chunk in
+reverse order.
+
+  .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-sharedKernel
+    :end-before: END-TUTORIAL-sharedKernel
+    :dedent:
+
+The important steps are:
+
+1. declare block-local shared memory,
+2. cooperatively fill it,
+3. synchronize the block,
+4. read from the shared chunk.
+
+The "reverse order" work is only there to keep the example small.
+The same structure is what you would use in more realistic kernels:
+
+- load a small image chunk before applying a blur or stencil,
+- stage a matrix chunk before a transpose or matrix multiply step,
+- or cache a short chunk of data before several neighboring threads reuse it.
+
+Launching a Shared-Memory Kernel
+--------------------------------
+
+  .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-sharedLaunch
+    :end-before: END-TUTORIAL-sharedLaunch
+    :dedent:
+
+This example uses ``CVec`` for the frame extent because compile-time-known extents are the simplest way to express a fixed shared-memory chunk.
+
+Dynamic Shared Memory
+---------------------
+
+Dynamic shared memory is useful when the amount of temporary storage depends on the launch configuration or the kernel arguments.
+In alpaka you allocate it indirectly: the runtime reserves a byte buffer for each block, and the kernel accesses it through ``onAcc::getDynSharedMem<T>(acc)``.
+
+There are two supported ways to tell alpaka how many bytes to reserve.
+
+Dynamic Size Through a Kernel Member
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The most direct option is to give the kernel object a public ``uint32_t dynSharedMemBytes`` member.
+This works well when the required size is already known when the kernel object is created.
+
+  .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-dynSharedMemberKernel
+    :end-before: END-TUTORIAL-dynSharedMemberKernel
+    :dedent:
+
+When you launch that kernel, set the byte count in the kernel object itself.
+
+  .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-dynSharedMemberLaunch
+    :end-before: END-TUTORIAL-dynSharedMemberLaunch
+    :dedent:
+
+This form is simple and readable, but it is intentionally limited: the size can only depend on data you put into the kernel object.
+
+Dynamic Size Through ``BlockDynSharedMemBytes`` Trait
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the size should depend on the executor or the kernel arguments, alpaka uses a trait specialization.
+It is not possible to access the frame specification in the trait, therefor this examples is using a user defined data chunk size passed through the kernel arguments.
+If you provide neither a ``dynSharedMemBytes`` member nor a ``BlockDynSharedMemBytes`` specialization, alpaka reserves no dynamic shared memory for that kernel.
+
+  .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-dynSharedTraitSpec
+    :end-before: END-TUTORIAL-dynSharedTraitSpec
+    :dedent:
+
+The kernel itself still uses ``getDynSharedMem`` in the normal way.
+If your kernel provides a member ``uint32_t dynSharedMemBytes`` as shown in the previous example the member variable is ignored and the trait specialization is used instead.
+
+  .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-dynSharedTraitKernel
+    :end-before: END-TUTORIAL-dynSharedTraitKernel
+    :dedent:
+
+The difference when launching the kernel in comparison to the previous example is that the kernel is not initialized with the byte value and there is an additional chunk size argument.
+
+  .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-dynSharedTraitKernelChunked
+    :end-before: END-TUTORIAL-dynSharedTraitKernelChunked
+    :dedent:
+
+Practical Advice
+----------------
+
+- Shared memory is local to one block. Different blocks cannot see each other's shared data.
+- Shared memory is not initialized automatically.
+- Every thread that reads shared data written by other threads usually needs a block synchronization first.
+- Reusing the same shared-memory id returns the same storage again; a different id gives you different storage.
+- use ``declareSharedVar()`` for a single shared scalar or one small fixed object.
+- Use ``declareSharedMdArray()`` multidimensional data.
+- Use ``getDynSharedMem()`` when the temporary size depends on kernel arguments.
+- Start with small chunks and a simple mapping before trying to micro-optimize the memory layout.
+
+Common Mistakes
+---------------
+
+- Treating shared memory as if different blocks could see the same storage.
+- Reading shared values before a required block synchronization.
+- Introducing shared memory before checking that the data is reused.
+- Using dynamic shared memory when a small fixed chunk would already be simpler and clearer.
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>120_sharedMemory.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/120_sharedMemory.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>

--- a/docs/source/tutorial/synchronization.rst
+++ b/docs/source/tutorial/synchronization.rst
@@ -56,3 +56,4 @@ Complete Source File
 .. raw:: html
 
    </details>
+   <br/>

--- a/docs/source/tutorial/synchronization.rst
+++ b/docs/source/tutorial/synchronization.rst
@@ -1,0 +1,58 @@
+Synchronization
+===============
+
+``onAcc::syncBlockThreads`` is the basic in-kernel synchronization primitive.
+It is a thread block barrier: every participating thread in the same thread block waits until the others reach the same point, and only then do they continue.
+
+This is the primitive you need when one phase of a kernel produces data that a later phase in the same block will consume.
+The most common reason is block-local reuse, such as loading a chunk/tile once and then letting other threads read from it.
+
+What ``syncBlockThreads`` Means
+-------------------------------
+
+- It synchronizes threads inside a thread block.
+- It does not synchronize different blocks with one another.
+- It is a thread barrier, not just a memory-ordering hint.
+- It is usually paired with :ref:`shared memory <shared-memory>`, but the important concept is the collective phase boundary between "write" and "read".
+- It must be guaranteed that every thread in the block reaches the same barrier, otherwise the behavior is undefined.
+
+If you only need memory ordering without a blocking thread barrier, check :doc:`memFence`.
+
+Chunk Reuse Example
+-------------------
+
+The next kernel loads one frame as data chunk into thread block-local shared memory, synchronizes the block, and then lets every thread read
+its own value together with the next neighbor.
+The key idea is the reuse pattern: one phase fills the chunk, the next phase consumes it.
+Without the synchronization point, those neighbor reads could race with threads that are still writing the chunk.
+
+  .. literalinclude:: ../../snippets/example/110_synchronization.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-syncKernel
+    :end-before: END-TUTORIAL-syncKernel
+    :dedent:
+
+Launching the kernel the :ref:`Frame extent <frame>` will be used as user defined chunking, therefore the launch shape is influencing the in kernel data reuse pattern.
+
+Practical Advice
+----------------
+
+- Place the barrier after the last write that other threads must see and before the first dependent read.
+- Use synchronization to separate phases, not to "be safe" everywhere, else you will get a very slow kernel.
+- If one thread block reuses the same shared memory again, e.g. in loops, add another barrier before overwriting data that other threads may still read.
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>110_synchronization.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/110_synchronization.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>


### PR DESCRIPTION
Provide a synchronization and shared memory section, including different mini examples.

The next section of #492

note: The synchronization is placed before shared memory is explained. 
For the synchronization example, shared memory is used, which is explained in the next section. 
Within the synchronization section, we are linking to the shared memory section. 
Since shared memory usage is more complex compared to block synchronization, this order is chosen.
