### PR TITLE
CI: install GCC via bash script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# for shfmt
+[*.sh]
+# like -i=4
+indent_style = space
+indent_size = 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: job configuration environment variables
+        run: $APCI_ALPAKA_ROOT/script/ci/print_vars.sh
       # Install base dependencies
       - name: Install base dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,74 +32,127 @@ jobs:
     strategy:
       matrix:
         config:
-          - { compiler: gcc, version: "12", cuda: "no", hip: "no", container: "ubuntu:24.04" }
-          - { compiler: gcc, version: "13", cuda: "no", hip: "no", container: "ubuntu:24.04" }
+          - { compiler: gcc, version: "12", cuda: "no", hip: "no", container: "ubuntu:24.04",
+              env : {APCI_DEVICE_COMPILER : gcc@12} }
+          - { compiler: gcc, version: "13", cuda: "no", hip: "no", container: "ubuntu:24.04",
+              env : {APCI_DEVICE_COMPILER : gcc@13} }
           # tbb backend on
-          - { compiler: gcc, version: "13", cuda: "no", hip: "no", container: "ubuntu:24.04", tbb: "on" }
-          - { compiler: gcc, version: "14", cuda: "no", hip: "no", container: "ubuntu:24.04" }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0" }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0" , simd: "EMULATION", hwloc: "no"  }
+          - { compiler: gcc, version: "13", cuda: "no", hip: "no", container: "ubuntu:24.04", tbb: "on",
+              env : {APCI_DEVICE_COMPILER : gcc@13} }
+          - { compiler: gcc, version: "14", cuda: "no", hip: "no", container: "ubuntu:24.04",
+              env : {APCI_DEVICE_COMPILER: gcc@14} }
+          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0",
+              env : {APCI_DEVICE_COMPILER: gcc@15, ALPAKA_CI_DEVICE_COMPILER_VER : 15} }
+          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0" , simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER: gcc@15} }
           # clang host compiler
-          - { compiler: clang, version: "17", cuda: "no", hip: "no", container: "ubuntu:24.04" }
-          - { compiler: clang, version: "18", cuda: "no", hip: "no", container: "ubuntu:24.04" }
-          - { compiler: clang, version: "19", cuda: "no", hip: "no", container: "ubuntu:24.04" }
-          - { compiler: clang, version: "20", cuda: "no", hip: "no", container: "ubuntu:24.04" }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04" }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", simd: "EMULATION", hwloc: "no"  }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", tbb: "on" }
+          - { compiler: clang, version: "17", cuda: "no", hip: "no", container: "ubuntu:24.04",
+              env : {APCI_DEVICE_COMPILER : clang@17} }
+          - { compiler: clang, version: "18", cuda: "no", hip: "no", container: "ubuntu:24.04",
+              env : {APCI_DEVICE_COMPILER : clang@18} }
+          - { compiler: clang, version: "19", cuda: "no", hip: "no", container: "ubuntu:24.04",
+              env : {APCI_DEVICE_COMPILER : clang@19} }
+          - { compiler: clang, version: "20", cuda: "no", hip: "no", container: "ubuntu:24.04",
+              env : {APCI_DEVICE_COMPILER : clang@20} }
+          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
+          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
+          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", tbb: "on",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
           # nvcc CUDA (nvcc does not contain simd option because nvcc can not use std::simd and is always using simd emulation
-          - { compiler: nvcc, version: "", cuda: "12.5", hip: "no", container: "nvidia/cuda:12.5.1-devel-ubuntu24.04" }
-          - { compiler: nvcc, version: "", cuda: "12.6", hip: "no", container: "nvidia/cuda:12.6.3-devel-ubuntu24.04" }
-          - { compiler: nvcc, version: "", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04" }
-          - { compiler: nvcc, version: "", cuda: "12.9", hip: "no", container: "nvidia/cuda:12.9.1-devel-ubuntu24.04" }
-          - { compiler: nvcc, version: "", cuda: "13.0", hip: "no", container: "nvidia/cuda:13.0.0-devel-ubuntu24.04" }
-          - { compiler: nvcc, version: "", cuda: "13.1", hip: "no", container: "nvidia/cuda:13.1.0-devel-ubuntu24.04" }
-          - { compiler: nvcc, version: "", cuda: "13.2", hip: "no", container: "nvidia/cuda:13.2.0-devel-ubuntu24.04" }
+          - { compiler: nvcc, version: "", cuda: "12.5", hip: "no", container: "nvidia/cuda:12.5.1-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : nvcc@12.5} }
+          - { compiler: nvcc, version: "", cuda: "12.6", hip: "no", container: "nvidia/cuda:12.6.3-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : nvcc@12.6} }
+          - { compiler: nvcc, version: "", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : nvcc@12.8} }
+          - { compiler: nvcc, version: "", cuda: "12.9", hip: "no", container: "nvidia/cuda:12.9.1-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : nvcc@12.9} }
+          - { compiler: nvcc, version: "", cuda: "13.0", hip: "no", container: "nvidia/cuda:13.0.0-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : nvcc@13.0} }
+          - { compiler: nvcc, version: "", cuda: "13.1", hip: "no", container: "nvidia/cuda:13.1.0-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : nvcc@13.1} }
+          - { compiler: nvcc, version: "", cuda: "13.2", hip: "no", container: "nvidia/cuda:13.2.0-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : nvcc@13.2} }
           # clang-cuda (device compile with clang)
-          - { compiler: clang, version: "20", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04" }
-          - { compiler: clang, version: "21", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04" }
-          - { compiler: clang, version: "21", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04", simd: "EMULATION", hwloc: "no"  }
+          - { compiler: clang, version: "20", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : clang@20} }
+          - { compiler: clang, version: "21", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
+          - { compiler: clang, version: "21", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04", simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
           # clang with ROCm HIP
-          - { compiler: clang, version: "18", cuda: "no", hip: "6.2.4", container: "rocm/dev-ubuntu-24.04:6.2.4" }
-          - { compiler: clang, version: "18", cuda: "no", hip: "6.3.4", container: "rocm/dev-ubuntu-24.04:6.3.4" }
-          - { compiler: clang, version: "19", cuda: "no", hip: "6.4.2", container: "rocm/dev-ubuntu-24.04:6.4.2" }
-          - { compiler: clang, version: "20", cuda: "no", hip: "7.0", container: "rocm/dev-ubuntu-24.04:7.0" }
-          - { compiler: clang, version: "20", cuda: "no", hip: "7.1", container: "rocm/dev-ubuntu-24.04:7.1" }
-          - { compiler: clang, version: "22", cuda: "no", hip: "7.2", container: "rocm/dev-ubuntu-24.04:7.2" }
-          - { compiler: clang, version: "22", cuda: "no", hip: "7.2", container: "rocm/dev-ubuntu-24.04:7.2", simd: "EMULATION", hwloc: "no"  }
+          - { compiler: clang, version: "18", cuda: "no", hip: "6.2.4", container: "rocm/dev-ubuntu-24.04:6.2.4",
+              env : {APCI_DEVICE_COMPILER : clang@18} }
+          - { compiler: clang, version: "18", cuda: "no", hip: "6.3.4", container: "rocm/dev-ubuntu-24.04:6.3.4",
+              env : {APCI_DEVICE_COMPILER : clang@18} }
+          - { compiler: clang, version: "19", cuda: "no", hip: "6.4.2", container: "rocm/dev-ubuntu-24.04:6.4.2",
+              env : {APCI_DEVICE_COMPILER : clang@19} }
+          - { compiler: clang, version: "20", cuda: "no", hip: "7.0", container: "rocm/dev-ubuntu-24.04:7.0",
+              env : {APCI_DEVICE_COMPILER : clang@20} }
+          - { compiler: clang, version: "20", cuda: "no", hip: "7.1", container: "rocm/dev-ubuntu-24.04:7.1",
+              env : {APCI_DEVICE_COMPILER : clang@20} }
+          - { compiler: clang, version: "22", cuda: "no", hip: "7.2", container: "rocm/dev-ubuntu-24.04:7.2",
+              env : {APCI_DEVICE_COMPILER : clang@22} }
+          - { compiler: clang, version: "22", cuda: "no", hip: "7.2", container: "rocm/dev-ubuntu-24.04:7.2", simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : clang@22} }
           # SYCL
-          - { compiler: icpx, version: "2025.1", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.1.3-0-devel-ubuntu24.04" }
-          - { compiler: icpx, version: "2025.2", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu24.04" }
-          - { compiler: icpx, version: "2025.3", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.3.0-0-devel-ubuntu24.04" }
-          - { compiler: icpx, version: "2025.3", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.3.0-0-devel-ubuntu24.04", simd: "EMULATION", hwloc: "no" }
+          - { compiler: icpx, version: "2025.1", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.1.3-0-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : icpx@2025.1} }
+          - { compiler: icpx, version: "2025.2", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : icpx@2025.2} }
+          - { compiler: icpx, version: "2025.3", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.3.0-0-devel-ubuntu24.04",
+              env : {APCI_DEVICE_COMPILER : icpx@2025.3} }
+          - { compiler: icpx, version: "2025.3", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.3.0-0-devel-ubuntu24.04", simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : icpx@2025.3} }
           # Use/validate oneAPI-provided oneTBB package with the latest icpx toolchain
-          - { compiler: icpx, version: "2025.3", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.3.0-0-devel-ubuntu24.04", tbb: "on" }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "asan" }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "asan" , simd: "EMULATION", hwloc: "no"  }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "tsan" }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "tsan" , simd: "EMULATION", hwloc: "no"  }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "lsan" }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "lsan" , simd: "EMULATION", hwloc: "no"  }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "ubsan" }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "ubsan" , simd: "EMULATION", hwloc: "no"  }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "asan" }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "asan" , simd: "EMULATION", hwloc: "no"  }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "tsan" }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "tsan" , simd: "EMULATION", hwloc: "no"  }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "lsan" }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "lsan" , simd: "EMULATION", hwloc: "no"  }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "ubsan" }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "ubsan" , simd: "EMULATION", hwloc: "no"  }
+          - { compiler: icpx, version: "2025.3", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.3.0-0-devel-ubuntu24.04", tbb: "on",
+              env : {APCI_DEVICE_COMPILER : icpx@2025.3} }
+          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "asan",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
+          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "asan" , simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
+          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "tsan",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
+          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "tsan" , simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
+          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "lsan",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
+          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "lsan" , simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
+          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "ubsan",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
+          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "ubsan" , simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : clang@21} }
+          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "asan",
+              env : {APCI_DEVICE_COMPILER : gcc@15} }
+          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "asan" , simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : gcc@15} }
+          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "tsan",
+              env : {APCI_DEVICE_COMPILER : gcc@15} }
+          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "tsan" , simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : gcc@15} }
+          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "lsan",
+              env : {APCI_DEVICE_COMPILER : gcc@15} }
+          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "lsan" , simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : gcc@15} }
+          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "ubsan",
+              env : {APCI_DEVICE_COMPILER : gcc@15} }
+          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "ubsan" , simd: "EMULATION", hwloc: "no",
+              env : {APCI_DEVICE_COMPILER : gcc@15} }
       fail-fast: false
 
     # Specify the container to use based on the matrix configuration
     container:
       image: ${{ matrix.config.container }}
+    
+    env: ${{ matrix.config.env }}
 
     steps:
       # Checkout the repository
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Install base dependencies
       - name: Install base dependencies
@@ -118,22 +171,8 @@ jobs:
           # GCC/Clang jobs use the distro-provided oneTBB development package to satisfy find_package(TBB)
           apt-get update
           apt-get install -y libtbb-dev
-
-      # Install GCC if specified
-      - name: Install GCC
-        if: matrix.config.compiler == 'gcc'
-        run: |
-          # install gcc only if not already available, pre installed gcc can not be called with the version number as postfix
-          if [ $(gcc --version | awk '{print($3)}' | head -n 1 | cut -d"." -f1) -ne ${{matrix.config.version}} ] ; then
-            # install requested GCC if it is not already available
-            if ! command -v gcc-${{ matrix.config.version }} >/dev/null 2>&1; then
-              apt-get update
-              apt-get install -y gcc-${{ matrix.config.version }} g++-${{ matrix.config.version }}
-              # select requested GCC as default
-              update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.config.version }} 100 \
-                                  --slave /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.config.version }}
-            fi
-          fi
+      - name: Install software dependencies
+        run: $GITHUB_WORKSPACE/script/ci/install_dependencies.sh
       # Install Clang if specified
       - name: Install Clang
         if: matrix.config.compiler == 'clang' && matrix.config.hip == 'no'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,8 @@ jobs:
 
       # Configure CMake with the selected compiler and options
       - name: Configure CMake
+        run: $APCI_ALPAKA_ROOT/script/ci/configure.sh
+      - name: Configure CMake (old solution)
         run: |
           mkdir build && cd build
           if [ "${{ matrix.config.compiler }}" = "gcc" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   alpaka_cmake_flags: "-Dalpaka_COMPILE_PEDANTIC=ON -Dalpaka_DOCS=ON -Dalpaka_TESTS=ON -Dalpaka_BENCHMARKS=ON -Dalpaka_EXAMPLES=ON -DBUILD_TESTING=ON -Dalpaka_HEADERCHECKS=ON -Dalpaka_LOG=dynamic -Dalpaka_FAST_MATH=OFF"
+  APCI_ALPAKA_ROOT: ${{ github.workspace }}
 
 jobs:
   pre-commit:
@@ -172,7 +173,7 @@ jobs:
           apt-get update
           apt-get install -y libtbb-dev
       - name: Install software dependencies
-        run: $GITHUB_WORKSPACE/script/ci/install_dependencies.sh
+        run: $APCI_ALPAKA_ROOT/script/ci/install_dependencies.sh
       # Install Clang if specified
       - name: Install Clang
         if: matrix.config.compiler == 'clang' && matrix.config.hip == 'no'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
           echo "TSAN_OPTIONS=suppressions=${SANITIZERS_DIR}/tsan_suppressions.txt,ignore_noninstrumented_modules=1" >> $GITHUB_ENV
           echo "LSAN_OPTIONS=suppressions=${SANITIZERS_DIR}/lsan_suppressions.txt" >> $GITHUB_ENV
           echo "UBSAN_OPTIONS=suppressions=${SANITIZERS_DIR}/ubsan_suppressions.txt" >> $GITHUB_ENV
+          $APCI_ALPAKA_ROOT/script/ci/utils/install_helper_apps.sh
 
       - name: Install oneTBB
         if: matrix.config.tbb == 'on' && matrix.config.compiler != 'icpx'
@@ -174,8 +175,8 @@ jobs:
           # GCC/Clang jobs use the distro-provided oneTBB development package to satisfy find_package(TBB)
           apt-get update
           apt-get install -y libtbb-dev
-      - name: Install software dependencies
-        run: $APCI_ALPAKA_ROOT/script/ci/install_dependencies.sh
+      - name: Install GCC
+        run: $APCI_ALPAKA_ROOT/script/ci/install/gcc.sh
       # Install Clang if specified
       - name: Install Clang
         if: matrix.config.compiler == 'clang' && matrix.config.hip == 'no'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
     # Specify the container to use based on the matrix configuration
     container:
       image: ${{ matrix.config.container }}
-    
+
     env: ${{ matrix.config.env }}
 
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@
   variables:
     APCI_ALPAKA_ROOT: "$CI_PROJECT_DIR"
   script:
+    - $APCI_ALPAKA_ROOT/script/ci/print_vars.sh
     - $APCI_ALPAKA_ROOT/script/ci/install_dependencies.sh
     - $APCI_ALPAKA_ROOT/script/ci/configure.sh
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,17 @@
+.gcc-base:
+  image: docker.io/ubuntu:24.04
+  variables:
+    APCI_ALPAKA_ROOT: "$CI_PROJECT_DIR"
+  script:
+    - $APCI_ALPAKA_ROOT/script/ci/install_dependencies.sh
+    - $APCI_ALPAKA_ROOT/script/ci/configure.sh
+
+gcc-13:
+  extends: .gcc-base
+  variables:
+    APCI_DEVICE_COMPILER : gcc@13
+
+gcc-15:
+  extends: .gcc-base
+  variables:
+    APCI_DEVICE_COMPILER : gcc@15

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -10,12 +10,17 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
 
 script_msg "Run CMake configure (configure.sh)"
 
-load_variable_if_not_exist APCI_CC_COMPILER
-load_variable_if_not_exist APCI_CXX_COMPILER
+parse_compiler_version "$APCI_DEVICE_COMPILER"
 
-CMAKE_ARGS=(
-    "-DCMAKE_CC_COMPILER=$APCI_CC_COMPILER"
-    "-DCMAKE_CXX_COMPILER=$APCI_CXX_COMPILER"
-)
+# TODO: remove me, if all install scripts are ported
+if [[ "$compiler_name" == "gcc" ]]; then
+    load_variable_if_not_exist APCI_CC_COMPILER
+    load_variable_if_not_exist APCI_CXX_COMPILER
 
-echo_green "cmake ${CMAKE_ARGS[*]}"
+    CMAKE_ARGS=(
+        "-DCMAKE_CC_COMPILER=$APCI_CC_COMPILER"
+        "-DCMAKE_CXX_COMPILER=$APCI_CXX_COMPILER"
+    )
+
+    echo_green "cmake ${CMAKE_ARGS[*]}"
+fi

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+# shellcheck source=script/ci/utils/default.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
+
+script_msg "Run CMake configure (configure.sh)"
+
+load_variable_if_not_exist APCI_CC_COMPILER
+load_variable_if_not_exist APCI_CXX_COMPILER
+
+CMAKE_ARGS=(
+    "-DCMAKE_CC_COMPILER=$APCI_CC_COMPILER"
+    "-DCMAKE_CXX_COMPILER=$APCI_CXX_COMPILER"
+)
+
+echo_green "cmake ${CMAKE_ARGS[*]}"

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -49,7 +49,9 @@ if [[ "$compiler_name" == "gcc" ]]; then
     APCI_CC_COMPILER="${gcc_base_path}/gcc-${compiler_version}"
     APCI_CXX_COMPILER="${gcc_base_path}/g++-${compiler_version}"
 
+    echo_green "${APCI_CC_COMPILER} --version"
     $APCI_CC_COMPILER --version
+    echo_green "${APCI_CXX_COMPILER} --version"
     $APCI_CXX_COMPILER --version
 
     store_variable APCI_CC_COMPILER
@@ -59,4 +61,6 @@ if [[ "$compiler_name" == "gcc" ]]; then
     export APCI_CXX_COMPILER
 
     unset gcc_base_path
+else
+    echo_green "Skipped install GCC because it is not required for the job"
 fi

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -22,8 +22,9 @@ if [[ "$compiler_name" == "gcc" ]]; then
     if [[ "$(gcc --version | awk '{print($3)}' | head -n 1 | cut -d"." -f1)" -ne "${compiler_version}" ]]; then
         # install requested GCC if it is not already available
         if ! command -v "gcc-${compiler_version}" >/dev/null 2>&1; then
-            DEBIAN_FRONTEND=noninteractive apt update
-            DEBIAN_FRONTEND=noninteractive apt install -y "gcc-${compiler_version}" "g++-${compiler_version}"
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            DEBIAN_FRONTEND=noninteractive sudo apt update
+            DEBIAN_FRONTEND=noninteractive sudo apt install -y "gcc-${compiler_version}" "g++-${compiler_version}"
             # select requested GCC as default
             # TODO: Remove me, if ACPI_CXX_COMPILER is used in production.
             # Changing the system host compiler is pretty dangerous and error prone.

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -25,9 +25,19 @@ if [[ "$compiler_name" == "gcc" ]]; then
             DEBIAN_FRONTEND=noninteractive apt update
             DEBIAN_FRONTEND=noninteractive apt install -y "gcc-${compiler_version}" "g++-${compiler_version}"
             # select requested GCC as default
-            # TODO: Set instead an environment variable. Changing the system host compiler is pretty dangerous and error prone
+            # TODO: Remove me, if ACPI_CXX_COMPILER is used in production.
+            # Changing the system host compiler is pretty dangerous and error prone.
             update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-${compiler_version}" 100 \
                 --slave /usr/bin/g++ g++ "/usr/bin/g++-${compiler_version}"
         fi
     fi
+
+    export APCI_CC_COMPILER="/usr/bin/gcc-${compiler_version}"
+    export APCI_CXX_COMPILER="/usr/bin/g++-${compiler_version}"
+
+    $APCI_CC_COMPILER --version
+    $APCI_CXX_COMPILER --version
+
+    store_variable APCI_CC_COMPILER
+    store_variable APCI_CXX_COMPILER
 fi

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -32,12 +32,16 @@ if [[ "$compiler_name" == "gcc" ]]; then
         fi
     fi
 
-    export APCI_CC_COMPILER="/usr/bin/gcc-${compiler_version}"
-    export APCI_CXX_COMPILER="/usr/bin/g++-${compiler_version}"
+    # TODO: should be exported here. Because of a bug in typeofvar(), it does not work at the moment
+    APCI_CC_COMPILER="/usr/bin/gcc-${compiler_version}"
+    APCI_CXX_COMPILER="/usr/bin/g++-${compiler_version}"
 
     $APCI_CC_COMPILER --version
     $APCI_CXX_COMPILER --version
 
     store_variable APCI_CC_COMPILER
     store_variable APCI_CXX_COMPILER
+
+    export APCI_CC_COMPILER
+    export APCI_CXX_COMPILER
 fi

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -23,7 +23,7 @@ if [[ "$compiler_name" == "gcc" ]]; then
         # install requested GCC if it is not already available
         if ! command -v "gcc-${compiler_version}" >/dev/null 2>&1; then
             apt-get update
-            apt-get install -y "gcc-${compiler_version}" "gcc-${compiler_version}"
+            apt-get install -y "gcc-${compiler_version}" "g++-${compiler_version}"
             # select requested GCC as default
             # TODO: Set instead an environment variable. Changing the system host compiler is pretty dangerous and error prone
             update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-${compiler_version}" 100 \

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -22,8 +22,8 @@ if [[ "$compiler_name" == "gcc" ]]; then
     if [[ "$(gcc --version | awk '{print($3)}' | head -n 1 | cut -d"." -f1)" -ne "${compiler_version}" ]]; then
         # install requested GCC if it is not already available
         if ! command -v "gcc-${compiler_version}" >/dev/null 2>&1; then
-            apt-get update
-            apt-get install -y "gcc-${compiler_version}" "g++-${compiler_version}"
+            DEBIAN_FRONTEND=noninteractive apt update
+            DEBIAN_FRONTEND=noninteractive apt install -y "gcc-${compiler_version}" "g++-${compiler_version}"
             # select requested GCC as default
             # TODO: Set instead an environment variable. Changing the system host compiler is pretty dangerous and error prone
             update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-${compiler_version}" 100 \

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -32,9 +32,22 @@ if [[ "$compiler_name" == "gcc" ]]; then
         fi
     fi
 
+    # we assume gcc, g++, gcc-<version> and g++-<version> are in the same folder
+    gcc_base_path="$(dirname "$(which gcc)")"
+
+    # workaround for gcc container
+    # there is no g++-<version> executable
+    for exe_name in gcc g++; do
+        version_exe_name="${gcc_base_path}/${exe_name}-${compiler_version}"
+        if [[ ! -f "${version_exe_name}" ]]; then
+            ln -s "${gcc_base_path}/${exe_name}" "${version_exe_name}"
+        fi
+        unset version_exe_name
+    done
+
     # TODO: should be exported here. Because of a bug in typeofvar(), it does not work at the moment
-    APCI_CC_COMPILER="/usr/bin/gcc-${compiler_version}"
-    APCI_CXX_COMPILER="/usr/bin/g++-${compiler_version}"
+    APCI_CC_COMPILER="${gcc_base_path}/gcc-${compiler_version}"
+    APCI_CXX_COMPILER="${gcc_base_path}/g++-${compiler_version}"
 
     $APCI_CC_COMPILER --version
     $APCI_CXX_COMPILER --version
@@ -44,4 +57,6 @@ if [[ "$compiler_name" == "gcc" ]]; then
 
     export APCI_CC_COMPILER
     export APCI_CXX_COMPILER
+
+    unset gcc_base_path
 fi

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+# shellcheck source=script/ci/utils/default.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
+
+# TODO: add guard which fails if runner is MacOS or Windows -> implementation is Linux specific
+
+: "${APCI_DEVICE_COMPILER?'The device compiler must be specified'}"
+
+parse_compiler_version "$APCI_DEVICE_COMPILER"
+
+if [[ "$compiler_name" == "gcc" ]]; then
+    install_msg "GCC $compiler_version"
+
+    # install gcc only if not already available, pre installed gcc can not be called with the version number as postfix
+    if [[ "$(gcc --version | awk '{print($3)}' | head -n 1 | cut -d"." -f1)" -ne "${compiler_version}" ]]; then
+        # install requested GCC if it is not already available
+        if ! command -v "gcc-${compiler_version}" >/dev/null 2>&1; then
+            apt-get update
+            apt-get install -y "gcc-${compiler_version}" "gcc-${compiler_version}"
+            # select requested GCC as default
+            # TODO: Set instead an environment variable. Changing the system host compiler is pretty dangerous and error prone
+            update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-${compiler_version}" 100 \
+                --slave /usr/bin/g++ g++ "/usr/bin/g++-${compiler_version}"
+        fi
+    fi
+fi

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -9,7 +9,9 @@
 # shellcheck source=script/ci/utils/default.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
 
-# TODO: add guard which fails if runner is MacOS or Windows -> implementation is Linux specific
+if [[ "$APCI_OS_NAME" != "Linux" ]]; then
+    exit_error "Install GCC script does not support Windows or MacOS"
+fi
 
 : "${APCI_DEVICE_COMPILER?'The device compiler must be specified'}"
 
@@ -47,9 +49,8 @@ if [[ "$compiler_name" == "gcc" ]]; then
         unset version_exe_name
     done
 
-    # TODO: should be exported here. Because of a bug in typeofvar(), it does not work at the moment
-    APCI_CC_COMPILER="${gcc_base_path}/gcc-${compiler_version}"
-    APCI_CXX_COMPILER="${gcc_base_path}/g++-${compiler_version}"
+    export APCI_CC_COMPILER="${gcc_base_path}/gcc-${compiler_version}"
+    export APCI_CXX_COMPILER="${gcc_base_path}/g++-${compiler_version}"
 
     echo_green "${APCI_CC_COMPILER} --version"
     $APCI_CC_COMPILER --version
@@ -58,9 +59,6 @@ if [[ "$compiler_name" == "gcc" ]]; then
 
     store_variable APCI_CC_COMPILER
     store_variable APCI_CXX_COMPILER
-
-    export APCI_CC_COMPILER
-    export APCI_CXX_COMPILER
 
     unset gcc_base_path
 else

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -15,11 +15,12 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 
-if [[ "$compiler_name" == "gcc" ]]; then
-    install_msg "GCC $compiler_version"
+script_msg "Install GCC"
 
+if [[ "$compiler_name" == "gcc" ]]; then
     # install gcc only if not already available, pre installed gcc can not be called with the version number as postfix
-    if [[ "$(gcc --version | awk '{print($3)}' | head -n 1 | cut -d"." -f1)" -ne "${compiler_version}" ]]; then
+    if [[ ! $(command -v gcc) || "$(gcc --version | awk '{print($3)}' | head -n 1 | cut -d"." -f1)" -ne "${compiler_version}" ]]; then
+        install_msg "GCC $compiler_version"
         # install requested GCC if it is not already available
         if ! command -v "gcc-${compiler_version}" >/dev/null 2>&1; then
             sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/script/ci/install_dependencies.sh
+++ b/script/ci/install_dependencies.sh
@@ -12,5 +12,7 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/sudo.sh"
 
 : "${APCI_DEVICE_COMPILER?'The device compiler must be specified'}"
 
+script_msg "Install software dependencies (install_dependencies.sh)"
+
 # shellcheck source=script/ci/install/gcc.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/install/gcc.sh"

--- a/script/ci/install_dependencies.sh
+++ b/script/ci/install_dependencies.sh
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 
-APCI_ALPAKA_ROOT=$(realpath ../..)
-
 # shellcheck source=script/ci/utils/default.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
 # shellcheck source=script/ci/utils/sudo.sh

--- a/script/ci/install_dependencies.sh
+++ b/script/ci/install_dependencies.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+APCI_ALPAKA_ROOT=$(realpath ../..)
+
+# shellcheck source=script/ci/utils/default.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
+# shellcheck source=script/ci/utils/sudo.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/sudo.sh"
+
+: "${APCI_DEVICE_COMPILER?'The device compiler must be specified'}"
+
+# shellcheck source=script/ci/install/gcc.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/install/gcc.sh"

--- a/script/ci/install_dependencies.sh
+++ b/script/ci/install_dependencies.sh
@@ -7,8 +7,8 @@
 
 # shellcheck source=script/ci/utils/default.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
-# shellcheck source=script/ci/utils/sudo.sh
-source "${APCI_ALPAKA_ROOT}/script/ci/utils/sudo.sh"
+# shellcheck source=script/ci/utils/install_helper_apps.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/install_helper_apps.sh"
 
 : "${APCI_DEVICE_COMPILER?'The device compiler must be specified'}"
 

--- a/script/ci/print_vars.sh
+++ b/script/ci/print_vars.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+# print all variables which are required to run the job configuration
+
+# shellcheck source=script/ci/utils/default.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
+
+for e in $(env | grep -e "^APCI_"); do
+    echo_yellow "$e"
+done

--- a/script/ci/utils/color_echo.sh
+++ b/script/ci/utils/color_echo.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+# colored output
+
+echo_green() {
+    # `-t 1`: if executed in terminal
+    # `tput colors`: if no colors available, the value is negative
+    if [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
+        echo -e "\e[1;32m$1\e[0m"
+    else
+        echo -e "$1"
+    fi
+}
+
+echo_blue() {
+    # `-t 1`: if executed in terminal
+    # `tput colors`: if no colors available, the value is negative
+    if [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
+        echo -e "\e[1;34m$1\e[0m"
+    else
+        echo -e "$1"
+    fi
+}
+
+echo_yellow() {
+    # `-t 1`: if executed in terminal
+    # `tput colors`: if no colors available, the value is negative
+    if [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
+        echo -e "\e[1;33m$1\e[0m"
+    else
+        echo -e "$1"
+    fi
+}
+
+echo_red() {
+    # `-t 1`: if executed in terminal
+    # `tput colors`: if no colors available, the value is negative
+    if [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
+        echo -e "\e[1;31m$1\e[0m"
+    else
+        echo -e "$1"
+    fi
+}

--- a/script/ci/utils/color_echo.sh
+++ b/script/ci/utils/color_echo.sh
@@ -10,7 +10,7 @@
 echo_green() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
-    if [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
+    if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
         echo -e "\e[1;32m$1\e[0m"
     else
         echo -e "$1"
@@ -20,7 +20,7 @@ echo_green() {
 echo_blue() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
-    if [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
+    if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
         echo -e "\e[1;34m$1\e[0m"
     else
         echo -e "$1"
@@ -30,7 +30,7 @@ echo_blue() {
 echo_yellow() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
-    if [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
+    if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
         echo -e "\e[1;33m$1\e[0m"
     else
         echo -e "$1"
@@ -40,7 +40,7 @@ echo_yellow() {
 echo_red() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
-    if [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
+    if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
         echo -e "\e[1;31m$1\e[0m"
     else
         echo -e "$1"

--- a/script/ci/utils/default.sh
+++ b/script/ci/utils/default.sh
@@ -9,6 +9,8 @@
 
 : "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
 
+# shellcheck source=script/ci/utils/setup_vars.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/setup_vars.sh"
 # shellcheck source=script/ci/utils/set.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/set.sh"
 # shellcheck source=script/ci/utils/color_echo.sh

--- a/script/ci/utils/default.sh
+++ b/script/ci/utils/default.sh
@@ -17,3 +17,5 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/set.sh"
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/color_echo.sh"
 # shellcheck source=script/ci/utils/misc.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/misc.sh"
+# shellcheck source=script/ci/utils/var_storage.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/var_storage.sh"

--- a/script/ci/utils/default.sh
+++ b/script/ci/utils/default.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+# source a set of util functions, which are required nearly everywhere
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+
+# shellcheck source=script/ci/utils/set.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/set.sh"
+# shellcheck source=script/ci/utils/color_echo.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/color_echo.sh"
+# shellcheck source=script/ci/utils/misc.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/misc.sh"

--- a/script/ci/utils/install_helper_apps.sh
+++ b/script/ci/utils/install_helper_apps.sh
@@ -25,4 +25,5 @@ fi
 
 DEBIAN_FRONTEND=noninteractive apt update
 # python3 is required for var_storage.sh
-DEBIAN_FRONTEND=noninteractive apt install -y python3
+# software-properties-common: 'add-apt-repository' and certificates for wget https download
+DEBIAN_FRONTEND=noninteractive apt install -y python3 software-properties-common

--- a/script/ci/utils/install_helper_apps.sh
+++ b/script/ci/utils/install_helper_apps.sh
@@ -7,23 +7,30 @@
 
 : "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
 
+# shellcheck source=script/ci/utils/setup_vars.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/setup_vars.sh"
 # shellcheck source=script/ci/utils/set.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/set.sh"
 # shellcheck source=script/ci/utils/color_echo.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/color_echo.sh"
+# shellcheck source=script/ci/utils/misc.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/misc.sh"
 
 # inside the agc-container, the user is root and does not require sudo
 # to compatibility to other container, fake the missing sudo command
 if ! command -v sudo &>/dev/null; then
     if [[ "$APCI_OS_NAME" == "Linux" ]]; then
-        echo_yellow "install sudo"
+        install_msg "sudo"
 
-        DEBIAN_FRONTEND=noninteractive apt update
+        lazy_apt_update
         DEBIAN_FRONTEND=noninteractive apt install -y sudo
     fi
 fi
 
-DEBIAN_FRONTEND=noninteractive apt update
+lazy_apt_update
 # python3 is required for var_storage.sh
 # software-properties-common: 'add-apt-repository' and certificates for wget https download
-DEBIAN_FRONTEND=noninteractive apt install -y python3 software-properties-common
+_helper_apps=(python3 software-properties-common)
+install_msg "${_helper_apps[*]}"
+DEBIAN_FRONTEND=noninteractive apt install -y "${_helper_apps[@]}"
+unset _helper_apps

--- a/script/ci/utils/install_helper_apps.sh
+++ b/script/ci/utils/install_helper_apps.sh
@@ -22,3 +22,7 @@ if ! command -v sudo &>/dev/null; then
         DEBIAN_FRONTEND=noninteractive apt install -y sudo
     fi
 fi
+
+DEBIAN_FRONTEND=noninteractive apt update
+# python3 is required for var_storage.sh
+DEBIAN_FRONTEND=noninteractive apt install -y python3

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -15,6 +15,11 @@ install_msg() {
     echo_green "[INSTALL]: $1"
 }
 
+# display a install message in green
+script_msg() {
+    echo_green "[SCRIPT]: $1"
+}
+
 # display a error message in red
 error_msg() {
     echo_red "[ERROR]: $1"

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -52,3 +52,12 @@ parse_compiler_version() {
     export compiler_name
     export compiler_version
 }
+
+# does an 'apt update' only if no 'apt update' was done before
+# ATTENTION: If you add a new ppa no 'apt update' is performed. Instead call directly
+# `DEBIAN_FRONTEND=noninteractive apt update`.
+lazy_apt_update() {
+    if [[ -z "$(ls -A '/var/lib/apt/lists/')" ]]; then
+        DEBIAN_FRONTEND=noninteractive apt update
+    fi
+}

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+
+# shellcheck source=script/ci/utils/color_echo.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils//color_echo.sh"
+
+# display a install message in green
+install_msg() {
+    echo_green "[INSTALL]: $1"
+}
+
+# display a error message in red
+error_msg() {
+    echo_red "[ERROR]: $1"
+}
+
+exit_error() {
+    error_msg "$1"
+    if [[ $# -lt 2 ]]; then
+        exit 1
+    else
+        exit "$2"
+    fi
+}
+
+# Parse compiler version string with the shape of compiler_name@compiler_version and
+# store result in variables compiler_name and compiler_version.
+#
+# Example:
+#
+# parse_compiler_version gcc@15
+# echo $compiler_name # output: gcc
+# echo $compiler_version # output: 15
+parse_compiler_version() {
+    if ! echo "$1" | grep -q '@'; then
+        exit_error "parse_compiler_version(): No @ in variable string '${1}'"
+    fi
+
+    IFS='@' read -r compiler_name compiler_version <<<"$1"
+
+    export compiler_name
+    export compiler_version
+}

--- a/script/ci/utils/set.sh
+++ b/script/ci/utils/set.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+#-------------------------------------------------------------------------------
+# -e: exit as soon as one command returns a non-zero exit code
+# -o pipefail: pipeline returns exit code of the rightmost command with a non-zero exit code
+# -u: treat unset variables as an error
+# -v: Print shell input lines as they are read
+# -x: Print command traces before executing command
+
+# exit by default if the command does not return 0
+# can be deactivated by setting the environment variable alpaka_DISABLE_EXIT_FAILURE
+# for example for local debugging in a Docker container
+if [[ -z ${alpaka_DISABLE_EXIT_FAILURE+x} ]]; then
+    set -e
+fi
+
+set -ou pipefail
+
+# uncomment me for debugging
+# set -vx

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -8,10 +8,16 @@
 # setup environment variables depending on os environment (on local system, GitLab CI, GitHub Action ...)
 
 if [[ -n ${GITHUB_ACTIONS+x} ]]; then
+    # force color output
+    export TERM=xterm-256color
+
     export APCI_OS_NAME="$RUNNER_OS"
 fi
 
 if [[ -n ${GITLAB_CI+x} ]]; then
+    # force color output
+    export TERM=xterm-256color
+
     if echo "${CI_RUNNER_EXECUTABLE_ARCH}" | grep -q -i "linux"; then
         export APCI_OS_NAME=Linux
     fi

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+# setup environment variables depending on os environment (on local system, GitLab CI, GitHub Action ...)
+
+if [[ -n ${GITHUB_ACTIONS+x} ]]; then
+    export APCI_OS_NAME="$RUNNER_OS"
+fi

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -10,3 +10,17 @@
 if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     export APCI_OS_NAME="$RUNNER_OS"
 fi
+
+if [[ -n ${GITLAB_CI+x} ]]; then
+    if echo "${CI_RUNNER_EXECUTABLE_ARCH}" | grep -q -i "linux"; then
+        export APCI_OS_NAME=Linux
+    fi
+    # not validated because we didn't used a windows runner yet
+    if echo "${CI_RUNNER_EXECUTABLE_ARCH}" | grep -q -i "windows"; then
+        export APCI_OS_NAME=Windows
+    fi
+    # not validated because we didn't used a MacOS runner yet
+    if echo "${CI_RUNNER_EXECUTABLE_ARCH}" | grep -q -i "macos"; then
+        export APCI_OS_NAME=macOS
+    fi
+fi

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -10,6 +10,7 @@
 if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     # force color output
     export TERM=xterm-256color
+    export _APCI_FORCE_COLOR_OUTPUT=1
 
     export APCI_OS_NAME="$RUNNER_OS"
 fi
@@ -17,6 +18,7 @@ fi
 if [[ -n ${GITLAB_CI+x} ]]; then
     # force color output
     export TERM=xterm-256color
+    export _APCI_FORCE_COLOR_OUTPUT=1
 
     if echo "${CI_RUNNER_EXECUTABLE_ARCH}" | grep -q -i "linux"; then
         export APCI_OS_NAME=Linux

--- a/script/ci/utils/sudo.sh
+++ b/script/ci/utils/sudo.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+
+# shellcheck source=script/ci/utils/set.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/set.sh"
+# shellcheck source=script/ci/utils/color_echo.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/color_echo.sh"
+
+# inside the agc-container, the user is root and does not require sudo
+# to compatibility to other container, fake the missing sudo command
+if ! command -v sudo &>/dev/null; then
+    if [[ "$ALPAKA_CI_OS_NAME" == "Linux" ]]; then
+        echo_yellow "install sudo"
+
+        DEBIAN_FRONTEND=noninteractive apt update
+        DEBIAN_FRONTEND=noninteractive apt install -y sudo
+    fi
+fi

--- a/script/ci/utils/sudo.sh
+++ b/script/ci/utils/sudo.sh
@@ -15,7 +15,7 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/color_echo.sh"
 # inside the agc-container, the user is root and does not require sudo
 # to compatibility to other container, fake the missing sudo command
 if ! command -v sudo &>/dev/null; then
-    if [[ "$ALPAKA_CI_OS_NAME" == "Linux" ]]; then
+    if [[ "$APCI_OS_NAME" == "Linux" ]]; then
         echo_yellow "install sudo"
 
         DEBIAN_FRONTEND=noninteractive apt update

--- a/script/ci/utils/var_storage.sh
+++ b/script/ci/utils/var_storage.sh
@@ -10,16 +10,15 @@
 # shellcheck source=script/ci/utils/misc.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/misc.sh"
 
-# TODO: does not support exported variables. Should be fixable.
 typeofvar() {
     local type_signature
     type_signature=$(declare -p "$1" 2>/dev/null)
 
-    if [[ "$type_signature" =~ "declare --" ]]; then
+    if [[ "$type_signature" =~ declare\ (--|-x) ]]; then
         printf "string"
-    elif [[ "$type_signature" =~ "declare -a" ]]; then
+    elif [[ "$type_signature" =~ declare\ (-a|-ax) ]]; then
         printf "array"
-    elif [[ "$type_signature" =~ "declare -A" ]]; then
+    elif [[ "$type_signature" =~ declare\ (-A|-Ax) ]]; then
         printf "map"
     else
         printf "none"

--- a/script/ci/utils/var_storage.sh
+++ b/script/ci/utils/var_storage.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+
+# shellcheck source=script/ci/utils/misc.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/misc.sh"
+
+typeofvar() {
+    local type_signature
+    type_signature=$(declare -p "$1" 2>/dev/null)
+
+    if [[ "$type_signature" =~ "declare --" ]]; then
+        printf "string"
+    elif [[ "$type_signature" =~ "declare -a" ]]; then
+        printf "array"
+    elif [[ "$type_signature" =~ "declare -A" ]]; then
+        printf "map"
+    else
+        printf "none"
+    fi
+}
+
+# store a variable in a file, which can be loaded later
+# set variable name as first argument
+store_variable() {
+    if [[ $# -lt 1 ]]; then
+        exit_error "store_variable(): variable name is not set" 2
+    fi
+
+    if ! declare -p "$1" >/dev/null 2>&1; then
+        exit_error "store_variable(): variable '$1' does not exist" 1
+    fi
+
+    var_name="$1"
+    var_type="$(typeofvar "${var_name}")"
+    # scalar value (handles newlines safely)
+    local var_values=()
+
+    case $var_type in
+    "string")
+        local tmp_value
+        eval "tmp_value=\"\${$1}\""
+        var_values+=("$tmp_value")
+        ;;
+    "array")
+        local -a tmp_array
+        eval "tmp_array=(\"\${${1}[@]}\")"
+        var_values=("${tmp_array[@]}")
+        ;;
+    "map")
+        local -a keys
+        eval "keys=(\"\${!${1}[@]}\")"
+        local k v
+        for k in "${keys[@]}"; do
+            # Use printf to avoid word-splitting in values
+            eval "v=\"\${${1}[\"\$k\"]}\""
+            var_values+=("$(printf '%s=%s' "$k" "$v")")
+        done
+        ;;
+    *)
+        exit_error "store_variable() unknown variable type for ${var_name}"
+        ;;
+    esac
+
+    "${APCI_ALPAKA_ROOT}/script/ci/utils/var_storage/var_write.py" --name "${var_name}" --type "${var_type}" "${var_values[@]}"
+}
+
+# load a variable from a file
+# set variable name as first argument
+# failed if the variable was not stored
+load_variable() {
+    if [[ $# -lt 1 ]]; then
+        exit_error "load_variable(): variable name is not set"
+    fi
+
+    var_name="$1"
+
+    if ! "${APCI_ALPAKA_ROOT}/script/ci/utils/var_storage/var_read.py" --name "${var_name}" --exist; then
+        exit_error "load_variable(): variable ${var_name} was not stored."
+    fi
+    local var_type
+    local var_values
+    var_type=$("${APCI_ALPAKA_ROOT}/script/ci/utils/var_storage/var_read.py" --name "${var_name}" --type)
+    var_values=$("${APCI_ALPAKA_ROOT}/script/ci/utils/var_storage/var_read.py" --name "${var_name}")
+
+    case $var_type in
+    "string")
+        declare -g -- "$var_name=$var_values"
+        ;;
+    "array")
+        declare -g -a "$var_name=$var_values"
+        ;;
+    "map")
+        declare -g -A "$var_name=$var_values"
+        ;;
+    *)
+        exit_error "store_variable() unknown variable type for ${var_name}"
+        ;;
+    esac
+}
+
+# load a variable from a file if does not exist
+# set variable name as first argument
+# failed if the variable was not stored
+load_variable_if_not_exist() {
+    if [[ $# -lt 1 ]]; then
+        exit_error "read_var(): variable name is not set" 2
+    fi
+
+    if ! declare -p "$1" >/dev/null 2>&1; then
+        load_variable "$@"
+    fi
+}

--- a/script/ci/utils/var_storage.sh
+++ b/script/ci/utils/var_storage.sh
@@ -10,6 +10,7 @@
 # shellcheck source=script/ci/utils/misc.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/misc.sh"
 
+# TODO: does not support exported variables. Should be fixable.
 typeofvar() {
     local type_signature
     type_signature=$(declare -p "$1" 2>/dev/null)

--- a/script/ci/utils/var_storage/get_storage_path.py
+++ b/script/ci/utils/var_storage/get_storage_path.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import pathlib
+import os
+
+def get_storage_path() -> pathlib.Path:
+    """Return the path to variable storage file depending on the
+    environment variables
+
+    Returns:
+        pathlib.Path: variable storage file path
+    """
+    if "VAR_STORAGE_PATH" in os.environ:
+        return pathlib.Path(os.environ["VAR_STORAGE_PATH"])
+
+    tmp_folder = pathlib.Path(os.environ.get("TMPDIR", "/tmp"))
+    return tmp_folder / "var_storage.json"
+
+if __name__ == "__main__":
+    print(get_storage_path())

--- a/script/ci/utils/var_storage/var_read.py
+++ b/script/ci/utils/var_storage/var_read.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import argparse
+import pathlib
+import json
+import sys
+
+from var_types import VarType
+from get_storage_path import get_storage_path
+
+
+def get_args():
+    """Get command line arguments"""
+    parser = argparse.ArgumentParser(description="Write bash variables to a json file.")
+    parser.add_argument(
+        "--type",
+        action="store_true",
+        help="Get variable type",
+    )
+    parser.add_argument(
+        "--exist",
+        action="store_true",
+        help="Check if variable name exist. Application exist with 0, if key exist.",
+    )
+    parser.add_argument(
+        "--name",
+        required=True,
+        type=str,
+        help="Variable name",
+    )
+    parser.add_argument(
+        "--path",
+        type=str,
+        help="Path to the variable storage file",
+    )
+    return parser.parse_args()
+
+
+def read_config(path: pathlib.Path) -> dict[str, str | list[str] | dict[str, str]]:
+    """Load variables from file."""
+    with open(path, "r", encoding="utf-8") as f:
+        load_var_storage = json.load(f)
+    return load_var_storage
+
+
+def get_type(values: str | list[str] | dict[str, str]) -> VarType:
+    """Get the type of a variable.
+
+    Args:
+        values (str | list[str] | dict[str, str]): Variable
+
+    Raises:
+        RuntimeError: If the type is not known
+
+    Returns:
+        VarType: The type
+    """
+    if isinstance(values, str):
+        return VarType.STRING
+    if isinstance(values, list):
+        return VarType.ARRAY
+    if isinstance(values, dict):
+        return VarType.MAP
+
+    raise RuntimeError(f"Unknown VarType for value: {values} ({type(values)})")
+
+
+def json_to_bash_type(values: str | list[str] | dict[str, str]) -> str:
+    """Take a value in json notation and return the equivalent bash notation.
+
+    Args:
+        values (str | list[str] | dict[str, str]): The variable
+
+    Raises:
+        RuntimeError: The type of the variable is not known.
+
+    Returns:
+        str: bash notation of the variable.
+    """
+    val_type: VarType = get_type(values)
+    if val_type == VarType.STRING:
+        return str(values)
+    if val_type == VarType.ARRAY:
+        return "(" + " ".join(values) + ")"
+    if val_type == VarType.MAP:
+        return "(" + " ".join(f"[{kv[0]}]={kv[1]}" for kv in values.items()) + ")"
+
+    raise RuntimeError(f"Unknown VarType for value: {values} ({type(values)})")
+
+
+if __name__ == "__main__":
+    args = get_args()
+    if args.path:
+        var_storage_path = pathlib.Path(args.path)
+    else:
+        var_storage_path = get_storage_path()
+
+    var_storage = read_config(var_storage_path)
+
+    if args.exist:
+        sys.exit(0 if args.name in var_storage else 1)
+
+    entry = var_storage[args.name]
+    if args.type:
+        print(get_type(entry).value)
+        sys.exit(0)
+
+    print(json_to_bash_type(entry))

--- a/script/ci/utils/var_storage/var_types.py
+++ b/script/ci/utils/var_storage/var_types.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class VarType(StrEnum):
+    STRING = "string"
+    ARRAY = "array"
+    MAP = "map"

--- a/script/ci/utils/var_storage/var_write.py
+++ b/script/ci/utils/var_storage/var_write.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+import argparse
+import pathlib
+import json
+
+from var_types import VarType
+from get_storage_path import get_storage_path
+
+
+def get_args():
+    """Get command line arguments"""
+    parser = argparse.ArgumentParser(description="Write bash variables to a json file.")
+    parser.add_argument(
+        "--type",
+        required=True,
+        type=str,
+        choices=[e.value for e in VarType],
+        help="Variable type",
+    )
+    parser.add_argument(
+        "--name",
+        required=True,
+        type=str,
+        help="Variable name",
+    )
+    parser.add_argument(
+        "--path",
+        type=str,
+        help="Path to the variable storage file",
+    )
+    parser.add_argument(
+        "values",
+        type=str,
+        nargs="*",
+        help="Variable values",
+    )
+    return parser.parse_args()
+
+
+def bash_to_json_type(
+    var_type: VarType, values: list[str]
+) -> str | list[str] | dict[str, str]:
+    """Take a variable in bash notation and return json equivalent.
+
+    Args:
+        var_type (VarType): the type of the variable
+        values (list[str]): the bash value
+
+    Raises:
+        RuntimeError: If type is unknown
+
+    Returns:
+        str | list[str] | dict[str, str]: The value
+            in a python struct which can be directly mapped to json.
+    """
+
+    if var_type == VarType.STRING:
+        return "" if len(values) == 0 else values[0]
+
+    if var_type == VarType.ARRAY:
+        return values
+
+    if var_type == VarType.MAP:
+        return dict(item.split("=", 1) for item in values)
+
+    raise RuntimeError(f"Unknown VarType: {type}")
+
+
+def write(var_type: VarType, name: str, values: list[str], path: pathlib.Path):
+    """Write variable to the storage file.
+
+    Args:
+        var_type (VarType): Type of the variable.
+        name (str): Name of the variable
+        values (list[str]): Value of the variable
+        path (pathlib.Path): Path of the storage variable.
+    """
+    json_value = bash_to_json_type(var_type, values)
+
+    if not path.exists():
+        var_storage = {}
+    else:
+        with open(path, "r", encoding="utf-8") as f:
+            var_storage = json.load(f)
+
+    var_storage[name] = json_value
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(var_storage, f, indent=4)
+
+
+if __name__ == "__main__":
+    args = get_args()
+    if args.path:
+        var_storage_path = pathlib.Path(args.path)
+    else:
+        var_storage_path = get_storage_path()
+
+    write(args.type, args.name, args.values, var_storage_path)


### PR DESCRIPTION
Start to modularise the CI steps. Use bash scripts instead write everything in the GitHub Actions yaml. 

This PR contains a lot of infrastructure bash scripts for the modularization and ports only one CI step for testing purpose. Ported the GCC install step. This PR enables the following features:

- support GitHub Actions and GitLab CI
- enables setting environment variables to configure the job
- Add the `var_storage` functionality. It allows to write and read bash variables to file. Therefore scripts can be separated executed instead everything needs to be source stating from a top-level script.

# Notes

- The `configure.sh` has no functionality. It only verifies if the several install scripts stores the for CMake configure  required variables are stored.
- The `gitlab-ci.yml` contains only really basic jobs to test the scripts. Later the jobs will be generated with a generator.