### PR TITLE
add worker group `worker::allThreads`

### DIFF
--- a/benchmark/HACCmk/src/main_alpaka.cpp
+++ b/benchmark/HACCmk/src/main_alpaka.cpp
@@ -73,7 +73,7 @@ namespace haccmkAlpaka
                 float yyi = yy[i];
                 float zzi = zz[i];
 
-                auto simdGrid = onAcc::SimdAlgo{onAcc::WorkerGroup{Vec{0}, Vec{1}}};
+                auto simdGrid = onAcc::SimdAlgo{onAcc::worker::allThreads};
                 move = simdGrid.transformReduce(
                     acc,
                     Vec{n2},

--- a/include/alpaka/mem/ThreadSpace.hpp
+++ b/include/alpaka/mem/ThreadSpace.hpp
@@ -60,7 +60,7 @@ namespace alpaka
         }
 
         template<concepts::CVector T_CSelect>
-        constexpr ThreadSpace mapTo(T_CSelect selection) const requires(T_ThreadIdx::dim() > T_CSelect::dim())
+        constexpr auto mapTo(T_CSelect selection) const requires(T_ThreadIdx::dim() > T_CSelect::dim())
         {
             alpaka::unused(selection);
 
@@ -70,8 +70,9 @@ namespace alpaka
             auto allElements = iotaCVec<IdxType, dim>();
             constexpr auto notSelectedDims = filter(allElements, T_CSelect{});
 
-            auto threadIndex = m_threadIdx;
-            auto numThreads = m_threadCount;
+            // Transform into a universal vector because the input could be a CVec which is read only.
+            auto threadIndex = typename ALPAKA_TYPEOF(m_threadIdx)::UniVec{m_threadIdx};
+            auto numThreads = typename ALPAKA_TYPEOF(m_threadCount)::UniVec{m_threadCount};
 
             // map not selected dimensions to the slowest selected dimension
             for(uint32_t x = 0u; x < notSelectedDims.dim(); ++x)
@@ -90,7 +91,7 @@ namespace alpaka
                 numThreads[T_CSelect{}[0]] *= old;
             }
 
-            return {threadIndex, numThreads};
+            return ThreadSpace<ALPAKA_TYPEOF(threadIndex), ALPAKA_TYPEOF(numThreads)>{threadIndex, numThreads};
         }
 
         T_ThreadIdx m_threadIdx;

--- a/include/alpaka/onAcc/WorkerGroup.hpp
+++ b/include/alpaka/onAcc/WorkerGroup.hpp
@@ -125,6 +125,13 @@ namespace alpaka::onAcc
         constexpr auto linearWarpsInGrid = WorkerGroup{origin::grid, unit::warps};
 
         constexpr auto linearBlocksInGrid = WorkerGroup{origin::grid, unit::blocks, linearized};
+
+        /** Represent the identity of the executor thread.
+         *
+         * All threads are in the same worker group.
+         * If used with onAcc::makeIdxMap(), any thread is getting all indices of the range.
+         */
+        constexpr auto allThreads = WorkerGroup{origin::thread, unit::threads};
     } // namespace worker
 
 } // namespace alpaka::onAcc

--- a/include/alpaka/onAcc/internal/interfaceImpl.hpp
+++ b/include/alpaka/onAcc/internal/interfaceImpl.hpp
@@ -91,6 +91,27 @@ namespace alpaka::onAcc
         };
 
         template<concepts::Acc T_Acc>
+        struct GetIdxWithin::Op<T_Acc, ALPAKA_TYPEOF(origin::thread), ALPAKA_TYPEOF(unit::threads)>
+        {
+            /** The identity of the thread.
+             *
+             * @return Zero for all components of the extent.
+             */
+            constexpr alpaka::concepts::Vector auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::thread),
+                ALPAKA_TYPEOF(unit::threads)) const
+            {
+                using ExtentType = ALPAKA_TYPEOF(acc[layer::thread].idx());
+
+                using ValueType = typename ExtentType::type;
+                constexpr uint32_t dim = ExtentType::dim();
+
+                return fillCVec<ValueType, dim, 0u>();
+            }
+        };
+
+        template<concepts::Acc T_Acc>
         struct GetExtentsOf::Op<T_Acc, ALPAKA_TYPEOF(origin::warp), ALPAKA_TYPEOF(unit::threads)>
         {
             constexpr alpaka::concepts::CVector<uint32_t> auto operator()(
@@ -167,6 +188,26 @@ namespace alpaka::onAcc
                 ALPAKA_TYPEOF(unit::threads)) const
             {
                 return acc[layer::block].count() * acc[layer::thread].count();
+            }
+        };
+
+        template<concepts::Acc T_Acc>
+        struct GetExtentsOf::Op<T_Acc, ALPAKA_TYPEOF(origin::thread), ALPAKA_TYPEOF(unit::threads)>
+        {
+            /** The identity of the thread.
+             *
+             * @return One for all components of the extent.
+             */
+            constexpr alpaka::concepts::Vector auto operator()(
+                T_Acc const& acc,
+                ALPAKA_TYPEOF(origin::thread),
+                ALPAKA_TYPEOF(unit::threads)) const
+            {
+                using ExtentType = ALPAKA_TYPEOF(acc[layer::thread].count());
+                using ValueType = typename ExtentType::type;
+                constexpr uint32_t dim = ExtentType::dim();
+
+                return fillCVec<ValueType, dim, 1u>();
             }
         };
     } // namespace internalCompute

--- a/include/alpaka/onAcc/tag.hpp
+++ b/include/alpaka/onAcc/tag.hpp
@@ -19,6 +19,7 @@ namespace alpaka::onAcc
      */
     namespace origin
     {
+        ALPAKA_TAG(thread);
         ALPAKA_TAG(warp);
         ALPAKA_TAG(block);
         ALPAKA_TAG(grid);
@@ -54,6 +55,11 @@ namespace alpaka::onAcc
 
         template<>
         struct IsOrigin<ALPAKA_TYPEOF(origin::grid)> : std::true_type
+        {
+        };
+
+        template<>
+        struct IsOrigin<ALPAKA_TYPEOF(origin::thread)> : std::true_type
         {
         };
 

--- a/test/unit/queue/queue.cpp
+++ b/test/unit/queue/queue.cpp
@@ -217,10 +217,8 @@ struct IotaKernelNDSelection
             /* fameBaseIdx is unique for each thread block.
              * Therefor the workgroup for iterating over the frames in other dimensions must be one.
              */
-            for(auto frameIdx : onAcc::makeIdxMap(
-                    acc,
-                    onAcc::WorkerGroup{numFrames.fill(0), numFrames.fill(1)},
-                    IdxRange{fameBaseIdx, numFrames})[T_Selection{}])
+            for(auto frameIdx :
+                onAcc::makeIdxMap(acc, onAcc::worker::allThreads, IdxRange{fameBaseIdx, numFrames})[T_Selection{}])
             {
                 for(auto elemIdx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, onAcc::range::frameExtent))
                     if(linearize(acc[frame::extent], elemIdx) == 1u)


### PR DESCRIPTION
`worker::allThreads` is a worker group with a single slot. Together with `onAcc:::makeIdxMap()`, all threads will get the same id's to process.

This is a long-planned feature to avoid complicated worker group generation e.g. `onAcc::WorkerGroup{numFrames.fill(0), numFrames.fill(1)}`
Until last week, I was not aware of how to implement it for multidimensional groups. 
Now I realized that we already have all dependencies with `WorkerGroup` which support a `unit` and `origin.`