### PR TITLE
support alpaka-group-container

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,28 @@
 .gcc-base:
-  image: docker.io/ubuntu:24.04
   variables:
     APCI_ALPAKA_ROOT: "$CI_PROJECT_DIR"
   script:
     - $APCI_ALPAKA_ROOT/script/ci/job_info.sh
     - $APCI_ALPAKA_ROOT/script/ci/install_dependencies.sh
     - $APCI_ALPAKA_ROOT/script/ci/configure.sh
+  tags:
+  - x86_64
+  - cpuonly
 
 gcc-13:
+  image: docker.io/ubuntu:24.04
   extends: .gcc-base
   variables:
     APCI_DEVICE_COMPILER : gcc@13
 
 gcc-15:
+  image: docker.io/ubuntu:24.04
   extends: .gcc-base
   variables:
     APCI_DEVICE_COMPILER : gcc@15
+
+gcc-12-agc:
+  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu24.04-gcc:4.0
+  extends: .gcc-base
+  variables:
+    APCI_DEVICE_COMPILER : gcc@12

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -20,37 +20,48 @@ parse_compiler_version "$APCI_DEVICE_COMPILER"
 script_msg "Install GCC"
 
 if [[ "$compiler_name" == "gcc" ]]; then
-    # install gcc only if not already available, pre installed gcc can not be called with the version number as postfix
-    if [[ ! $(command -v gcc) || "$(gcc --version | awk '{print($3)}' | head -n 1 | cut -d"." -f1)" -ne "${compiler_version}" ]]; then
-        install_msg "GCC $compiler_version"
-        # install requested GCC if it is not already available
-        if ! command -v "gcc-${compiler_version}" >/dev/null 2>&1; then
-            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-            DEBIAN_FRONTEND=noninteractive sudo apt update
-            DEBIAN_FRONTEND=noninteractive sudo apt install -y "gcc-${compiler_version}" "g++-${compiler_version}"
-            # select requested GCC as default
-            # TODO: Remove me, if ACPI_CXX_COMPILER is used in production.
-            # Changing the system host compiler is pretty dangerous and error prone.
-            update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-${compiler_version}" 100 \
-                --slave /usr/bin/g++ g++ "/usr/bin/g++-${compiler_version}"
+    if agc-manager -e "gcc@${compiler_version}"; then
+        echo_green "use preinstalled gcc@${compiler_version}"
+
+        # TODO: because of a bug in agc-manager the gcc/g++ base path is wrong. Search for gcc/g++ instead.
+        # `APCI_CC_COMPILER="$(agc-manager -b gcc@${compiler_version})/gcc-${compiler_version}"`
+        APCI_CC_COMPILER=$(which "gcc-${compiler_version}")
+        APCI_CXX_COMPILER=$(which "g++-${compiler_version}")
+        export APCI_CC_COMPILER
+        export APCI_CXX_COMPILER
+    else
+        # install gcc only if not already available, pre installed gcc can not be called with the version number as postfix
+        if [[ ! $(command -v gcc) || "$(gcc --version | awk '{print($3)}' | head -n 1 | cut -d"." -f1)" -ne "${compiler_version}" ]]; then
+            install_msg "GCC $compiler_version"
+            # install requested GCC if it is not already available
+            if ! command -v "gcc-${compiler_version}" >/dev/null 2>&1; then
+                sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+                DEBIAN_FRONTEND=noninteractive sudo apt update
+                DEBIAN_FRONTEND=noninteractive sudo apt install -y "gcc-${compiler_version}" "g++-${compiler_version}"
+                # select requested GCC as default
+                # TODO: Remove me, if ACPI_CXX_COMPILER is used in production.
+                # Changing the system host compiler is pretty dangerous and error prone.
+                update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-${compiler_version}" 100 \
+                    --slave /usr/bin/g++ g++ "/usr/bin/g++-${compiler_version}"
+            fi
         fi
+
+        # we assume gcc, g++, gcc-<version> and g++-<version> are in the same folder
+        gcc_base_path="$(dirname "$(which gcc)")"
+
+        # workaround for gcc container
+        # there is no g++-<version> executable
+        for exe_name in gcc g++; do
+            version_exe_name="${gcc_base_path}/${exe_name}-${compiler_version}"
+            if [[ ! -f "${version_exe_name}" ]]; then
+                ln -s "${gcc_base_path}/${exe_name}" "${version_exe_name}"
+            fi
+            unset version_exe_name
+        done
+
+        export APCI_CC_COMPILER="${gcc_base_path}/gcc-${compiler_version}"
+        export APCI_CXX_COMPILER="${gcc_base_path}/g++-${compiler_version}"
     fi
-
-    # we assume gcc, g++, gcc-<version> and g++-<version> are in the same folder
-    gcc_base_path="$(dirname "$(which gcc)")"
-
-    # workaround for gcc container
-    # there is no g++-<version> executable
-    for exe_name in gcc g++; do
-        version_exe_name="${gcc_base_path}/${exe_name}-${compiler_version}"
-        if [[ ! -f "${version_exe_name}" ]]; then
-            ln -s "${gcc_base_path}/${exe_name}" "${version_exe_name}"
-        fi
-        unset version_exe_name
-    done
-
-    export APCI_CC_COMPILER="${gcc_base_path}/gcc-${compiler_version}"
-    export APCI_CXX_COMPILER="${gcc_base_path}/g++-${compiler_version}"
 
     echo_green "${APCI_CC_COMPILER} --version"
     $APCI_CC_COMPILER --version

--- a/script/ci/install_dependencies.sh
+++ b/script/ci/install_dependencies.sh
@@ -12,6 +12,9 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/install_helper_apps.sh"
 
 : "${APCI_DEVICE_COMPILER?'The device compiler must be specified'}"
 
+# disable false positive
+# shellcheck disable=SC2218
+# SC2218: This function is only defined later. Move the definition up.
 script_msg "Install software dependencies (install_dependencies.sh)"
 
 # shellcheck source=script/ci/install/gcc.sh

--- a/script/ci/utils/helper_apps/agc-manager.sh
+++ b/script/ci/utils/helper_apps/agc-manager.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+
+# shellcheck source=script/ci/utils/setup_vars.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/setup_vars.sh"
+# shellcheck source=script/ci/utils/set.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/set.sh"
+# shellcheck source=script/ci/utils/color_echo.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/color_echo.sh"
+
+# the agc-manager only exists in the agc-container
+# set alias to false, so each time if we ask the agc-manager if a software is installed, it will
+# return false and the installation of software will be triggered
+if command -v agc-manager >/dev/null 2>&1; then
+    echo_green "found agc-manager"
+else
+    echo_yellow "install fake agc-manager"
+    export PRINT_INSTALL_AGC_MANAGER=true
+
+    echo -e "#!/bin/bash\n\nexit 1" >>agc-manager
+
+    if [[ "$APCI_OS_NAME" = "Linux" ]]; then
+        sudo chmod +x agc-manager
+        sudo mv agc-manager /usr/bin/agc-manager
+    elif [[ "$APCI_OS_NAME" = "Windows" ]]; then
+        chmod +x agc-manager
+        mv agc-manager /usr/bin
+    elif [[ "$APCI_OS_NAME" = "macOS" ]]; then
+        sudo chmod +x agc-manager
+        sudo mv agc-manager /usr/local/bin
+    else
+        echo_red "installing agc-manager: " \
+            "unknown operation system: ${APCI_OS_NAME}"
+        exit 1
+    fi
+fi

--- a/script/ci/utils/helper_apps/sudo.sh
+++ b/script/ci/utils/helper_apps/sudo.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+
+# shellcheck source=script/ci/utils/setup_vars.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/setup_vars.sh"
+# shellcheck source=script/ci/utils/set.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/set.sh"
+# shellcheck source=script/ci/utils/color_echo.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/color_echo.sh"
+# shellcheck source=script/ci/utils/misc.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/misc.sh"
+
+# inside the agc-container, the user is root and does not require sudo
+# to compatibility to other container, fake the missing sudo command
+if ! command -v sudo &>/dev/null; then
+    if [[ "$APCI_OS_NAME" == "Linux" ]]; then
+        install_msg "sudo"
+
+        lazy_apt_update
+        DEBIAN_FRONTEND=noninteractive apt install -y sudo
+    fi
+fi

--- a/script/ci/utils/install_helper_apps.sh
+++ b/script/ci/utils/install_helper_apps.sh
@@ -16,16 +16,23 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/color_echo.sh"
 # shellcheck source=script/ci/utils/misc.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/misc.sh"
 
-# inside the agc-container, the user is root and does not require sudo
-# to compatibility to other container, fake the missing sudo command
-if ! command -v sudo &>/dev/null; then
-    if [[ "$APCI_OS_NAME" == "Linux" ]]; then
-        install_msg "sudo"
+########################
+# install sudo
+########################
 
-        lazy_apt_update
-        DEBIAN_FRONTEND=noninteractive apt install -y sudo
-    fi
-fi
+# shellcheck source=script/ci/utils/helper_apps/sudo.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/helper_apps/sudo.sh"
+
+########################
+# install agc-manager
+########################
+
+# shellcheck source=script/ci/utils/helper_apps/agc-manager.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/helper_apps/agc-manager.sh"
+
+########################
+# install via apt
+########################
 
 lazy_apt_update
 # python3 is required for var_storage.sh


### PR DESCRIPTION
The [alpaka-group-container](https://codebase.helmholtz.cloud/crp/alpaka-group-container) provides a lot of preinstalled software dependencies for testing. To check, which software is installed, the `agc-manager` needs to be used.

# TODO

- [x] merge #532 before