### PR TITLE
HACCmk: use a warmup round

### DIFF
--- a/benchmark/HACCmk/src/main_alpaka.cpp
+++ b/benchmark/HACCmk/src/main_alpaka.cpp
@@ -205,10 +205,12 @@ namespace haccmkAlpaka
             onHost::wait(devAcc);
             auto end = std::chrono::steady_clock::now();
             auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
-            total_time += time;
+            // first round is a warmup round
+            if(i != 0)
+                total_time += time;
         }
 
-        printf("Average kernel execution time %f (s)\n", (total_time * 1e-9f) / repeat);
+        printf("Average kernel execution time %f (s)\n", (total_time * 1e-9f) / (repeat - 1));
         onHost::memcpy(queue, vx2, d_vx2, n1);
         onHost::memcpy(queue, vy2, d_vy2, n1);
         onHost::memcpy(queue, vz2, d_vz2, n1);

--- a/benchmark/HACCmk/src/main_orig.cpp
+++ b/benchmark/HACCmk/src/main_orig.cpp
@@ -103,9 +103,11 @@ void haccmk(
 
             auto end = std::chrono::steady_clock::now();
             auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
-            total_time += time;
+            // first round is a warmup round
+            if(r != 0)
+                total_time += time;
         }
-        printf("Average kernel execution time %f (s)\n", (total_time * 1e-9f) / repeat);
+        printf("Average kernel execution time %f (s)\n", (total_time * 1e-9f) / (repeat - 1));
 #if defined(_OPENMP)
 #    pragma omp target update from(vx2[0 : n], vy2[0 : n], vz2[0 : n])
 #endif

--- a/benchmark/HACCmk/src/misc.hpp
+++ b/benchmark/HACCmk/src/misc.hpp
@@ -76,6 +76,9 @@ namespace hacc
             return EXIT_FAILURE;
         }
 
+        // The first round is a warmup round and timings will not be monitored.
+        numRepetitions += 1;
+
         return EXIT_SUCCESS;
     }
 


### PR DESCRIPTION
Ignore the timings of the first round and use it as a warm-up round.
alpaka was showing worse results because, due to the offloading model, the data was not touched within the first round.
I introduced a warmup round, which is typical for benchmarks, into alpaka and the original code.
This makes the results better comparable.