### PR TITLE
fix `Simd::fill()`

### DIFF
--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -189,8 +189,13 @@ namespace alpaka
          * @param value Value which is set for all lanes
          * @return new Simd<...>
          */
-        static constexpr auto fill(concepts::Convertible<T_Type> auto const& value)
+        static constexpr auto fill(concepts::Convertible<T_Type> auto value)
         {
+            /* Note the function is taking value as copy because it is typically a scalar value.
+             * If a const reference is used, it would not be possible to pass a host defined constexpr value into
+             * fill() when CUDA is used. Issue was seen with nvcc CUDA 13.0.2. see
+             * https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#constexpr-variables
+             */
             return Simd{Storage::fill(static_cast<T_Type>(value))};
         }
 

--- a/include/alpaka/simd/internal/EmuSimd.hpp
+++ b/include/alpaka/simd/internal/EmuSimd.hpp
@@ -94,7 +94,7 @@ namespace alpaka
 
             /** @} */
 
-            static constexpr auto fill(T_Type const& value)
+            static constexpr auto fill(T_Type value)
             {
                 return EmuSimd([&value](uint32_t const) { return value; });
             }

--- a/include/alpaka/simd/internal/StdSimd.hpp
+++ b/include/alpaka/simd/internal/StdSimd.hpp
@@ -92,7 +92,7 @@ namespace alpaka
                 return alpakaStdSimd::where(mask.asNativeType(), asNativeType());
             }
 
-            static constexpr auto fill(T_Type const& value)
+            static constexpr auto fill(T_Type value)
             {
                 return StdSimd{BaseType(value)};
             }


### PR DESCRIPTION
... together with CUDA 13.0.2
The reason is that CUDA can not take a constexpr host variable as a reference.
This pattern is used in the Babelstream kernel `SimdInitOp`.

nvcc is so nice and add a `trap` into the kernel if you call a device function which takes a reference and your value is a constexpr host variable. It is then crashing at runtime with `'unspecified launch failure'` instead of failing during the compilation.