### PR TITLE
refactor `FrameSpec`, `ThreadSpec` and enqueue interface

### DIFF
--- a/benchmark/HACCmk/src/main_alpaka.cpp
+++ b/benchmark/HACCmk/src/main_alpaka.cpp
@@ -170,7 +170,7 @@ namespace haccmkAlpaka
         uint32_t frameExtent = alpaka::divExZero(possibleChunkSize, numElementsPerThread);
         frameExtent = std::bit_floor(frameExtent);
         frameExtent = frameExtent < devProps.warpSize ? devProps.warpSize : frameExtent;
-        auto frameSpec = onHost::FrameSpec{numeFrames, static_cast<int>(frameExtent)};
+        auto frameSpec = onHost::FrameSpec{numeFrames, static_cast<int>(frameExtent), exec};
 
         std::cout << "FrameSpec " << frameSpec << std::endl;
 
@@ -201,7 +201,7 @@ namespace haccmkAlpaka
                 mp_rsm,
                 fcoeff};
 
-            queue.enqueue(exec, frameSpec, haccKernel);
+            queue.enqueue(frameSpec, haccKernel);
             onHost::wait(devAcc);
             auto end = std::chrono::steady_clock::now();
             auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();

--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -224,7 +224,7 @@ void testKernels(auto const deviceSpec, auto const exec)
     uint32_t elementsPerFrameItem = getNumElemPerThread<DataType>(queue);
 
     auto numFrames = divExZero(arraySize, static_cast<Idx>(blockThreadExtentMain) * elementsPerFrameItem);
-    auto dataBlocking = onHost::FrameSpec{numFrames, static_cast<Idx>(blockThreadExtentMain)};
+    auto dataBlocking = onHost::FrameSpec{numFrames, static_cast<Idx>(blockThreadExtentMain), exec};
 
     // To record runtime data generated while running the kernels
     RuntimeResults runtimeResults;
@@ -270,7 +270,6 @@ void testKernels(auto const deviceSpec, auto const exec)
         [&]()
         {
             queue.enqueue(
-                exec,
                 dataBlocking,
                 KernelBundle{SimdForEachKernel{}, SimdInitOp{}, bufAccInputA, bufAccInputB, bufAccOutputC});
         },
@@ -292,7 +291,6 @@ void testKernels(auto const deviceSpec, auto const exec)
                 [&]()
                 {
                     queue.enqueue(
-                        exec,
                         dataBlocking,
                         KernelBundle{SimdForEachKernel{}, SimdCopyOp{}, bufAccInputA, bufAccOutputC});
                 },
@@ -300,8 +298,7 @@ void testKernels(auto const deviceSpec, auto const exec)
 
             // Test the scaling-kernel. Calculate B=scalar*C. Where C = A.
             measureKernelExec(
-                [&]()
-                { queue.enqueue(exec, dataBlocking, SimdForEachKernel{}, SimdMultOp{}, bufAccInputB, bufAccOutputC); },
+                [&]() { queue.enqueue(dataBlocking, SimdForEachKernel{}, SimdMultOp{}, bufAccInputB, bufAccOutputC); },
                 "MultKernel");
 
             // Test the addition-kernel. Calculate C=A+B. Where B=scalar*C or B=scalar*A.
@@ -309,7 +306,6 @@ void testKernels(auto const deviceSpec, auto const exec)
                 [&]()
                 {
                     queue.enqueue(
-                        exec,
                         dataBlocking,
                         KernelBundle{SimdForEachKernel{}, SimdAddOp{}, bufAccInputA, bufAccInputB, bufAccOutputC});
                 },
@@ -323,7 +319,6 @@ void testKernels(auto const deviceSpec, auto const exec)
                 [&]()
                 {
                     queue.enqueue(
-                        exec,
                         dataBlocking,
                         KernelBundle{SimdForEachKernel{}, SimdTriadOp{}, bufAccInputA, bufAccInputB, bufAccOutputC});
                 },
@@ -362,7 +357,6 @@ void testKernels(auto const deviceSpec, auto const exec)
                 [&]()
                 {
                     queue.enqueue(
-                        exec,
                         dataBlocking,
                         KernelBundle{SimdForEachKernel{}, SimdNStreamOp{}, bufAccInputA, bufAccInputB, bufAccOutputC});
                 },

--- a/docs/snippets/cheatsheet/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet/cheatsheet.cpp
@@ -380,7 +380,8 @@ auto main() -> int
         {
             // BEGIN-CHEATSHEET-autoFrameSpec
             // DataType is used to optimize the kernel parameters for working on data of this type
-            onHost::concepts::FrameSpec auto frameSpec = onHost::getFrameSpec<DataType>(device, extentMd);
+            onHost::concepts::FrameSpec auto frameSpec
+                = onHost::getFrameSpec<DataType>(device, exec::anyExecutor, extentMd);
             // END-CHEATSHEET-autoFrameSpec
 
             unused(frameSpec);
@@ -400,7 +401,9 @@ auto main() -> int
                 queue.enqueue(frameSpec, KernelBundle{kernel, kernelArgs...});
                 // or use a specific executor
                 auto executor = exec::cpuSerial;
-                queue.enqueue(executor, frameSpec, KernelBundle{kernel, kernelArgs...});
+                queue.enqueue(
+                    onHost::FrameSpec{frameSpec.getNumFrames(), frameSpec.getFrameExtents(), executor},
+                    KernelBundle{kernel, kernelArgs...});
                 // END-CHEATSHEET-enqueueKernel
             };
             unused(foo);

--- a/docs/snippets/dataStorage/datastorage_writeable_datasource.cpp
+++ b/docs/snippets/dataStorage/datastorage_writeable_datasource.cpp
@@ -14,7 +14,8 @@ alpaka::Vec extents{111};
 alpaka::onHost::SharedBuffer in = alpaka::onHost::alloc<int>(dev, extents);
 alpaka::onHost::SharedBuffer out = alpaka::onHost::alloc<int>(dev, extents);
 
-alpaka::onHost::concepts::FrameSpec auto frameSpec = alpaka::onHost::getFrameSpec<int>(dev, extents);
+alpaka::onHost::concepts::FrameSpec auto frameSpec
+    = alpaka::onHost::getFrameSpec<int>(dev, alpaka::exec::anyExecutor, extents);
 
 // ===== End: main first part =====
 

--- a/docs/snippets/example/050_kernel.cpp
+++ b/docs/snippets/example/050_kernel.cpp
@@ -67,7 +67,8 @@ TEMPLATE_LIST_TEST_CASE("tutorial kernel intro vector add", "[docs]", docs::test
     /* Let alpaka calculate a well-functioning `frameSpec` for you.
      * This assumes that you are using `onAcc::makeIdxMap` in the kernel.
      */
-    onHost::concepts::FrameSpec auto frameSpec = onHost::getFrameSpec<int>(device, Vec{numElements});
+    onHost::concepts::FrameSpec auto frameSpec
+        = onHost::getFrameSpec<int>(device, exec::anyExecutor, Vec{numElements});
 
     /* Create a kernel object and enqueue it along with the `frameSpec´ and kernel arguments.
      * Depending on how many tasks are still in the queue, the kernel may be executed immediately or after a delay.

--- a/docs/snippets/example/080_multidim.cpp
+++ b/docs/snippets/example/080_multidim.cpp
@@ -65,7 +65,7 @@ TEMPLATE_LIST_TEST_CASE("tutorial multidimensional stencil kernel", "[docs]", do
     onHost::memset(queue, outBuffer, 0x00);
 
     // BEGIN-TUTORIAL-multidimFrameSpec
-    onHost::concepts::FrameSpec auto frameSpec = onHost::getFrameSpec<int>(device, problemExtents);
+    onHost::concepts::FrameSpec auto frameSpec = onHost::getFrameSpec<int>(device, exec::anyExecutor, problemExtents);
     // END-TUTORIAL-multidimFrameSpec
 
     // BEGIN-TUTORIAL-multidimKernelLaunch

--- a/docs/snippets/example/090_kernelParallelism.cpp
+++ b/docs/snippets/example/090_kernelParallelism.cpp
@@ -16,20 +16,20 @@ struct ImageTileHierarchyKernel
 {
     ALPAKA_FN_ACC void operator()(
         onAcc::concepts::Acc auto const& acc,
+        concepts::Vector auto const tileExtent,
         concepts::IDataSource auto const& input,
         concepts::IMdSpan auto mask,
         concepts::IMdSpan auto rowCounts,
         int threshold) const
     {
         auto const imageExtent = input.getExtents();
-        auto const tileExtent = acc[frame::extent];
 
-        for(auto blockStart :
+        for(auto tileStart :
             onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec{0u, 0u}, imageExtent, tileExtent}))
         {
             for(auto localIdx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{tileExtent}))
             {
-                auto globalIdx = blockStart + localIdx;
+                auto globalIdx = tileStart + localIdx;
                 if(globalIdx[0u] < imageExtent[0u] && globalIdx[1u] < imageExtent[1u])
                 {
                     mask[globalIdx] = input[globalIdx] >= threshold ? 1u : 0u;
@@ -39,7 +39,7 @@ struct ImageTileHierarchyKernel
             for(auto warpRow :
                 onAcc::makeIdxMap(acc, onAcc::worker::linearWarpsInBlock, onAcc::range::linearWarpsInBlock))
             {
-                auto rowStart = blockStart + Vec{warpRow.x(), 0u};
+                auto rowStart = tileStart + Vec{warpRow.x(), 0u};
                 if(rowStart[0u] >= imageExtent[0u] || warpRow.x() >= tileExtent[0u])
                 {
                     continue;
@@ -106,7 +106,9 @@ TEMPLATE_LIST_TEST_CASE("tutorial hierarchy blocks threads warps", "[docs]", doc
 
     // BEGIN-TUTORIAL-hierarchyLaunch
     onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{divExZero(imageExtent, tileExtent), tileExtent};
-    queue.enqueue(frameSpec, KernelBundle{ImageTileHierarchyKernel{}, inputBuffer, maskBuffer, rowCountsBuffer, 5});
+    queue.enqueue(
+        frameSpec,
+        KernelBundle{ImageTileHierarchyKernel{}, tileExtent, inputBuffer, maskBuffer, rowCountsBuffer, 5});
     // END-TUTORIAL-hierarchyLaunch
 
     onHost::memcpy(queue, hostMask, maskBuffer);
@@ -159,22 +161,20 @@ struct ChunkedVectorAddKernel
 {
     ALPAKA_FN_ACC void operator()(
         onAcc::concepts::Acc auto const& acc,
+        auto const linearNumFrames,
+        concepts::CVector auto const linearFrameExtent,
         concepts::IMdSpan auto out,
         concepts::IDataSource auto const& in0,
         concepts::IDataSource auto const& in1) const
     {
-        auto frameExtent = acc[frame::extent];
-        auto linearNumFrames = Vec{acc[frame::count].product()};
-        auto linearFrameExtent = Vec{frameExtent.product()};
-
         for(auto linearFrameIdx : onAcc::makeIdxMap(acc, onAcc::worker::linearBlocksInGrid, IdxRange{linearNumFrames}))
         {
-            auto tile = onAcc::declareSharedMdArray<int, uniqueId()>(acc, frameExtent);
+            auto tile = onAcc::declareSharedMdArray<int, uniqueId()>(acc, linearFrameExtent);
 
             for(auto linearFrameElem :
                 onAcc::makeIdxMap(acc, onAcc::worker::linearThreadsInBlock, IdxRange{linearFrameExtent}))
             {
-                auto globalIdx = linearFrameIdx * frameExtent + linearFrameElem;
+                auto globalIdx = linearFrameIdx * linearFrameExtent + linearFrameElem;
                 tile[linearFrameElem] = in0[globalIdx];
             }
 
@@ -183,7 +183,7 @@ struct ChunkedVectorAddKernel
             for(auto linearFrameElem :
                 onAcc::makeIdxMap(acc, onAcc::worker::linearThreadsInBlock, IdxRange{linearFrameExtent}))
             {
-                auto globalIdx = linearFrameIdx * frameExtent + linearFrameElem;
+                auto globalIdx = linearFrameIdx * linearFrameExtent + linearFrameElem;
                 out[globalIdx] = tile[linearFrameElem] + in1[globalIdx];
             }
 
@@ -221,7 +221,9 @@ TEMPLATE_LIST_TEST_CASE("tutorial chunked frames kernel", "[docs]", docs::test::
     auto numFrames = Vec{totalElems / frameElementCount};
     onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{numFrames, frameExtent};
 
-    queue.enqueue(frameSpec, KernelBundle{ChunkedVectorAddKernel{}, outBuffer, in0Buffer, in1Buffer});
+    queue.enqueue(
+        frameSpec,
+        KernelBundle{ChunkedVectorAddKernel{}, numFrames.product(), frameExtent, outBuffer, in0Buffer, in1Buffer});
     // END-TUTORIAL-chunkedLaunch
 
     onHost::memcpy(queue, hostOut, outBuffer);

--- a/docs/snippets/example/110_synchronization.cpp
+++ b/docs/snippets/example/110_synchronization.cpp
@@ -20,10 +20,10 @@ struct NeighborReuseKernel
     ALPAKA_FN_ACC void operator()(
         onAcc::concepts::Acc auto const& acc,
         concepts::IMdSpan auto out,
-        concepts::IDataSource auto const& in) const
+        concepts::IDataSource auto const& in,
+        concepts::CVector auto chunkExtents) const
     {
-        auto const chunkExtent = acc[frame::extent];
-        auto chunk = onAcc::declareSharedMdArray<int, uniqueId()>(acc, acc[frame::extent]);
+        auto chunk = onAcc::declareSharedMdArray<int, uniqueId()>(acc, chunkExtents);
 
         /* Iterate in chunks over the output data.
          * It is assumed that the input data have at least the extents of the output.
@@ -31,17 +31,17 @@ struct NeighborReuseKernel
         for(auto chunkOffset : onAcc::makeIdxMap(
                 acc,
                 onAcc::worker::blocksInGrid,
-                IdxRange{Vec{0u}, static_cast<uint32_t>(out.getExtents().x()), chunkExtent}))
+                IdxRange{Vec{0u}, static_cast<uint32_t>(out.getExtents().x()), chunkExtents}))
         {
             // fill the shared data chunk
-            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtents}))
                 chunk[idx] = in[chunkOffset + idx];
 
             onAcc::syncBlockThreads(acc);
 
-            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtents}))
             {
-                auto neighborIdx = (idx.x() + 1u) % chunkExtent;
+                auto neighborIdx = (idx.x() + 1u) % chunkExtents;
                 out[chunkOffset + idx] = chunk[idx] + chunk[neighborIdx];
             }
 
@@ -73,9 +73,10 @@ TEMPLATE_LIST_TEST_CASE("tutorial in-kernel synchronization", "[docs]", docs::te
 
     // BEGIN-TUTORIAL-syncLaunch
     constexpr uint32_t chunkSize = 8u;
+    auto chunkExtents = CVec<uint32_t, chunkSize>{};
     onHost::concepts::FrameSpec auto frameSpec
-        = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), CVec<uint32_t, chunkSize>{}};
-    queue.enqueue(frameSpec, KernelBundle{NeighborReuseKernel{}, outputBuffer, inputBuffer});
+        = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), chunkExtents};
+    queue.enqueue(frameSpec, KernelBundle{NeighborReuseKernel{}, outputBuffer, inputBuffer, chunkExtents});
     // END-TUTORIAL-syncLaunch
 
     onHost::memcpy(queue, hostOutput, outputBuffer);

--- a/docs/snippets/example/120_sharedMemory.cpp
+++ b/docs/snippets/example/120_sharedMemory.cpp
@@ -52,7 +52,7 @@ struct BlockSumKernel
 // END-TUTORIAL-sharedScalarKernel
 
 // BEGIN-TUTORIAL-sharedKernel
-struct ReverseFrameKernel
+struct ReverseChunkKernel
 {
     ALPAKA_FN_ACC void operator()(
         onAcc::concepts::Acc auto const& acc,
@@ -222,7 +222,7 @@ TEMPLATE_LIST_TEST_CASE("tutorial shared memory chunk", "[docs]", docs::test::Te
     auto chunkExtents = CVec<uint32_t, chunkSize>{};
     onHost::concepts::FrameSpec auto frameSpec
         = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), frameExtents};
-    queue.enqueue(frameSpec, KernelBundle{ReverseFrameKernel{}, outputBuffer, inputBuffer, chunkExtents});
+    queue.enqueue(frameSpec, KernelBundle{ReverseChunkKernel{}, outputBuffer, inputBuffer, chunkExtents});
     // END-TUTORIAL-sharedLaunch
 
     onHost::memcpy(queue, hostOutput, outputBuffer);

--- a/docs/snippets/example/120_sharedMemory.cpp
+++ b/docs/snippets/example/120_sharedMemory.cpp
@@ -57,13 +57,13 @@ struct ReverseFrameKernel
     ALPAKA_FN_ACC void operator()(
         onAcc::concepts::Acc auto const& acc,
         concepts::IMdSpan auto out,
-        concepts::IDataSource auto const& in) const
+        concepts::IDataSource auto const& in,
+        concepts::CVector auto chunkExtents) const
     {
-        auto const chunkExtent = acc[frame::extent];
         /* Each shared memory declaration is required to have a unique id.
          * Use the preprocessor macro `__COUNTER__` or `alpaka::uniqueId()`.
          */
-        auto chunk = onAcc::declareSharedMdArray<int, uniqueId()>(acc, chunkExtent);
+        auto chunk = onAcc::declareSharedMdArray<int, uniqueId()>(acc, chunkExtents);
 
         /* Iterate in chunks over the output data.
          * It is assumed that the input data have at least the extents of the output.
@@ -71,18 +71,18 @@ struct ReverseFrameKernel
         for(auto chunkOffset : onAcc::makeIdxMap(
                 acc,
                 onAcc::worker::blocksInGrid,
-                IdxRange{Vec{0u}, static_cast<uint32_t>(out.getExtents().x()), chunkExtent}))
+                IdxRange{Vec{0u}, static_cast<uint32_t>(out.getExtents().x()), chunkExtents}))
         {
             // initialize the shared chunk
-            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtents}))
                 chunk[idx] = in[chunkOffset + idx];
 
             onAcc::syncBlockThreads(acc);
 
             // each thread is flushing to the output
-            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtents}))
             {
-                auto reverseIdx = Vec{chunkExtent - 1u - idx.x()};
+                auto reverseIdx = Vec{chunkExtents - 1u - idx.x()};
                 out[chunkOffset + idx] = chunk[reverseIdx];
             }
 
@@ -102,10 +102,10 @@ struct DynamicReverseKernel
     ALPAKA_FN_ACC void operator()(
         onAcc::concepts::Acc auto const& acc,
         concepts::IMdSpan auto out,
-        concepts::IDataSource auto const& in) const
+        concepts::IDataSource auto const& in,
+        uint32_t chunkSize) const
     {
         auto* chunk = onAcc::getDynSharedMem<int>(acc);
-        auto const chunkExtent = acc[frame::extent];
 
         /* Iterate in chunks over the output data.
          * It is assumed that the input data have at least the extents of the output.
@@ -113,18 +113,18 @@ struct DynamicReverseKernel
         for(auto chunkOffset : onAcc::makeIdxMap(
                 acc,
                 onAcc::worker::blocksInGrid,
-                IdxRange{Vec{0u}, static_cast<uint32_t>(out.getExtents().x()), chunkExtent}))
+                IdxRange{Vec{0u}, static_cast<uint32_t>(out.getExtents().x()), chunkSize}))
         {
             // initialize the shared chunk
-            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
                 chunk[idx.x()] = in[chunkOffset + idx];
 
             onAcc::syncBlockThreads(acc);
 
             // each thread is flushing to the output
-            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtent}))
+            for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
             {
-                auto reverseIdx = acc[frame::extent].x() - 1u - idx.x();
+                auto reverseIdx = chunkSize - 1u - idx.x();
                 out[chunkOffset + idx] = chunk[reverseIdx];
             }
 
@@ -216,10 +216,13 @@ TEMPLATE_LIST_TEST_CASE("tutorial shared memory chunk", "[docs]", docs::test::Te
     onHost::memcpy(queue, inputBuffer, hostInput);
 
     // BEGIN-TUTORIAL-sharedLaunch
-    constexpr uint32_t chunkSize = 8u;
+    constexpr uint32_t frameExtents = 4u;
+    // Use a larger chunk size than the frame extent to guarantee each thread is calculating at least two values.
+    constexpr uint32_t chunkSize = frameExtents * 2u;
+    auto chunkExtents = CVec<uint32_t, chunkSize>{};
     onHost::concepts::FrameSpec auto frameSpec
-        = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), CVec<uint32_t, chunkSize>{}};
-    queue.enqueue(frameSpec, KernelBundle{ReverseFrameKernel{}, outputBuffer, inputBuffer});
+        = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), frameExtents};
+    queue.enqueue(frameSpec, KernelBundle{ReverseFrameKernel{}, outputBuffer, inputBuffer, chunkExtents});
     // END-TUTORIAL-sharedLaunch
 
     onHost::memcpy(queue, hostOutput, outputBuffer);
@@ -248,8 +251,7 @@ TEMPLATE_LIST_TEST_CASE("tutorial shared memory scalar value", "[docs]", docs::t
     onHost::memcpy(queue, inputBuffer, hostInput);
 
     constexpr uint32_t chunkSize = 8u;
-    onHost::concepts::FrameSpec auto frameSpec
-        = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), CVec<uint32_t, chunkSize>{}};
+    onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), chunkSize};
     queue.enqueue(frameSpec, KernelBundle{BlockSumKernel{}, outputBuffer, inputBuffer});
 
     onHost::wait(queue);
@@ -277,11 +279,18 @@ TEMPLATE_LIST_TEST_CASE("tutorial dynamic shared memory via member", "[docs]", d
     onHost::memcpy(queue, inputBuffer, hostInput);
 
     // BEGIN-TUTORIAL-dynSharedMemberLaunch
-    uint32_t chunkSize = 8u;
-    onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), chunkSize};
+    uint32_t frameExtents = 4u;
+    // Use a larger chunk size than the frame extent to guarantee each thread is calculating at least two values.
+    uint32_t chunkSize = frameExtents * 2u;
+    onHost::concepts::FrameSpec auto frameSpec
+        = onHost::FrameSpec{alpaka::divCeil(dataExtent, chunkSize), frameExtents};
     queue.enqueue(
         frameSpec,
-        KernelBundle{DynamicReverseKernel{static_cast<uint32_t>(chunkSize * sizeof(int))}, outputBuffer, inputBuffer});
+        KernelBundle{
+            DynamicReverseKernel{static_cast<uint32_t>(chunkSize * sizeof(int))},
+            outputBuffer,
+            inputBuffer,
+            chunkSize});
     // END-TUTORIAL-dynSharedMemberLaunch
 
     onHost::memcpy(queue, hostOutput, outputBuffer);

--- a/docs/snippets/example/20_simdKernel.cpp
+++ b/docs/snippets/example/20_simdKernel.cpp
@@ -83,13 +83,12 @@ TEST_CASE("MD vector simd add kernel", "[docs]")
     concepts::Vector auto numFrames
         = divExZero(computeBufferOut.getExtents(), frameExtents * frameExtents.fill(1).rAssign(elementsPerFrameItem));
     // The frame specification is not required to be a multiple of the extent, it can be smaller.
-    auto frameSpec = onHost::FrameSpec{numFrames, frameExtents};
+    auto frameSpec = onHost::FrameSpec{numFrames, frameExtents, exec::cpuSerial};
     std::cout << frameSpec << std::endl;
     onHost::wait(computeQueue);
     auto const beginT = std::chrono::high_resolution_clock::now();
     // we enforce serial execution because this executor is always available deviceKind::cpu and api::host
     computeQueue.enqueue(
-        exec::cpuSerial,
         frameSpec,
         KernelBundle{MDVectorSimdAdd{}, computeBufferOut, computeBufferIn0, computeBufferIn1});
     onHost::wait(computeQueue);

--- a/docs/source/tutorial/kernelParallelism.rst
+++ b/docs/source/tutorial/kernelParallelism.rst
@@ -56,8 +56,6 @@ Here frames stop being just a launch shape and become reusable tiles of work.
 
 There are a few moving parts in this pattern:
 
-- ``acc[frame::extent]`` is the current frame shape.
-- ``acc[frame::count]`` tells you how many frames exist.
 - ``linearBlocksInGrid`` lets blocks iterate over frames.
 - ``linearThreadsInBlock`` lets threads iterate over elements inside one frame.
 

--- a/docs/source/tutorial/sharedMemory.rst
+++ b/docs/source/tutorial/sharedMemory.rst
@@ -39,8 +39,8 @@ Static Shared Memory Array
 
 The next example is showing a chunk-wise permutation of the indices.
 For each chunk the id's should be stored in reverse order into the output.
-The frame extent from the kernel launch parameters will be re-used as chunk extents.
-The frame extent is a `CVec` and therefore known at compile time, this allows its usage as extents to declare static shared memory.
+The frame extent from the kernel launch parameters and the chunk extents are not required to match.
+The chunks extent is a `CVec` and therefore known at compile time, this allows its usage as extents to declare static shared memory.
 Static shared memory compared to dynamic shared memory, shown in the next example,
 has the benefits that the developer is not required to manage the shared memory chunk by hand and in case it is multidimensional it provides address calculations optimizations.
 
@@ -66,15 +66,13 @@ Launching a Shared-Memory Kernel
     :end-before: END-TUTORIAL-sharedLaunch
     :dedent:
 
-As mentioned before ``CVec`` for the frame extent is required to allow the reuse of the frame extents within the kernel to allocate the static shared memory chunk.
-
 Dynamic Shared Memory
 ---------------------
 
 Dynamic shared memory is useful when the amount of shared memory depends on kernel launch parameters or the kernel arguments.
 In alpaka it will be automatically allocated indirectly for each thread block before kernel invocation.
 Again the chunk-wise index reverse example is used.
-The difference to the example before is that the frame extent is now a runtime value and to get the shared memory within the kernel ``onAcc::getDynSharedMem<T>(acc)`` is used.
+The difference to the example before is that the chunk extent is now a runtime value and to get the shared memory within the kernel ``onAcc::getDynSharedMem<T>(acc)`` is used.
 You will only get a flat pointer to the allocated data without any information about how many values are valid.
 The developer is responsible that the number of allocated bytes at kernel launch time and used within a kernel match.
 
@@ -106,7 +104,8 @@ Dynamic Size Through ``BlockDynSharedMemBytes`` Trait
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When the size should depend on the executor or the kernel arguments, alpaka uses a trait specialization.
-It is not possible to access the frame specification in the trait, therefore this example is using a user-defined data chunk size passed through the kernel arguments.
+The user-defined data chunk size passed through the kernel arguments is used to calculate the required amount of shared memory to hold a single chunk per thread block.
+The required data to hold a chunk is intended to be independent of the thread specification to control the amount of reused data.
 If you provide neither a ``dynSharedMemBytes`` member nor a trait implementation ``alpaka::onHost::trait::BlockDynSharedMemBytes`` specialization, alpaka reserves no dynamic shared memory for that kernel.
 
   .. literalinclude:: ../../snippets/example/120_sharedMemory.cpp

--- a/docs/source/tutorial/sharedMemory.rst
+++ b/docs/source/tutorial/sharedMemory.rst
@@ -40,7 +40,7 @@ Static Shared Memory Array
 The next example is showing a chunk-wise permutation of the indices.
 For each chunk the id's should be stored in reverse order into the output.
 The frame extent from the kernel launch parameters and the chunk extents are not required to match.
-The chunks extent is a `CVec` and therefore known at compile time, this allows its usage as extents to declare static shared memory.
+The chunks extent is a ``CVec`` and therefore known at compile time, this allows its usage as extents to declare static shared memory.
 Static shared memory compared to dynamic shared memory, shown in the next example,
 has the benefits that the developer is not required to manage the shared memory chunk by hand and in case it is multidimensional it provides address calculations optimizations.
 

--- a/docs/source/tutorial/synchronization.rst
+++ b/docs/source/tutorial/synchronization.rst
@@ -21,7 +21,7 @@ If you only need memory ordering without a blocking thread barrier, check :doc:`
 Chunk Reuse Example
 -------------------
 
-The next kernel loads one frame as data chunk into thread block-local shared memory, synchronizes the block, and then lets every thread read
+The next kernel loads one data chunk into thread block-local shared memory, synchronizes the block, and then lets every thread read
 its own value together with the next neighbor.
 The key idea is the reuse pattern: one phase fills the chunk, the next phase consumes it.
 Without the synchronization point, those neighbor reads could race with threads that are still writing the chunk.
@@ -31,8 +31,6 @@ Without the synchronization point, those neighbor reads could race with threads 
     :start-after: BEGIN-TUTORIAL-syncKernel
     :end-before: END-TUTORIAL-syncKernel
     :dedent:
-
-Launching the kernel the :ref:`Frame extent <frame>` will be used as user defined chunking, therefore the launch shape is influencing the in kernel data reuse pattern.
 
 Practical Advice
 ----------------

--- a/example/boundaryIter/src/boundaryIter.cpp
+++ b/example/boundaryIter/src/boundaryIter.cpp
@@ -83,7 +83,7 @@ int example(auto const devSpec, auto const computeExec)
     }
 
     auto chunkSize = alpaka::fillCVec<IdxType, Dimensions, 2>();
-    auto frameSpec = onHost::FrameSpec{divCeil(size, chunkSize), chunkSize};
+    auto frameSpec = onHost::FrameSpec{divCeil(size, chunkSize), chunkSize, computeExec};
 
     auto exampleKernel = BoundaryExampleKernel{};
 
@@ -99,7 +99,7 @@ int example(auto const devSpec, auto const computeExec)
         }
 
         auto const bd = makeCoreBoundaryDirection<Dimensions>();
-        blockingQueue.enqueue(computeExec, frameSpec, KernelBundle{exampleKernel, view, viewTarget, bd});
+        blockingQueue.enqueue(frameSpec, KernelBundle{exampleKernel, view, viewTarget, bd});
     }
 
     {
@@ -125,7 +125,7 @@ int example(auto const devSpec, auto const computeExec)
         }
 
         auto const bd = makeCoreBoundaryDirection<Dimensions>(halo);
-        blockingQueue.enqueue(computeExec, frameSpec, KernelBundle{exampleKernel, view, viewTarget, bd});
+        blockingQueue.enqueue(frameSpec, KernelBundle{exampleKernel, view, viewTarget, bd});
     }
 
     {
@@ -142,7 +142,7 @@ int example(auto const devSpec, auto const computeExec)
         }
 
         auto const bd = makeCoreBoundaryDirection<Dimensions>(lowerHalo, upperHalo);
-        blockingQueue.enqueue(computeExec, frameSpec, KernelBundle{exampleKernel, view, viewTarget, bd});
+        blockingQueue.enqueue(frameSpec, KernelBundle{exampleKernel, view, viewTarget, bd});
     }
 
     return EXIT_SUCCESS;

--- a/example/grayScale/src/grayScale.cpp
+++ b/example/grayScale/src/grayScale.cpp
@@ -203,7 +203,7 @@ auto example(T_Cfg const& cfg, size_t numElements, size_t numberOfRuns, bool ena
     // Define frameExtent
     Vec<size_t, 1u> frameExtent = 256u;
     uint32_t elementsPerWorker = getNumElemPerThread<Data>(queue);
-    auto dataBlocking = onHost::FrameSpec{divCeil(extent, frameExtent * elementsPerWorker), frameExtent};
+    auto dataBlocking = onHost::FrameSpec{divCeil(extent, frameExtent * elementsPerWorker), frameExtent, exec};
 
     std::cout << "Using alpaka accelerator: " << onHost::demangledName(exec) << " for "
               << deviceSpec.getApi().getName() << std::endl;
@@ -218,7 +218,7 @@ auto example(T_Cfg const& cfg, size_t numElements, size_t numberOfRuns, bool ena
         onHost::wait(queue);
 
         auto const beginKernelT = std::chrono::high_resolution_clock::now();
-        queue.enqueue(exec, dataBlocking, KernelBundle{kernel, bufAccARGB, static_cast<size_t>(extent[0])});
+        queue.enqueue(dataBlocking, KernelBundle{kernel, bufAccARGB, static_cast<size_t>(extent[0])});
         onHost::wait(queue);
         auto const endKernelT = std::chrono::high_resolution_clock::now();
         double const kernelRuntime = std::chrono::duration<double>(endKernelT - beginKernelT).count();

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -152,11 +152,11 @@ namespace alpaka::example::heatEquation
         StencilKernel stencilKernel;
         BoundaryKernel boundaryKernel;
 
-        auto const dataBlockingStencil = FrameSpec{numChunks, chunkSize};
+        auto const dataBlockingStencil = FrameSpec{numChunks, chunkSize, computeExec};
 
         auto const longestSide = std::max(numNodesWithHalo.y(), numNodesWithHalo.x());
         auto const dataBlockingBorder
-            = FrameSpec{Vec{longestSide / chunkSize.x()}, Vec{std::max(chunkSize.y(), chunkSize.x())}};
+            = FrameSpec{Vec{longestSide / chunkSize.x()}, Vec{std::max(chunkSize.y(), chunkSize.x())}, computeExec};
 
         auto const startTime = std::chrono::high_resolution_clock::now();
 
@@ -165,7 +165,6 @@ namespace alpaka::example::heatEquation
         {
             // Compute next values
             computeQueue.enqueue(
-                computeExec,
                 dataBlockingStencil,
                 KernelBundle{
                     stencilKernel,
@@ -179,7 +178,6 @@ namespace alpaka::example::heatEquation
                     dt});
 
             computeQueue.enqueue(
-                computeExec,
                 dataBlockingBorder,
                 KernelBundle{boundaryKernel, uNextBufAcc.getMdSpan(), numNodesWithHalo, step, dx, dy, dt});
 

--- a/example/nBody/src/nBody.cpp
+++ b/example/nBody/src/nBody.cpp
@@ -176,7 +176,7 @@ namespace alpaka::example::nBody
 
         // The frame spec describes the logical parallelism exposed to the kernel, not the exact mapping on the threads
         // and the blocks of the backend.
-        auto const frameSpec = FrameSpec{numChunks, chunkSize};
+        auto const frameSpec = FrameSpec{numChunks, chunkSize, computeExec};
 
         // Make an instance of the kernel object to use later
         UpdateVelocitiesKernel updateVelocitiesKernel;
@@ -190,15 +190,11 @@ namespace alpaka::example::nBody
             // Queue one step of the simulation
             // The kernel bundle contains the kernel first, then all its arguments *except* the accelerator, which is
             // implicitly passed by alpaka.
-            computeQueue.enqueue(
-                computeExec,
-                frameSpec,
-                KernelBundle{updateVelocitiesKernel, particleData, chunkSize, dt});
+            computeQueue.enqueue(frameSpec, KernelBundle{updateVelocitiesKernel, particleData, chunkSize, dt});
 
             // execute velocity updates using simd concurrency
             onHost::concurrent<BaseType>(
                 computeQueue,
-                computeExec,
                 particleData.xPositions.getExtents(),
                 updatePositionsKernel,
                 particleData.xPositions,

--- a/example/randomInit/src/randomInit.cpp
+++ b/example/randomInit/src/randomInit.cpp
@@ -61,13 +61,10 @@ struct RandomInitKernelUniform
     //! @param size is the number of elements to process
     ALPAKA_FN_ACC void operator()(auto const& acc, auto outBins, uint32_t size) const
     {
-        // Calculate total number of elements across all frames
-        auto totalFrameExtens = acc[alpaka::frame::count] * acc[alpaka::frame::extent];
-
         // printf("Total number of elements: %u\n", totalFrameExtens);
-        //  Iterate over the global range of frame elements
+        //  Each thread is generating it's own seed
         for(auto [seed] :
-            alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{totalFrameExtens}))
+            alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::onAcc::range::threadsInGrid))
         // Initialize the Philox engine with the global frame element ID as the seed
         {
             // Philox generates uniform integer random numbers
@@ -75,7 +72,9 @@ struct RandomInitKernelUniform
 
             auto seedVec = alpaka::Vec{static_cast<uint32_t>(seed)};
             // Define workgroup
-            auto workGroup = alpaka::onAcc::WorkerGroup{seedVec, totalFrameExtens};
+            constexpr auto tInGrid = alpaka::onAcc::range::threadsInGrid;
+            auto numThreadGroups = tInGrid.getIdxRange(acc).distance();
+            auto workGroup = alpaka::onAcc::WorkerGroup{seedVec, numThreadGroups};
 
             // Iterate over the workgroup
             for([[maybe_unused]] auto [index] : alpaka::onAcc::makeIdxMap(acc, workGroup, alpaka::IdxRange{size}))
@@ -108,19 +107,18 @@ struct RandomInitKernel
     //! @param size is the number of elements to process
     ALPAKA_FN_ACC void operator()(auto const& acc, auto outBins, uint32_t size) const
     {
-        // Calculate total number of elements across all frames
-        auto totalFrameExtens = acc[alpaka::frame::count] * acc[alpaka::frame::extent];
-
-        // Iterate over the global range of frame elements
+        //  Each thread is generating it's own seed
         for(auto [seed] :
-            alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{totalFrameExtens}))
+            alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::onAcc::range::threadsInGrid))
         // Initialize the Philox engine with the global frame element ID as the seed
         {
             alpaka::rand::engine::Philox4x32x10 engine(static_cast<uint32_t>(seed));
 
             auto seedVec = alpaka::Vec{static_cast<uint32_t>(seed)};
             // Define workgroup
-            auto workGroup = alpaka::onAcc::WorkerGroup{seedVec, totalFrameExtens};
+            constexpr auto tInGrid = alpaka::onAcc::range::threadsInGrid;
+            auto numThreadGroups = tInGrid.getIdxRange(acc).distance();
+            auto workGroup = alpaka::onAcc::WorkerGroup{seedVec, numThreadGroups};
 
 
             // Iterate over the workgroup
@@ -207,11 +205,11 @@ bool testRandomInitKernels(
     // Frame size
 
     // Launch the 1-dimensional kernel with scalar size
-    auto frameSpec = alpaka::onHost::getFrameSpec<T_Data>(device, alpaka::Vec{blockSize});
+    auto frameSpec = alpaka::onHost::getFrameSpec<T_Data>(device, computeExec, alpaka::Vec{blockSize});
 
     // TEST - 1: Philox Generator generates integer random numbers
     std::cout << "- Testing RandomInitKernel with a grid of " << frameSpec << "\n";
-    queue.enqueue(computeExec, frameSpec, RandomInitKernel{}, outBins_d.getMdSpan(), size);
+    queue.enqueue(frameSpec, RandomInitKernel{}, outBins_d.getMdSpan(), size);
 
     // Copy the results from the device to the host
     alpaka::onHost::memcpy(queue, outBins_h, outBins_d);
@@ -257,7 +255,7 @@ bool testRandomInitKernels(
     alpaka::onHost::memcpy(queue, outBins_d, outBins_h);
 
     std::cout << "- Testing RandomInitKernelUniform with a grid of " << frameSpec << "\n";
-    queue.enqueue(computeExec, frameSpec, RandomInitKernelUniform{}, outBins_d.getMdSpan(), size);
+    queue.enqueue(frameSpec, RandomInitKernelUniform{}, outBins_d.getMdSpan(), size);
 
     // Wait for all the operations to complete
     alpaka::onHost::wait(queue);
@@ -285,7 +283,7 @@ bool testRandomInitKernels(
     alpaka::onHost::memcpy(queue, outBins_d, outBins_h);
 
     std::cout << "- Testing RandomInitKernelVec with a grid of " << frameSpec << "\n";
-    queue.enqueue(computeExec, frameSpec, RandomInitKernelVec{}, outBins_d.getMdSpan(), size);
+    queue.enqueue(frameSpec, RandomInitKernelVec{}, outBins_d.getMdSpan(), size);
 
     // Wait for all the operations to complete
     alpaka::onHost::wait(queue);

--- a/example/randomInit/src/randomInitNormal.hpp
+++ b/example/randomInit/src/randomInitNormal.hpp
@@ -26,14 +26,16 @@ struct RandomInitKernelNormal
     //! @param stdDev   standard deviation
     ALPAKA_FN_ACC void operator()(auto const& acc, auto outArray, auto mean, auto stdDev) const
     {
-        auto totalFrameExtents = acc[alpaka::frame::count] * acc[alpaka::frame::extent];
-
+        //  Each thread is generating it's own seed
         for(auto [seed] :
-            alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::IdxRange{totalFrameExtents}))
+            alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInGrid, alpaka::onAcc::range::threadsInGrid))
         {
             alpaka::rand::engine::Philox4x32x10 engine(static_cast<uint32_t>(seed));
             auto seedVec = alpaka::Vec{static_cast<uint32_t>(seed)};
-            auto workGroup = alpaka::onAcc::WorkerGroup{seedVec, totalFrameExtents};
+            // Define workgroup
+            constexpr auto tInGrid = alpaka::onAcc::range::threadsInGrid;
+            auto numThreadGroups = tInGrid.getIdxRange(acc).distance();
+            auto workGroup = alpaka::onAcc::WorkerGroup{seedVec, numThreadGroups};
 
             // Normal distribution with parameters
             alpaka::rand::distribution::NormalReal normalDist(mean, stdDev);
@@ -136,12 +138,12 @@ int exampleDispatch(auto const cfg, uint32_t numElements, auto const& mean, auto
     // Allocate output host and device buffers
     auto outArray_h = onHost::alloc<T_Data>(host, numElements);
     auto outArray_d = onHost::allocLike(device, outArray_h);
-    auto frameSpec = onHost::getFrameSpec<T_Data>(device, Vec{blockSizeNormal});
+    auto frameSpec = onHost::getFrameSpec<T_Data>(device, computeExec, Vec{blockSizeNormal});
 
     onHost::Queue queue = device.makeQueue();
 
     std::cout << "- Testing RandomInitKernelNormal with a grid of " << frameSpec << "\n";
-    queue.enqueue(computeExec, frameSpec, RandomInitKernelNormal{}, outArray_d.getMdSpan(), mean, stdDev);
+    queue.enqueue(frameSpec, RandomInitKernelNormal{}, outArray_d.getMdSpan(), mean, stdDev);
 
     onHost::wait(queue);
     onHost::memcpy(queue, outArray_h, outArray_d);

--- a/example/scan/src/scan.hpp
+++ b/example/scan/src/scan.hpp
@@ -47,15 +47,15 @@ namespace alpaka::example::scan
     public:
         ALPAKA_FN_ACC void operator()(
             auto const& acc,
+            concepts::Vector auto const numChunks,
+            concepts::CVector auto const chunkExtents,
             concepts::IDataSource auto const& inputVec,
             concepts::IMdSpan auto outputVec,
             auto... blockSums) const
         {
             using DeviceType = ALPAKA_TYPEOF(acc.getDeviceKind());
-            concepts::Vector auto numFrames = acc[frame::count];
 
-            concepts::CVector auto _ = acc[frame::extent];
-            concepts::CVector auto frameExtent = CVec<IdxType, elsPerThread * _.x()>{};
+            concepts::CVector auto largeChunkExtents = CVec<IdxType, elsPerThread * chunkExtents.x()>{};
             concepts::Vector auto numElements = inputVec.getExtents();
 
             /* This kernel is called with 1-dimensional frame extents.
@@ -63,34 +63,35 @@ namespace alpaka::example::scan
              * All thread blocks will be used to iterate over the frames. Each thread block will handle one or more
              * frames.
              */
-            for(auto frameIdx :
-                onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec<IdxType, 1u>{0}, numFrames}))
+            for(auto chunkIdx :
+                onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec<IdxType, 1u>{0}, numChunks}))
             {
                 auto tmp = onAcc::declareSharedMdArray<Data, uniqueId()>(
                     acc,
-                    CVec<IdxType, conflictFreeAccess<DeviceType>(frameExtent.x())>{});
-                auto const frameOffset = frameExtent * frameIdx;
+                    CVec<IdxType, conflictFreeAccess<DeviceType>(largeChunkExtents.x())>{});
+                auto const chunkOffset = largeChunkExtents * chunkIdx;
 
                 // -- COPY TO SHARED MEM --
-                for(auto frameElem : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{frameExtent}))
+                for(auto idxInChunk :
+                    onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{largeChunkExtents}))
                 {
-                    if(frameOffset + frameElem < numElements)
-                        tmp[conflictFreeAccess<DeviceType>(frameElem)] = inputVec[frameOffset + frameElem];
+                    if(chunkOffset + idxInChunk < numElements)
+                        tmp[conflictFreeAccess<DeviceType>(idxInChunk)] = inputVec[chunkOffset + idxInChunk];
                     else
-                        tmp[conflictFreeAccess<DeviceType>(frameElem)] = 0;
+                        tmp[conflictFreeAccess<DeviceType>(idxInChunk)] = 0;
                 }
 
                 // -- UP-SWEEP / REDUCE --
-                for(IdxType d = frameExtent.x() / 2_idx, offset = 1_idx; d > 0; d >>= 1, offset <<= 1)
+                for(IdxType d = largeChunkExtents.x() / 2_idx, offset = 1_idx; d > 0; d >>= 1, offset <<= 1)
                 {
                     onAcc::syncBlockThreads(acc);
-                    for(auto frameElem : onAcc::makeIdxMap(
+                    for(auto idxInChunk : onAcc::makeIdxMap(
                             acc,
                             onAcc::worker::threadsInBlock,
                             IdxRange{CVec<IdxType, 0>{}, Vec<IdxType, 1>{2_idx * d}, 2_idx}))
                     {
-                        IdxType left = offset * (frameElem + 1_idx).x() - 1_idx;
-                        IdxType right = offset * (frameElem + 2_idx).x() - 1_idx;
+                        IdxType left = offset * (idxInChunk + 1_idx).x() - 1_idx;
+                        IdxType right = offset * (idxInChunk + 2_idx).x() - 1_idx;
                         left = conflictFreeAccess<DeviceType>(left);
                         right = conflictFreeAccess<DeviceType>(right);
                         tmp[right] += tmp[left];
@@ -98,31 +99,32 @@ namespace alpaka::example::scan
                 }
                 onAcc::syncBlockThreads(acc);
 
-                for([[maybe_unused]] auto frameElem :
+                for([[maybe_unused]] auto idxInChunk :
                     onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{1}))
                 {
                     // -- SAVE BLOCK SUMS --
                     if constexpr(sizeof...(blockSums))
                     {
                         auto _blockSums = std::get<0>(std::make_tuple(blockSums...));
-                        _blockSums[frameIdx] = tmp[conflictFreeAccess<DeviceType>(frameExtent - 1_idx)];
+                        _blockSums[chunkIdx] = tmp[conflictFreeAccess<DeviceType>(largeChunkExtents - 1_idx)];
                     }
 
                     // -- SET 0 --
-                    tmp[conflictFreeAccess<DeviceType>(frameExtent - 1_idx)] = 0;
+                    tmp[conflictFreeAccess<DeviceType>(largeChunkExtents - 1_idx)] = 0;
                 }
 
                 // -- DOWN-SWEEP --
-                for(IdxType d = 1, offset = frameExtent.x() / 2_idx; d < frameExtent; d <<= 1, offset >>= 1)
+                for(IdxType d = 1, offset = largeChunkExtents.x() / 2_idx; d < largeChunkExtents;
+                    d <<= 1, offset >>= 1)
                 {
                     onAcc::syncBlockThreads(acc);
-                    for(auto frameElem : onAcc::makeIdxMap(
+                    for(auto idxInChunk : onAcc::makeIdxMap(
                             acc,
                             onAcc::worker::threadsInBlock,
                             IdxRange{CVec<IdxType, 0>{}, Vec<IdxType, 1>{2_idx * d}, 2_idx}))
                     {
-                        IdxType left = offset * (frameElem.x() + 1_idx) - 1_idx;
-                        IdxType right = offset * (frameElem.x() + 2_idx) - 1_idx;
+                        IdxType left = offset * (idxInChunk.x() + 1_idx) - 1_idx;
+                        IdxType right = offset * (idxInChunk.x() + 2_idx) - 1_idx;
                         left = conflictFreeAccess<DeviceType>(left);
                         right = conflictFreeAccess<DeviceType>(right);
                         auto t = tmp[left];
@@ -133,15 +135,16 @@ namespace alpaka::example::scan
                 onAcc::syncBlockThreads(acc);
 
                 // -- WRITE BACK --
-                for(auto frameElem : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{frameExtent}))
+                for(auto idxInChunk :
+                    onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{largeChunkExtents}))
                 {
-                    if(frameOffset + frameElem < numElements)
+                    if(chunkOffset + idxInChunk < numElements)
                     {
                         if constexpr(SCAN_TYPE == EXCLUSIVE_SCAN)
-                            outputVec[frameOffset + frameElem] = tmp[conflictFreeAccess<DeviceType>(frameElem)];
+                            outputVec[chunkOffset + idxInChunk] = tmp[conflictFreeAccess<DeviceType>(idxInChunk)];
                         else if constexpr(SCAN_TYPE == INCLUSIVE_SCAN)
-                            outputVec[frameOffset + frameElem]
-                                = inputVec[frameOffset + frameElem] + tmp[conflictFreeAccess<DeviceType>(frameElem)];
+                            outputVec[chunkOffset + idxInChunk]
+                                = inputVec[chunkOffset + idxInChunk] + tmp[conflictFreeAccess<DeviceType>(idxInChunk)];
                     }
                 }
                 onAcc::syncBlockThreads(acc);
@@ -156,10 +159,10 @@ namespace alpaka::example::scan
     public:
         ALPAKA_FN_ACC void operator()(
             auto const& acc,
+            concepts::Vector auto const chunkExtents,
             concepts::IMdSpan auto const& blockSums,
             concepts::IMdSpan auto outputVec) const
         {
-            concepts::CVector auto frameExtent = acc[frame::extent];
             concepts::Vector auto numElements = outputVec.getExtents();
 
             auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
@@ -167,7 +170,7 @@ namespace alpaka::example::scan
                 acc,
                 numElements,
                 [&](auto const&, auto&& simdOut) constexpr
-                { simdOut = simdOut.load() + blockSums[simdOut.getIdx() / frameExtent]; },
+                { simdOut = simdOut.load() + blockSums[simdOut.getIdx() / chunkExtents]; },
                 outputVec);
         }
     };
@@ -183,10 +186,10 @@ namespace alpaka::example::scan
         // Instantiate the kernel function object
         Scan_ScanBlocksKernel<SCAN_TYPE> scanBlocks;
 
-        // Define frameExtent
-        constexpr auto frameExtent = CVec<IdxType, 256u>{};
-        constexpr auto const adjustedFrameExtent = frameExtent * elsPerThread;
-        auto const frameSpec = onHost::FrameSpec{divCeil(inputVec.getExtents(), adjustedFrameExtent), frameExtent};
+        constexpr auto chunkExtent = CVec<IdxType, 256u>{};
+        constexpr auto const largeChunkExtents = chunkExtent * elsPerThread;
+        auto numLargeChunks = divCeil(inputVec.getExtents(), largeChunkExtents);
+        auto const frameSpec = onHost::FrameSpec{numLargeChunks, chunkExtent, exec};
 
         if(frameSpec.getNumFrames() > 1_idx)
         {
@@ -199,14 +202,19 @@ namespace alpaka::example::scan
 
             IdxType elementsPerWorker = getNumElemPerThread<Data>(queue);
             auto addIncrementsFrameSpec = onHost::FrameSpec{
-                divCeil(inputVec.getExtents(), adjustedFrameExtent * elementsPerWorker),
-                CVec<IdxType, adjustedFrameExtent.x()>{}};
+                divCeil(inputVec.getExtents(), largeChunkExtents * elementsPerWorker),
+                CVec<IdxType, largeChunkExtents.x()>{},
+                exec};
 
             // enqueue the kernel execution tasks
-            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
+            queue.enqueue(
+                frameSpec,
+                KernelBundle{scanBlocks, numLargeChunks, chunkExtent, inputVec, outputVec, increments});
             // always recurse into exclusive scan
             scan<EXCLUSIVE_SCAN>(exec, devAcc, queue, increments, blockSums);
-            queue.enqueue(exec, addIncrementsFrameSpec, KernelBundle{addIncrements, blockSums, outputVec});
+            queue.enqueue(
+                addIncrementsFrameSpec,
+                KernelBundle{addIncrements, largeChunkExtents, blockSums, outputVec});
 
             // need to wait here until the previous call is done before we can destruct the buffers for
             // increments/blockSums when running out of scope
@@ -215,7 +223,7 @@ namespace alpaka::example::scan
         else
         {
             // problem fits within 1 frame
-            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec});
+            queue.enqueue(frameSpec, KernelBundle{scanBlocks, numLargeChunks, chunkExtent, inputVec, outputVec});
         }
     }
 } // namespace alpaka::example::scan

--- a/example/scan/src/scan_improved.hpp
+++ b/example/scan/src/scan_improved.hpp
@@ -111,16 +111,16 @@ namespace alpaka::example::scan
     public:
         ALPAKA_FN_ACC void operator()(
             auto const& acc,
+            concepts::Vector auto const numChunks,
+            concepts::CVector auto const largeChunkExtents,
             concepts::IDataSource auto const& inputVec,
             concepts::IMdSpan auto outputVec,
             auto... blockSums) const
         {
             using DeviceType = ALPAKA_TYPEOF(acc.getDeviceKind());
-            concepts::Vector auto numFrames = acc[frame::count];
 
             concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
-            concepts::CVector auto frameExtent = acc[frame::extent];
-            constexpr auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
+            constexpr auto elsPerThread = largeChunkExtents.x() / numThreadsPerBlock.x();
             concepts::CVector auto chunkExtent = CVec<IdxType, elsPerThread * numThreadsPerBlock.x()>{};
             concepts::Vector auto numElements = inputVec.getExtents();
 
@@ -147,11 +147,11 @@ namespace alpaka::example::scan
              * All thread blocks will be used to iterate over the frames. Each thread block will handle one or more
              * frames.
              */
-            for(auto frameIdx :
-                onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec<IdxType, 1u>{0}, numFrames}))
+            for(auto chunkIdx :
+                onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec<IdxType, 1u>{0}, numChunks}))
             {
                 bool const lastFrameFull = validElementsInLastFrame == chunkExtent;
-                bool const isLastFrame = frameIdx == numFrames - 1_idx;
+                bool const isLastFrame = chunkIdx == numChunks - 1_idx;
 
                 // allocate "per-thread" register memory to store all mini blocks of a thread persistently
                 LocalArray regMem;
@@ -159,7 +159,7 @@ namespace alpaka::example::scan
                 auto tmp = onAcc::declareSharedMdArray<Data, uniqueId()>(
                     acc,
                     CVec<IdxType, conflictFreeAccess<DeviceType>(miniBlocksPerChunk - 1_idx) + 1_idx>{});
-                auto const frameOffset = chunkExtent * frameIdx;
+                auto const frameOffset = chunkExtent * chunkIdx;
 
                 for(auto frameElem : onAcc::makeIdxMap(
                         acc,
@@ -232,7 +232,7 @@ namespace alpaka::example::scan
                     if constexpr(sizeof...(blockSums))
                     {
                         auto _blockSums = std::get<0>(std::make_tuple(blockSums...));
-                        _blockSums[frameIdx] = tmp[conflictFreeAccess<DeviceType>(miniBlocksPerChunk - 1_idx)];
+                        _blockSums[chunkIdx] = tmp[conflictFreeAccess<DeviceType>(miniBlocksPerChunk - 1_idx)];
                     }
 
                     // -- SET 0 --
@@ -333,13 +333,13 @@ namespace alpaka::example::scan
     public:
         ALPAKA_FN_ACC void operator()(
             auto const& acc,
+            concepts::CVector auto const largeChunkExtents,
             concepts::IMdSpan auto const& blockSums,
             concepts::IMdSpan auto outputVec) const
         {
             concepts::Vector auto numElements = outputVec.getExtents();
             concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
-            concepts::CVector auto frameExtent = acc[frame::extent];
-            constexpr auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
+            constexpr auto elsPerThread = largeChunkExtents.x() / numThreadsPerBlock.x();
             concepts::CVector auto chunkExtent = CVec<IdxType, elsPerThread * numThreadsPerBlock.x()>{};
 
             auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
@@ -365,8 +365,8 @@ namespace alpaka::example::scan
 
         // Define chunkExtent
         constexpr auto chunkExtent = CVec<IdxType, 2048u>{};
-        auto numFrames = divCeil(inputVec.getExtents(), chunkExtent);
-        auto const frameSpec = onHost::FrameSpec{numFrames, chunkExtent, CVec<IdxType, 256u>{}};
+        alpaka::Vec numChunks = divCeil(inputVec.getExtents(), chunkExtent);
+        auto const frameSpec = onHost::FrameSpec{numChunks, CVec<IdxType, 256u>{}, exec};
 
         if(frameSpec.getNumFrames() > 1_idx)
         {
@@ -378,7 +378,9 @@ namespace alpaka::example::scan
             auto blockSums = onHost::alloc<Data>(devAcc, frameSpec.getNumFrames());
 
             // enqueue the kernel execution tasks
-            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
+            queue.enqueue(
+                frameSpec,
+                KernelBundle{scanBlocks, numChunks, chunkExtent, inputVec, outputVec, increments});
 
             // always recurse into exclusive scan
             scan<EXCLUSIVE_SCAN>(exec, devAcc, queue, increments, blockSums);
@@ -386,7 +388,7 @@ namespace alpaka::example::scan
             // increments need to stay valid until here
             increments.keepAlive(queue);
 
-            queue.enqueue(exec, frameSpec, KernelBundle{addIncrements, blockSums, outputVec});
+            queue.enqueue(frameSpec, KernelBundle{addIncrements, chunkExtent, blockSums, outputVec});
 
             // block sums need to stay valid until here
             blockSums.keepAlive(queue);
@@ -394,7 +396,7 @@ namespace alpaka::example::scan
         else
         {
             // problem fits within 1 frame
-            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec});
+            queue.enqueue(frameSpec, KernelBundle{scanBlocks, numChunks, chunkExtent, inputVec, outputVec});
         }
     }
 } // namespace alpaka::example::scan

--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -105,10 +105,10 @@ void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto comp
     alpaka::onHost::memset(queue, out_d, 0x00);
 
     // launch the 1-dimensional kernel with scalar size
-    auto frameSpec = alpaka::onHost::FrameSpec{32u, 32u};
+    auto frameSpec = alpaka::onHost::FrameSpec{32u, 32u, computeExec};
 
     std::cout << "Testing VectorAddKernel with scalar indices with a grid of " << frameSpec << "\n";
-    queue.enqueue(computeExec, frameSpec, VectorAddKernel{}, in1_d, in2_d, out_d, size);
+    queue.enqueue(frameSpec, VectorAddKernel{}, in1_d, in2_d, out_d, size);
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);
@@ -130,7 +130,7 @@ void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto comp
 
 
     std::cout << "Testing VectorAddKernel with vector indices with a grid of " << frameSpec << "\n";
-    queue.enqueue(computeExec, frameSpec, VectorAddKernel1D{}, in1_d, in2_d, out_d, Vec1D{size});
+    queue.enqueue(frameSpec, VectorAddKernel1D{}, in1_d, in2_d, out_d, Vec1D{size});
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);
@@ -192,10 +192,10 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
     alpaka::onHost::memset(queue, out_d, 0x00);
 
     // launch the 3-dimensional kernel
-    auto frameSpec = alpaka::onHost::FrameSpec{Vec3D{5, 5, 1}, Vec3D{4, 4, 4}};
+    auto frameSpec = alpaka::onHost::FrameSpec{Vec3D{5, 5, 1}, Vec3D{4, 4, 4}, computeExec};
     std::cout << "Testing VectorAddKernel3D with vector indices with a grid of " << frameSpec << "\n";
 
-    queue.enqueue(computeExec, frameSpec, VectorAddKernel3D{}, in1_d, in2_d, out_d, ndsize);
+    queue.enqueue(frameSpec, VectorAddKernel3D{}, in1_d, in2_d, out_d, ndsize);
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -115,7 +115,7 @@ void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto comp
      * to the kernel; alpaka may automatically adjust the number of blocks or threads per block and map that to a
      * different physical block/thread configuration.
      */
-    alpaka::onHost::concepts::ThreadSpec auto threadSpec = alpaka::onHost::ThreadSpec{32u, 32u};
+    alpaka::onHost::concepts::ThreadSpec auto threadSpec = alpaka::onHost::ThreadSpec{32u, 32u, computeExec};
 
     // launch the 1-dimensional kernel with scalar size
     if constexpr(alpaka::isSeqExecutor(computeExec))
@@ -123,7 +123,7 @@ void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto comp
         /* Some executors allow only a single thread for the block.
          * You must write your kernel independent of the number of threads per block.
          */
-        threadSpec = alpaka::onHost::ThreadSpec{threadSpec.getNumBlocks(), 1u};
+        threadSpec = alpaka::onHost::ThreadSpec{threadSpec.getNumBlocks(), 1u, computeExec};
     }
 
     // fill the output buffer with zeros; the size is known from the buffer objects
@@ -131,7 +131,7 @@ void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto comp
 
     std::cout << "Testing VectorAddKernel with vector indices with " << threadSpec.getNumBlocks() << " blocks and "
               << threadSpec.getNumThreads() << "\n";
-    queue.enqueue(computeExec, threadSpec, VectorAddKernel1D{}, in1_d, in2_d, out_d, Vec1D{size});
+    queue.enqueue(threadSpec, VectorAddKernel1D{}, in1_d, in2_d, out_d, Vec1D{size});
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);
@@ -200,7 +200,8 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
      * To simplify this example the number of elements per dimension must be a multiple of the number of threads of the
      * corresponding dimension.
      */
-    alpaka::onHost::concepts::ThreadSpec auto threadSpec = alpaka::onHost::ThreadSpec{Vec3D{1, 2, 4}, Vec3D{4, 4, 4}};
+    alpaka::onHost::concepts::ThreadSpec auto threadSpec
+        = alpaka::onHost::ThreadSpec{Vec3D{1, 2, 4}, Vec3D{4, 4, 4}, computeExec};
 
     // launch the 1-dimensional kernel with scalar size
     if constexpr(alpaka::isSeqExecutor(computeExec))
@@ -208,14 +209,16 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
         /* Some executors allow only a single thread for the block.
          * We map threads to blocks in this example.
          */
-        threadSpec
-            = alpaka::onHost::ThreadSpec{threadSpec.getNumBlocks() * threadSpec.getNumThreads(), Vec3D::fill(1u)};
+        threadSpec = alpaka::onHost::ThreadSpec{
+            threadSpec.getNumBlocks() * threadSpec.getNumThreads(),
+            Vec3D::fill(1u),
+            computeExec};
     }
 
     std::cout << "Testing VectorAddKernel with vector indices with " << threadSpec.getNumBlocks() << " blocks and "
               << threadSpec.getNumThreads() << "\n";
 
-    queue.enqueue(computeExec, threadSpec, VectorAddKernel3D{}, in1_d, in2_d, out_d, ndsize);
+    queue.enqueue(threadSpec, VectorAddKernel3D{}, in1_d, in2_d, out_d, ndsize);
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -25,24 +25,20 @@ struct VectorAddKernel1D
     template<typename TAcc>
     ALPAKA_FN_ACC void operator()(
         TAcc const& acc,
+        alpaka::concepts::CVector auto chunkSize,
         alpaka::concepts::IDataSource auto const& in1,
         alpaka::concepts::IDataSource auto const& in2,
         alpaka::concepts::IMdSpan auto out) const
     {
-        // product() returns a scalar therefore we need the explicit Vec1D type
-        Vec1D linearNumFrames = acc[alpaka::frame::count].product();
-        auto frameExtent = acc[alpaka::frame::extent];
-        Vec1D linearFrameExtent = frameExtent.product();
-
         /* This kernel is called with 1- dimensional frame extents, nevertheless we will linearize the indices
          * explicitly which allow calling this kernel with M-dimensional frames extents too.
          *
          * All thread blocks will be used to iterate over the frames. Each thread block will handle one or more frames.
          */
-        for(auto linearFrameIdx : alpaka::onAcc::makeIdxMap(
+        for(auto chunkOffset : alpaka::onAcc::makeIdxMap(
                 acc,
                 alpaka::onAcc::worker::linearBlocksInGrid,
-                alpaka::IdxRange{linearNumFrames}))
+                alpaka::IdxRange{Vec1D{0}, in1.getExtents(), chunkSize}))
         {
             /* We will use a 1-dimensional shared memory array to load the data from in1 for the corresponding frame
              * into it and use the cached data to compute the final result. Take care, shared memory is never
@@ -51,16 +47,16 @@ struct VectorAddKernel1D
              * The extents of a shared memory array must be known at compile time, therefore it is required that the
              * frame extent on the host side is of the type CVec.
              */
-            auto sharedIn1Data = alpaka::onAcc::declareSharedMdArray<float, alpaka::uniqueId()>(acc, frameExtent);
+            auto sharedIn1Data = alpaka::onAcc::declareSharedMdArray<float, alpaka::uniqueId()>(acc, chunkSize);
 
             // iterate over elements within the frame and use all threads from the thread block
-            for(auto linearFrameElem : alpaka::onAcc::makeIdxMap(
+            for(auto inChunkIdx : alpaka::onAcc::makeIdxMap(
                     acc,
                     alpaka::onAcc::worker::linearThreadsInBlock,
-                    alpaka::IdxRange{linearFrameExtent}))
+                    alpaka::IdxRange{chunkSize}))
             {
-                auto const globalDataIdx = linearFrameIdx * frameExtent + linearFrameElem;
-                sharedIn1Data[linearFrameElem] = in1[globalDataIdx];
+                auto const globalDataIdx = chunkOffset + inChunkIdx;
+                sharedIn1Data[inChunkIdx] = in1[globalDataIdx];
             }
 
             /* The synchronization is required because we will use for the second loop over frame element indicis a
@@ -68,14 +64,14 @@ struct VectorAddKernel1D
              */
             alpaka::onAcc::syncBlockThreads(acc);
 
-            for(auto linearFrameElem : alpaka::onAcc::makeIdxMap(
+            for(auto inChunkIdx : alpaka::onAcc::makeIdxMap(
                     acc,
                     alpaka::onAcc::worker::linearThreadsInBlock,
-                    alpaka::IdxRange{linearFrameExtent},
+                    alpaka::IdxRange{chunkSize},
                     alpaka::onAcc::traverse::tiled))
             {
-                auto const globalDataIdx = linearFrameIdx * frameExtent + linearFrameElem;
-                out[globalDataIdx] = sharedIn1Data[linearFrameElem] + in2[globalDataIdx];
+                auto const globalDataIdx = chunkOffset + inChunkIdx;
+                out[globalDataIdx] = sharedIn1Data[inChunkIdx] + in2[globalDataIdx];
             }
 
             /* Synchronization is required if the same thread block is calculating more than one frame.
@@ -92,13 +88,11 @@ struct VectorAddKernel3D
     template<typename TAcc>
     ALPAKA_FN_ACC void operator()(
         TAcc const& acc,
+        alpaka::concepts::CVector auto chunkExtents,
         alpaka::concepts::IDataSource auto const& in1,
         alpaka::concepts::IDataSource auto const& in2,
         alpaka::concepts::IMdSpan auto out) const
     {
-        auto numFramesMD = acc[alpaka::frame::count];
-        auto frameExtentMD = acc[alpaka::frame::extent];
-
         /* We will use a 3-dimensional shared memory array to load the data from in1 for the corresponding frame into
          * it and use the cached data to compute the final result. Take care, shared memory is never initialized and
          * will contain garbage after the creation.
@@ -106,22 +100,24 @@ struct VectorAddKernel3D
          * The extents of a shared memory array must be known at compile time, therefore it is required that the frame
          * extent on the host side is of the type CVec.
          */
-        auto sharedIn1Data = alpaka::onAcc::declareSharedMdArray<float, alpaka::uniqueId()>(acc, frameExtentMD);
+        auto sharedIn1Data = alpaka::onAcc::declareSharedMdArray<float, alpaka::uniqueId()>(acc, chunkExtents);
 
         /* This kernel is called with 1- dimensional frame extents, nevertheless we will linearize the indices
          * explicitly which allow calling this kernel with M-dimensional frames extents too.
          *
          * All thread blocks will be used to iterate over the frames. Each thread block will handle one or more frames.
          */
-        for(auto frameIdxMD :
-            alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::blocksInGrid, alpaka::IdxRange{numFramesMD}))
+        for(auto chunkOffset : alpaka::onAcc::makeIdxMap(
+                acc,
+                alpaka::onAcc::worker::blocksInGrid,
+                alpaka::IdxRange{Vec3D::fill(0), in1.getExtents(), chunkExtents}))
         {
             // iterate over elements within the frame and use all threads from the thread block
-            for(auto frameElemIdxMD :
-                alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInBlock, alpaka::IdxRange{frameExtentMD}))
+            for(auto inChunkIdx :
+                alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInBlock, alpaka::IdxRange{chunkExtents}))
             {
-                auto const globalDataIdxMD = frameIdxMD * frameExtentMD + frameElemIdxMD;
-                sharedIn1Data[frameElemIdxMD] = in1[globalDataIdxMD];
+                auto const globalDataIdxMD = chunkOffset + inChunkIdx;
+                sharedIn1Data[inChunkIdx] = in1[globalDataIdxMD];
             }
 
             /* The synchronization is required because we will use for the second loop over frame element indicis a
@@ -129,14 +125,14 @@ struct VectorAddKernel3D
              */
             alpaka::onAcc::syncBlockThreads(acc);
 
-            for(auto frameElemIdxMD : alpaka::onAcc::makeIdxMap(
+            for(auto inChunkIdx : alpaka::onAcc::makeIdxMap(
                     acc,
                     alpaka::onAcc::worker::threadsInBlock,
-                    alpaka::IdxRange{frameExtentMD},
+                    alpaka::IdxRange{chunkExtents},
                     alpaka::onAcc::traverse::tiled))
             {
-                auto const globalDataIdxMD = frameIdxMD * frameExtentMD + frameElemIdxMD;
-                out[globalDataIdxMD] = sharedIn1Data[frameElemIdxMD] + in2[globalDataIdxMD];
+                auto const globalDataIdxMD = chunkOffset + inChunkIdx;
+                out[globalDataIdxMD] = sharedIn1Data[inChunkIdx] + in2[globalDataIdxMD];
             }
 
             /* Synchronization is required if the same thread block is calculating more than one frame.
@@ -190,18 +186,18 @@ void testVectorAddKernel(alpaka::onHost::concepts::Device auto device, auto comp
     alpaka::onHost::memset(queue, out_d, 0x00);
 
     // launch the 1-dimensional kernel
-    constexpr auto frameExtent = 32u;
-    auto numFrames = size / frameExtent;
+    constexpr auto chunkSize = 32u;
+    auto numFrames = size / chunkSize;
     // The kernel assumes that the problem size is a multiple of the frame size.
-    verify((numFrames * frameExtent) == size);
+    verify((numFrames * chunkSize) == size);
 
-    auto frameSpec = alpaka::onHost::FrameSpec{numFrames, alpaka::CVec<uint32_t, frameExtent>{}};
+    auto frameSpec = alpaka::onHost::FrameSpec{numFrames, chunkSize, computeExec};
 
     // fill the output buffer with zeros; the size is known from the buffer objects
     alpaka::onHost::memset(queue, out_d, 0x00);
 
     std::cout << "Testing VectorAddKernel with vector indices with a grid of " << frameSpec << "\n";
-    queue.enqueue(computeExec, frameSpec, VectorAddKernel1D{}, in1_d, in2_d, out_d);
+    queue.enqueue(frameSpec, VectorAddKernel1D{}, alpaka::CVec<uint32_t, chunkSize>{}, in1_d, in2_d, out_d);
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);
@@ -264,16 +260,16 @@ void testVectorAddKernel3D(alpaka::onHost::concepts::Device auto device, auto co
 
 
     // launch the 3-dimensional kernel
-    auto frameExtent = alpaka::CVec<uint32_t, 4, 4, 2>{};
-    auto numFrames = ndsize / frameExtent;
+    auto chunkExtents = alpaka::CVec<uint32_t, 4, 4, 2>{};
+    auto numFrames = ndsize / chunkExtents;
     // The kernel assumes that the problem size is a multiple of the frame size.
-    verify((numFrames * frameExtent).product() == size);
+    verify((numFrames * chunkExtents).product() == size);
 
-    auto frameSpec = alpaka::onHost::FrameSpec{numFrames, frameExtent};
+    auto frameSpec = alpaka::onHost::FrameSpec{numFrames, chunkExtents, computeExec};
 
     std::cout << "Testing VectorAddKernel3D with vector indices with a grid of " << frameSpec << "\n";
 
-    queue.enqueue(computeExec, frameSpec, VectorAddKernel3D{}, in1_d, in2_d, out_d);
+    queue.enqueue(frameSpec, VectorAddKernel3D{}, chunkExtents, in1_d, in2_d, out_d);
 
     // copy the results from the device to the host
     alpaka::onHost::memcpy(queue, out_h, out_d);

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -126,7 +126,7 @@ auto example(auto const deviceSpec, auto const exec, size_t numElements, size_t 
     Vec<size_t, 1u> chunkSize = 256u;
     // how many elements one worker should compute to ensure vectorization or instruction parallelism
     uint32_t elementsPerWorker = getNumElemPerThread<Data>(queue);
-    auto dataBlocking = onHost::FrameSpec{divCeil(extent, chunkSize * elementsPerWorker), chunkSize};
+    auto dataBlocking = onHost::FrameSpec{divCeil(extent, chunkSize * elementsPerWorker), chunkSize, exec};
 
     // Instantiate the kernel function object
     VectorAddKernel kernel;
@@ -149,7 +149,7 @@ auto example(auto const deviceSpec, auto const exec, size_t numElements, size_t 
         onHost::wait(queue);
         auto const beginT = std::chrono::high_resolution_clock::now();
         // Enqueue the kernel execution task
-        queue.enqueue(exec, dataBlocking, taskKernel);
+        queue.enqueue(dataBlocking, taskKernel);
         // wait in case we are using an asynchronous queue to time actual kernel runtime
         onHost::wait(queue);
         auto const endT = std::chrono::high_resolution_clock::now();

--- a/include/alpaka/api/executor.hpp
+++ b/include/alpaka/api/executor.hpp
@@ -1,0 +1,43 @@
+/* Copyright 2024 René Widera, Mehmet Yusufoglu
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/api/cuda/executor.hpp"
+#include "alpaka/api/hip/executor.hpp"
+#include "alpaka/api/host/executor.hpp"
+#include "alpaka/api/oneApi/executor.hpp"
+#include "alpaka/api/trait.hpp"
+
+#include <string>
+
+namespace alpaka
+{
+    namespace exec
+    {
+        /** Automatic executor selection
+         *
+         * If this executor is used in alpaka interfaces, the best fitting available executor will automatically
+         * select. The selection based often on the device or queue provided in the interfaces.
+         */
+        struct AnyExecutor
+        {
+            static std::string getName()
+            {
+                return "AnyExecutor";
+            }
+        };
+
+        /** @copydoc AnyExecutor */
+        constexpr AnyExecutor anyExecutor;
+    } // namespace exec
+
+    namespace trait
+    {
+        template<>
+        struct IsExecutor<exec::AnyExecutor> : std::true_type
+        {
+        };
+    } // namespace trait
+} // namespace alpaka

--- a/include/alpaka/api/generic.hpp
+++ b/include/alpaka/api/generic.hpp
@@ -69,7 +69,8 @@ namespace alpaka::internal::generic
         ALPAKA_LOG_FUNCTION(onHost::logger::memory);
 
         auto extents = onHost::getExtents(dest);
-        auto frameSpec = onHost::internal::getFrameSpec<T_Value>(*onHost::internal::getDevice(internalQueue), extents);
+        auto frameSpec
+            = onHost::internal::getFrameSpec<T_Value>(*onHost::internal::getDevice(internalQueue), executor, extents);
 
         ALPAKA_LOG_INFO(
             onHost::logger::memory,
@@ -81,10 +82,6 @@ namespace alpaka::internal::generic
                 return ss.str();
             });
 
-        onHost::internal::enqueue(
-            internalQueue,
-            executor,
-            frameSpec,
-            KernelBundle{SimdFillKernel{}, dest, elementValue});
+        onHost::internal::enqueue(internalQueue, frameSpec, KernelBundle{SimdFillKernel{}, dest, elementValue});
     }
 } // namespace alpaka::internal::generic

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -298,74 +298,79 @@ namespace alpaka::onHost
          */
         template<
             typename T_Platform,
-            onHost::concepts::FrameSpec T_FrameSpec,
+            alpaka::concepts::Vector T_NumFrames,
+            alpaka::concepts::Vector T_FrameExtents,
             alpaka::concepts::KernelBundle T_KernelBundle>
-        struct AdjustThreadSpec::Op<cpu::Device<T_Platform>, exec::CpuSerial, T_FrameSpec, T_KernelBundle>
+        struct AdjustThreadSpec::
+            Op<cpu::Device<T_Platform>, FrameSpec<T_NumFrames, T_FrameExtents, exec::CpuSerial>, T_KernelBundle>
         {
-            using T_NumThreads = T_FrameSpec::ThreadExtentsVecType;
+            using FrameSpecType = FrameSpec<T_NumFrames, T_FrameExtents, exec::CpuSerial>;
 
             auto operator()(
                 cpu::Device<T_Platform> const& device,
-                exec::CpuSerial const& executor,
-                T_FrameSpec const& dataBlocking,
-                T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_NumThreads>
+                FrameSpecType const& frameSpec,
+                T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_FrameExtents>
             {
-                alpaka::unused(device, executor, dataBlocking, kernelBundle);
+                alpaka::unused(device, kernelBundle);
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel);
+
                 /// @todo add shortcut to create a CVec with equal values
-                auto const allOne
-                    = ALPAKA_TYPEOF(iotaCVec<typename T_NumThreads::type, T_NumThreads::dim()>())::template fill<1u>();
-                return ThreadSpec{allOne, allOne};
+                auto const allOne = ALPAKA_TYPEOF(
+                    iotaCVec<typename T_FrameExtents::type, T_FrameExtents::dim()>())::template fill<1u>();
+                return ThreadSpec{allOne, allOne, frameSpec.getExecutor()};
             }
 
             auto operator()(
                 cpu::Device<T_Platform> const& device,
-                exec::CpuSerial const& executor,
-                T_FrameSpec const& dataBlocking,
+                FrameSpecType const& frameSpec,
                 T_KernelBundle const& kernelBundle) const
             {
-                alpaka::unused(device, executor, dataBlocking, kernelBundle);
+                alpaka::unused(device, kernelBundle);
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel);
                 /// @todo add shortcut to create a CVec with equal values
-                auto const allOne
-                    = ALPAKA_TYPEOF(iotaCVec<typename T_NumThreads::type, T_NumThreads::dim()>())::template fill<1u>();
-                return ThreadSpec{allOne, allOne};
+                auto const allOne = ALPAKA_TYPEOF(
+                    iotaCVec<typename T_FrameExtents::type, T_FrameExtents::dim()>())::template fill<1u>();
+                return ThreadSpec{allOne, allOne, frameSpec.getExecutor()};
             }
         };
 
         template<
             typename T_Platform,
             alpaka::concepts::Executor T_Executor,
-            onHost::concepts::FrameSpec T_FrameSpec,
+            alpaka::concepts::Vector T_NumFrames,
+            alpaka::concepts::Vector T_FrameExtents,
             alpaka::concepts::KernelBundle T_KernelBundle>
         requires exec::isSeqExecutor_v<T_Executor>
-        struct AdjustThreadSpec::Op<cpu::Device<T_Platform>, T_Executor, T_FrameSpec, T_KernelBundle>
+        struct AdjustThreadSpec::
+            Op<cpu::Device<T_Platform>, FrameSpec<T_NumFrames, T_FrameExtents, T_Executor>, T_KernelBundle>
         {
-            using T_NumThreads = T_FrameSpec::ThreadExtentsVecType;
+            using FrameSpecType = FrameSpec<T_NumFrames, T_FrameExtents, T_Executor>;
 
             auto operator()(
                 cpu::Device<T_Platform> const& device,
-                T_Executor const& executor,
-                T_FrameSpec const& dataBlocking,
-                T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_NumThreads>
+                FrameSpecType const& frameSpec,
+                T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_FrameExtents>
             {
-                alpaka::unused(device, executor, kernelBundle);
+                alpaka::unused(device, kernelBundle);
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel);
-                auto numThreadBlocks = dataBlocking.getThreadSpec().getNumBlocks();
-                return ThreadSpec{numThreadBlocks, T_NumThreads::template fill<1u>()};
+
+                // map the number of frames to thread blocks
+                auto numThreadBlocks = frameSpec.getNumFrames();
+                return ThreadSpec{numThreadBlocks, T_FrameExtents::template fill<1u>(), frameSpec.getExecutor()};
             }
 
             auto operator()(
                 cpu::Device<T_Platform> const& device,
-                T_Executor const& executor,
-                T_FrameSpec const& dataBlocking,
+                FrameSpecType const& frameSpec,
                 T_KernelBundle const& kernelBundle) const
             {
-                alpaka::unused(device, executor, kernelBundle);
+                alpaka::unused(device, kernelBundle);
                 ALPAKA_LOG_FUNCTION(alpaka::onHost::logger::kernel);
-                auto numThreadBlocks = dataBlocking.getThreadSpec().getNumBlocks();
-                auto const numThreads = Vec<typename T_NumThreads::type, T_NumThreads::dim()>::fill(1);
-                return ThreadSpec{numThreadBlocks, numThreads};
+
+                // map the number of frames to thread blocks
+                auto numThreadBlocks = frameSpec.getNumFrames();
+                auto const numThreads = Vec<typename T_FrameExtents::type, T_FrameExtents::dim()>::fill(1);
+                return ThreadSpec{numThreadBlocks, numThreads, frameSpec.getExecutor()};
             }
         };
 

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -147,12 +147,12 @@ namespace alpaka::onHost
 
             friend struct internal::Enqueue;
 
-            template<alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_NumThreads>
-            void enqueue(
-                auto const executor,
-                ThreadSpec<T_NumBlocks, T_NumThreads> const& threadBlocking,
-                auto const& kernelBundle)
+            template<alpaka::onHost::concepts::ThreadSpec T_ThreadSpec>
+            void enqueue(T_ThreadSpec const& threadSpec, auto const& kernelBundle)
             {
+                static_assert(
+                    ALPAKA_TYPEOF(threadSpec)::getExecutor() != exec::anyExecutor,
+                    "'exec::anyExecutor' can not be used to enqueue an kernel.");
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::queue);
                 auto deviceKind = alpaka::getDeviceKind(m_device);
 
@@ -161,29 +161,26 @@ namespace alpaka::onHost
                  * by the callback thread. */
                 bool setThreadAffinity = m_isBlocking;
                 submit(
-                    [kernelBundle, executor, threadBlocking, deviceKind, numIdx = m_numaIdx, setThreadAffinity]()
+                    [kernelBundle, threadSpec, deviceKind, numIdx = m_numaIdx, setThreadAffinity]()
                     {
                         auto moreLayer = Dict{
+                            DictEntry(object::launchedWidthFrameSpec, std::false_type{}),
                             DictEntry(object::api, api::host),
                             DictEntry(object::deviceKind, deviceKind),
-                            DictEntry(object::exec, executor)};
-                        onAcc::Acc acc = makeAcc(executor, threadBlocking, numIdx, setThreadAffinity);
+                            DictEntry(object::exec, threadSpec.getExecutor())};
+                        onAcc::Acc acc = makeAcc(threadSpec, numIdx, setThreadAffinity);
                         acc(kernelBundle, moreLayer);
                     });
             }
 
-            template<
-                alpaka::concepts::Executor T_Executor,
-                alpaka::concepts::Vector T_NumFrames,
-                alpaka::concepts::Vector T_FrameExtents,
-                alpaka::concepts::Vector T_ThreadExtents>
-            void enqueue(
-                T_Executor const executor,
-                FrameSpec<T_NumFrames, T_FrameExtents, T_ThreadExtents> const& frameSpec,
-                auto const& kernelBundle)
+            template<alpaka::onHost::concepts::FrameSpec T_FrameSpec>
+            void enqueue(T_FrameSpec const& frameSpec, auto const& kernelBundle)
             {
+                static_assert(
+                    ALPAKA_TYPEOF(frameSpec)::getExecutor() != exec::anyExecutor,
+                    "'exec::anyExecutor' can not be used to enqueue an kernel.");
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::queue);
-                auto threadBlocking = internal::adjustThreadSpec(*m_device.get(), executor, frameSpec, kernelBundle);
+                auto adjustedThreadSpec = internal::adjustThreadSpec(*m_device.get(), frameSpec, kernelBundle);
                 auto deviceKind = alpaka::getDeviceKind(m_device);
 
                 /* Only set the thread affinity if we use a blocking queue, else the affinity is already set in the
@@ -191,21 +188,14 @@ namespace alpaka::onHost
                  * by the callback thread. */
                 bool setThreadAffinity = m_isBlocking;
                 submit(
-                    [kernelBundle,
-                     executor,
-                     threadBlocking,
-                     deviceKind,
-                     frameSpec,
-                     numIdx = m_numaIdx,
-                     setThreadAffinity]()
+                    [kernelBundle, adjustedThreadSpec, deviceKind, numIdx = m_numaIdx, setThreadAffinity]()
                     {
                         auto moreLayer = Dict{
-                            DictEntry(frame::count, frameSpec.getNumFrames()),
-                            DictEntry(frame::extent, frameSpec.getFrameExtents()),
+                            DictEntry(object::launchedWidthFrameSpec, std::true_type{}),
                             DictEntry(object::api, api::host),
                             DictEntry(object::deviceKind, deviceKind),
-                            DictEntry(object::exec, executor)};
-                        onAcc::Acc acc = makeAcc(executor, threadBlocking, numIdx, setThreadAffinity);
+                            DictEntry(object::exec, adjustedThreadSpec.getExecutor())};
+                        onAcc::Acc acc = makeAcc(adjustedThreadSpec, numIdx, setThreadAffinity);
                         acc(kernelBundle, moreLayer);
                     });
             }

--- a/include/alpaka/api/host/exec/OmpBlocks.hpp
+++ b/include/alpaka/api/host/exec/OmpBlocks.hpp
@@ -101,9 +101,12 @@ namespace alpaka::onHost
         };
     } // namespace cpu
 
-    inline auto makeAcc(exec::CpuOmpBlocks, auto const& threadBlocking, uint32_t numaIdx, bool setThreadAffinity)
+    inline auto makeAcc(
+        alpaka::onHost::concepts::ThreadSpec auto const& threadSpec,
+        uint32_t numaIdx,
+        bool setThreadAffinity) requires std::same_as<ALPAKA_TYPEOF(threadSpec.getExecutor()), exec::CpuOmpBlocks>
     {
-        return cpu::OmpBlocks(threadBlocking, numaIdx, setThreadAffinity);
+        return cpu::OmpBlocks(threadSpec, numaIdx, setThreadAffinity);
     }
 } // namespace alpaka::onHost
 

--- a/include/alpaka/api/host/exec/Serial.hpp
+++ b/include/alpaka/api/host/exec/Serial.hpp
@@ -88,8 +88,11 @@ namespace alpaka::onHost
         };
     } // namespace cpu
 
-    inline auto makeAcc(exec::CpuSerial, auto const& threadBlocking, uint32_t numaIdx, bool setThreadAffinity)
+    inline auto makeAcc(
+        alpaka::onHost::concepts::ThreadSpec auto const& threadSpec,
+        uint32_t numaIdx,
+        bool setThreadAffinity) requires std::same_as<ALPAKA_TYPEOF(threadSpec.getExecutor()), exec::CpuSerial>
     {
-        return cpu::Serial(threadBlocking, numaIdx, setThreadAffinity);
+        return cpu::Serial(threadSpec, numaIdx, setThreadAffinity);
     }
 } // namespace alpaka::onHost

--- a/include/alpaka/api/host/exec/TbbBlocks.hpp
+++ b/include/alpaka/api/host/exec/TbbBlocks.hpp
@@ -129,12 +129,11 @@ namespace alpaka::onHost
     } // namespace cpu
 
     inline auto makeAcc(
-        alpaka::exec::CpuTbbBlocks,
-        auto const& threadBlocking,
+        alpaka::onHost::concepts::ThreadSpec auto const& threadSpec,
         uint32_t numaIdx,
-        bool setThreadAffinity)
+        bool setThreadAffinity) requires std::same_as<ALPAKA_TYPEOF(threadSpec.getExecutor()), exec::CpuTbbBlocks>
     {
-        return cpu::TbbBlocks(threadBlocking, numaIdx, setThreadAffinity);
+        return cpu::TbbBlocks(threadSpec, numaIdx, setThreadAffinity);
     }
 } // namespace alpaka::onHost
 #endif

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -319,21 +319,104 @@ namespace alpaka::onHost::internal
     template<
         typename T_Device,
         alpaka::concepts::Executor T_Executor,
-        onHost::concepts::ThreadSpec T_ThreadSpec,
+        alpaka::concepts::Vector T_NumBlocks,
+        alpaka::concepts::Vector T_NumThreads,
         alpaka::concepts::KernelBundle T_KernelBundle>
-    struct Enqueue::Kernel<syclGeneric::Queue<T_Device>, T_Executor, T_ThreadSpec, T_KernelBundle>
+    struct Enqueue::
+        Kernel<syclGeneric::Queue<T_Device>, ThreadSpec<T_NumBlocks, T_NumThreads, T_Executor>, T_KernelBundle>
     {
         void operator()(
             syclGeneric::Queue<T_Device>& queue,
-            T_Executor const executor,
-            T_ThreadSpec const& threadBlocking,
+            ThreadSpec<T_NumBlocks, T_NumThreads, T_Executor> const& threadSpec,
             T_KernelBundle const& kernelBundle) const
         {
+            static_assert(
+                ALPAKA_TYPEOF(threadSpec)::getExecutor() != exec::anyExecutor,
+                "'exec::anyExecutor' can not be used to enqueue an kernel.");
+            ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::queue);
+
             constexpr auto st_shared_mem_bytes = onAcc::oneApi::StaticSharedMemory::sizeLookupBufferInBytes(
                 ALPAKA_SYCL_NUM_MAX_SHARED_MEMORY_ALLOCATIONS);
             // allocate dynamic shared memory -- needs at least 1 byte to make the Xilinx Runtime happy
             u_int32_t blockDynSharedMemBytes
-                = std::max(u_int32_t(1), onHost::getDynSharedMemBytes(executor, threadBlocking, kernelBundle));
+                = std::max(u_int32_t(1), onHost::getDynSharedMemBytes(T_Executor{}, threadSpec, kernelBundle));
+            assert(
+                st_shared_mem_bytes + blockDynSharedMemBytes
+                <= queue.m_device->getNativeHandle().first.template get_info<sycl::info::device::local_mem_size>());
+
+            sycl::event ev = queue.dispatchWarpSize(
+                [&](auto warpSize) requires std::same_as<
+                    std::integral_constant<
+                        typename ALPAKA_TYPEOF(warpSize)::value_type,
+                        ALPAKA_TYPEOF(warpSize)::value>,
+                    ALPAKA_TYPEOF(warpSize)>
+                {
+                    return queue.m_queue.submit(
+                        [warpSize, threadSpec, kernelBundle, blockDynSharedMemBytes](sycl::handler& cgh)
+                        {
+                            using ApiType = decltype(getApi(queue));
+                            using DeviceKindType = ALPAKA_TYPEOF(getDeviceKind(queue));
+
+                            auto st_shared_accessor
+                                = sycl::local_accessor<std::byte>{sycl::range<1>{st_shared_mem_bytes}, cgh};
+
+                            auto dyn_shared_accessor
+                                = sycl::local_accessor<std::byte>{sycl::range<1>{blockDynSharedMemBytes}, cgh};
+
+                            auto workerDesc = detail::getWorkerDescription(threadSpec);
+                            auto optimizedThreadSpec = workerDesc.second;
+                            constexpr uint32_t syclDim = workerDesc.first.dimensions;
+
+                            constexpr uint32_t w = ALPAKA_TYPEOF(warpSize)::value;
+                            detail::EnqueueKernelWithWarpSize<syclDim, w, ALPAKA_SYCL_SUBGROUP_SIZE & w>::call(
+                                cgh,
+                                workerDesc.first,
+                                kernelBundle,
+                                st_shared_accessor,
+                                dyn_shared_accessor,
+                                optimizedThreadSpec,
+                                DictEntry(object::api, ApiType{}),
+                                DictEntry(object::deviceKind, DeviceKindType{}),
+                                DictEntry(object::exec, T_Executor{}),
+                                DictEntry(object::launchedWidthFrameSpec, std::bool_constant<false>{}),
+                                DictEntry(object::warpSize, warpSize));
+                        });
+                });
+
+            queue.setLastEvent(ev);
+            if(queue.isBlocking())
+                ev.wait_and_throw();
+        }
+    };
+
+    template<
+        typename T_Device,
+        alpaka::concepts::Executor T_Executor,
+        alpaka::concepts::Vector T_NumFrames,
+        alpaka::concepts::Vector T_FrameExtents,
+        alpaka::concepts::KernelBundle T_KernelBundle>
+    struct Enqueue::
+        Kernel<syclGeneric::Queue<T_Device>, FrameSpec<T_NumFrames, T_FrameExtents, T_Executor>, T_KernelBundle>
+    {
+        void operator()(
+            syclGeneric::Queue<T_Device>& queue,
+            FrameSpec<T_NumFrames, T_FrameExtents, T_Executor> const& frameSpec,
+            T_KernelBundle const& kernelBundle) const
+        {
+            static_assert(
+                ALPAKA_TYPEOF(frameSpec)::getExecutor() != exec::anyExecutor,
+                "'exec::anyExecutor' can not be used to enqueue an kernel.");
+            ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::queue);
+
+            auto const threadBlocking = internal::adjustThreadSpec(*queue.m_device.get(), frameSpec, kernelBundle);
+
+            constexpr auto st_shared_mem_bytes = onAcc::oneApi::StaticSharedMemory::sizeLookupBufferInBytes(
+                ALPAKA_SYCL_NUM_MAX_SHARED_MEMORY_ALLOCATIONS);
+
+            // allocate dynamic shared memory -- needs at least 1 byte to make the Xilinx Runtime happy
+            u_int32_t blockDynSharedMemBytes
+                = std::max(u_int32_t(1), onHost::getDynSharedMemBytes(T_Executor{}, threadBlocking, kernelBundle));
+
             assert(
                 st_shared_mem_bytes + blockDynSharedMemBytes
                 <= queue.m_device->getNativeHandle().first.template get_info<sycl::info::device::local_mem_size>());
@@ -350,77 +433,6 @@ namespace alpaka::onHost::internal
                         {
                             using ApiType = decltype(getApi(queue));
                             using DeviceKindType = ALPAKA_TYPEOF(getDeviceKind(queue));
-
-                            auto st_shared_accessor
-                                = sycl::local_accessor<std::byte>{sycl::range<1>{st_shared_mem_bytes}, cgh};
-
-                            auto dyn_shared_accessor
-                                = sycl::local_accessor<std::byte>{sycl::range<1>{blockDynSharedMemBytes}, cgh};
-
-                            auto workerDesc = detail::getWorkerDescription(threadBlocking);
-                            auto optimizedThreadSpec = workerDesc.second;
-                            constexpr uint32_t syclDim = workerDesc.first.dimensions;
-
-                            constexpr uint32_t w = ALPAKA_TYPEOF(warpSize)::value;
-                            detail::EnqueueKernelWithWarpSize<syclDim, w, ALPAKA_SYCL_SUBGROUP_SIZE & w>::call(
-                                cgh,
-                                workerDesc.first,
-                                kernelBundle,
-                                st_shared_accessor,
-                                dyn_shared_accessor,
-                                optimizedThreadSpec,
-                                DictEntry(object::api, ApiType{}),
-                                DictEntry(object::deviceKind, DeviceKindType{}),
-                                DictEntry(object::exec, T_Executor{}),
-                                DictEntry(object::warpSize, warpSize));
-                        });
-                });
-
-            queue.setLastEvent(ev);
-            if(queue.isBlocking())
-                ev.wait_and_throw();
-        }
-    };
-
-    template<
-        typename T_Device,
-        alpaka::concepts::Executor T_Executor,
-        onHost::concepts::FrameSpec T_FrameSpec,
-        alpaka::concepts::KernelBundle T_KernelBundle>
-    struct Enqueue::Kernel<syclGeneric::Queue<T_Device>, T_Executor, T_FrameSpec, T_KernelBundle>
-    {
-        void operator()(
-            syclGeneric::Queue<T_Device>& queue,
-            T_Executor const executor,
-            T_FrameSpec const& frameSpec,
-            T_KernelBundle const& kernelBundle) const
-        {
-            auto const threadBlocking
-                = internal::adjustThreadSpec(*queue.m_device.get(), executor, frameSpec, kernelBundle);
-
-            constexpr auto st_shared_mem_bytes = onAcc::oneApi::StaticSharedMemory::sizeLookupBufferInBytes(
-                ALPAKA_SYCL_NUM_MAX_SHARED_MEMORY_ALLOCATIONS);
-
-            // allocate dynamic shared memory -- needs at least 1 byte to make the Xilinx Runtime happy
-            u_int32_t blockDynSharedMemBytes
-                = std::max(u_int32_t(1), onHost::getDynSharedMemBytes(executor, threadBlocking, kernelBundle));
-
-            assert(
-                st_shared_mem_bytes + blockDynSharedMemBytes
-                <= queue.m_device->getNativeHandle().first.template get_info<sycl::info::device::local_mem_size>());
-
-            sycl::event ev = queue.dispatchWarpSize(
-                [&](auto warpSize) requires std::same_as<
-                    std::integral_constant<
-                        typename ALPAKA_TYPEOF(warpSize)::value_type,
-                        ALPAKA_TYPEOF(warpSize)::value>,
-                    ALPAKA_TYPEOF(warpSize)>
-                {
-                    return queue.m_queue.submit(
-                        [warpSize, threadBlocking, frameSpec, kernelBundle, blockDynSharedMemBytes](sycl::handler& cgh)
-                        {
-                            using ApiType = decltype(getApi(queue));
-                            using DeviceKindType = ALPAKA_TYPEOF(getDeviceKind(queue));
                             auto st_shared_accessor
                                 = sycl::local_accessor<std::byte>{sycl::range<1>{st_shared_mem_bytes}, cgh};
                             auto dyn_shared_accessor
@@ -442,8 +454,7 @@ namespace alpaka::onHost::internal
                                 DictEntry(object::api, ApiType{}),
                                 DictEntry(object::deviceKind, DeviceKindType{}),
                                 DictEntry(object::exec, T_Executor{}),
-                                DictEntry(frame::count, frameSpec.getNumFrames()),
-                                DictEntry(frame::extent, frameSpec.getFrameExtents()),
+                                DictEntry(object::launchedWidthFrameSpec, std::bool_constant<true>{}),
                                 DictEntry(object::warpSize, warpSize));
                         });
                 });

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -293,21 +293,22 @@ namespace alpaka::onHost
         template<
             typename T_Platform,
             alpaka::concepts::Executor T_Executor,
-            onHost::concepts::FrameSpec T_FrameSpec,
+            alpaka::concepts::Vector T_NumFrames,
+            alpaka::concepts::Vector T_FrameExtents,
             alpaka::concepts::KernelBundle T_KernelBundle>
-        struct AdjustThreadSpec::Op<syclGeneric::Device<T_Platform>, T_Executor, T_FrameSpec, T_KernelBundle>
+        struct AdjustThreadSpec::
+            Op<syclGeneric::Device<T_Platform>, FrameSpec<T_NumFrames, T_FrameExtents, T_Executor>, T_KernelBundle>
         {
-            using T_NumThreads = T_FrameSpec::ThreadExtentsVecType;
+            using FrameSpecType = FrameSpec<T_NumFrames, T_FrameExtents, T_Executor>;
 
             auto operator()(
                 syclGeneric::Device<T_Platform> const& device,
-                T_Executor const& executor,
-                T_FrameSpec const& dataBlocking,
-                T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_NumThreads>
+                FrameSpecType const& frameSpec,
+                T_KernelBundle const& kernelBundle) const requires alpaka::concepts::CVector<T_FrameExtents>
             {
-                alpaka::unused(device, executor, kernelBundle);
+                alpaka::unused(device, kernelBundle);
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::device);
-                auto numThreads = dataBlocking.getThreadSpec().getNumThreads();
+                auto numThreads = frameSpec.getFrameExtents();
 
                 /** This limit is not exact but for typical GPUs, Intel, NVIDIA and AMD we can at least use 1024
                  * threads per block.
@@ -317,22 +318,21 @@ namespace alpaka::onHost
                 constexpr typename ALPAKA_TYPEOF(numThreads)::type hardwareLimitThreadsPerBlock = 1024u;
 
                 constexpr auto result = api::util::adjustToLimit<hardwareLimitThreadsPerBlock, 0u, 1u>(numThreads);
-                return ThreadSpec{dataBlocking.getThreadSpec().getNumBlocks(), result};
+                return ThreadSpec{frameSpec.getNumFrames(), result};
             }
 
             auto operator()(
                 syclGeneric::Device<T_Platform> const& device,
-                T_Executor const& executor,
-                T_FrameSpec const& dataBlocking,
+                FrameSpecType const& frameSpec,
                 T_KernelBundle const& kernelBundle) const
             {
-                alpaka::unused(executor, kernelBundle);
+                alpaka::unused(kernelBundle);
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::device);
-                auto numThreadsPerBlocks = dataBlocking.getThreadSpec().getNumThreads();
+                auto numThreadsPerBlocks = frameSpec.getFrameExtents();
                 auto const maxThreadsPerBlock = device.m_properties.maxThreadsPerBlock;
 
                 auto result = api::util::adjustToLimit(numThreadsPerBlocks, maxThreadsPerBlock);
-                return ThreadSpec{dataBlocking.getThreadSpec().getNumBlocks(), result};
+                return ThreadSpec{frameSpec.getNumFrames(), result};
             }
         };
 

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -373,21 +373,22 @@ namespace alpaka::onHost
 
         template<
             typename T_Platform,
-            alpaka::concepts::Executor T_Executor,
-            onHost::concepts::FrameSpec T_FrameSpec,
+            alpaka::concepts::UnifiedCudaHipExecutor T_Executor,
+            alpaka::concepts::Vector T_NumFrames,
+            alpaka::concepts::Vector T_FrameExtents,
             alpaka::concepts::KernelBundle T_KernelBundle>
-        struct AdjustThreadSpec::Op<unifiedCudaHip::Device<T_Platform>, T_Executor, T_FrameSpec, T_KernelBundle>
+        struct AdjustThreadSpec::
+            Op<unifiedCudaHip::Device<T_Platform>, FrameSpec<T_NumFrames, T_FrameExtents, T_Executor>, T_KernelBundle>
         {
-            using T_NumThreads = T_FrameSpec::ThreadExtentsVecType;
+            using FrameSpecType = FrameSpec<T_NumFrames, T_FrameExtents, T_Executor>;
 
             auto operator()(
                 unifiedCudaHip::Device<T_Platform> const&,
-                T_Executor const&,
-                T_FrameSpec const& dataBlocking,
-                T_KernelBundle const&) const requires alpaka::concepts::CVector<T_NumThreads>
+                FrameSpecType const& frameSpec,
+                T_KernelBundle const&) const requires alpaka::concepts::CVector<T_FrameExtents>
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::device);
-                auto numThreads = dataBlocking.getThreadSpec().getNumThreads();
+                auto numThreads = frameSpec.getFrameExtents();
 
                 /** All modern NVIDIA and AMD GPUs support at least 1014 threads.
                  * @attention: Due to lmem, shared memory or register usage the limit could be lower. In this case the
@@ -397,21 +398,20 @@ namespace alpaka::onHost
                 constexpr typename ALPAKA_TYPEOF(numThreads)::type hardwareLimitThreadsPerBlock = 1024u;
 
                 constexpr auto result = api::util::adjustToLimit<hardwareLimitThreadsPerBlock, 0u, 1u>(numThreads);
-                return ThreadSpec{dataBlocking.getThreadSpec().getNumBlocks(), result};
+                return ThreadSpec{frameSpec.getNumFrames(), result, frameSpec.getExecutor()};
             }
 
             auto operator()(
                 unifiedCudaHip::Device<T_Platform> const& device,
-                T_Executor const&,
-                T_FrameSpec const& dataBlocking,
+                FrameSpecType const& frameSpec,
                 T_KernelBundle const&) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::device);
-                auto numThreadsPerBlocks = dataBlocking.getThreadSpec().getNumThreads();
+                auto numThreadsPerBlocks = frameSpec.getFrameExtents();
                 auto const maxThreadsPerBlock = device.m_properties.maxThreadsPerBlock;
 
                 auto result = api::util::adjustToLimit(numThreadsPerBlocks, maxThreadsPerBlock);
-                return ThreadSpec{dataBlocking.getThreadSpec().getNumBlocks(), result};
+                return ThreadSpec{frameSpec.getNumFrames(), result, frameSpec.getExecutor()};
             }
         };
     } // namespace internal

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -187,36 +187,7 @@ namespace alpaka::onHost
             alpaka::concepts::Api T_Api,
             alpaka::concepts::DeviceKind T_DeviceKind,
             alpaka::concepts::Executor T_Executor,
-            typename TKernelBundle,
-            typename T_OptimizedThreadSpec,
-            typename T_NumFrames,
-            typename T_FrameSize>
-        __global__ void gpuKernel(
-            TKernelBundle const kernelBundle,
-            T_OptimizedThreadSpec const optimizedThreadSpec,
-            T_NumFrames const numFrames,
-            T_FrameSize const frameExtent)
-        {
-            constexpr auto warpSizeValue = alpaka::onAcc::unifiedCudaHip::internal::WarpSize::Get<T_DeviceKind>{}();
-            auto acc = onAcc::Acc{
-                Dict{
-                    DictEntry(layer::block, onAcc::unifiedCudaHip::BlockLayer{optimizedThreadSpec}),
-                    DictEntry(layer::thread, onAcc::unifiedCudaHip::ThreadLayer{optimizedThreadSpec}),
-                    DictEntry(frame::count, numFrames),
-                    DictEntry(frame::extent, frameExtent),
-                    DictEntry(action::threadBlockSync, onAcc::unifiedCudaHip::Sync{}),
-                    DictEntry(object::api, T_Api{}),
-                    DictEntry(object::deviceKind, T_DeviceKind{}),
-                    DictEntry(object::exec, T_Executor{}),
-                    DictEntry(object::warpSize, warpSizeValue)},
-            };
-            kernelBundle(acc);
-        }
-
-        template<
-            alpaka::concepts::Api T_Api,
-            alpaka::concepts::DeviceKind T_DeviceKind,
-            alpaka::concepts::Executor T_Executor,
+            bool launchedWidthFrameSpec,
             typename TKernelBundle,
             typename T_OptimizedThreadSpec>
         __global__ void gpuKernel(TKernelBundle const kernelBundle, T_OptimizedThreadSpec const optimizedThreadSpec)
@@ -226,6 +197,7 @@ namespace alpaka::onHost
                 Dict{
                     DictEntry(layer::block, onAcc::unifiedCudaHip::BlockLayer{optimizedThreadSpec}),
                     DictEntry(layer::thread, onAcc::unifiedCudaHip::ThreadLayer{optimizedThreadSpec}),
+                    DictEntry(object::launchedWidthFrameSpec, std::bool_constant<launchedWidthFrameSpec>{}),
                     DictEntry(action::threadBlockSync, onAcc::unifiedCudaHip::Sync{}),
                     DictEntry(object::api, T_Api{}),
                     DictEntry(object::deviceKind, T_DeviceKind{}),
@@ -268,19 +240,22 @@ namespace alpaka::onHost
             };
 
             template<
-                alpaka::concepts::Executor T_Executor,
+                bool launchedWidthFrameSpec,
                 typename T_Device,
-                typename T_NumBlocks,
-                typename T_NumThreads,
-                typename T_KernelBundle,
-                typename... T_Args>
+                alpaka::concepts::Vector T_NumBlocks,
+                alpaka::concepts::Vector T_NumThreads,
+                alpaka::concepts::Executor T_Executor,
+                typename T_KernelBundle>
             void operator()(
-                T_Executor const,
                 unifiedCudaHip::Queue<T_Device>& queue,
-                ThreadSpec<T_NumBlocks, T_NumThreads> const& threadSpec,
-                T_KernelBundle const& kernelBundle,
-                T_Args const&... args) const
+                ThreadSpec<T_NumBlocks, T_NumThreads, T_Executor> const& threadSpec,
+                T_KernelBundle const& kernelBundle) const
             {
+                static_assert(
+                    ALPAKA_TYPEOF(threadSpec)::getExecutor() != exec::anyExecutor,
+                    "'exec::anyExecutor' can not be used to enqueue an kernel.");
+                ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::queue);
+
                 using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ApiInterface,
@@ -318,9 +293,9 @@ namespace alpaka::onHost
                     ALPAKA_TYPEOF(getApi(queue)),
                     ALPAKA_TYPEOF(getDeviceKind(queue)),
                     T_Executor,
+                    launchedWidthFrameSpec,
                     T_KernelBundle,
-                    ALPAKA_TYPEOF(optimizedThreadSpec),
-                    T_Args...>;
+                    ALPAKA_TYPEOF(optimizedThreadSpec)>;
 
                 uint32_t blockDynSharedMemBytes
                     = onHost::getDynSharedMemBytes(exec::gpuCuda, threadSpec, kernelBundle);
@@ -329,7 +304,7 @@ namespace alpaka::onHost
                     convertVecToUniformCudaHipDim(numBlocks),
                     convertVecToUniformCudaHipDim(numThreadsPerBlock),
                     static_cast<std::size_t>(blockDynSharedMemBytes),
-                    queue.getNativeHandle()>>>(kernelBundle, optimizedThreadSpec, args...);
+                    queue.getNativeHandle()>>>(kernelBundle, optimizedThreadSpec);
 
                 queue.conditionalWait();
             }
@@ -445,20 +420,19 @@ namespace alpaka::onHost
         template<
             typename T_Device,
             alpaka::concepts::UnifiedCudaHipExecutor T_Executor,
-            typename T_NumBlocks,
-            typename T_NumThreads,
+            alpaka::concepts::Vector T_NumBlocks,
+            alpaka::concepts::Vector T_NumThreads,
             typename T_KernelBundle>
         struct Enqueue::
-            Kernel<unifiedCudaHip::Queue<T_Device>, T_Executor, ThreadSpec<T_NumBlocks, T_NumThreads>, T_KernelBundle>
+            Kernel<unifiedCudaHip::Queue<T_Device>, ThreadSpec<T_NumBlocks, T_NumThreads, T_Executor>, T_KernelBundle>
         {
             void operator()(
                 unifiedCudaHip::Queue<T_Device>& queue,
-                T_Executor const executor,
-                ThreadSpec<T_NumBlocks, T_NumThreads> const& threadBlocking,
+                ThreadSpec<T_NumBlocks, T_NumThreads, T_Executor> const& threadSpec,
                 T_KernelBundle const& kernelBundle) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::queue);
-                unifiedCudaHip::CallKernel{}(executor, queue, threadBlocking, kernelBundle);
+                unifiedCudaHip::CallKernel{}.template operator()<false>(queue, threadSpec, kernelBundle);
             }
         };
 
@@ -467,30 +441,21 @@ namespace alpaka::onHost
             alpaka::concepts::UnifiedCudaHipExecutor T_Executor,
             typename T_NumFrames,
             typename T_FrameExtents,
-            typename T_ThreadExtents,
             typename T_KernelBundle>
-        struct Enqueue::Kernel<
-            unifiedCudaHip::Queue<T_Device>,
-            T_Executor,
-            FrameSpec<T_NumFrames, T_FrameExtents, T_ThreadExtents>,
-            T_KernelBundle>
+        struct Enqueue::
+            Kernel<unifiedCudaHip::Queue<T_Device>, FrameSpec<T_NumFrames, T_FrameExtents, T_Executor>, T_KernelBundle>
         {
             void operator()(
                 unifiedCudaHip::Queue<T_Device>& queue,
-                T_Executor const executor,
-                FrameSpec<T_NumFrames, T_FrameExtents, T_ThreadExtents> const& frameSpec,
+                FrameSpec<T_NumFrames, T_FrameExtents, T_Executor> const& frameSpec,
                 T_KernelBundle const& kernelBundle) const
             {
+                static_assert(
+                    ALPAKA_TYPEOF(frameSpec)::getExecutor() != exec::anyExecutor,
+                    "'exec::anyExecutor' can not be used to enqueue an kernel.");
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::queue);
-                auto threadBlocking
-                    = internal::adjustThreadSpec(*queue.m_device.get(), executor, frameSpec, kernelBundle);
-                unifiedCudaHip::CallKernel{}(
-                    executor,
-                    queue,
-                    threadBlocking,
-                    kernelBundle,
-                    frameSpec.getNumFrames(),
-                    frameSpec.getFrameExtents());
+                auto threadBlocking = internal::adjustThreadSpec(*queue.m_device.get(), frameSpec, kernelBundle);
+                unifiedCudaHip::CallKernel{}.template operator()<true>(queue, threadBlocking, kernelBundle);
             }
         };
 

--- a/include/alpaka/onAcc/Acc.hpp
+++ b/include/alpaka/onAcc/Acc.hpp
@@ -72,6 +72,24 @@ namespace alpaka::onAcc
             return T_Storage::operator[](object::deviceKind);
         }
 
+        /** Check if a frame spec was used to enqueue the kernel
+         *
+         * To be able to use the result as constexpr value you must call the static function via the type
+         * `Acc_t::launchedWithFrameSpec()` else the warp size can only be used as runtime value.
+         *
+         * If the kernel was enqueued via a frame specification the thread specification to within the kernel can
+         * differ, the number of thread block is not necessary equal to the number of frames and the thread block
+         * extent is not necessary equal to the frame extents.
+         *
+         * @return true if the kernel was launched based on a frame specification, false if a thread specification was
+         * used.
+         */
+        static constexpr bool launchedWithFrameSpec()
+        {
+            // is std::true_type or std::false_type
+            return ALPAKA_TYPEOF(std::declval<T_Storage>()[object::launchedWidthFrameSpec])::value;
+        }
+
         /** Get the warp size
          *
          * To be able to use the warp size as constexpr value you must call the static function via the type

--- a/include/alpaka/onAcc/internal/IdxRange.hpp
+++ b/include/alpaka/onAcc/internal/IdxRange.hpp
@@ -45,36 +45,6 @@ namespace alpaka::onAcc::internal
                 return IdxRange{extent};
         }
     };
-
-    namespace idxTrait
-    {
-        struct TotalFrameSpecExtent
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[frame::count] * acc[frame::extent];
-            }
-        };
-
-        struct FrameCount
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[frame::count];
-            }
-        };
-
-        struct FrameExtent
-        {
-            template<typename T_Acc>
-            constexpr auto operator()(T_Acc const& acc) const
-            {
-                return acc[frame::extent];
-            }
-        };
-    } // namespace idxTrait
 } // namespace alpaka::onAcc::internal
 
 namespace alpaka::trait

--- a/include/alpaka/onAcc/range.hpp
+++ b/include/alpaka/onAcc/range.hpp
@@ -10,10 +10,6 @@ namespace alpaka::onAcc
 {
     namespace range
     {
-        constexpr auto totalFrameSpecExtent = internal::IdxRangeFn{internal::idxTrait::TotalFrameSpecExtent{}};
-        constexpr auto frameCount = internal::IdxRangeFn{internal::idxTrait::FrameCount{}};
-        constexpr auto frameExtent = internal::IdxRangeFn{internal::idxTrait::FrameExtent{}};
-
         constexpr auto threadsInGrid = internal::IdxRangeLazy{origin::grid, unit::threads};
         constexpr auto blocksInGrid = internal::IdxRangeLazy{origin::grid, unit::blocks};
         constexpr auto threadsInBlock = internal::IdxRangeLazy{origin::block, unit::threads};

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -331,8 +331,9 @@ namespace alpaka::onHost
     template<typename T_DataType, typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     inline constexpr auto getFrameSpec(
         Device<T_Api, T_DeviceKind> const& device,
+        alpaka::concepts::Executor auto executor,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
-        return internal::getFrameSpec<T_DataType>(*device.get(), extents);
+        return internal::getFrameSpec<T_DataType>(*device.get(), executor, extents);
     }
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/FrameSpec.hpp
+++ b/include/alpaka/onHost/FrameSpec.hpp
@@ -42,7 +42,7 @@ namespace alpaka::onHost
         alpaka::concepts::Vector T_NumFrames,
         alpaka::concepts::Vector<typename T_NumFrames::type, T_NumFrames::dim()> T_FrameExtents,
         alpaka::concepts::Executor T_Executor = alpaka::exec::AnyExecutor>
-    struct FrameSpec : T_Executor
+    struct FrameSpec
     {
         using index_type = typename T_NumFrames::type;
 
@@ -64,7 +64,7 @@ namespace alpaka::onHost
             alpaka::unused(executor);
         }
 
-        [[nodiscard]] static constexpr T_Executor getExecutor()
+        [[nodiscard]] static constexpr T_Executor getExecutor() noexcept
         {
             return T_Executor{};
         }

--- a/include/alpaka/onHost/FrameSpec.hpp
+++ b/include/alpaka/onHost/FrameSpec.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/Vec.hpp"
+#include "alpaka/api/executor.hpp"
 #include "alpaka/concepts.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/onHost/ThreadSpec.hpp"
@@ -19,70 +20,53 @@ namespace alpaka::onHost
      * A frame specification describes how a multidimensional index range [0; K) is divided into fixed-size chunks,
      * called frames (NF), each with a frame extent (FE), where `K = NF * FE`.
      * K does not need to match the problem size (P), e.g., the number of elements in a buffer you want to process in a
-     * kernel. How NF and FE are mapped to physical worker threads and thread blocks within the kernel depends entirely
-     * on the kernel implementation. Often, the best performance of a kernel can be achieved if `K <= P`, and if the
-     * kernel uses SIMD operations, `K <= P/(SIMD width)`. A kernel enqueued with a frame specification should always
-     * be written to be executable with any `FrameSpec` and should not depend on hard-coded thread numbers, to ensure
+     * kernel. Often, the best performance of a kernel can be achieved if `K <= P`, and if the
+     * kernel uses SIMD operations, `K <= P/(SIMD width)`.
+     * alpaka derives the onHost::ThreadSpec to launch the kernel, based on a hysteric and additional launch
+     * information from the `FrameSpec`. Therefor a kernel enqueued with a frame specification should always be written
+     * to be executable with any onHost::ThreadSpec and should not depend on hard-coded thread numbers, to ensure
      * portability between devices.
      *
      * A `FrameSpec` is therefore not equivalent to a CUDA-style grid description. It specifies only the maximum
      * parallelism made available to the kernel. It does not guarantee the number of physical thread blocks, nor the
      * number of physical threads per block used by the backend. If exact control over blocks and threads is required,
-     * use `alpaka::onHost::ThreadSpec`.
+     * use onHost::ThreadSpec.
      *
-     * The specification contains three parameters:
-     * - `numFrames`: The n-dimensional number of frames.
-     * - `frameExtents`: The n-dimensional size of one logical frame.
-     * - `threadSpec` (optional): Backend-specific description of the actual execution resources consisting of the
-     *   number of blocks and threads. By default, this is automatically chosen by alpaka when starting a kernel to
-     *   fit the `alpaka::onHost::Device` and `alpaka::exec`, ensuring compatibility. User-provided specifications
-     *   might reduce the (performance-)portability.
+     * @tparam T_NumFrames The n-dimensional number of frames.
+     * @tparam T_FrameExtents The n-dimensional size of one logical frame.
+     * @tparam T_Executor The executor used to translate the onHost::ThreadSpec into a thread block hierarchy.
+     * If the executor is exec::AnyExecutor alpaka will select a good fitting executor for the action where the
+     * ThreadSpec is used.
      */
     template<
         alpaka::concepts::Vector T_NumFrames,
         alpaka::concepts::Vector<typename T_NumFrames::type, T_NumFrames::dim()> T_FrameExtents,
-        alpaka::concepts::Vector<typename T_NumFrames::type, T_NumFrames::dim()> T_ThreadExtents>
-    struct FrameSpec
+        alpaka::concepts::Executor T_Executor = alpaka::exec::AnyExecutor>
+    struct FrameSpec : T_Executor
     {
         using index_type = typename T_NumFrames::type;
 
         using NumFramesVecType = T_NumFrames;
         using FrameExtentsVecType = T_FrameExtents;
-        using ThreadExtentsVecType = T_ThreadExtents;
-        using ThreadSpecType = ThreadSpec<T_NumFrames, T_ThreadExtents>;
 
     private:
         NumFramesVecType m_numFrames;
         FrameExtentsVecType m_frameExtents;
-        ThreadSpecType m_threadSpec;
 
     public:
-        constexpr FrameSpec(T_NumFrames const& numFrames, T_FrameExtents const& frameExtent)
-            : m_numFrames(numFrames)
-            , m_frameExtents(frameExtent)
-            , m_threadSpec(numFrames, frameExtent)
-        {
-        }
-
         constexpr FrameSpec(
             T_NumFrames const& numFrames,
             T_FrameExtents const& frameExtent,
-            T_ThreadExtents const& numThreads)
+            T_Executor executor = T_Executor{})
             : m_numFrames(numFrames)
             , m_frameExtents(frameExtent)
-            , m_threadSpec(numFrames, numThreads)
         {
+            alpaka::unused(executor);
         }
 
-        constexpr FrameSpec(
-            T_NumFrames const& numFrames,
-            T_FrameExtents const& frameExtent,
-            T_NumFrames numBlocks,
-            T_FrameExtents const& numThreads)
-            : m_numFrames(numFrames)
-            , m_frameExtents(frameExtent)
-            , m_threadSpec(numBlocks, numThreads)
+        [[nodiscard]] static constexpr T_Executor getExecutor()
         {
+            return T_Executor{};
         }
 
         [[nodiscard]] constexpr NumFramesVecType const& getNumFrames() const noexcept
@@ -95,11 +79,6 @@ namespace alpaka::onHost
             return m_frameExtents;
         }
 
-        [[nodiscard]] constexpr ThreadSpecType const& getThreadSpec() const noexcept
-        {
-            return m_threadSpec;
-        }
-
         [[nodiscard]] static consteval uint32_t dim()
         {
             return T_FrameExtents::dim();
@@ -110,22 +89,14 @@ namespace alpaka::onHost
     FrameSpec(T_NumFrames const&, T_FrameExtents const&) -> FrameSpec<
         alpaka::trait::getVec_t<T_NumFrames>,
         alpaka::trait::getVec_t<T_FrameExtents>,
-        alpaka::trait::getVec_t<T_FrameExtents>>;
+        alpaka::exec::AnyExecutor>;
 
     template<
         alpaka::concepts::VectorOrScalar T_NumFrames,
         alpaka::concepts::VectorOrScalar T_FrameExtents,
-        alpaka::concepts::VectorOrScalar T_ThreadExtents>
-    FrameSpec(T_NumFrames const&, T_FrameExtents const&, T_ThreadExtents const&) -> FrameSpec<
-        alpaka::trait::getVec_t<T_NumFrames>,
-        alpaka::trait::getVec_t<T_FrameExtents>,
-        alpaka::trait::getVec_t<T_ThreadExtents>>;
-
-    template<alpaka::concepts::VectorOrScalar T_NumFrames, alpaka::concepts::VectorOrScalar T_FrameExtents>
-    FrameSpec(T_NumFrames const&, T_FrameExtents const&, T_NumFrames const&, T_FrameExtents const&) -> FrameSpec<
-        alpaka::trait::getVec_t<T_NumFrames>,
-        alpaka::trait::getVec_t<T_FrameExtents>,
-        alpaka::trait::getVec_t<T_FrameExtents>>;
+        alpaka::concepts::Executor T_Executor>
+    FrameSpec(T_NumFrames const&, T_FrameExtents const&, T_Executor)
+        -> FrameSpec<alpaka::trait::getVec_t<T_NumFrames>, alpaka::trait::getVec_t<T_FrameExtents>, T_Executor>;
 
     namespace trait
     {
@@ -137,8 +108,8 @@ namespace alpaka::onHost
         template<
             alpaka::concepts::Vector T_NumFrames,
             alpaka::concepts::Vector T_FrameExtents,
-            alpaka::concepts::Vector T_ThreadExtents>
-        struct IsFrameSpec<onHost::FrameSpec<T_NumFrames, T_FrameExtents, T_ThreadExtents>> : std::true_type
+            alpaka::concepts::Executor T_Executor>
+        struct IsFrameSpec<onHost::FrameSpec<T_NumFrames, T_FrameExtents, T_Executor>> : std::true_type
         {
         };
     } // namespace trait
@@ -171,8 +142,7 @@ namespace alpaka::onHost
 
     std::ostream& operator<<(std::ostream& s, concepts::FrameSpec auto const& d)
     {
-        return s << "FrameSpec{ frames=" << d.getNumFrames() << ", frameExtent=" << d.getFrameExtents() << ", "
-                 << d.getThreadSpec() << " }";
+        return s << "FrameSpec{ frames=" << d.getNumFrames() << ", frameExtent=" << d.getFrameExtents() << " }";
     }
 
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -10,6 +10,7 @@
 #include "alpaka/onHost/Event.hpp"
 #include "alpaka/onHost/concepts.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
+#include "alpaka/onHost/trait.hpp"
 
 #include <memory>
 
@@ -100,78 +101,38 @@ namespace alpaka::onHost
 
         /** Enqueue a kernel functor to a queue.
          *
-         * @param executor Description how native worker threads will be mapped and grouped to compute grid layers
-         * (blocks, threads).
-         * @param domainSpec Thread or frame specification which provides a chunked description of the thread or frame
-         * index domain.
-         * @param f The compute kernel functor.
-         * @param args Arguments passed to the kernel functor.
-         */
-        void enqueue(
-            auto const executor,
-            onHost::concepts::ThreadOrFrameSpec auto const& domainSpec,
-            auto const& f,
-            auto&&... args) const
-        {
-            internal::enqueue(
-                *m_queue.get(),
-                executor,
-                domainSpec,
-                KernelBundle{f, onHost::makeAccessibleOnAcc(ALPAKA_FORWARD(args))...});
-        }
-
-        /** Enqueue a kernel functor to a queue.
-         *
-         * An available default executor is selected automatically. The default executor is the executor with the
-         * highest parallelism/performance.
-         *
-         * @param domainSpec Thread or frame specification which provides a chunked description of the thread or frame
-         * index domain.
-         * @param f The compute kernel functor.
-         * @param args Arguments passed to the kernel functor.
-         */
-        void enqueue(onHost::concepts::ThreadOrFrameSpec auto const& domainSpec, auto const& f, auto&&... args) const
-        {
-            auto executors = supportedExecutors(internal::getDevice(*m_queue.get()), exec::allExecutors);
-            internal::enqueue(
-                *m_queue.get(),
-                std::get<0>(executors),
-                domainSpec,
-                KernelBundle{f, onHost::makeAccessibleOnAcc(ALPAKA_FORWARD(args))...});
-        }
-
-        /** Enqueue a kernel functor to a queue.
-         *
-         * An available default executor is selected automatically. The default executor is the executor with the
-         * highest parallelism/performance.
-         *
-         * @param domainSpec Thread or frame specification which provides a chunked description of the thread or frame
-         * index domain.
-         * @param kernelBundle The compute kernel and its arguments.
-         */
-        template<typename TKernelFn, typename... TArgs>
-        void enqueue(
-            onHost::concepts::ThreadOrFrameSpec auto const& domainSpec,
-            KernelBundle<TKernelFn, TArgs...> const& kernelBundle) const
-        {
-            auto executors = supportedExecutors(internal::getDevice(*m_queue.get()), exec::allExecutors);
-            internal::enqueue(*m_queue.get(), std::get<0>(executors), domainSpec, kernelBundle);
-        }
-
-        /** Enqueue a kernel functor to a queue.
-         *
-         * @param executor Description how native worker threads will be mapped and grouped to compute grid layers
-         * (blocks, threads).
-         * @param domainSpec Thread or frame specification which provides a chunked description of the thread or frame
-         * index domain.
+         * @param launchCfg Thread or frame specification which provides a chunked description of the thread or
+         * frame index domain.
          * @param kernelBundle The compute kernel and its arguments.
          */
         void enqueue(
-            alpaka::concepts::Executor auto const executor,
-            onHost::concepts::ThreadOrFrameSpec auto const& domainSpec,
+            onHost::concepts::ThreadOrFrameSpec auto const& launchCfg,
             alpaka::concepts::KernelBundle auto const& kernelBundle) const
         {
-            internal::enqueue(*m_queue.get(), executor, domainSpec, kernelBundle);
+            if constexpr(ALPAKA_TYPEOF(launchCfg)::getExecutor() == alpaka::exec::anyExecutor)
+            {
+                auto executors
+                    = alpaka::onHost::supportedExecutors(internal::getDevice(*m_queue.get()), exec::allExecutors);
+                FrameSpec frameSpecWithExecutor
+                    = FrameSpec{launchCfg.getNumFrames(), launchCfg.getFrameExtents(), std::get<0>(executors)};
+                internal::enqueue(*m_queue.get(), frameSpecWithExecutor, kernelBundle);
+            }
+            else
+            {
+                internal::enqueue(*m_queue.get(), launchCfg, kernelBundle);
+            }
+        }
+
+        /** Enqueue a kernel functor to a queue.
+         *
+         * @param launchCfg Thread or frame specification which provides a chunked description of the thread or
+         * frame index domain.
+         * @param f The compute kernel functor.
+         * @param args Arguments passed to the kernel functor.
+         */
+        void enqueue(onHost::concepts::ThreadOrFrameSpec auto const& launchCfg, auto const& f, auto&&... args) const
+        {
+            enqueue(launchCfg, KernelBundle{f, onHost::makeAccessibleOnAcc(ALPAKA_FORWARD(args))...});
         }
 
         /** Enqueue an operation which is executed on the host side.

--- a/include/alpaka/onHost/ThreadSpec.hpp
+++ b/include/alpaka/onHost/ThreadSpec.hpp
@@ -29,7 +29,7 @@ namespace alpaka::onHost
         alpaka::concepts::Vector T_NumBlocks,
         alpaka::concepts::Vector<typename T_NumBlocks::type, T_NumBlocks::dim()> T_NumThreads,
         alpaka::concepts::Executor T_Executor = alpaka::exec::AnyExecutor>
-    struct ThreadSpec : T_Executor
+    struct ThreadSpec
     {
         using index_type = typename T_NumBlocks::type;
         using NumBlocksVecType = typename T_NumBlocks::UniVec;
@@ -40,15 +40,11 @@ namespace alpaka::onHost
         NumThreadsVecType m_numThreads;
 
     public:
-        constexpr ThreadSpec(T_NumBlocks const& numBlocks, T_NumThreads const& numThreadsPerBlock)
+        constexpr ThreadSpec(
+            T_NumBlocks const& numBlocks,
+            T_NumThreads const& numThreadsPerBlock,
+            T_Executor executor = T_Executor{})
             : m_numBlocks(numBlocks)
-            , m_numThreads(numThreadsPerBlock)
-        {
-        }
-
-        constexpr ThreadSpec(T_NumBlocks const& numBlocks, T_NumThreads const& numThreadsPerBlock, T_Executor executor)
-            : T_Executor(std::move(executor))
-            , m_numBlocks(numBlocks)
             , m_numThreads(numThreadsPerBlock)
         {
             alpaka::unused(executor);

--- a/include/alpaka/onHost/ThreadSpec.hpp
+++ b/include/alpaka/onHost/ThreadSpec.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/Vec.hpp"
+#include "alpaka/api/executor.hpp"
 #include "alpaka/concepts.hpp"
 #include "alpaka/core/common.hpp"
 
@@ -20,11 +21,15 @@ namespace alpaka::onHost
      *
      * In contrast to `alpaka::onHost::FrameSpec`, a `ThreadSpec` is not a logical frame decomposition. It is used
      * when a kernel requires exact guarantees about the number of blocks and the size of each block.
+     *
+     * @tparam T_Executor If the executor is alpaka::exec::AnyExecutor alpaka will select a good fitting executor for
+     * the action where the ThreadSpec is used.
      */
     template<
         alpaka::concepts::Vector T_NumBlocks,
-        alpaka::concepts::Vector<typename T_NumBlocks::type, T_NumBlocks::dim()> T_NumThreads>
-    struct ThreadSpec
+        alpaka::concepts::Vector<typename T_NumBlocks::type, T_NumBlocks::dim()> T_NumThreads,
+        alpaka::concepts::Executor T_Executor = alpaka::exec::AnyExecutor>
+    struct ThreadSpec : T_Executor
     {
         using index_type = typename T_NumBlocks::type;
         using NumBlocksVecType = typename T_NumBlocks::UniVec;
@@ -39,6 +44,19 @@ namespace alpaka::onHost
             : m_numBlocks(numBlocks)
             , m_numThreads(numThreadsPerBlock)
         {
+        }
+
+        constexpr ThreadSpec(T_NumBlocks const& numBlocks, T_NumThreads const& numThreadsPerBlock, T_Executor executor)
+            : T_Executor(std::move(executor))
+            , m_numBlocks(numBlocks)
+            , m_numThreads(numThreadsPerBlock)
+        {
+            alpaka::unused(executor);
+        }
+
+        [[nodiscard]] static constexpr T_Executor getExecutor()
+        {
+            return T_Executor{};
         }
 
         [[nodiscard]] constexpr NumThreadsVecType const& getNumThreads() const noexcept
@@ -61,6 +79,13 @@ namespace alpaka::onHost
     ThreadSpec(T_NumBlocks const&, T_NumThreads const&)
         -> ThreadSpec<alpaka::trait::getVec_t<T_NumBlocks>, alpaka::trait::getVec_t<T_NumThreads>>;
 
+    template<
+        alpaka::concepts::VectorOrScalar T_NumBlocks,
+        alpaka::concepts::VectorOrScalar T_NumThreads,
+        alpaka::concepts::Executor T_Executor>
+    ThreadSpec(T_NumBlocks const&, T_NumThreads const&, T_Executor)
+        -> ThreadSpec<alpaka::trait::getVec_t<T_NumBlocks>, alpaka::trait::getVec_t<T_NumThreads>, T_Executor>;
+
     namespace trait
     {
         template<typename T>
@@ -68,8 +93,11 @@ namespace alpaka::onHost
         {
         };
 
-        template<alpaka::concepts::Vector T_NumBlocks, alpaka::concepts::Vector T_NumThreads>
-        struct IsThreadSpec<onHost::ThreadSpec<T_NumBlocks, T_NumThreads>> : std::true_type
+        template<
+            alpaka::concepts::Vector T_NumBlocks,
+            alpaka::concepts::Vector T_NumThreads,
+            alpaka::concepts::Executor T_Executor>
+        struct IsThreadSpec<onHost::ThreadSpec<T_NumBlocks, T_NumThreads, T_Executor>> : std::true_type
         {
         };
     } // namespace trait

--- a/include/alpaka/onHost/algo/concurrent.hpp
+++ b/include/alpaka/onHost/algo/concurrent.hpp
@@ -49,7 +49,18 @@ namespace alpaka::onHost
         auto&& fn,
         alpaka::concepts::IDataSource auto&&... inOut)
     {
-        internal::concurrent<T_DataType>(queue, exec, extents, ALPAKA_FORWARD(fn), ALPAKA_FORWARD(inOut)...);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::concurrent<T_DataType>(
+                queue,
+                std::get<0>(availableExecutors),
+                extents,
+                ALPAKA_FORWARD(fn),
+                ALPAKA_FORWARD(inOut)...);
+        }
+        else
+            internal::concurrent<T_DataType>(queue, exec, extents, ALPAKA_FORWARD(fn), ALPAKA_FORWARD(inOut)...);
     }
 
     /**

--- a/include/alpaka/onHost/algo/internal/concurrent.hpp
+++ b/include/alpaka/onHost/algo/internal/concurrent.hpp
@@ -49,7 +49,7 @@ namespace alpaka::onHost::internal
         alpaka::concepts::IDataSource auto&&... in)
     {
         Vec const extentMd = extents;
-        auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), extentMd);
+        auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), exec, extentMd);
 
         ALPAKA_LOG_INFO(
             onHost::logger::memory,
@@ -62,7 +62,6 @@ namespace alpaka::onHost::internal
             });
 
         queue.enqueue(
-            exec,
             frameSpec,
             KernelBundle{SimdConcurrentKernel{}, extentMd, ALPAKA_FORWARD(fn), ALPAKA_FORWARD(in)...});
     }

--- a/include/alpaka/onHost/algo/internal/iota.hpp
+++ b/include/alpaka/onHost/algo/internal/iota.hpp
@@ -58,7 +58,7 @@ namespace alpaka::onHost::internal
         alpaka::concepts::IMdSpan auto&&... inputs)
     {
         Vec const extentMd = extents;
-        auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), extentMd);
+        auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), exec, extentMd);
 
         ALPAKA_LOG_INFO(
             onHost::logger::memory,
@@ -70,6 +70,6 @@ namespace alpaka::onHost::internal
                 return ss.str();
             });
 
-        queue.enqueue(exec, frameSpec, KernelBundle{SimdIotaKernel{}, extentMd, initValue, ALPAKA_FORWARD(inputs)...});
+        queue.enqueue(frameSpec, KernelBundle{SimdIotaKernel{}, extentMd, initValue, ALPAKA_FORWARD(inputs)...});
     }
 } // namespace alpaka::onHost::internal

--- a/include/alpaka/onHost/algo/internal/scan.hpp
+++ b/include/alpaka/onHost/algo/internal/scan.hpp
@@ -117,17 +117,17 @@ namespace alpaka::onHost::internal
     public:
         ALPAKA_FN_ACC void operator()(
             auto const& acc,
+            alpaka::concepts::Vector auto const numChunks,
+            alpaka::concepts::CVector auto const largeChunkExtents,
             alpaka::concepts::IDataSource auto const& inputVec,
             alpaka::concepts::IMdSpan auto outputVec,
             auto... blockSums) const
         {
             using DeviceType = ALPAKA_TYPEOF(acc.getDeviceKind());
             using AccType = ALPAKA_TYPEOF(acc);
-            alpaka::concepts::Vector auto numFrames = acc[frame::count];
 
             alpaka::concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
-            alpaka::concepts::CVector auto frameExtent = acc[frame::extent];
-            constexpr std::integral auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
+            constexpr std::integral auto elsPerThread = largeChunkExtents.x() / numThreadsPerBlock.x();
             alpaka::concepts::CVector auto chunkExtent = CVec<T_Idx, elsPerThread * numThreadsPerBlock.x()>{};
             alpaka::concepts::Vector auto numElements = inputVec.getExtents();
 
@@ -146,18 +146,18 @@ namespace alpaka::onHost::internal
              * All thread blocks will be used to iterate over the frames. Each thread block will handle one or more
              * frames.
              */
-            for(auto frameIdx :
-                onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec<T_Idx, 1u>{0}, numFrames}))
+            for(auto chunkIdx :
+                onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{Vec<T_Idx, 1u>{0}, numChunks}))
             {
                 bool const lastFrameFull = validElementsInLastFrame == chunkExtent;
-                bool const isLastFrame = frameIdx == numFrames - T_Idx{1};
+                bool const isLastFrame = chunkIdx == numChunks - T_Idx{1};
 
                 // allocate "per-thread" register memory to store all mini blocks of a thread persistently
                 LocalArray regMem;
 
                 constexpr auto conflictFreeAdr = conflictFreeAccess<AccType>(miniBlocksPerChunk - T_Idx{1}) + T_Idx{1};
                 auto tmp = onAcc::declareSharedMdArray<T_Data, uniqueId()>(acc, CVec<T_Idx, conflictFreeAdr>{});
-                auto const frameOffset = chunkExtent * frameIdx;
+                auto const frameOffset = chunkExtent * chunkIdx;
 
                 for(auto frameElem : onAcc::makeIdxMap(
                         acc,
@@ -231,7 +231,7 @@ namespace alpaka::onHost::internal
                     if constexpr(sizeof...(blockSums))
                     {
                         auto _blockSums = std::get<0>(std::make_tuple(blockSums...));
-                        _blockSums[frameIdx] = tmp[conflictFreeAccess<AccType>(miniBlocksPerChunk - T_Idx{1})];
+                        _blockSums[chunkIdx] = tmp[conflictFreeAccess<AccType>(miniBlocksPerChunk - T_Idx{1})];
                     }
 
                     // -- SET 0 --
@@ -334,13 +334,13 @@ namespace alpaka::onHost::internal
     public:
         ALPAKA_FN_ACC void operator()(
             auto const& acc,
+            alpaka::concepts::CVector auto const largeChunkExtents,
             alpaka::concepts::IMdSpan auto const& blockSums,
             alpaka::concepts::IMdSpan auto outputVec) const
         {
             alpaka::concepts::Vector auto numElements = outputVec.getExtents();
             alpaka::concepts::CVector auto numThreadsPerBlock = acc[layer::thread].count();
-            alpaka::concepts::CVector auto frameExtent = acc[frame::extent];
-            constexpr auto elsPerThread = frameExtent.x() / numThreadsPerBlock.x();
+            constexpr auto elsPerThread = largeChunkExtents.x() / numThreadsPerBlock.x();
             alpaka::concepts::CVector auto chunkExtent = CVec<T_Idx, elsPerThread * numThreadsPerBlock.x()>{};
 
             auto simdGrid = onAcc::SimdAlgo{onAcc::worker::threadsInGrid};
@@ -397,8 +397,8 @@ namespace alpaka::onHost::internal
 
         // Define chunkExtent
         constexpr auto chunkExtent = CVec<T_Idx, chunkSize>{};
-        alpaka::Vec numFrames = divCeil(inputVec.getExtents(), chunkExtent);
-        auto const frameSpec = onHost::FrameSpec{numFrames, chunkExtent, CVec<T_Idx, 256u>{}};
+        alpaka::Vec numChunks = divCeil(inputVec.getExtents(), chunkExtent);
+        auto const frameSpec = onHost::FrameSpec{numChunks, CVec<T_Idx, 256u>{}};
 
         ALPAKA_LOG_INFO(
             onHost::logger::memory,
@@ -410,7 +410,7 @@ namespace alpaka::onHost::internal
                     ss << ", scanType= INCLUSIVE_SCAN";
                 else if(SCAN_TYPE == EXCLUSIVE_SCAN)
                     ss << ", scanType= EXCLUSIVE_SCAN";
-                ss << ", numFrames= " << numFrames;
+                ss << ", numFrames= " << numChunks;
                 ss << ", chunkExtent= " << chunkExtent;
                 ss << ", value_type=" << onHost::demangledName<T_Data>();
                 ss << "}";
@@ -436,16 +436,18 @@ namespace alpaka::onHost::internal
             auto bufferNext = buffer.getSubView(bufSizeBytes, buffer.getExtents() - bufSizeBytes);
 
             // enqueue the kernel execution tasks
-            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec, increments});
+            queue.enqueue(
+                frameSpec,
+                KernelBundle{scanBlocks, numChunks, chunkExtent, inputVec, outputVec, increments});
 
             // always recurse into exclusive scan
             scan<EXCLUSIVE_SCAN>(queue, devAcc, exec, bufferNext, increments, increments);
-            queue.enqueue(exec, frameSpec, KernelBundle{addIncrements, increments, outputVec});
+            queue.enqueue(frameSpec, KernelBundle{addIncrements, chunkExtent, increments, outputVec});
         }
         else
         {
             // problem fits within 1 frame
-            queue.enqueue(exec, frameSpec, KernelBundle{scanBlocks, inputVec, outputVec});
+            queue.enqueue(frameSpec, KernelBundle{scanBlocks, numChunks, chunkExtent, inputVec, outputVec});
         }
     }
 

--- a/include/alpaka/onHost/algo/internal/transform.hpp
+++ b/include/alpaka/onHost/algo/internal/transform.hpp
@@ -89,7 +89,7 @@ namespace alpaka::onHost::internal
     {
         auto extentMd = onHost::getExtents(out);
         using DataType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>;
-        auto frameSpec = getFrameSpec<DataType>(queue.getDevice(), extentMd);
+        auto frameSpec = getFrameSpec<DataType>(queue.getDevice(), exec, extentMd);
 
         ALPAKA_LOG_INFO(
             onHost::logger::memory,
@@ -102,7 +102,6 @@ namespace alpaka::onHost::internal
             });
 
         queue.enqueue(
-            exec,
             frameSpec,
             KernelBundle{SimdTransformKernel{}, ALPAKA_FORWARD(out), ALPAKA_FORWARD(fn), ALPAKA_FORWARD(in)...});
     }

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -46,9 +46,7 @@ namespace alpaka::onHost::internal
             // Shared memory for block-wide reduction
             T_DataType* dynS = onAcc::getDynSharedMem<T_DataType>(acc);
             auto pitchMd = alpaka::calculatePitchesFromExtents<T_DataType>(chunkExtents);
-            auto tbSum = MdSpan{dynS, chunkExtents, pitchMd}; // makeMdSpan(dynS, frameExtent, pitchMd);
-            //  auto tbSum = onAcc::declareSharedMdArray<T_DataType, uniqueId()>(acc, CVec<uint32_t, 2>{});
-            // T_DataType* dynS = &tbSum[0];
+            auto tbSum = MdSpan{dynS, chunkExtents, pitchMd};
 
             auto traverseInFrame = alpaka::onAcc::makeIdxMap(
                 acc,
@@ -62,18 +60,18 @@ namespace alpaka::onHost::internal
                 tbSum[elemIdxInFrame] = neutralElement;
             }
 
-            auto const frameDataExtent = numChunks * chunkExtents;
+            auto const chunkDataExtent = numChunks * chunkExtents;
             auto traverseOverFrames = alpaka::onAcc::makeIdxMap(
                 acc,
                 alpaka::onAcc::worker::blocksInGrid,
-                alpaka::IdxRange{frameDataExtent.fill(0), frameDataExtent, chunkExtents});
+                alpaka::IdxRange{chunkDataExtent.fill(0), chunkDataExtent, chunkExtents});
 
-            for(auto frameIdx : traverseOverFrames)
+            for(auto chunkIdx : traverseOverFrames)
             {
-                for(alpaka::concepts::Vector auto elemIdxInFrame : traverseInFrame)
+                for(alpaka::concepts::Vector auto elemIdxInChunk : traverseInFrame)
                 {
                     auto allThreads = alpaka::onAcc::SimdAlgo{
-                        alpaka::onAcc::WorkerGroup{frameIdx + elemIdxInFrame, frameDataExtent}};
+                        alpaka::onAcc::WorkerGroup{chunkIdx + elemIdxInChunk, chunkDataExtent}};
 
                     // reduce functor with simd package support
                     callTransformFn(
@@ -81,7 +79,7 @@ namespace alpaka::onHost::internal
                         allThreads,
                         extentMd,
                         neutralElement,
-                        tbSum[elemIdxInFrame],
+                        tbSum[elemIdxInChunk],
                         reduceFunc,
                         transformFunc,
                         ALPAKA_FORWARD(inputs)...);
@@ -224,13 +222,6 @@ namespace alpaka::onHost::internal
         using IndexType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(extentMd)>;
         auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), exec, extentMd);
 
-        /* Derive the chunks size and number of chunks from the SIMD optimized frame specification.
-         * Having the chunking independent of the number of threads in a block helps to control the numerical precision
-         * to reduce numerical issues due to long chains of reductions.
-         */
-        auto numChunks = frameSpec.getNumFrames();
-        auto chunkExtents = frameSpec.getFrameExtents();
-
         /* Adjust the launch parameters to not oversubscribe a device too much.
          *
          * @todo: This heuristic should be adjusted based on benchmarking different cases.
@@ -250,6 +241,13 @@ namespace alpaka::onHost::internal
                 static_cast<IndexType>(numMultiProcessors * multiprocessorScaling));
             frameSpec = FrameSpec{adjsutedNumFrames, frameSpec.getFrameExtents(), exec};
         }
+
+        /* Derive the chunk size and number of chunks from the SIMD optimized frame specification.
+         * The chunking parameters influences the numerical precision because it provides the possibility to control
+         * the length of the accumulation chain of a single thread.
+         */
+        auto numChunks = frameSpec.getNumFrames();
+        auto chunkExtents = frameSpec.getFrameExtents();
 
         auto kernelFn = SimdTransformReduceKernel{
             static_cast<uint32_t>(frameSpec.getFrameExtents().product() * sizeof(T_DataType))};

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -29,6 +29,8 @@ namespace alpaka::onHost::internal
         template<typename T_DataType>
         ALPAKA_FN_ACC void operator()(
             onAcc::concepts::Acc auto const& acc,
+            alpaka::concepts::Vector auto const& numChunks,
+            alpaka::concepts::Vector auto const& chunkExtents,
             alpaka::concepts::Vector auto const& extentMd,
             T_DataType const& neutralElement,
             alpaka::concepts::IMdSpan auto output,
@@ -40,18 +42,18 @@ namespace alpaka::onHost::internal
                 std::is_same_v<ALPAKA_TYPEOF(neutralElement), alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(output)>>,
                 "The neutral element type must match the data output type.");
 
-            auto numFrames = acc[alpaka::frame::count];
-            alpaka::concepts::Vector auto frameExtent = acc[alpaka::frame::extent];
 
             // Shared memory for block-wide reduction
             T_DataType* dynS = onAcc::getDynSharedMem<T_DataType>(acc);
-            auto pitchMd = alpaka::calculatePitchesFromExtents<T_DataType>(frameExtent);
-            auto tbSum = MdSpan{dynS, frameExtent, pitchMd}; // makeMdSpan(dynS, frameExtent, pitchMd);
+            auto pitchMd = alpaka::calculatePitchesFromExtents<T_DataType>(chunkExtents);
+            auto tbSum = MdSpan{dynS, chunkExtents, pitchMd}; // makeMdSpan(dynS, frameExtent, pitchMd);
             //  auto tbSum = onAcc::declareSharedMdArray<T_DataType, uniqueId()>(acc, CVec<uint32_t, 2>{});
             // T_DataType* dynS = &tbSum[0];
 
-            auto traverseInFrame
-                = alpaka::onAcc::makeIdxMap(acc, alpaka::onAcc::worker::threadsInBlock, alpaka::IdxRange{frameExtent});
+            auto traverseInFrame = alpaka::onAcc::makeIdxMap(
+                acc,
+                alpaka::onAcc::worker::threadsInBlock,
+                alpaka::IdxRange{chunkExtents});
 
             // Initialize shared memory by setting all elements to the neutral element or identity value
             // for the reduction operation.
@@ -60,11 +62,11 @@ namespace alpaka::onHost::internal
                 tbSum[elemIdxInFrame] = neutralElement;
             }
 
-            auto const frameDataExtent = numFrames * frameExtent;
+            auto const frameDataExtent = numChunks * chunkExtents;
             auto traverseOverFrames = alpaka::onAcc::makeIdxMap(
                 acc,
                 alpaka::onAcc::worker::blocksInGrid,
-                alpaka::IdxRange{frameDataExtent.fill(0), frameDataExtent, frameExtent});
+                alpaka::IdxRange{frameDataExtent.fill(0), frameDataExtent, chunkExtents});
 
             for(auto frameIdx : traverseOverFrames)
             {
@@ -95,7 +97,7 @@ namespace alpaka::onHost::internal
             for(auto [linearSharedElemIdx] : alpaka::onAcc::makeIdxMap(
                     acc,
                     alpaka::onAcc::worker::linearThreadsInBlock,
-                    alpaka::IdxRange{blockSize, frameExtent.product()}))
+                    alpaka::IdxRange{blockSize, chunkExtents.product()}))
             {
                 dynS[laneIdInBlock] = reduceFunc(dynS[laneIdInBlock], dynS[linearSharedElemIdx]);
             }
@@ -220,11 +222,18 @@ namespace alpaka::onHost::internal
     {
         auto extentMd = onHost::getExtents(in0);
         using IndexType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(extentMd)>;
-        auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), extentMd);
+        auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), exec, extentMd);
 
-        /* Adjust the number of frames to a maximum based on the number of multiprocessors of the device.
-         * The number of frames is kept as low as possible to reduce numerical issue due to long chains of reductions.
-         * Each frame is using an atomic operation to reduce the value of the full frame.
+        /* Derive the chunks size and number of chunks from the SIMD optimized frame specification.
+         * Having the chunking independent of the number of threads in a block helps to control the numerical precision
+         * to reduce numerical issues due to long chains of reductions.
+         */
+        auto numChunks = frameSpec.getNumFrames();
+        auto chunkExtents = frameSpec.getFrameExtents();
+
+        /* Adjust the launch parameters to not oversubscribe a device too much.
+         *
+         * @todo: This heuristic should be adjusted based on benchmarking different cases.
          */
         {
             IndexType multiprocessorScaling = 1u;
@@ -239,7 +248,7 @@ namespace alpaka::onHost::internal
             auto adjsutedNumFrames = alpaka::api::util::adjustToLimit(
                 frameSpec.getNumFrames(),
                 static_cast<IndexType>(numMultiProcessors * multiprocessorScaling));
-            frameSpec = FrameSpec{adjsutedNumFrames, frameSpec.getFrameExtents()};
+            frameSpec = FrameSpec{adjsutedNumFrames, frameSpec.getFrameExtents(), exec};
         }
 
         auto kernelFn = SimdTransformReduceKernel{
@@ -258,10 +267,11 @@ namespace alpaka::onHost::internal
 
         onHost::fill(queue, out, neutralElement, out.getExtents().fill(1));
         queue.enqueue(
-            exec,
             frameSpec,
             KernelBundle{
                 kernelFn,
+                numChunks,
+                chunkExtents,
                 extentMd,
                 neutralElement,
                 out,

--- a/include/alpaka/onHost/algo/iota.hpp
+++ b/include/alpaka/onHost/algo/iota.hpp
@@ -39,13 +39,25 @@ namespace alpaka::onHost
             && std::conjunction_v<
                 std::is_convertible<T_DataType, typename alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(outOther)>>...>)
     {
-        internal::iota(
-            queue,
-            exec,
-            onHost::getExtents(out0),
-            initValue,
-            ALPAKA_FORWARD(out0),
-            ALPAKA_FORWARD(outOther)...);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::iota(
+                queue,
+                std::get<0>(availableExecutors),
+                onHost::getExtents(out0),
+                initValue,
+                ALPAKA_FORWARD(out0),
+                ALPAKA_FORWARD(outOther)...);
+        }
+        else
+            internal::iota(
+                queue,
+                exec,
+                onHost::getExtents(out0),
+                initValue,
+                ALPAKA_FORWARD(out0),
+                ALPAKA_FORWARD(outOther)...);
     }
 
     /**

--- a/include/alpaka/onHost/algo/reduce.hpp
+++ b/include/alpaka/onHost/algo/reduce.hpp
@@ -35,14 +35,27 @@ namespace alpaka::onHost
         auto&& binaryReduceFn,
         auto&& in) requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
     {
-        internal::transformReduce(
-            queue,
-            exec,
-            neutralElement,
-            out,
-            ALPAKA_FORWARD(binaryReduceFn),
-            std::identity{},
-            ALPAKA_FORWARD(in));
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::transformReduce(
+                queue,
+                std::get<0>(availableExecutors),
+                neutralElement,
+                out,
+                ALPAKA_FORWARD(binaryReduceFn),
+                std::identity{},
+                ALPAKA_FORWARD(in));
+        }
+        else
+            internal::transformReduce(
+                queue,
+                exec,
+                neutralElement,
+                out,
+                ALPAKA_FORWARD(binaryReduceFn),
+                std::identity{},
+                ALPAKA_FORWARD(in));
     }
 
     /**

--- a/include/alpaka/onHost/algo/scan.hpp
+++ b/include/alpaka/onHost/algo/scan.hpp
@@ -44,23 +44,46 @@ namespace alpaka::onHost
      */
     void inclusiveScan(
         auto const& queue,
-        alpaka::concepts::Executor auto& exec,
+        alpaka::concepts::Executor auto exec,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, buffer, outputVec, inputVec);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::scan<internal::INCLUSIVE_SCAN>(
+                queue,
+                devAcc,
+                std::get<0>(availableExecutors),
+                buffer,
+                outputVec,
+                inputVec);
+        }
+        else
+            internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, buffer, outputVec, inputVec);
     }
 
     void inclusiveScan(
         auto const& queue,
-        alpaka::concepts::Executor auto& exec,
+        alpaka::concepts::Executor auto exec,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, outputVec, inputVec);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::scan<internal::INCLUSIVE_SCAN>(
+                queue,
+                devAcc,
+                std::get<0>(availableExecutors),
+                outputVec,
+                inputVec);
+        }
+        else
+            internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, outputVec, inputVec);
     }
 
     /** @} */
@@ -79,21 +102,39 @@ namespace alpaka::onHost
      */
     void inclusiveScanInPlace(
         auto const& queue,
-        alpaka::concepts::Executor auto& exec,
+        alpaka::concepts::Executor auto exec,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, buffer, dataVec, dataVec);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::scan<internal::INCLUSIVE_SCAN>(
+                queue,
+                devAcc,
+                std::get<0>(availableExecutors),
+                buffer,
+                dataVec,
+                dataVec);
+        }
+        else
+            internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, buffer, dataVec, dataVec);
     }
 
     void inclusiveScanInPlace(
         auto const& queue,
-        alpaka::concepts::Executor auto& exec,
+        alpaka::concepts::Executor auto exec,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, dataVec, dataVec);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, std::get<0>(availableExecutors), dataVec, dataVec);
+        }
+        else
+            internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, dataVec, dataVec);
     }
 
     /** @} */
@@ -113,23 +154,46 @@ namespace alpaka::onHost
      */
     void exclusiveScan(
         auto const& queue,
-        alpaka::concepts::Executor auto& exec,
+        alpaka::concepts::Executor auto exec,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, buffer, outputVec, inputVec);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::scan<internal::EXCLUSIVE_SCAN>(
+                queue,
+                devAcc,
+                std::get<0>(availableExecutors),
+                buffer,
+                outputVec,
+                inputVec);
+        }
+        else
+            internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, buffer, outputVec, inputVec);
     }
 
     void exclusiveScan(
         auto const& queue,
-        alpaka::concepts::Executor auto& exec,
+        alpaka::concepts::Executor auto exec,
         alpaka::concepts::IMdSpan auto& outputVec,
         alpaka::concepts::IDataSource auto const& inputVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, outputVec, inputVec);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::scan<internal::EXCLUSIVE_SCAN>(
+                queue,
+                devAcc,
+                std::get<0>(availableExecutors),
+                outputVec,
+                inputVec);
+        }
+        else
+            internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, outputVec, inputVec);
     }
 
     /** @} */
@@ -148,21 +212,39 @@ namespace alpaka::onHost
      */
     void exclusiveScanInPlace(
         auto const& queue,
-        alpaka::concepts::Executor auto& exec,
+        alpaka::concepts::Executor auto exec,
         alpaka::concepts::IMdSpan auto& buffer,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, buffer, dataVec, dataVec);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::scan<internal::EXCLUSIVE_SCAN>(
+                queue,
+                devAcc,
+                std::get<0>(availableExecutors),
+                buffer,
+                dataVec,
+                dataVec);
+        }
+        else
+            internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, buffer, dataVec, dataVec);
     }
 
     void exclusiveScanInPlace(
         auto const& queue,
-        alpaka::concepts::Executor auto& exec,
+        alpaka::concepts::Executor auto exec,
         alpaka::concepts::IMdSpan auto& dataVec)
     {
         auto devAcc = queue.getDevice();
-        internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, dataVec, dataVec);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, std::get<0>(availableExecutors), dataVec, dataVec);
+        }
+        else
+            internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, dataVec, dataVec);
     }
 
     /** @} */

--- a/include/alpaka/onHost/algo/transform.hpp
+++ b/include/alpaka/onHost/algo/transform.hpp
@@ -55,7 +55,18 @@ namespace alpaka::onHost
         auto&& fn,
         alpaka::concepts::IDataSource auto&&... in)
     {
-        internal::transform(queue, exec, ALPAKA_FORWARD(out), ALPAKA_FORWARD(fn), ALPAKA_FORWARD(in)...);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::transform(
+                queue,
+                std::get<0>(availableExecutors),
+                ALPAKA_FORWARD(out),
+                ALPAKA_FORWARD(fn),
+                ALPAKA_FORWARD(in)...);
+        }
+        else
+            internal::transform(queue, exec, ALPAKA_FORWARD(out), ALPAKA_FORWARD(fn), ALPAKA_FORWARD(in)...);
     }
 
     /**

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -67,14 +67,27 @@ namespace alpaka::onHost
         alpaka::concepts::IDataSource auto&&... in)
         requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
     {
-        internal::transformReduce(
-            queue,
-            exec,
-            neutralElement,
-            out,
-            ALPAKA_FORWARD(binaryReduceFn),
-            ALPAKA_FORWARD(transformFn),
-            ALPAKA_FORWARD(in)...);
+        if constexpr(exec == alpaka::exec::anyExecutor)
+        {
+            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
+            internal::transformReduce(
+                queue,
+                std::get<0>(availableExecutors),
+                neutralElement,
+                out,
+                ALPAKA_FORWARD(binaryReduceFn),
+                ALPAKA_FORWARD(transformFn),
+                ALPAKA_FORWARD(in)...);
+        }
+        else
+            internal::transformReduce(
+                queue,
+                exec,
+                neutralElement,
+                out,
+                ALPAKA_FORWARD(binaryReduceFn),
+                ALPAKA_FORWARD(transformFn),
+                ALPAKA_FORWARD(in)...);
     }
 
     /**

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -192,18 +192,13 @@ namespace alpaka::onHost
         {
             template<
                 typename T_Queue,
-                alpaka::concepts::Executor T_Executor,
-                onHost::concepts::ThreadOrFrameSpec T_BlockCfg,
+                onHost::concepts::ThreadOrFrameSpec T_LaunchCfg,
                 alpaka::concepts::KernelBundle T_KernelBundle>
             struct Kernel
             {
-                void operator()(
-                    T_Queue& queue,
-                    T_Executor const executor,
-                    T_BlockCfg const& blockCfg,
-                    T_KernelBundle const& kernelBundle) const
+                void operator()(T_Queue& queue, T_LaunchCfg const& launchCfg, T_KernelBundle const& kernelBundle) const
                 {
-                    queue.enqueue(executor, blockCfg, kernelBundle);
+                    queue.enqueue(launchCfg, kernelBundle);
                 }
             };
 
@@ -248,34 +243,30 @@ namespace alpaka::onHost
         template<typename TKernelFn, typename... TArgs>
         inline void enqueue(
             auto& queue,
-            auto const executor,
-            onHost::concepts::ThreadOrFrameSpec auto const& blockCfg,
+            onHost::concepts::ThreadOrFrameSpec auto const& launchCfg,
             KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
         {
-            Enqueue::Kernel<
-                ALPAKA_TYPEOF(queue),
-                ALPAKA_TYPEOF(executor),
-                ALPAKA_TYPEOF(blockCfg),
-                KernelBundle<TKernelFn, TArgs...>>{}(queue, executor, blockCfg, kernelBundle);
+            Enqueue::Kernel<ALPAKA_TYPEOF(queue), ALPAKA_TYPEOF(launchCfg), KernelBundle<TKernelFn, TArgs...>>{}(
+                queue,
+                launchCfg,
+                kernelBundle);
         }
 
         struct AdjustThreadSpec
         {
             template<
                 typename T_Device,
-                alpaka::concepts::Executor T_Executor,
                 onHost::concepts::FrameSpec T_FrameSpec,
                 alpaka::concepts::KernelBundle T_KernelBundle>
             struct Op
             {
                 auto operator()(
                     T_Device const& device,
-                    T_Executor const& executor,
                     T_FrameSpec const& frameSpec,
                     T_KernelBundle const& kernelBundle) const
                 {
-                    alpaka::unused(device, executor, kernelBundle);
-                    return frameSpec.getThreadSpec();
+                    alpaka::unused(device, frameSpec.getExecutor(), kernelBundle);
+                    return ThreadSpec{frameSpec.getNumFrames(), frameSpec.getFrameExtents(), frameSpec.getExecutor()};
                 }
             };
         };
@@ -283,15 +274,14 @@ namespace alpaka::onHost
         template<typename TKernelFn, typename... TArgs>
         static auto adjustThreadSpec(
             auto const& device,
-            auto const& executor,
-            onHost::concepts::FrameSpec auto const& dataBlocking,
+            onHost::concepts::FrameSpec auto const& frameSpec,
             KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
         {
-            return AdjustThreadSpec::Op<
-                ALPAKA_TYPEOF(device),
-                ALPAKA_TYPEOF(executor),
-                ALPAKA_TYPEOF(dataBlocking),
-                KernelBundle<TKernelFn, TArgs...>>{}(device, executor, dataBlocking, kernelBundle);
+            return AdjustThreadSpec::
+                Op<ALPAKA_TYPEOF(device), ALPAKA_TYPEOF(frameSpec), KernelBundle<TKernelFn, TArgs...>>{}(
+                    device,
+                    frameSpec,
+                    kernelBundle);
         }
 
         struct Data
@@ -502,6 +492,7 @@ namespace alpaka::onHost
         template<typename T_DataType>
         inline constexpr auto getFrameSpec(
             auto const& internalDevice,
+            alpaka::concepts::Executor auto executor,
             alpaka::concepts::VectorOrScalar auto const& extents)
         {
             Vec extentMd = extents;
@@ -546,7 +537,7 @@ namespace alpaka::onHost
             alpaka::concepts::Vector auto numFrames
                 = divExZero(extentMd, frameExtents * frameExtents.fill(1).rAssign(elementsPerFrameItem));
             // The frame specification is not required to be a multiple of the extent, it can be smaller.
-            auto frameSpec = FrameSpec{numFrames, frameExtents};
+            auto frameSpec = FrameSpec{numFrames, frameExtents, executor};
             return frameSpec;
         }
     } // namespace internal

--- a/include/alpaka/tag.hpp
+++ b/include/alpaka/tag.hpp
@@ -31,6 +31,8 @@ namespace alpaka
 
         ALPAKA_TAG(exec);
 
+        ALPAKA_TAG(launchedWidthFrameSpec);
+
         ALPAKA_TAG(deviceSpec);
 
         ALPAKA_TAG(dynSharedMemBytes);
@@ -261,12 +263,6 @@ namespace alpaka
         ALPAKA_TAG(shared);
         ALPAKA_TAG(dynShared);
     } // namespace layer
-
-    namespace frame
-    {
-        ALPAKA_TAG(count);
-        ALPAKA_TAG(extent);
-    } // namespace frame
 
     namespace action
     {

--- a/test/unit/atomic/atomic.cpp
+++ b/test/unit/atomic/atomic.cpp
@@ -225,14 +225,12 @@ struct TestAtomicOperations
         T value = static_cast<T>(32);
 
         queue.enqueue(
-            exec,
-            onHost::FrameSpec{1u, 1u},
+            onHost::FrameSpec{1u, 1u, exec},
             KernelBundle{AtomicTestKernel<alpaka::onAcc::scope::Block, T>{}, status.data(), value});
         REQUIRE(status[0]);
 
         queue.enqueue(
-            exec,
-            onHost::FrameSpec{1u, 1u},
+            onHost::FrameSpec{1u, 1u, exec},
             KernelBundle{AtomicTestKernel<alpaka::onAcc::scope::Device, T>{}, status.data(), value});
 
         REQUIRE(status[0]);

--- a/test/unit/atomic/atomicAdd.cpp
+++ b/test/unit/atomic/atomicAdd.cpp
@@ -16,16 +16,16 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDevice
 struct AtomicIncrementKernel
 {
     template<typename TAcc, typename TCounter>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, TCounter counter) const
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, TCounter counter, auto repetitions) const
     {
         /** To make the behavior consistent across all backends, we iterate over the full frame extent and use a for
          * loop and set range to totalFrameSpecExtent. If a single `alpaka::onAcc::atomicAdd(acc, &(counter[Vec{0u}]),
          * 1u);` is used instead of a for loop, cpuSerial backend returns 1 instead of numberOfBlocks. Makes only one
          * addition.
          */
-        for(auto const& idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, onAcc::range::totalFrameSpecExtent))
+        for(auto const& idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{repetitions}))
         {
-            (void) idx;
+            alpaka::unused(idx);
             alpaka::onAcc::atomicAdd(acc, &(counter[Vec{0u}]), 1u);
         }
     }
@@ -60,7 +60,7 @@ TEMPLATE_LIST_TEST_CASE("cpu atomic add increments", "[executor][atomic]", TestA
     constexpr Vec blocks = Vec{64u};
     constexpr Vec threads = Vec{1u};
 
-    queue.enqueue(exec, onHost::FrameSpec{blocks, threads}, KernelBundle{AtomicIncrementKernel{}, counterDev});
+    queue.enqueue(onHost::FrameSpec{blocks, threads, exec}, KernelBundle{AtomicIncrementKernel{}, counterDev, blocks});
     onHost::memcpy(queue, counterHost, counterDev);
     onHost::wait(queue);
 

--- a/test/unit/block/block.cpp
+++ b/test/unit/block/block.cpp
@@ -18,22 +18,18 @@ using TestApis = std::decay_t<decltype(allBackends(enabledApis, exec::enabledExe
 
 struct BlockIotaKernel
 {
-    ALPAKA_FN_ACC void operator()(auto const& acc, auto out, auto numBlocks) const
+    ALPAKA_FN_ACC void operator()(auto const& acc, auto out, auto numChunks, auto chunkExtents) const
     {
-        auto const numDataElemInBlock = acc[frame::extent];
         for(auto blockIdx : onAcc::makeIdxMap(
                 acc,
                 onAcc::worker::blocksInGrid,
-                IdxRange{ALPAKA_TYPEOF(numBlocks)::fill(0), numBlocks * numDataElemInBlock, numDataElemInBlock},
+                IdxRange{ALPAKA_TYPEOF(numChunks)::fill(0), numChunks * chunkExtents, chunkExtents},
                 onAcc::traverse::tiled,
                 onAcc::layout::contiguous))
         {
             auto blockOffset = blockIdx;
-            for(auto inBlockOffset : onAcc::makeIdxMap(
-                    acc,
-                    onAcc::worker::threadsInBlock,
-                    onAcc::range::frameExtent,
-                    onAcc::traverse::tiled))
+            for(auto inBlockOffset :
+                onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkExtents}, onAcc::traverse::tiled))
             {
                 out[blockOffset + inBlockOffset] = (blockOffset + inBlockOffset).x();
             }
@@ -59,16 +55,18 @@ TEMPLATE_LIST_TEST_CASE("block iota", "", TestApis)
     INFO("device properties=" << device.getDeviceProperties());
 
     Queue queue = device.makeQueue();
-    constexpr Vec numBlocks = Vec{9u};
-    constexpr Vec blockExtent = Vec{4u};
-    constexpr Vec dataExtent = numBlocks * blockExtent;
+    constexpr Vec numChunks = Vec{9u};
+    constexpr Vec chunkExtents = Vec{4u};
+    constexpr Vec dataExtent = numChunks * chunkExtents;
     INFO("block iota exec=" << onHost::demangledName(exec));
     auto dBuff = onHost::alloc<uint32_t>(device, dataExtent);
 
     auto hBuff = onHost::allocHostLike(dBuff);
     onHost::wait(queue);
 
-    queue.enqueue(exec, FrameSpec{numBlocks / 2u, blockExtent}, KernelBundle{BlockIotaKernel{}, dBuff, numBlocks});
+    queue.enqueue(
+        FrameSpec{numChunks / 2u, chunkExtents, exec},
+        KernelBundle{BlockIotaKernel{}, dBuff, numChunks, chunkExtents});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);
 

--- a/test/unit/concepts/concepts.cpp
+++ b/test/unit/concepts/concepts.cpp
@@ -58,14 +58,14 @@ TEST_CASE("frame spec concepts", "[concepts][framespec]")
     using TestVec2 = Vec<size_t, 2>;
     using TestVec3 = Vec<size_t, 3>;
 
-    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec1, TestVec1, TestVec1>>);
-    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec2, TestVec2, TestVec2>, size_t>);
-    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec3, TestVec3, TestVec3>, size_t, 3>);
-    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec2, TestVec2, TestVec2>, size_t, 2>);
+    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec1, TestVec1>>);
+    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec2, TestVec2>, size_t>);
+    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec3, TestVec3>, size_t, 3>);
+    STATIC_CHECK(onHost::concepts::FrameSpec<FrameSpec<TestVec2, TestVec2>, size_t, 2>);
 
-    STATIC_CHECK_FALSE(onHost::concepts::FrameSpec<FrameSpec<TestVec1, TestVec1, TestVec1>, int>);
-    STATIC_CHECK_FALSE(onHost::concepts::FrameSpec<FrameSpec<TestVec2, TestVec2, TestVec2>, size_t, 3>);
-    STATIC_CHECK_FALSE(onHost::concepts::FrameSpec<FrameSpec<TestVec3, TestVec3, TestVec3>, int, 2>);
+    STATIC_CHECK_FALSE(onHost::concepts::FrameSpec<FrameSpec<TestVec1, TestVec1>, int>);
+    STATIC_CHECK_FALSE(onHost::concepts::FrameSpec<FrameSpec<TestVec2, TestVec2>, size_t, 3>);
+    STATIC_CHECK_FALSE(onHost::concepts::FrameSpec<FrameSpec<TestVec3, TestVec3>, int, 2>);
 }
 
 TEST_CASE("thread spec concepts", "[concepts][threadspec]")

--- a/test/unit/cvecKernelCall/cvecKernelCall.cpp
+++ b/test/unit/cvecKernelCall/cvecKernelCall.cpp
@@ -25,20 +25,19 @@ struct KernelCVecFrameExtents
     template<onAcc::concepts::Acc T_Acc>
     ALPAKA_FN_ACC void operator()(T_Acc const& acc, auto result) const
     {
-        alpaka::concepts::CVector auto frameExtent = acc[alpaka::frame::extent];
+        static_assert(T_Acc::launchedWithFrameSpec());
         // compile will fail if the type is silently cast to non CVec type
         [[maybe_unused]] alpaka::concepts::CVector auto blockThreadCount
             = acc.getExtentsOf(onAcc::origin::block, onAcc::unit::threads);
         [[maybe_unused]] alpaka::concepts::CVector auto blockThreadCount2 = acc[alpaka::layer::thread].count();
         static_assert(blockThreadCount2 == blockThreadCount);
-        static_assert(frameExtent.x() == 43u);
-        result[0] = frameExtent.x() == 43u;
 
         // warp size must be accessible at compile time, this is only possible if we us ethe accelerator type
         constexpr uint32_t warpSize = ALPAKA_TYPEOF(acc)::getWarpSize();
         constexpr uint32_t warpSizeFn = onAcc::warp::getSize<T_Acc>();
 
         static_assert(warpSize == warpSizeFn);
+        result[0] = true;
     }
 };
 
@@ -68,8 +67,7 @@ TEMPLATE_LIST_TEST_CASE("CVec frame extent kernel call", "", TestApis)
     onHost::wait(queue);
     {
         queue.enqueue(
-            exec,
-            FrameSpec{Vec{1u}, CVec<uint32_t, 43u>{}},
+            FrameSpec{Vec{1u}, CVec<uint32_t, 43u>{}, exec},
             KernelBundle{KernelCVecFrameExtents{}, dBuff.getView()});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
@@ -82,6 +80,7 @@ struct KernelCVecThreadExtents
     template<onAcc::concepts::Acc T_Acc>
     ALPAKA_FN_ACC void operator()(T_Acc const& acc, auto result) const
     {
+        static_assert(!T_Acc::launchedWithFrameSpec());
         // compile will fail if the type is silently cast to non CVec type
         alpaka::concepts::CVector auto blockThreadCount = acc[alpaka::layer::thread].count();
         static_assert(blockThreadCount.x() == 1u);
@@ -121,10 +120,9 @@ TEMPLATE_LIST_TEST_CASE("CVec thread extent kernel call", "", TestApis)
     onHost::wait(queue);
     {
         queue.enqueue(
-            exec,
             // we need to use one thread per thread block because serial executors will reduce the number of threads to
             // a single thread
-            ThreadSpec{Vec{1u}, CVec<uint32_t, 1u>{}},
+            ThreadSpec{Vec{1u}, CVec<uint32_t, 1u>{}, exec},
             KernelBundle{KernelCVecThreadExtents{}, dBuff});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);

--- a/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -99,8 +99,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
     onHost::wait(queue);
     {
         queue.enqueue(
-            exec,
-            FrameSpec{numBlocks, blockExtent},
+            FrameSpec{numBlocks, blockExtent, exec},
             KernelBundle{DeviceGlobalMemKernelVec{}, dBuff, dataExtent});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
@@ -115,8 +114,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
     // scalar
     {
         queue.enqueue(
-            exec,
-            FrameSpec{numBlocks, blockExtent},
+            FrameSpec{numBlocks, blockExtent, exec},
             KernelBundle{DeviceGlobalMemKernelScalar{}, dBuff, dataExtent});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
@@ -131,8 +129,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
     // C array
     {
         queue.enqueue(
-            exec,
-            FrameSpec{numBlocks, blockExtent},
+            FrameSpec{numBlocks, blockExtent, exec},
             KernelBundle{DeviceGlobalMemKernelCArray{}, dBuff, dataExtent});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
@@ -147,8 +144,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
     // C array 2D
     {
         queue.enqueue(
-            exec,
-            FrameSpec{numBlocks, blockExtent},
+            FrameSpec{numBlocks, blockExtent, exec},
             KernelBundle{DeviceGlobalMemKernelCArray2D{}, dBuff, dataExtent});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
@@ -231,7 +227,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem copy", "", TestApis)
         queue.enqueueHostFn([&]() { val = 0u; });
         // check that we can copy from device to host
         onHost::memcpy(queue, &val, globalScalar);
-        queue.enqueue(exec, FrameSpec{numBlocks, blockExtent}, KernelBundle{DeviceGlobalMemCpyScalarKernel{}, dBuff});
+        queue.enqueue(FrameSpec{numBlocks, blockExtent, exec}, KernelBundle{DeviceGlobalMemCpyScalarKernel{}, dBuff});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);
         // check that copy from device to host worked
@@ -260,8 +256,7 @@ TEMPLATE_LIST_TEST_CASE("device global mem copy", "", TestApis)
         queue.enqueueHostFn([&]() { val[1][2] = 0u; });
         onHost::memcpy(queue, val, global2DCArray);
         queue.enqueue(
-            exec,
-            FrameSpec{numBlocks, blockExtent},
+            FrameSpec{numBlocks, blockExtent, exec},
             KernelBundle{DeviceGlobalMemCpyCArray2DKernel{}, dBuff});
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::wait(queue);

--- a/test/unit/frame/getFrameSpec.cpp
+++ b/test/unit/frame/getFrameSpec.cpp
@@ -41,25 +41,25 @@ void checkFrameSpec(onHost::concepts::FrameSpec auto const& frameSpec, concepts:
 }
 
 template<typename T>
-void testScalar(auto const& computeDev)
+void testScalar(auto const& computeDev, alpaka::concepts::Executor auto exec)
 {
     auto testValues = GENERATE(1, 2, 31, 128, 129, 257, 513, 10000, 100000);
 
 
     // test lvalue
-    auto const frameSpec = alpaka::onHost::getFrameSpec<T>(computeDev, testValues);
+    auto const frameSpec = alpaka::onHost::getFrameSpec<T>(computeDev, exec, testValues);
 
     checkFrameSpec(frameSpec, testValues);
 }
 
 template<typename T>
-void testVector(auto const& computeDev)
+void testVector(auto const& computeDev, alpaka::concepts::Executor auto exec)
 {
     auto test = [&](auto vec)
     {
         {
             // test lvalue
-            auto const frameSpec = alpaka::onHost::getFrameSpec<T>(computeDev, vec);
+            auto const frameSpec = alpaka::onHost::getFrameSpec<T>(computeDev, exec, vec);
 
             checkFrameSpec(frameSpec, vec);
         }
@@ -83,10 +83,11 @@ TEMPLATE_LIST_TEST_CASE("getFrameSpec scalar", "", TestBackends)
     auto cfg = TestType::makeDict();
 
     auto deviceSpec = cfg[alpaka::object::deviceSpec];
+    auto exec = cfg[alpaka::object::exec];
     auto devSelector = alpaka::onHost::makeDeviceSelector(deviceSpec);
 
     onHost::Device computeDev = devSelector.makeDevice(0);
-    std::apply([&]<typename... T>(T...) { (testScalar<T>(computeDev), ...); }, TestBufferElemTypes{});
+    std::apply([&]<typename... T>(T...) { (testScalar<T>(computeDev, exec), ...); }, TestBufferElemTypes{});
 }
 
 TEMPLATE_LIST_TEST_CASE("getFrameSpec vector", "", TestBackends)
@@ -94,8 +95,9 @@ TEMPLATE_LIST_TEST_CASE("getFrameSpec vector", "", TestBackends)
     auto cfg = TestType::makeDict();
 
     auto deviceSpec = cfg[alpaka::object::deviceSpec];
+    auto exec = cfg[alpaka::object::exec];
     auto devSelector = alpaka::onHost::makeDeviceSelector(deviceSpec);
 
     onHost::Device computeDev = devSelector.makeDevice(0);
-    std::apply([&]<typename... T>(T...) { (testVector<T>(computeDev), ...); }, TestBufferElemTypes{});
+    std::apply([&]<typename... T>(T...) { (testVector<T>(computeDev, exec), ...); }, TestBufferElemTypes{});
 }

--- a/test/unit/intrinsic/clz.cpp
+++ b/test/unit/intrinsic/clz.cpp
@@ -55,14 +55,14 @@ TEMPLATE_LIST_TEST_CASE("clz", "[intrinsic][clz]", TestBackends)
     alpaka::onHost::memcpy(queue, devInput, hostInput);
 
     // Define execution parameters
-    auto const frameSpec = alpaka::onHost::getFrameSpec<uint64_t>(devAcc, devInput.getExtents());
+    auto const frameSpec = alpaka::onHost::getFrameSpec<uint64_t>(devAcc, computeExec, devInput.getExtents());
 
     // Create kernel
     PopcountKernel kernel;
     auto const taskKernel = alpaka::KernelBundle{kernel, devOutput, devInput};
 
     // Execute the kernel
-    queue.enqueue(computeExec, frameSpec, taskKernel);
+    queue.enqueue(frameSpec, taskKernel);
 
     // Copy data from device to host
     std::vector<int> hostOutput(size);

--- a/test/unit/intrinsic/ffs.cpp
+++ b/test/unit/intrinsic/ffs.cpp
@@ -69,14 +69,14 @@ TEMPLATE_LIST_TEST_CASE("ffs", "[intrinsic][ffs]", TestBackends)
     alpaka::onHost::memcpy(queue, devInput, hostInput);
 
     // Define execution parameters
-    auto const frameSpec = alpaka::onHost::getFrameSpec<uint64_t>(devAcc, devInput.getExtents());
+    auto const frameSpec = alpaka::onHost::getFrameSpec<uint64_t>(devAcc, computeExec, devInput.getExtents());
 
     // Create kernel
     TestKernel kernel;
     auto const taskKernel = alpaka::KernelBundle{kernel, devOutput, devInput};
 
     // Execute the kernel
-    queue.enqueue(computeExec, frameSpec, taskKernel);
+    queue.enqueue(frameSpec, taskKernel);
 
     // Copy data from device to host
     std::vector<int> hostOutput(size);

--- a/test/unit/intrinsic/popc.cpp
+++ b/test/unit/intrinsic/popc.cpp
@@ -62,14 +62,14 @@ TEMPLATE_LIST_TEST_CASE("popcount", "[intrinsic][popc]", TestBackends)
     alpaka::onHost::memcpy(queue, devInput, hostInput);
 
     // Define execution parameters
-    auto const frameSpec = alpaka::onHost::getFrameSpec<uint64_t>(devAcc, devInput.getExtents());
+    auto const frameSpec = alpaka::onHost::getFrameSpec<uint64_t>(devAcc, computeExec, devInput.getExtents());
 
     // Create kernel
     TestKernel kernel;
     auto const taskKernel = alpaka::KernelBundle{kernel, devOutput, devInput};
 
     // Execute the kernel
-    queue.enqueue(computeExec, frameSpec, taskKernel);
+    queue.enqueue(frameSpec, taskKernel);
 
     // Copy data from device to host
     std::vector<int> hostOutput(size);

--- a/test/unit/math/TestTemplate.hpp
+++ b/test/unit/math/TestTemplate.hpp
@@ -173,7 +173,7 @@ namespace mathtest
             // Let alpaka calculate good block and grid sizes given our full problem extent
             constexpr uint32_t frameExtents = 256;
             onHost::concepts::FrameSpec auto frameSpec
-                = onHost::FrameSpec{divExZero(capacity, frameExtents), frameExtents};
+                = onHost::FrameSpec{divExZero(capacity, frameExtents), frameExtents, exec};
             auto kernel = KernelBundle{
                 TestKernel<capacity>{},
                 results.m_deviceBuffer.getMdSpan(),
@@ -191,7 +191,7 @@ namespace mathtest
             results.copyToDevice(queue);
 
             // Enqueue the kernel execution task.
-            queue.enqueue(exec, frameSpec, kernel);
+            queue.enqueue(frameSpec, kernel);
 
             // Copy back the results (encapsulated in the buffer class).
             results.copyFromDevice(queue);

--- a/test/unit/math/executeOnComputeDevice.hpp
+++ b/test/unit/math/executeOnComputeDevice.hpp
@@ -64,9 +64,9 @@ namespace alpaka::test
         auto dBufferResults = onHost::allocLike(device, hBufferResults);
         onHost::memset(queue, dBufferResults, static_cast<std::uint8_t>(true));
         // Let alpaka calculate good block and grid sizes given our full problem extent
-        onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{1u, 1u};
+        onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{1u, 1u, exec};
         auto kernel = KernelBundle{kernelFnObj, dBufferResults, ALPAKA_FORWARD(args)...};
-        queue.enqueue(exec, frameSpec, kernel);
+        queue.enqueue(frameSpec, kernel);
         onHost::memcpy(queue, hBufferResults, dBufferResults);
         alpaka::onHost::wait(queue);
         return hBufferResults[0];

--- a/test/unit/mem/alloc.cpp
+++ b/test/unit/mem/alloc.cpp
@@ -35,8 +35,7 @@ void validateAccess(auto device, alpaka::concepts::Executor auto exec, concepts:
     REQUIRE(onHost::isDataAccessible(deviceQueue, deviceAccessibleData) == true);
     onHost::fill(deviceQueue, deviceStatus, 0);
     deviceQueue.enqueue(
-        exec,
-        getFrameSpec<float>(deviceQueue.getDevice(), deviceAccessibleData.getExtents()),
+        getFrameSpec<float>(deviceQueue.getDevice(), exec, deviceAccessibleData.getExtents()),
         KernelBundle{IotaValidate{}, deviceStatus, deviceAccessibleData});
     onHost::memcpy(deviceQueue, hostStatus, deviceStatus);
     onHost::wait(deviceQueue);

--- a/test/unit/mem/allocDeferred.cpp
+++ b/test/unit/mem/allocDeferred.cpp
@@ -39,8 +39,7 @@ void allocDeferredImplicitWait(auto device, auto exec)
         auto sharedBuffer = onHost::allocDeferred<float>(queue0, 10ul);
         onHost::fill(queue0, sharedBuffer, 3.14159265f);
         queue0.enqueue(
-            exec,
-            getFrameSpec<float>(queue0.getDevice(), sharedBuffer.getExtents()),
+            getFrameSpec<float>(queue0.getDevice(), exec, sharedBuffer.getExtents()),
             KernelBundle{RaceCheckKernel{}, dBufferResults, sharedBuffer});
         /* sharedBuffer is detroyed here before the kernel is finshed.
          * If the view is not waiting for all work in the queue enqueued before the destructor of the view is called,
@@ -77,8 +76,7 @@ void allocDeferredExplicitWait(auto device, auto exec)
 
         onHost::fill(queue0, sharedBuffer, 3.14159265f);
         queue0.enqueue(
-            exec,
-            getFrameSpec<float>(queue0.getDevice(), sharedBuffer.getExtents()),
+            getFrameSpec<float>(queue0.getDevice(), exec, sharedBuffer.getExtents()),
             KernelBundle{RaceCheckKernel{}, dBufferResults, sharedBuffer});
         /* sharedBuffer is detroyed here before the kernel is finshed.
          * If the view is not waiting for all work in the queue enqueued before the destructor of the view is called,

--- a/test/unit/mem/keepAlive.cpp
+++ b/test/unit/mem/keepAlive.cpp
@@ -54,10 +54,10 @@ TEMPLATE_LIST_TEST_CASE("keep alive", "", TestApis)
         // enqueue everything in this scope
         auto scopedBuffer = onHost::allocDeferred<int>(queue, N);
 
-        auto framespec = getFrameSpec<int>(device, scopedBuffer.getExtents());
+        auto framespec = getFrameSpec<int>(device, exec, scopedBuffer.getExtents());
 
         // fill scoped buffer
-        queue.enqueue(exec, framespec, KernelBundle{IotaKernel{}, scopedBuffer});
+        queue.enqueue(framespec, KernelBundle{IotaKernel{}, scopedBuffer});
 
         // copy back to the original
         onHost::memcpy(queue, originalBuffer, scopedBuffer);

--- a/test/unit/mem/memFenceBasic.cpp
+++ b/test/unit/mem/memFenceBasic.cpp
@@ -24,7 +24,7 @@ struct MemoryFenceTestKernel
     {
         using namespace alpaka::onAcc;
         // Iterate over all logical thread indices in the launched frame.
-        for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, onAcc::range::totalFrameSpecExtent))
+        for(auto idx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
         {
             // Initial write; any subsequent fence must not block, just enforce visibility / ordering.
             out[idx.x()] = static_cast<uint32_t>(idx.x());
@@ -67,8 +67,7 @@ TEMPLATE_LIST_TEST_CASE("thread fence operations", "[memFence][basic]", TestApis
 
     // Launch kernel; frame layout splits extent by frameSize for multi-dimensional convenience.
     queue.enqueue(
-        exec,
-        onHost::FrameSpec{extent / frameSize, frameSize},
+        onHost::FrameSpec{extent / frameSize, frameSize, exec},
         KernelBundle{MemoryFenceTestKernel{}, dBuff});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);

--- a/test/unit/mem/memFenceProducerConsumer.cpp
+++ b/test/unit/mem/memFenceProducerConsumer.cpp
@@ -130,8 +130,7 @@ TEMPLATE_LIST_TEST_CASE("memFence producer-consumer publication", "[memFence][pr
      * @todo: find out if this strange behaviour is an bug (most likely) or somewhere documented in SYCL or OneApi.
      */
     queue.enqueue(
-        exec,
-        onHost::ThreadSpec{3, 1},
+        onHost::ThreadSpec{3, 1, exec},
         KernelBundle{ProducerConsumerKernel{}, payload, flags, mis, iterations});
     onHost::wait(queue);
 
@@ -295,7 +294,7 @@ TEMPLATE_LIST_TEST_CASE("memFence block shared-memory ordering", "[memFence][blo
 
     {
         flag[0u] = 1u;
-        queue.enqueue(exec, onHost::FrameSpec{1, 2}, KernelBundle{BlockSharedMemOrderKernel{}, flag});
+        queue.enqueue(onHost::FrameSpec{1, 2, exec}, KernelBundle{BlockSharedMemOrderKernel{}, flag});
         onHost::wait(queue);
         CHECK(flag[0u] == 1u);
     }
@@ -307,7 +306,7 @@ TEMPLATE_LIST_TEST_CASE("memFence block shared-memory ordering", "[memFence][blo
         flag[0u] = 1u;
         // Device-scope variant, use thread specification to guarantee that we have two thread blocks
         // A frame specification is allowed silently to change the number of real thread blocks and the block size
-        queue.enqueue(exec, onHost::ThreadSpec{2, 1}, KernelBundle{DeviceFenceTestKernel{}, flag, vars_dev.data()});
+        queue.enqueue(onHost::ThreadSpec{2, 1, exec}, KernelBundle{DeviceFenceTestKernel{}, flag, vars_dev.data()});
         onHost::wait(queue);
         CHECK(flag[0u] == 1u);
     }
@@ -320,10 +319,9 @@ TEMPLATE_LIST_TEST_CASE("memFence block shared-memory ordering", "[memFence][blo
         auto queue1 = device.makeQueue();
 
         flag[0u] = 1u;
-        queue.enqueue(exec, onHost::ThreadSpec{1, 1}, KernelBundle{DeviceFenceTestKernelWriter{}, vars_dev.data()});
+        queue.enqueue(onHost::ThreadSpec{1, 1, exec}, KernelBundle{DeviceFenceTestKernelWriter{}, vars_dev.data()});
         queue1.enqueue(
-            exec,
-            onHost::ThreadSpec{1, 1},
+            onHost::ThreadSpec{1, 1, exec},
             KernelBundle{DeviceFenceTestKernelReader{}, flag, vars_dev.data()});
         onHost::wait(queue);
         onHost::wait(queue1);

--- a/test/unit/precision/precision.cpp
+++ b/test/unit/precision/precision.cpp
@@ -47,8 +47,7 @@ void iotaTest(auto& queue, auto exec, auto kernel, auto const extents, auto fram
     using KenelIdxScalarType = typename ALPAKA_TYPEOF(frameSize)::type;
     onHost::wait(queue);
     queue.enqueue(
-        exec,
-        FrameSpec{pCast<KenelIdxScalarType>(extents) / frameSize, frameSize},
+        FrameSpec{pCast<KenelIdxScalarType>(extents) / frameSize, frameSize, exec},
         KernelBundle{kernel, dBuff});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);

--- a/test/unit/queue/blockingQueue.cpp
+++ b/test/unit/queue/blockingQueue.cpp
@@ -31,7 +31,7 @@ struct BlockingTestKernel
 {
     ALPAKA_FN_ACC void operator()(auto const& acc, auto out, uint32_t value) const
     {
-        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, onAcc::range::totalFrameSpecExtent))
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
         {
             out[i.x()] = value;
         }
@@ -72,8 +72,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue memory operations", "[bq][memory]", Test
     // Test kernel execution with blocking queue 0
     constexpr auto frameSize = CVec<uint32_t, 4u>{};
     blockingQueue0.enqueue(
-        exec,
-        onHost::FrameSpec{extent / frameSize, frameSize},
+        onHost::FrameSpec{extent / frameSize, frameSize, exec},
         KernelBundle{BlockingTestKernel{}, dBuff, testValue});
 
     // With blocking queue 1, operations should be synchronous
@@ -100,7 +99,7 @@ struct WriteValueKernel
 
     ALPAKA_FN_ACC void operator()(auto const& acc, auto view) const
     {
-        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, onAcc::range::totalFrameSpecExtent))
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{view.getExtents()}))
         {
             view[i.x()] = value;
         }
@@ -114,7 +113,7 @@ struct FillKernel
 
     ALPAKA_FN_ACC void operator()(auto const& acc, auto out) const
     {
-        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, onAcc::range::totalFrameSpecExtent))
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
         {
             out[i.x()] = v;
         }
@@ -145,7 +144,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue chained operations", "[bq][chain]", Test
     // keep one larger extent for coverage
     constexpr Vec extent = Vec{32u};
     constexpr auto frameSize = CVec<uint32_t, 4u>{};
-    auto frameSpec = onHost::FrameSpec{extent / frameSize, frameSize};
+    auto frameSpec = onHost::FrameSpec{extent / frameSize, frameSize, exec};
 
     // Device buffers
     auto dBufBlocking = onHost::alloc<uint32_t>(device, extent);
@@ -154,8 +153,8 @@ TEMPLATE_LIST_TEST_CASE("blocking queue chained operations", "[bq][chain]", Test
 
     // 1) Blocking queue: chain two kernels then memcpy, no wait.
     // First kernel writes 3, second overwrites with 11.
-    qBlocking0.enqueue(exec, frameSpec, KernelBundle{WriteValueKernel{3u}, dBufBlocking});
-    qBlocking1.enqueue(exec, frameSpec, KernelBundle{WriteValueKernel{11u}, dBufBlocking});
+    qBlocking0.enqueue(frameSpec, KernelBundle{WriteValueKernel{3u}, dBufBlocking});
+    qBlocking1.enqueue(frameSpec, KernelBundle{WriteValueKernel{11u}, dBufBlocking});
     // blocking finished here
     onHost::memcpy(qBlocking2, hBufBlocking, dBufBlocking);
     meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(hBufBlocking[idx] == 11u); });
@@ -163,7 +162,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue chained operations", "[bq][chain]", Test
     // 2) allocDeferred chain on blocking queue: allocate asynchronously, immediately fill then memcpy.
     // should be ready due to blocking policy of the queue
     auto dBufAsync = onHost::allocDeferred<uint32_t>(qBlocking0, extent);
-    qBlocking1.enqueue(exec, frameSpec, KernelBundle{WriteValueKernel{kTestFillValue}, dBufAsync});
+    qBlocking1.enqueue(frameSpec, KernelBundle{WriteValueKernel{kTestFillValue}, dBufAsync});
     auto hBufAsync = onHost::allocHostLike(dBufAsync);
     onHost::memcpy(qBlocking2, hBufAsync, dBufAsync);
     meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(hBufAsync[idx] == kTestFillValue); });
@@ -185,7 +184,7 @@ TEMPLATE_LIST_TEST_CASE("mixed queues independence", "[bq][mixed]", TestApis)
 
     constexpr Vec extent = Vec{8u};
     constexpr auto frameSize = CVec<uint32_t, 4u>{};
-    auto frameSpec = onHost::FrameSpec{extent / frameSize, frameSize};
+    auto frameSpec = onHost::FrameSpec{extent / frameSize, frameSize, exec};
 
     auto qBlocking = device.makeQueue(queueKind::blocking);
     auto qNonBlocking = device.makeQueue(queueKind::nonBlocking);
@@ -195,7 +194,7 @@ TEMPLATE_LIST_TEST_CASE("mixed queues independence", "[bq][mixed]", TestApis)
     auto hBuf = onHost::allocHostLike(dBuf);
 
     // Blocking queue: immediate completion guaranteed
-    qBlocking.enqueue(exec, frameSpec, KernelBundle{WriteValueKernel{3u}, dBuf});
+    qBlocking.enqueue(frameSpec, KernelBundle{WriteValueKernel{3u}, dBuf});
     // Returns after kernel done
     onHost::memcpy(qNonBlocking, hBuf, dBuf);
     onHost::wait(qNonBlocking);
@@ -241,7 +240,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue event semantics", "[bq][event]", TestApi
     // Use global FillKernel (defined above)
 
     constexpr auto frameSize = CVec<uint32_t, 4u>{};
-    qBlocking.enqueue(exec, onHost::FrameSpec{extent / frameSize, frameSize}, KernelBundle{FillKernel{123u}, dBuf});
+    qBlocking.enqueue(onHost::FrameSpec{extent / frameSize, frameSize, exec}, KernelBundle{FillKernel{123u}, dBuf});
 
     auto e2 = device.makeEvent();
     // all prior work (kernel) complete when this returns
@@ -255,7 +254,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue event semantics", "[bq][event]", TestApi
     //   (event already complete; consumer wait should be instantaneous)
     auto e3 = device.makeEvent();
     // enqueue trivial kernel + event on blocking queue
-    qBlocking.enqueue(exec, onHost::FrameSpec{extent / frameSize, frameSize}, KernelBundle{FillKernel{77u}, dBuf});
+    qBlocking.enqueue(onHost::FrameSpec{extent / frameSize, frameSize, exec}, KernelBundle{FillKernel{77u}, dBuf});
     qBlocking.enqueue(e3);
     CHECK(e3.isComplete());
 
@@ -270,8 +269,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue event semantics", "[bq][event]", TestApi
     auto qBlockingCons = device.makeQueue(queueKind::blocking);
     auto e4 = device.makeEvent();
     qNonBlockingProd.enqueue(
-        exec,
-        onHost::FrameSpec{extent / frameSize, frameSize},
+        onHost::FrameSpec{extent / frameSize, frameSize, exec},
         KernelBundle{FillKernel{55u}, dBuf});
     // may not be complete yet
     qNonBlockingProd.enqueue(e4);

--- a/test/unit/queue/kernelMD.cpp
+++ b/test/unit/queue/kernelMD.cpp
@@ -58,8 +58,7 @@ void validate(auto& queue, auto& device, auto exec, auto testCase)
     onHost::wait(queue);
     auto frameSize = testCase.m_frameSize;
     queue.enqueue(
-        exec,
-        onHost::FrameSpec{divExZero(extentMd, frameSize), frameSize},
+        onHost::FrameSpec{divExZero(extentMd, frameSize), frameSize, exec},
         KernelBundle{LastSetDataBlockIdx{}, dBuff, extentMd});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);

--- a/test/unit/queue/queue.cpp
+++ b/test/unit/queue/queue.cpp
@@ -44,7 +44,7 @@ TEMPLATE_LIST_TEST_CASE("kernel no arguments", "", TestApis)
     onHost::Queue queue = device.makeQueue(queueKind::blocking);
     INFO("exec=" << onHost::demangledName(exec));
 
-    queue.enqueue(exec, onHost::FrameSpec{1, 1}, KernelBundle{NoArgumentsKernel{}});
+    queue.enqueue(onHost::FrameSpec{1, 1, exec}, KernelBundle{NoArgumentsKernel{}});
 }
 
 struct IotaKernel
@@ -52,8 +52,8 @@ struct IotaKernel
     ALPAKA_FN_ACC void operator()(auto const& acc, auto out) const
     {
         // check that frame extent keeps compile time const-ness
-        static_assert(alpaka::concepts::CVector<ALPAKA_TYPEOF(acc[frame::extent])>);
-        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, onAcc::range::totalFrameSpecExtent))
+        static_assert(alpaka::concepts::CVector<ALPAKA_TYPEOF(acc[layer::thread].count())>);
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
         {
             // Debug-only trace removed in favor of Catch2 diagnostics.
             out[i.x()] = i.x();
@@ -86,7 +86,7 @@ TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
     auto hBuff = onHost::allocHostLike(dBuff);
 
     constexpr auto frameSize = CVec<uint32_t, 4u>{};
-    queue.enqueue(exec, onHost::FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernel{}, dBuff});
+    queue.enqueue(onHost::FrameSpec{extent / frameSize, frameSize, exec}, KernelBundle{IotaKernel{}, dBuff});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);
     meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(idx.x() == hBuff[idx]); });
@@ -96,7 +96,7 @@ struct IotaKernelND
 {
     ALPAKA_FN_ACC void operator()(auto const& acc, auto out) const
     {
-        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, onAcc::range::totalFrameSpecExtent))
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
         {
             out[i] = i;
         }
@@ -129,7 +129,7 @@ TEMPLATE_LIST_TEST_CASE("iota2D", "", TestApis)
 
     onHost::wait(queue);
     constexpr auto frameSize = Vec{2u, 4u};
-    queue.enqueue(exec, onHost::FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernelND{}, dBuff});
+    queue.enqueue(onHost::FrameSpec{extent / frameSize, frameSize, exec}, KernelBundle{IotaKernelND{}, dBuff});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);
     meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(idx == hBuff[idx]); });
@@ -161,7 +161,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D", "", TestApis)
 
     onHost::wait(queue);
     constexpr auto frameSize = Vec{2u, 4u, 8u};
-    queue.enqueue(exec, onHost::FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernelND{}, dBuff});
+    queue.enqueue(onHost::FrameSpec{extent / frameSize, frameSize, exec}, KernelBundle{IotaKernelND{}, dBuff});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);
     meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(idx == hBuff[idx]); });
@@ -193,33 +193,40 @@ TEMPLATE_LIST_TEST_CASE("iota4D", "", TestApis)
 
     onHost::wait(queue);
     constexpr auto frameSize = Vec{2u, 4u, 8u, 4u};
-    queue.enqueue(exec, onHost::FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernelND{}, dBuff});
+    queue.enqueue(onHost::FrameSpec{extent / frameSize, frameSize, exec}, KernelBundle{IotaKernelND{}, dBuff});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);
     meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(idx == hBuff[idx]); });
 }
 
+/** Test index container dimension slicing
+ *
+ * @todo This is a very bad example for slicing. Find a better usefull example.
+ */
 template<typename T_Selection>
 struct IotaKernelNDSelection
 {
-    ALPAKA_FN_ACC void operator()(auto const& acc, auto out, auto numFrames) const
+    ALPAKA_FN_ACC void operator()(auto const& acc, auto out, alpaka::concepts::Vector auto chunkSize) const
     {
-        for(auto fameBaseIdx :
-            onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, onAcc::range::frameCount)[CVec<uint32_t, 0u>{}])
+        alpaka::concepts::Vector auto outExtents = out.getExtents();
+        // select z dimension only and iterate over y,x in the inner loops
+        for(auto dataOffset :
+            onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{outExtents})[CVec<uint32_t, 0u>{}])
         {
-            /* fameBaseIdx is unique for each thread block.
-             * Therefor the workgroup for iterating over the frames in other dimensions must be one.
-             */
-            for(auto frameIdx :
-                onAcc::makeIdxMap(acc, onAcc::worker::allThreads, IdxRange{fameBaseIdx, numFrames})[T_Selection{}])
+            // dataOffset is still 3-dimensional but contains 0 in y,x
+            static_assert(alpaka::concepts::Dim<ALPAKA_TYPEOF(dataOffset), 3>);
+            // All threads in a block now iterates over the dimensions sliced out in the for loop above.
+            for(auto fullDataIdx :
+                onAcc::makeIdxMap(acc, onAcc::worker::allThreads, IdxRange{dataOffset, outExtents})[T_Selection{}])
             {
-                for(auto elemIdx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, onAcc::range::frameExtent))
-                    if(linearize(acc[frame::extent], elemIdx) == 1u)
+                for(auto elemIdx : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{chunkSize}))
+                    // only elemIdx 1 is applying the change
+                    if(linearize(chunkSize, elemIdx) == 1u)
                     {
-                        // use atomics to detect data races where mre than one thread is updating the result
-                        onAcc::atomicAdd(acc, &(out[frameIdx][0]), frameIdx[0]);
-                        onAcc::atomicAdd(acc, &(out[frameIdx][1]), frameIdx[1]);
-                        onAcc::atomicAdd(acc, &(out[frameIdx][2]), frameIdx[2]);
+                        // use atomics to detect data races where more than one thread is updating the result
+                        onAcc::atomicAdd(acc, &(out[fullDataIdx][0]), fullDataIdx[0]);
+                        onAcc::atomicAdd(acc, &(out[fullDataIdx][1]), fullDataIdx[1]);
+                        onAcc::atomicAdd(acc, &(out[fullDataIdx][2]), fullDataIdx[2]);
                     }
             }
         }
@@ -246,7 +253,11 @@ TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
     onHost::Queue queue = device.makeQueue();
     constexpr Vec numBlocks = Vec{4u, 8u, 16u};
     auto numBlocksReduced = numBlocks;
-    numBlocksReduced.ref(CVec<uint32_t, 2u, 1u>{}) = 1u;
+
+    // Within the kernel we will iterate over y, x dimension
+    [[maybe_unused]] auto selection = CVec<uint32_t, 2u, 1u>{};
+    // start a 3D extent but with size 1 in y, x dimension
+    numBlocksReduced.ref(selection) = 1u;
 
     INFO("numBlocksReduced=" << numBlocksReduced);
     INFO("exec=" << onHost::demangledName(exec));
@@ -258,12 +269,12 @@ TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
     onHost::wait(queue);
     constexpr auto frameSize = Vec{1u, 1u, 2u};
 
-    [[maybe_unused]] auto selection = CVec<uint32_t, 2u, 1u>{};
+    /* Use a frame specification where we have frames in z only.
+     * The kernel is later responsible that each data point of the output is filled with data.
+     */
+    auto frameSpec = onHost::FrameSpec{numBlocksReduced, frameSize, exec};
 
-    queue.enqueue(
-        exec,
-        onHost::FrameSpec{numBlocksReduced, frameSize},
-        KernelBundle{IotaKernelNDSelection<ALPAKA_TYPEOF(selection)>{}, dBuff, numBlocks});
+    queue.enqueue(frameSpec, KernelBundle{IotaKernelNDSelection<ALPAKA_TYPEOF(selection)>{}, dBuff, frameSize});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);
     meta::ndLoopIncIdx(numBlocks, [&](auto idx) { CHECK(idx == hBuff[idx]); });

--- a/test/unit/rand/uniformReal.cpp
+++ b/test/unit/rand/uniformReal.cpp
@@ -159,8 +159,7 @@ void testCase(HelperPack<T_Engine, T_FP, T_Interval>, uint64_t seed, T_FP minF, 
 
     // ---- launch kernel -------------------------------------------------------
     queue.enqueue(
-        exec,
-        onHost::getFrameSpec<T_FP>(device, Vec{N}),
+        onHost::getFrameSpec<T_FP>(device, exec, Vec{N}),
         KernelBundle{UniformRealKernel<T_Engine, T_FP, T_Interval>{}, devRes.getMdSpan(), seed, minF, maxF});
 
     onHost::memcpy(queue, hostRes, devRes);

--- a/test/unit/sharedMem/sharedMem.cpp
+++ b/test/unit/sharedMem/sharedMem.cpp
@@ -18,22 +18,21 @@ template<uint32_t T_blockSize>
 struct SharedBlockIotaKernel
 {
     template<typename T>
-    ALPAKA_FN_ACC void operator()(T const& acc, auto out, auto numBlocks) const
+    ALPAKA_FN_ACC void operator()(T const& acc, auto out, auto numBlocks, auto blockExtents) const
     {
         auto& shared = declareSharedVar<uint32_t[T_blockSize], uniqueId()>(acc);
 
         for(auto blockIdx : onAcc::makeIdxMap(acc, onAcc::worker::blocksInGrid, IdxRange{numBlocks}))
         {
-            auto const numDataElemInBlock = acc[frame::extent];
-            auto blockOffset = blockIdx * numDataElemInBlock;
-            for(auto inBlockOffset : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, onAcc::range::frameExtent))
+            auto blockOffset = blockIdx * blockExtents;
+            for(auto inBlockOffset : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{blockExtents}))
             {
                 uint32_t id = (T_blockSize - 1u - inBlockOffset).x();
                 shared[id] = id;
             }
 
             alpaka::onAcc::syncBlockThreads(acc);
-            for(auto inBlockOffset : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, onAcc::range::frameExtent))
+            for(auto inBlockOffset : onAcc::makeIdxMap(acc, onAcc::worker::threadsInBlock, IdxRange{blockExtents}))
             {
                 out[blockOffset + inBlockOffset] = (blockOffset + shared[inBlockOffset.x()]).x();
             }
@@ -68,9 +67,8 @@ TEMPLATE_LIST_TEST_CASE("block shared iota", "[sharedMem]", TestApis)
     alpaka::onHost::wait(queue);
 
     queue.enqueue(
-        exec,
-        onHost::FrameSpec{numBlocks / 2u, blockExtent},
-        KernelBundle{SharedBlockIotaKernel<blockExtent.x()>{}, dBuff, numBlocks});
+        onHost::FrameSpec{numBlocks / 2u, blockExtent, exec},
+        KernelBundle{SharedBlockIotaKernel<blockExtent.x()>{}, dBuff, numBlocks, blockExtent});
     alpaka::onHost::memcpy(queue, hBuff, dBuff);
     alpaka::onHost::wait(queue);
 
@@ -203,19 +201,19 @@ TEMPLATE_LIST_TEST_CASE("block shared alias", "[SharedMem]", TestApis)
     auto hBuff = onHost::allocHostLike(dBuff);
     alpaka::onHost::wait(queue);
     {
-        queue.enqueue(exec, onHost::FrameSpec{numBlocks, blockExtent}, KernelBundle{SharedMemAlias{}, dBuff});
+        queue.enqueue(onHost::FrameSpec{numBlocks, blockExtent, exec}, KernelBundle{SharedMemAlias{}, dBuff});
         alpaka::onHost::memcpy(queue, hBuff, dBuff);
         alpaka::onHost::wait(queue);
         CHECK(hBuff[0] == true);
     }
     {
-        queue.enqueue(exec, onHost::FrameSpec{numBlocks, blockExtent}, KernelBundle{DynSharedMemMember{}, dBuff});
+        queue.enqueue(onHost::FrameSpec{numBlocks, blockExtent, exec}, KernelBundle{DynSharedMemMember{}, dBuff});
         alpaka::onHost::memcpy(queue, hBuff, dBuff);
         alpaka::onHost::wait(queue);
         CHECK(hBuff[0] == true);
     }
     {
-        queue.enqueue(exec, onHost::FrameSpec{numBlocks, blockExtent}, KernelBundle{DynSharedMemTrait{}, dBuff});
+        queue.enqueue(onHost::FrameSpec{numBlocks, blockExtent, exec}, KernelBundle{DynSharedMemTrait{}, dBuff});
         alpaka::onHost::memcpy(queue, hBuff, dBuff);
         alpaka::onHost::wait(queue);
         CHECK(hBuff[0] == true);
@@ -243,8 +241,7 @@ void test_index_type(auto& queue, auto const& exec, auto name)
     onHost::wait(queue);
 
     queue.enqueue(
-        exec,
-        onHost::FrameSpec{alpaka::Vec{1u}, alpaka::Vec{1u}},
+        onHost::FrameSpec{alpaka::Vec{1u}, alpaka::Vec{1u}, exec},
         KernelBundle{IndexTypeKernel<T_Idx>{}, dBuff});
     alpaka::onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);

--- a/test/unit/wait/device.cpp
+++ b/test/unit/wait/device.cpp
@@ -56,7 +56,7 @@ void executeWaitTest(auto& device, auto const& exec)
     for(uint32_t i = 0; i < numQueues; ++i)
     {
         auto kernelBundle = KernelBundle{WaitTestWriteKernel{}, devBufs[i]};
-        queues[i].enqueue(exec, onHost::FrameSpec{extent, frameSize}, kernelBundle);
+        queues[i].enqueue(onHost::FrameSpec{extent, frameSize, exec}, kernelBundle);
         // Note: We deliberately don't wait on individual queues here
     }
 
@@ -74,7 +74,7 @@ void executeWaitTest(auto& device, auto const& exec)
 
         // Enqueue multiple operations on same queue - they queue up asynchronously
         auto kernelBundle = KernelBundle{WaitTestWriteKernel{}, singleQueueBufs[i]};
-        singleQueue.enqueue(exec, onHost::FrameSpec{extent, frameSize}, kernelBundle);
+        singleQueue.enqueue(onHost::FrameSpec{extent, frameSize, exec}, kernelBundle);
     }
 
     // TEST: wait for device to complete ALL work on ALL queues (including single queue ops)

--- a/test/unit/warp/activemask.cpp
+++ b/test/unit/warp/activemask.cpp
@@ -85,13 +85,13 @@ TEMPLATE_LIST_TEST_CASE("warp activemask reflects participating lanes", "[warp][
 
     auto const blocks = Vec<std::uint32_t, 1u>{5u};
     auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
-    auto const frame = onHost::FrameSpec{blocks, threads};
+    auto const frame = onHost::FrameSpec{blocks, threads, exec};
 
     for(std::uint32_t inactiveLane = 0u; inactiveLane < warpExtent; ++inactiveLane)
     {
         // Sweep every lane once to confirm the mask drops exactly that participant.
         onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
-        queue.enqueue(exec, frame, KernelBundle{ActivemaskMultiThreadKernel{}, successDev, inactiveLane});
+        queue.enqueue(frame, KernelBundle{ActivemaskMultiThreadKernel{}, successDev, inactiveLane});
         onHost::memcpy(queue, successHost, successDev);
         onHost::wait(queue);
         INFO("backend=" << deviceSpec.getName() << " inactiveLane=" << inactiveLane);

--- a/test/unit/warp/all.cpp
+++ b/test/unit/warp/all.cpp
@@ -91,13 +91,13 @@ TEMPLATE_LIST_TEST_CASE("warp all vote honours only active lanes", "[warp][all]"
 
     auto const blocks = Vec<std::uint32_t, 1u>{5u};
     auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
-    auto const frame = onHost::FrameSpec{blocks, threads};
+    auto const frame = onHost::FrameSpec{blocks, threads, exec};
 
     for(std::uint32_t idx = 0u; idx < warpExtent; ++idx)
     {
         // Iterate over each potential trigger lane to verify masked votes.
         onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
-        queue.enqueue(exec, frame, KernelBundle{AllMultiThreadKernel{}, successDev, idx});
+        queue.enqueue(frame, KernelBundle{AllMultiThreadKernel{}, successDev, idx});
         onHost::memcpy(queue, successHost, successDev);
         onHost::wait(queue);
         INFO("backend=" << deviceSpec.getName() << " idx=" << idx);

--- a/test/unit/warp/any.cpp
+++ b/test/unit/warp/any.cpp
@@ -91,13 +91,13 @@ TEMPLATE_LIST_TEST_CASE("warp any vote observes active lanes", "[warp][any]", Wa
 
     auto const blocks = Vec<std::uint32_t, 1u>{5u};
     auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
-    auto const frame = onHost::FrameSpec{blocks, threads};
+    auto const frame = onHost::FrameSpec{blocks, threads, exec};
 
     for(std::uint32_t idx = 0u; idx < warpExtent; ++idx)
     {
         // Rotate through each candidate lane to ensure mask-gated votes succeed.
         onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
-        queue.enqueue(exec, frame, KernelBundle{AnyMultiThreadKernel{}, successDev, idx});
+        queue.enqueue(frame, KernelBundle{AnyMultiThreadKernel{}, successDev, idx});
         onHost::memcpy(queue, successHost, successDev);
         onHost::wait(queue);
         INFO("backend=" << deviceSpec.getName() << " idx=" << idx);

--- a/test/unit/warp/ballot.cpp
+++ b/test/unit/warp/ballot.cpp
@@ -103,7 +103,7 @@ TEMPLATE_LIST_TEST_CASE("warp ballot captures predicate lanes", "[warp][ballot]"
     auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
 
     onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
-    queue.enqueue(exec, onHost::FrameSpec{blocks, threads}, KernelBundle{BallotMultiThreadKernel{}, successDev});
+    queue.enqueue(onHost::FrameSpec{blocks, threads, exec}, KernelBundle{BallotMultiThreadKernel{}, successDev});
     onHost::memcpy(queue, successHost, successDev);
     onHost::wait(queue);
     INFO("backend=" << deviceSpec.getName());

--- a/test/unit/warp/getSize.cpp
+++ b/test/unit/warp/getSize.cpp
@@ -98,8 +98,7 @@ TEMPLATE_LIST_TEST_CASE("warp size trait matches runtime size", "[warp][getSize]
 
     onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
     queue.enqueue(
-        exec,
-        onHost::ThreadSpec{blocks, threads},
+        onHost::ThreadSpec{blocks, threads, exec},
         // Pass the host-side expectation down to the device for verification.
         KernelBundle{GetSizeKernel{}, successDev, static_cast<std::uint32_t>(warpExtent)});
     onHost::memcpy(queue, successHost, successDev);

--- a/test/unit/warp/iota.cpp
+++ b/test/unit/warp/iota.cpp
@@ -70,7 +70,7 @@ TEMPLATE_LIST_TEST_CASE("warp iota1D", "", TestApis)
      */
     auto frameSize = Vec{warpSize + 3u};
     onHost::fill(queue, dBuff, Vec{0u});
-    queue.enqueue(exec, onHost::FrameSpec{extent / frameSize, frameSize}, KernelBundle{IotaKernelND{}, dBuff, extent});
+    queue.enqueue(onHost::FrameSpec{extent / frameSize, frameSize, exec}, KernelBundle{IotaKernelND{}, dBuff, extent});
     onHost::memcpy(queue, hBuff, dBuff);
     onHost::wait(queue);
     meta::ndLoopIncIdx(extent, [&](auto idx) { CHECK(idx == hBuff[idx]); });

--- a/test/unit/warp/shfl.cpp
+++ b/test/unit/warp/shfl.cpp
@@ -123,7 +123,7 @@ TEMPLATE_LIST_TEST_CASE("warp shfl moves values between lanes", "[warp][shfl]", 
     auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
 
     onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
-    queue.enqueue(exec, onHost::FrameSpec{blocks, threads}, KernelBundle{ShflMultiThreadKernel{}, successDev});
+    queue.enqueue(onHost::FrameSpec{blocks, threads, exec}, KernelBundle{ShflMultiThreadKernel{}, successDev});
     onHost::memcpy(queue, successHost, successDev);
     onHost::wait(queue);
     INFO("backend=" << deviceSpec.getName());

--- a/test/unit/warp/shfl_down.cpp
+++ b/test/unit/warp/shfl_down.cpp
@@ -133,7 +133,7 @@ TEMPLATE_LIST_TEST_CASE("warp shflDown shifts toward higher lanes", "[warp][shfl
     auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
 
     onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
-    queue.enqueue(exec, onHost::FrameSpec{blocks, threads}, KernelBundle{ShflDownMultiThreadKernel{}, successDev});
+    queue.enqueue(onHost::FrameSpec{blocks, threads, exec}, KernelBundle{ShflDownMultiThreadKernel{}, successDev});
     onHost::memcpy(queue, successHost, successDev);
     onHost::wait(queue);
     INFO("backend=" << deviceSpec.getName());

--- a/test/unit/warp/shfl_up.cpp
+++ b/test/unit/warp/shfl_up.cpp
@@ -123,7 +123,7 @@ TEMPLATE_LIST_TEST_CASE("warp shflUp shifts toward lower lanes", "[warp][shfl_up
     auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
 
     onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
-    queue.enqueue(exec, onHost::FrameSpec{blocks, threads}, KernelBundle{ShflUpMultiThreadKernel{}, successDev});
+    queue.enqueue(onHost::FrameSpec{blocks, threads, exec}, KernelBundle{ShflUpMultiThreadKernel{}, successDev});
     onHost::memcpy(queue, successHost, successDev);
     onHost::wait(queue);
     INFO("backend=" << deviceSpec.getName());

--- a/test/unit/warp/shfl_xor.cpp
+++ b/test/unit/warp/shfl_xor.cpp
@@ -121,7 +121,7 @@ TEMPLATE_LIST_TEST_CASE("warp shflXor exchanges partner lanes", "[warp][shfl_xor
     auto const threads = Vec<std::uint32_t, 1u>{4u * warpExtent};
 
     onHost::memset(queue, successDev, static_cast<std::uint8_t>(true));
-    queue.enqueue(exec, onHost::FrameSpec{blocks, threads}, KernelBundle{ShflXorMultiThreadKernel{}, successDev});
+    queue.enqueue(onHost::FrameSpec{blocks, threads, exec}, KernelBundle{ShflXorMultiThreadKernel{}, successDev});
     onHost::memcpy(queue, successHost, successDev);
     onHost::wait(queue);
     INFO("backend=" << deviceSpec.getName());


### PR DESCRIPTION
- `FrameSpec`
  - The user specified frame specification is not forwared into the
   kernel.
  - A kernel can only query `acc.launchedWithFrameSpec()` to have information that the kernel start parameters and in kernel thread block configuration differ.
  - Is not holding a thread specification anymore.
  - Contains the executor and is therefore a launch configuration.
- ThreadSpec`: provides the used executor and is therefore a launch
  configuration.
- The executor is removed from the interface `queue.enqueue()`.


This PR is a **breaking** interface change, the number of frames and frame extents cann ot be used anymore within the kernel. If needed, the user is responsible for using explicit chunking and chunk sizes must be forwarded as arguments or kernel template parameters.

```C++
struct FooKernel
{
   ALPAKA_FN_ACC void operator(auto acc) const
  {
    for(auto elem :
            alpaka::onAcc::makeIdxMap(
                acc, 
                onAcc::worker::threadsInBlock, 
                onAcc::range::frameExtent))
            {
            }
  }
};
auto const frameSpec = FrameSpec{numChunks, chunkSize};
// ...
queue.enqueue(computeExec, frameSpec, FooKernel{});
```

became

```C++
struct FooKernel
{
   ALPAKA_FN_ACC void operator(auto acc, auto chunkExtents) const
  {
    for(auto elem :
            alpaka::onAcc::makeIdxMap(
                    acc, 
                    onAcc::worker::threadsInBlock, 
                    IdxRange{chunkExtents}))
            {
            }
  }
};

auto const frameSpec = FrameSpec{numChunks, chunkSize, computeExec};
queue.enqueue(frameSpec, FooKernel{}, chunkSize);
```


# Review

- the first commit is the changes required within alpaka
- all other commits using the new interface in different parts e.g. examples, docs, ...
- all places where frames were used within the kernel are replaced with explicit chunking and sometimes chunking was removed when it was not required.