### PR TITLE
refactor `makeIdxMap()` contigious mapping

### DIFF
--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -571,7 +571,7 @@ namespace alpaka
         template<typename T_OtherStorage>
         constexpr auto min(Vec<T_Type, T_dim, T_OtherStorage> const& rhs) const
         {
-            Vec result{};
+            typename Vec::UniVec result{};
             for(uint32_t d = 0u; d < T_dim; d++)
                 result[d] = std::min((*this)[d], rhs[d]);
             return result;

--- a/include/alpaka/mem/FlatIdxContainer.hpp
+++ b/include/alpaka/mem/FlatIdxContainer.hpp
@@ -221,19 +221,30 @@ namespace alpaka::onAcc
                 auto begin = m_idxRange.m_begin + groupOffset;
 
                 auto strideMD = m_idxRange.m_stride[selectedDims];
-
-                auto numElements = divCeil(
-                                       m_idxRange.distance()[selectedDims],
-                                       m_threadSpace.m_threadCount[selectedDims] * strideMD)
-                                       .product();
-                auto linearCurrent
-                    = linearize(m_threadSpace.m_threadCount[selectedDims], threadIdx[selectedDims]) * numElements;
                 auto extentMD = divCeil(m_idxRange.distance()[selectedDims], strideMD);
+
+                auto threadCountMD = m_threadSpace.m_threadCount[selectedDims];
+
+                auto numWorkerSlots = threadCountMD.product();
+                auto linearSlotIdx = linearize(threadCountMD, threadIdx[selectedDims]);
+
+                auto logicalExtent = extentMD.product();
+
+                // elements per slot
+                auto base = logicalExtent / numWorkerSlots;
+                // remainder elements will be given to the slots with id lower than rem
+                auto rem = logicalExtent % numWorkerSlots;
+
+                auto nextLinearSlotIdx = linearSlotIdx + IdxType{1};
+
+                auto linearCurrent = linearSlotIdx * base + std::min(linearSlotIdx, rem);
+                auto linearEnd = nextLinearSlotIdx * base + std::min(nextLinearSlotIdx, rem);
+
                 return const_iterator(
                     begin,
                     linearCurrent,
                     IdxType{1u},
-                    std::min(linearCurrent + numElements, extentMD.product()),
+                    std::min(linearEnd, logicalExtent),
                     extentMD,
                     strideMD);
             }
@@ -252,11 +263,22 @@ namespace alpaka::onAcc
             else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contiguous>)
             {
                 auto strideMD = m_idxRange.m_stride[selectedDims];
-                auto numElements
-                    = divCeil(m_idxRange.distance()[selectedDims], numThreads[selectedDims] * strideMD).product();
-                auto linearCurrent = linearize(numThreads[selectedDims], threadIdx[selectedDims]) * numElements;
                 auto extentMD = divCeil(m_idxRange.distance()[selectedDims], strideMD);
-                return const_iterator_end(std::min(linearCurrent + numElements, extentMD.product()));
+
+                auto numWorkerSlots = numThreads[selectedDims].product();
+                auto linearSlotIdx = linearize(numThreads[selectedDims], threadIdx[selectedDims]);
+
+                auto logicalExtent = extentMD.product();
+
+                // elements per slot
+                auto base = logicalExtent / numWorkerSlots;
+                // remainder elements will be given to the slots with id lower than rem
+                auto rem = logicalExtent % numWorkerSlots;
+
+                auto nextLinearSlotIdx = linearSlotIdx + IdxType{1};
+                auto linearEnd = nextLinearSlotIdx * base + std::min(nextLinearSlotIdx, rem);
+
+                return const_iterator_end(std::min(linearEnd, logicalExtent));
             }
         }
 

--- a/include/alpaka/mem/TiledIdxContainer.hpp
+++ b/include/alpaka/mem/TiledIdxContainer.hpp
@@ -264,15 +264,23 @@ namespace alpaka::onAcc
             }
             else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contiguous>)
             {
-                auto extent = m_idxRange.distance();
-                auto numElements = divCeil(extent, m_idxRange.m_stride * numThreads);
-                auto first = threadIdx * numElements * m_idxRange.m_stride;
+                IdxVecType extent = m_idxRange.distance();
+                IdxVecType logicalExtent = divCeil(extent, m_idxRange.m_stride);
 
-                return const_iterator(
-                    m_idxRange.m_begin,
-                    first,
-                    extent.min(first + numElements * m_idxRange.m_stride),
-                    m_idxRange.m_stride);
+                // elements per slot
+                IdxVecType base = logicalExtent / numThreads;
+                // remainder elements will be given to the slots with id lower than rem
+                IdxVecType rem = logicalExtent % numThreads;
+
+                IdxVecType firstLogical = threadIdx * base + threadIdx.min(rem);
+                IdxVecType first = firstLogical * m_idxRange.m_stride;
+
+                IdxVecType nextThreadIdx = threadIdx + IdxType{1};
+                IdxVecType endLogical = nextThreadIdx * base + nextThreadIdx.min(rem);
+                // crop to the end of the index range
+                IdxVecType end = extent.min(endLogical * m_idxRange.m_stride);
+
+                return const_iterator(m_idxRange.m_begin, first, end, m_idxRange.m_stride);
             }
         }
 
@@ -287,11 +295,20 @@ namespace alpaka::onAcc
             }
             else if constexpr(std::is_same_v<T_IdxMapperFn, layout::Contiguous>)
             {
-                auto extent = m_idxRange.distance();
-                auto numElements = divCeil(extent, m_idxRange.m_stride * numThreads);
-                auto first = threadIdx * numElements * m_idxRange.m_stride;
+                IdxVecType extent = m_idxRange.distance();
+                IdxVecType logicalExtent = divCeil(extent, m_idxRange.m_stride);
 
-                return const_iterator_end(m_idxRange.m_begin + extent.min(first + numElements * m_idxRange.m_stride));
+                // elements per slot
+                IdxVecType base = logicalExtent / numThreads;
+                // remainder elements will be given to the slots with id lower than rem
+                IdxVecType rem = logicalExtent % numThreads;
+
+                IdxVecType nextSlotIdx = threadIdx + IdxType{1};
+                IdxVecType endLogical = nextSlotIdx * base + nextSlotIdx.min(rem);
+                // crop to the end of the index range
+                IdxVecType end = extent.min(endLogical * m_idxRange.m_stride);
+
+                return const_iterator_end(m_idxRange.m_begin + end);
             }
         }
 

--- a/test/unit/kernel/makeIdxMap.cpp
+++ b/test/unit/kernel/makeIdxMap.cpp
@@ -1,0 +1,138 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+using namespace alpaka;
+
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
+
+template<onAcc::concepts::IdxTraversing T_Traverse, onAcc::concepts::IdxMapping T_IdxLayout>
+struct IotaKernelND
+{
+    ALPAKA_FN_ACC void operator()(auto const& acc, auto out, auto counter) const
+    {
+        for(auto i : onAcc::makeIdxMap(
+                acc,
+                onAcc::worker::threadsInGrid,
+                IdxRange{out.getExtents()},
+                T_Traverse{},
+                T_IdxLayout{}))
+        {
+            out[i] = i;
+            onAcc::atomicAdd(acc, &counter[i], 1u);
+        }
+    }
+};
+
+void testCombination(
+    auto queue,
+    auto exec,
+    concepts::Vector auto extents,
+    concepts::Vector auto frameSize,
+    auto policy)
+{
+    auto dBuff = onHost::alloc<ALPAKA_TYPEOF(extents)>(queue.getDevice(), extents);
+    auto dBuffCounter = onHost::alloc<uint32_t>(queue.getDevice(), extents);
+
+    auto hBuff = onHost::allocHostLike(dBuff);
+    auto hBuffCounter = onHost::allocHostLike(dBuffCounter);
+    onHost::wait(queue);
+    onHost::memset(queue, dBuff, 0u);
+    onHost::memset(queue, dBuffCounter, 0u);
+
+    queue.enqueue(
+        onHost::FrameSpec{alpaka::divExZero(extents, frameSize), frameSize, exec},
+        KernelBundle{IotaKernelND<ALPAKA_TYPEOF(policy.first), ALPAKA_TYPEOF(policy.second)>{}, dBuff, dBuffCounter});
+    onHost::memcpy(queue, hBuff, dBuff);
+    onHost::memcpy(queue, hBuffCounter, dBuffCounter);
+    onHost::wait(queue);
+    // Use REQUIRE instead of CHECK to avoid spamming the output if the results are wrong.
+    meta::ndLoopIncIdx(
+        extents,
+        [&](auto idx)
+        {
+            REQUIRE(idx == hBuff[idx]);
+            // fail if more or less than one invocation on the same data item is detected
+            REQUIRE(1u == hBuffCounter[idx]);
+        });
+}
+
+template<typename Queue, typename Exec, typename Extent, typename Policy>
+void runTest(Queue& queue, Exec exec, Extent const& extentsAndFrameSize, Policy const& policy)
+{
+    auto bufferExtents = extentsAndFrameSize.first;
+    auto frameExtents = extentsAndFrameSize.second;
+    DYNAMIC_SECTION(
+        "exec=" << onHost::demangledName(exec) << ", extent=" << bufferExtents << ", frameExtents=" << frameExtents
+                << ", policy=" << onHost::demangledName<Policy>())
+    {
+        testCombination(queue, exec, bufferExtents, frameExtents, policy);
+    }
+}
+
+/* The test is using iota to prove that each value in the buffer is set via makeIdxMap.
+ * Additionally, we atomically count taht each value is only set by a single thread and not twice.
+ * We test with different buffer extents, frame extents and policies for makeIdxMap to cover different edge cases of
+ * the makeIdxMap implementation.
+ */
+TEMPLATE_LIST_TEST_CASE("makeIdxMap", "[kernel][makeIdxMap]", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        SUCCEED("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
+
+    onHost::Queue queue = device.makeQueue();
+
+    // list of pairs with (bufferExtents, frameExtents)
+    auto extentsAndFrameSize = std::make_tuple(
+        // 1D
+        std::make_pair(Vec{2u}, Vec{3u}),
+        std::make_pair(Vec{7u}, Vec{2u}),
+        std::make_pair(Vec{101u}, Vec{101u}),
+        std::make_pair(Vec{997u}, Vec{2u}),
+        // 2D
+        std::make_pair(Vec{2u, 3u}, Vec{5u, 2u}),
+        std::make_pair(Vec{7u, 11u}, Vec{2u, 13u}),
+        std::make_pair(Vec{17u, 19u}, Vec{23u, 2u}),
+        std::make_pair(Vec{101u, 103u}, Vec{2u, 107u}),
+        // 3D
+        std::make_pair(Vec{2u, 3u, 5u}, Vec{7u, 2u, 3u}),
+        std::make_pair(Vec{11u, 13u, 17u}, Vec{2u, 19u, 5u}),
+        std::make_pair(Vec{29u, 31u, 37u}, Vec{41u, 2u, 3u}),
+        std::make_pair(Vec{43u, 47u, 53u}, Vec{2u, 59u, 5u}),
+        // 4D
+        std::make_pair(Vec{2u, 3u, 5u, 7u}, Vec{11u, 2u, 3u, 5u}),
+        std::make_pair(Vec{11u, 13u, 17u, 19u}, Vec{2u, 23u, 5u, 3u}),
+        std::make_pair(Vec{23u, 29u, 31u, 37u}, Vec{41u, 2u, 3u, 5u}),
+        std::make_pair(Vec{47u, 43u, 17u, 13u}, Vec{2u, 53u, 19u, 3u}));
+
+    // maybe_unused avoid warnings
+    [[maybe_unused]] auto policy = std::make_tuple(
+        std::pair<onAcc::traverse::Flat, onAcc::layout::Contiguous>{},
+        std::pair<onAcc::traverse::Flat, onAcc::layout::Strided>{},
+        std::pair<onAcc::traverse::Tiled, onAcc::layout::Contiguous>{},
+        std::pair<onAcc::traverse::Tiled, onAcc::layout::Strided>{});
+
+
+    auto runExtent = [&](auto const& extent)
+    { std::apply([&](auto const&... usedPolicy) { (runTest(queue, exec, extent, usedPolicy), ...); }, policy); };
+
+    std::apply([&](auto const&... extent) { (runExtent(extent), ...); }, extentsAndFrameSize);
+}


### PR DESCRIPTION
Change the way how id's are distributed to worker group slots are distributes.
The new distribution is keeping the workload per slot more even and avoid slots without work.
Add a unit test for `makeIdxMap` to test all combinations of layout and traverse policy.

before PR:
<img width="4360" height="4048" alt="image" src="https://github.com/user-attachments/assets/7a562b4e-de14-4420-8e56-9996a60edbaa" />

after PR:
<img width="4360" height="4048" alt="image" src="https://github.com/user-attachments/assets/71aa1ac1-c00c-4dd2-bfd5-979431245787" />
