### PR TITLE
fix pre-commit for `shellcheck`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,8 +43,8 @@ repos:
   rev: v3.13.1-1
   hooks:
     - id: shfmt
-- repo: https://github.com/koalaman/shellcheck-precommit
-  rev: v0.11.0
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.11.0.1
   hooks:
     - id: shellcheck
       # required that shellcheck can follow sourced scripts


### PR DESCRIPTION
fix #528

The original version of the pre-commit for shellcheck required docker. Switch the version used to support a non docker dependent version.