### PR TITLE
fix nvcc 12.3.2 compile issue

### DIFF
--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -121,11 +121,15 @@ namespace alpaka
          * This constructor is not constexpr because std::simd is using a reinterpret_cast during the initialization
          * with a generator and complains that this is not allowed in constexpr functions.
          */
-        template<typename F>
-        requires(std::is_invocable_v<F, std::integral_constant<uint32_t, 0u>>)
+        template<
+            typename F,
+            std::enable_if_t<std::is_invocable_v<F, std::integral_constant<uint32_t, 0u>>, uint32_t> = 0u>
         ALPAKA_FN_HOST_ACC explicit Simd(F&& generator)
             : Simd(std::forward<F>(generator), std::make_integer_sequence<uint32_t, T_width>{})
         {
+            /* Do not change the enable if to `requires(std::is_invocable_v<F, std::integral_constant<uint32_t, 0u>>)`
+             * nvcc 12.3.2 has a bug that creates compile issue when requires with std::is_invocable is used.
+             */
         }
 
         /** Constructor for SIMD pack


### PR DESCRIPTION
nvcc with CUDA 12.3.2 showed a bug when evaluating the expression
`requires(std::is_invocable_v<F, std::integral_constant<uint32_t, 0u>>)`

a workaround is to change it to old school sfinane.

error msg:
```
[100%] Building CUDA object test/CMakeFiles/unit_test_algorithm_transformReduce.dir/__/alpaka_build_files/cuda/alpaka/unit/algorithm/transformReduce.cpp.o
/usr/include/c++/11/array(95): error: template constraint not satisfied
      struct array
             ^
include/alpaka/Simd.hpp(125): note #3135-D: substitution of arguments "<alpaka::Simd<int, 4U, alpaka::internal::EmuSimd<int, 4U>>>" for requires-clause failed
          requires(std::is_invocable_v<F, std::integral_constant<uint32_t, 0u>>)
                   ^
include/alpaka/Simd.hpp(125): note #3043-D: atomic constraint evaluates to false
          requires(std::is_invocable_v<F, std::integral_constant<uint32_t, 0u>>)
                   ^
          detected during:
            instantiation of class "std::array<_Tp, _Nm> [with _Tp=alpaka::Simd<int, 4U, alpaka::internal::EmuSimd<int, 4U>>, _Nm=2UL]" at line 37 of include/alpaka/simd/internal/EmuSimd.hpp
            instantiation of class "alpaka::internal::EmuSimd<T_Type, T_width> [with T_Type=alpaka::Simd<int, 4U, alpaka::internal::EmuSimd<int, 4U>>, T_width=2U]" at line 76 of include/alpaka/Simd.hpp
            instantiation of class "alpaka::Simd<T_Type, T_width, T_Storage> [with T_Type=alpaka::Simd<int, 4U, alpaka::internal::EmuSimd<int, 4U>>, T_width=2U, T_Storage=alpaka::internal::EmuSimd<alpaka::Simd<int, 4U, alpaka::internal::EmuSimd<int, 4U>>, 2U>]" at line 157 of include/alpaka/onAcc/internal/SimdTransformReduce.hpp
            instantiation of function "lambda [](const auto &...)->auto [with <auto-1>=<alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>>]" at line 2541 of /usr/include/c++/11/type_traits
            instantiation of class "std::__result_of_impl<false, false, _Functor, _ArgTypes...> [with _Functor=lambda [](const auto &...)->auto, _ArgTypes=<alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>> &, alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>> &>]" at line 2555 of /usr/include/c++/11/type_traits
            [ 6 instantiation contexts not shown ]
            instantiation of "void alpaka::onAcc::internal::SimdTransformReduce<T_Parent>::reduceNextSimdized<T_simdWidth,T_numSimdPerFnCall,T_MemAlignment,<auto-1>,<auto-2>,<auto-3>,<auto-4>,<auto-5>,<auto-6>,<auto-7>...>(const auto &, auto &, auto &, auto &&, auto &&, alpaka::concepts::IDataSource auto &&, alpaka::concepts::IDataSource auto &&...) [with T_Parent=alpaka::onAcc::SimdAlgo<alpaka::onAcc::WorkerGroup<alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::onAcc::MultiDimensional<true>>, alpaka::onAcc::traverse::Flat, alpaka::onAcc::layout::Optimized>, T_simdWidth=4U, T_numSimdPerFnCall=2U, T_MemAlignment=alpaka::AutoAligned, <auto-1>=alpaka::onAcc::Acc<alpaka::Dict<alpaka::DictEntry<alpaka::layer::Block, alpaka::onAcc::unifiedCudaHip::BlockLayer<alpaka::onHost::ThreadSpec<alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::exec::GpuCuda>>>, alpaka::DictEntry<alpaka::layer::Thread, alpaka::onAcc::unifiedCudaHip::ThreadLayer<alpaka::onHost::ThreadSpec<alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::exec::GpuCuda>>>, alpaka::DictEntry<alpaka::Tag<std::integral_constant<size_t, 1UL>>, std::integral_constant<__nv_bool, true>>, alpaka::DictEntry<alpaka::Tag<std::integral_constant<size_t, 6UL>>, alpaka::onAcc::unifiedCudaHip::Sync>, alpaka::DictEntry<alpaka::object::Api, alpaka::api::Cuda>, alpaka::DictEntry<alpaka::object::DeviceKind, alpaka::deviceKind::NvidiaGpu>, alpaka::DictEntry<alpaka::Tag<std::integral_constant<std::size_t, 0UL>>, alpaka::exec::GpuCuda>, alpaka::DictEntry<alpaka::object::WarpSize, std::integral_constant<uint32_t, 32U>>>>, <auto-2>=alpaka::onAcc::FlatIdxContainer<alpaka::IdxRange<alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>>, alpaka::ThreadSpace<alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>>, alpaka::onAcc::layout::Strided, alpaka::Vec<uint32_t, 1U, alpaka::detail::CVec<uint32_t, 3U>>>::const_iterator, <auto-3>=alpaka::Simd<int, 4U, alpaka::internal::EmuSimd<int, 4U>>, <auto-4>=std::plus<void>, <auto-5>=lambda [](const auto &, alpaka::concepts::SimdPtr auto &&...)->auto, <auto-6>=const alpaka::View<alpaka::api::Cuda, int, alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::Alignment<128U>> &, <auto-7>=<const alpaka::View<alpaka::api::Cuda, int, alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::Alignment<128U>> &>]" at line 1838 of /usr/include/c++/11/tuple
            instantiation of "const __nv_bool std::__unpack_std_tuple [with _Trait=std::is_nothrow_invocable, _Tp=lambda [](auto...)->auto, _Tuple=std::tuple<alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::Vec<int, 3U, alpaka::ArrayStorage<int, 3U>>, alpaka::Vec<int, 3U, alpaka::ArrayStorage<int, 3U>>, alpaka::Vec<int, 3U, alpaka::ArrayStorage<int, 3U>>, alpaka::Vec<int, 2U, alpaka::ArrayStorage<int, 2U>>, alpaka::Vec<int, 1U, alpaka::ArrayStorage<int, 1U>>> &]" at line 1861 of /usr/include/c++/11/tuple
            instantiation of "decltype(auto) std::apply(_Fn &&, _Tuple &&) [with _Fn=lambda [](auto...)->auto, _Tuple=std::tuple<alpaka::Vec<int, 4U, alpaka::ArrayStorage<int, 4U>>, alpaka::Vec<int, 3U, alpaka::ArrayStorage<int, 3U>>, alpaka::Vec<int, 3U, alpaka::ArrayStorage<int, 3U>>, alpaka::Vec<int, 3U, alpaka::ArrayStorage<int, 3U>>, alpaka::Vec<int, 2U, alpaka::ArrayStorage<int, 2U>>, alpaka::Vec<int, 1U, alpaka::ArrayStorage<int, 1U>>> &]" at line 236 of /cuda/alpaka/unit/algorithm/transformReduce.cpp
            instantiation of "void CATCH2_INTERNAL_TEMPLATE_TEST_18<TestType>() [with TestType=alpaka::Dict<alpaka::DictEntry<alpaka::Tag<std::integral_constant<std::size_t, 2UL>>, alpaka::onHost::DeviceSpec<alpaka::api::Cuda, alpaka::deviceKind::NvidiaGpu>>, alpaka::DictEntry<alpaka::Tag<std::integral_constant<std::size_t, 0UL>>, alpaka::exec::GpuCuda>>]" at line 179 of /cuda/alpaka/unit/algorithm/transformReduce.cpp
            instantiation of "void <unnamed>::ns_CATCH2_INTERNAL_TEMPLATE_TEST_19::CATCH2_INTERNAL_TEMPLATE_TEST_19<Types...>::reg_tests() [with Types=<alpaka::Dict<alpaka::DictEntry<alpaka::Tag<std::integral_constant<std::size_t, 2UL>>, alpaka::onHost::DeviceSpec<alpaka::api::Cuda, alpaka::deviceKind::NvidiaGpu>>, alpaka::DictEntry<alpaka::Tag<std::integral_constant<std::size_t, 0UL>>, alpaka::exec::GpuCuda>>>]" at line 179 of /cuda/alpaka/unit/algorithm/transformReduce.cpp

```