### PR TITLE
update Catch2 to version 3.15

### DIFF
--- a/cmake/buildDependencies.cmake
+++ b/cmake/buildDependencies.cmake
@@ -15,7 +15,7 @@ function(alpaka_install_catch2)
                 WARNING
                 "Your System version of CATCH2 V3 should have set '-DCATCH_CONFIG_NO_POSIX_SIGNALS=ON', else some tests e.g. with managed memory can fail."
             )
-            find_package(Catch2 3.5.3 REQUIRED)
+            find_package(Catch2 3.15.0 REQUIRED)
             include(Catch)
         else()
             message(STATUS "download and install Catch2 locally")
@@ -23,7 +23,7 @@ function(alpaka_install_catch2)
             set(CATCH_CONFIG_NO_POSIX_SIGNALS ON)
             # get Catch2 v3 and build it from source with the same C++ standard as the tests
             include(FetchContent)
-            FetchContent_Declare(Catch2 GIT_REPOSITORY https://github.com/catchorg/Catch2.git GIT_TAG v3.5.3)
+            FetchContent_Declare(Catch2 GIT_REPOSITORY https://github.com/catchorg/Catch2.git GIT_TAG v3.15.0)
             FetchContent_MakeAvailable(Catch2)
             target_compile_features(Catch2 PUBLIC cxx_std_20)
             include(Catch)

--- a/docs/snippets/example/CMakeLists.txt
+++ b/docs/snippets/example/CMakeLists.txt
@@ -20,7 +20,9 @@ alpaka_install_catch2()
 #    extension.
 #  - folder: Takes all .cpp files in the specified folder and creates an test
 #    executable for each.
-function(alpaka_add_docs_target target_prefix folder)
+#  - ignore_files: List of source files which should be ignored and compile and
+#    test target should be created.
+function(alpaka_add_docs_target target_prefix folder ignore_files)
     message(DEBUG "doc snippets target prefix: ${target_prefix}")
 
     file(GLOB test_folders ${folder})
@@ -34,6 +36,12 @@ function(alpaka_add_docs_target target_prefix folder)
             foreach(source_file ${test_sources})
                 # the include folder is a special case, therefore ignore it
                 if(source_file STREQUAL "${test_folder}/include")
+                    continue()
+                endif()
+
+                get_filename_component(source_file_name_with_extension ${source_file} NAME)
+                if(source_file_name_with_extension IN_LIST ignore_files)
+                    message(DEBUG "skip file ${source_file_name_with_extension}")
                     continue()
                 endif()
 
@@ -58,4 +66,14 @@ function(alpaka_add_docs_target target_prefix folder)
     endforeach()
 endfunction()
 
-alpaka_add_docs_target(docs_test_ ${CMAKE_CURRENT_SOURCE_DIR})
+alpaka_add_docs_target(docs_test_ ${CMAKE_CURRENT_SOURCE_DIR} "000_elementWiseMultiplication.cpp")
+
+# 000_elementWiseMultiplication does not use CATCH2. Therefore add manually CMake target.
+set(_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION docs_test_000_elementWiseMultiplication)
+add_executable(
+    ${_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION}
+    "${CMAKE_CURRENT_SOURCE_DIR}/000_elementWiseMultiplication.cpp"
+)
+target_link_libraries(${_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION} PRIVATE alpaka::alpaka)
+alpaka_finalize(${_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION})
+add_test(NAME ${_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION} COMMAND ${_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION})

--- a/docs/snippets/example/CMakeLists.txt
+++ b/docs/snippets/example/CMakeLists.txt
@@ -20,9 +20,9 @@ alpaka_install_catch2()
 #    extension.
 #  - folder: Takes all .cpp files in the specified folder and creates an test
 #    executable for each.
-#  - ignore_files: List of source files which should be ignored and compile and
-#    test target should be created.
-function(alpaka_add_docs_target target_prefix folder ignore_files)
+#  - normal_test_files: List of source files which should be added as normal test
+#    without Catch2
+function(alpaka_add_docs_target target_prefix folder normal_test_files)
     message(DEBUG "doc snippets target prefix: ${target_prefix}")
 
     file(GLOB test_folders ${folder})
@@ -40,9 +40,10 @@ function(alpaka_add_docs_target target_prefix folder ignore_files)
                 endif()
 
                 get_filename_component(source_file_name_with_extension ${source_file} NAME)
-                if(source_file_name_with_extension IN_LIST ignore_files)
-                    message(DEBUG "skip file ${source_file_name_with_extension}")
-                    continue()
+                if(source_file_name_with_extension IN_LIST normal_test_files)
+                    set(catch2_test FALSE)
+                else()
+                    set(catch2_test TRUE)
                 endif()
 
                 get_filename_component(source_file_extension ${source_file} EXT)
@@ -57,9 +58,17 @@ function(alpaka_add_docs_target target_prefix folder ignore_files)
                         target_include_directories(${_test_target_name} PRIVATE ${test_folder}/include)
                     endif()
 
-                    target_link_libraries(${_test_target_name} PRIVATE Catch2::Catch2WithMain alpaka::alpaka)
+                    target_link_libraries(${_test_target_name} PRIVATE alpaka::alpaka)
+                    if(catch2_test)
+                        target_link_libraries(${_test_target_name} PRIVATE Catch2::Catch2WithMain)
+                    endif()
                     alpaka_finalize(${_test_target_name})
-                    catch_discover_tests(${_test_target_name})
+
+                    if(catch2_test)
+                        catch_discover_tests(${_test_target_name})
+                    else()
+                        add_test(NAME ${_test_target_name} COMMAND ${_test_target_name})
+                    endif()
                 endif()
             endforeach()
         endif()
@@ -67,13 +76,3 @@ function(alpaka_add_docs_target target_prefix folder ignore_files)
 endfunction()
 
 alpaka_add_docs_target(docs_test_ ${CMAKE_CURRENT_SOURCE_DIR} "000_elementWiseMultiplication.cpp")
-
-# 000_elementWiseMultiplication does not use CATCH2. Therefore add manually CMake target.
-set(_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION docs_test_000_elementWiseMultiplication)
-add_executable(
-    ${_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION}
-    "${CMAKE_CURRENT_SOURCE_DIR}/000_elementWiseMultiplication.cpp"
-)
-target_link_libraries(${_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION} PRIVATE alpaka::alpaka)
-alpaka_finalize(${_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION})
-add_test(NAME ${_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION} COMMAND ${_TARGET_DOC_ELEMENT_WISE_MULTIPLICATION})

--- a/test/unit/math/isSpecialIEEE.cpp
+++ b/test/unit/math/isSpecialIEEE.cpp
@@ -39,8 +39,24 @@ static void verifyIsSpecial()
     CHECK_FALSE(generic_math::isfinite(quietNaN));
 }
 
+/* TODO: remove me, if ICPX 2025.1 is not supported anymore.
+ *
+ * CATCH 3.15 use a Clang specific pragma to suppress the warning "-Wvariadic-macro-arguments-omitted".
+ * The warning was introduced in Clang 20.1. ICPX 2025.1 based on Clang 20.0 (dev version).
+ * Therefore, the detection if the warning is available does not work correctly, and we need to disable the warning
+ * of unknown warnings temporary.
+ */
+#if ALPAKA_COMP_ICPX && ALPAKA_COMP_ICPX < ALPAKA_VERSION_NUMBER(2025, 2, 0)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wunknown-warning-option"
+#endif
+
 // Regression guard to ensure ieee helper stays stable for each floating type.
 TEMPLATE_TEST_CASE("generic ieee helpers detect special values", "[math][generic][ieee]", float, double)
 {
     verifyIsSpecial<TestType>();
 }
+
+#if ALPAKA_COMP_ICPX && ALPAKA_COMP_ICPX < ALPAKA_VERSION_NUMBER(2025, 2, 0)
+#    pragma clang diagnostic pop
+#endif

--- a/test/unit/mem/concepts.cpp
+++ b/test/unit/mem/concepts.cpp
@@ -76,6 +76,18 @@ void iMdSpanCallByUniversalReference(concepts::IMdSpan auto&&)
 {
 }
 
+/* TODO: remove me, if ICPX 2025.1 is not supported anymore.
+ *
+ * CATCH 3.15 use a Clang specific pragma to suppress the warning "-Wvariadic-macro-arguments-omitted".
+ * The warning was introduced in Clang 20.1. ICPX 2025.1 based on Clang 20.0 (dev version).
+ * Therefore, the detection if the warning is available does not work correctly, and we need to disable the warning
+ * of unknown warnings temporary.
+ */
+#if ALPAKA_COMP_ICPX && ALPAKA_COMP_ICPX < ALPAKA_VERSION_NUMBER(2025, 2, 0)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wunknown-warning-option"
+#endif
+
 TEMPLATE_TEST_CASE_SIG(
     "IDataSource, IMdSpan, IView and IBuffer concept test",
     "[mem][concepts]",
@@ -183,6 +195,11 @@ TEMPLATE_TEST_CASE_SIG(
         STATIC_REQUIRE(alpaka::concepts::IBuffer<BufferType>);
     }
 }
+
+#if ALPAKA_COMP_ICPX && ALPAKA_COMP_ICPX < ALPAKA_VERSION_NUMBER(2025, 2, 0)
+#    pragma clang diagnostic pop
+#endif
+
 
 TEST_CASE("test alpaka::concepts::IMdSpan optional element type", "[mem][concepts]")
 {


### PR DESCRIPTION
Since 3.10, CHECK and REQUIRE are thread safe. Fix a bug in the blockingQueue test. We use `CHECK` in a `std::thread`.

https://github.com/alpaka-group/alpaka3/blob/a6ba4c03bd73773e6883c6e2db5c40b0c015f81f/test/unit/queue/blockingQueue.cpp#L396-L419