### PR TITLE
update dynamic shared memory interface

### DIFF
--- a/docs/snippets/cheatsheet/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet/cheatsheet.cpp
@@ -78,17 +78,17 @@ struct DynSharedMemTrait
 // specialization within the host code
 namespace alpaka::onHost::trait
 {
-    template<typename T_FrameSpec>
-    struct BlockDynSharedMemBytes<DynSharedMemTrait, T_FrameSpec>
+    template<concepts::ThreadSpec T_ThreadSpec>
+    struct BlockDynSharedMemBytes<DynSharedMemTrait, T_ThreadSpec>
     {
-        BlockDynSharedMemBytes(DynSharedMemTrait const& kernel, T_FrameSpec const& spec)
+        BlockDynSharedMemBytes(DynSharedMemTrait const& kernel, T_ThreadSpec const& spec)
         {
             alpaka::unused(kernel, spec);
         }
 
-        // the signature is very similar to the kernel operator() signature with the difference that the first
-        // parameter is the executor and not the accelerator
-        uint32_t operator()([[maybe_unused]] auto const executor, [[maybe_unused]] auto const&... args) const
+        // the signature is very similar to the kernel operator() signature with the difference that no accelerator is
+        // provided.
+        uint32_t operator()([[maybe_unused]] auto const&... args) const
         {
             return 32;
         }

--- a/docs/snippets/example/120_sharedMemory.cpp
+++ b/docs/snippets/example/120_sharedMemory.cpp
@@ -177,16 +177,16 @@ struct DynamicScaleKernel
 // BEGIN-TUTORIAL-dynSharedTraitSpec
 namespace alpaka::onHost::trait
 {
-    template<typename T_Spec>
+    template<concepts::ThreadSpec T_Spec>
     struct BlockDynSharedMemBytes<DynamicScaleKernel, T_Spec>
     {
         BlockDynSharedMemBytes(DynamicScaleKernel const&, T_Spec const& spec) : m_spec(spec)
         {
         }
 
-        uint32_t operator()(auto const executor, auto const& out, auto const& in, int factor, uint32_t chunkSize) const
+        uint32_t operator()(auto const& out, auto const& in, int factor, uint32_t chunkSize) const
         {
-            alpaka::unused(executor, out, in, factor);
+            alpaka::unused(out, in, factor);
             return static_cast<uint32_t>(chunkSize * sizeof(int));
         }
 

--- a/docs/source/tutorial/sharedMemory.rst
+++ b/docs/source/tutorial/sharedMemory.rst
@@ -104,6 +104,7 @@ Dynamic Size Through ``BlockDynSharedMemBytes`` Trait
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When the size should depend on the executor or the kernel arguments, alpaka uses a trait specialization.
+If you call a kernel with a frame specification the thread specification in the constructor of the trait will be the derived specification used to launch the kernel.
 The user-defined data chunk size passed through the kernel arguments is used to calculate the required amount of shared memory to hold a single chunk per thread block.
 The required data to hold a chunk is intended to be independent of the thread specification to control the amount of reused data.
 If you provide neither a ``dynSharedMemBytes`` member nor a trait implementation ``alpaka::onHost::trait::BlockDynSharedMemBytes`` specialization, alpaka reserves no dynamic shared memory for that kernel.

--- a/include/alpaka/api/host/exec/OmpBlocks.hpp
+++ b/include/alpaka/api/host/exec/OmpBlocks.hpp
@@ -55,18 +55,15 @@ namespace alpaka::onHost
                     auto blockSharedMem = onAcc::cpu::SingleThreadStaticShared<simdWidth>{};
 
                     // dynamic shared mem
-                    uint32_t blockDynSharedMemBytes
-                        = onHost::getDynSharedMemBytes(exec::cpuOmpBlocks, m_threadBlocking, kernelBundle);
+                    uint32_t blockDynSharedMemBytes = onHost::getDynSharedMemBytes(m_threadBlocking, kernelBundle);
                     auto const blockDynSharedMemEntry = DictEntry{layer::dynShared, std::ref(blockSharedMem)};
                     auto const blockDynSharedMemBytesEntry
                         = DictEntry{object::dynSharedMemBytes, std::ref(blockDynSharedMemBytes)};
 
                     /* Only add dynamic shared memory objects if defined by the user, if not we will get a clean static
                      * assert if the kernel tries to access dynamic shared memory */
-                    auto additionalDict = conditionalAppendDict<trait::HasUserDefinedDynSharedMemBytes<
-                        exec::CpuOmpBlocks,
-                        T_ThreadSpec,
-                        ALPAKA_TYPEOF(kernelBundle)>::value>(
+                    auto additionalDict = conditionalAppendDict<
+                        trait::HasUserDefinedDynSharedMemBytes<T_ThreadSpec, ALPAKA_TYPEOF(kernelBundle)>::value>(
                         dict,
                         Dict{blockDynSharedMemEntry, blockDynSharedMemBytesEntry});
 

--- a/include/alpaka/api/host/exec/Serial.hpp
+++ b/include/alpaka/api/host/exec/Serial.hpp
@@ -52,18 +52,15 @@ namespace alpaka::onHost
                 auto const blockSyncEntry = DictEntry{action::threadBlockSync, onAcc::cpu::NoOp{}};
 
                 // dynamic shared mem
-                uint32_t blockDynSharedMemBytes
-                    = onHost::getDynSharedMemBytes(exec::cpuSerial, m_threadBlocking, kernelBundle);
+                uint32_t blockDynSharedMemBytes = onHost::getDynSharedMemBytes(m_threadBlocking, kernelBundle);
                 auto const blockDynSharedMemEntry = DictEntry{layer::dynShared, std::ref(blockSharedMem)};
                 auto const blockDynSharedMemBytesEntry
                     = DictEntry{object::dynSharedMemBytes, std::ref(blockDynSharedMemBytes)};
 
                 /* Only add dynamic shared memory objects if defined by the user, if not we will get a clean static
                  * assert if the kernel tries to access dynamic shared memory */
-                auto additionalDict = conditionalAppendDict<trait::HasUserDefinedDynSharedMemBytes<
-                    exec::CpuSerial,
-                    T_ThreadSpec,
-                    ALPAKA_TYPEOF(kernelBundle)>::value>(
+                auto additionalDict = conditionalAppendDict<
+                    trait::HasUserDefinedDynSharedMemBytes<T_ThreadSpec, ALPAKA_TYPEOF(kernelBundle)>::value>(
                     dict,
                     Dict{blockDynSharedMemEntry, blockDynSharedMemBytesEntry});
 

--- a/include/alpaka/api/host/exec/TbbBlocks.hpp
+++ b/include/alpaka/api/host/exec/TbbBlocks.hpp
@@ -74,20 +74,15 @@ namespace alpaka::onHost
                             auto const blockSyncEntry = DictEntry{action::threadBlockSync, onAcc::cpu::NoOp{}};
 
                             // dynamic shared mem
-                            uint32_t blockDynSharedMemBytes = onHost::getDynSharedMemBytes(
-                                alpaka::exec::CpuTbbBlocks{},
-                                m_threadBlocking,
-                                kernelBundle);
+                            uint32_t blockDynSharedMemBytes
+                                = onHost::getDynSharedMemBytes(m_threadBlocking, kernelBundle);
                             auto const blockDynSharedMemEntry = DictEntry{layer::dynShared, std::ref(blockSharedMem)};
                             auto const blockDynSharedMemBytesEntry
                                 = DictEntry{object::dynSharedMemBytes, std::ref(blockDynSharedMemBytes)};
 
-                            auto additionalDict = conditionalAppendDict<trait::HasUserDefinedDynSharedMemBytes<
-                                alpaka::exec::CpuTbbBlocks,
-                                T_ThreadSpec,
-                                ALPAKA_TYPEOF(kernelBundle)>::value>(
-                                dict,
-                                Dict{blockDynSharedMemEntry, blockDynSharedMemBytesEntry});
+                            auto additionalDict = conditionalAppendDict<
+                                trait::HasUserDefinedDynSharedMemBytes<T_ThreadSpec, ALPAKA_TYPEOF(kernelBundle)>::
+                                    value>(dict, Dict{blockDynSharedMemEntry, blockDynSharedMemBytesEntry});
 
                             auto const warpSizeEntry
                                 = DictEntry{object::warpSize, std::integral_constant<uint32_t, 1u>{}};

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -339,7 +339,7 @@ namespace alpaka::onHost::internal
                 ALPAKA_SYCL_NUM_MAX_SHARED_MEMORY_ALLOCATIONS);
             // allocate dynamic shared memory -- needs at least 1 byte to make the Xilinx Runtime happy
             u_int32_t blockDynSharedMemBytes
-                = std::max(u_int32_t(1), onHost::getDynSharedMemBytes(T_Executor{}, threadSpec, kernelBundle));
+                = std::max(u_int32_t(1), onHost::getDynSharedMemBytes(threadSpec, kernelBundle));
             assert(
                 st_shared_mem_bytes + blockDynSharedMemBytes
                 <= queue.m_device->getNativeHandle().first.template get_info<sycl::info::device::local_mem_size>());
@@ -415,7 +415,7 @@ namespace alpaka::onHost::internal
 
             // allocate dynamic shared memory -- needs at least 1 byte to make the Xilinx Runtime happy
             u_int32_t blockDynSharedMemBytes
-                = std::max(u_int32_t(1), onHost::getDynSharedMemBytes(T_Executor{}, threadBlocking, kernelBundle));
+                = std::max(u_int32_t(1), onHost::getDynSharedMemBytes(threadBlocking, kernelBundle));
 
             assert(
                 st_shared_mem_bytes + blockDynSharedMemBytes

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -297,8 +297,7 @@ namespace alpaka::onHost
                     T_KernelBundle,
                     ALPAKA_TYPEOF(optimizedThreadSpec)>;
 
-                uint32_t blockDynSharedMemBytes
-                    = onHost::getDynSharedMemBytes(exec::gpuCuda, threadSpec, kernelBundle);
+                uint32_t blockDynSharedMemBytes = onHost::getDynSharedMemBytes(threadSpec, kernelBundle);
 
                 kernelName<<<
                     convertVecToUniformCudaHipDim(numBlocks),

--- a/include/alpaka/onHost/trait.hpp
+++ b/include/alpaka/onHost/trait.hpp
@@ -48,7 +48,7 @@ namespace alpaka::onHost
             };
         };
 
-        template<typename T_Kernel, typename T_Spec>
+        template<typename T_Kernel, concepts::ThreadSpec T_Spec>
         struct BlockDynSharedMemBytes
         {
             BlockDynSharedMemBytes(T_Kernel kernel, T_Spec spec)
@@ -56,60 +56,50 @@ namespace alpaka::onHost
                 alpaka::unused(kernel, spec);
             }
 
-            // requires (false) is disabling the function if you specialize these traits remove the require statement.
-            // Disabling is required to enable the trait evaluation only in cases where the user is defining the trait.
-            uint32_t operator()(alpaka::concepts::Executor auto const executor, auto const&... args) const
-                requires(false)
+            /** Get amount of dynamic shared memory in bytes.
+             *
+             * @attention requires (false) is disabling the function if you specialize these traits remove the require
+             * statement. Disabling is required to enable the trait evaluation only in cases where the user is defining
+             * the trait.
+             */
+            uint32_t operator()(auto const&... args) const requires(false)
             {
-                alpaka::unused(executor, args...);
+                alpaka::unused(args...);
                 return 0;
             }
         };
 
-        template<
-            alpaka::concepts::Executor T_Executor,
-            onHost::concepts::ThreadSpec T_ThreadSpec,
-            alpaka::concepts::KernelBundle T_KernelBundle>
+        template<onHost::concepts::ThreadSpec T_ThreadSpec, alpaka::concepts::KernelBundle T_KernelBundle>
         struct GetDynSharedMemBytes
         {
             static constexpr bool zeroSharedMemory = true;
 
-            uint32_t operator()(
-                T_Executor const executor,
-                T_ThreadSpec const spec,
-                [[maybe_unused]] T_KernelBundle const& kernelBundle) const
+            uint32_t operator()(T_ThreadSpec const spec, [[maybe_unused]] T_KernelBundle const& kernelBundle) const
             {
-                alpaka::unused(executor, spec);
+                alpaka::unused(spec);
                 return 0u;
             }
         };
 
-        template<alpaka::concepts::Executor T_Executor, typename T_Spec, typename T_KernelFn, typename... T_Args>
+        template<concepts::ThreadSpec T_Spec, typename T_KernelFn, typename... T_Args>
         requires requires() { std::declval<T_KernelFn>().dynSharedMemBytes; } || requires() {
             BlockDynSharedMemBytes<T_KernelFn, T_Spec>{std::declval<T_KernelFn>(), std::declval<T_Spec>()}(
-                std::declval<T_Executor>(),
                 std::declval<remove_restrict_t<std::decay_t<T_Args>>>()...);
         }
-        struct GetDynSharedMemBytes<T_Executor, T_Spec, KernelBundle<T_KernelFn, T_Args...>>
+        struct GetDynSharedMemBytes<T_Spec, KernelBundle<T_KernelFn, T_Args...>>
         {
             uint32_t operator()(
-                T_Executor const executor,
                 T_Spec const spec,
                 [[maybe_unused]] KernelBundle<T_KernelFn, T_Args...> const& kernelBundle) const
             {
                 if constexpr(requires {
                                  BlockDynSharedMemBytes<T_KernelFn, T_Spec>{kernelBundle.m_kernelFn, spec}(
-                                     executor,
                                      std::declval<remove_restrict_t<std::decay_t<T_Args>>>()...);
                              })
                 {
                     return alpaka::apply(
                         [&](auto const&... args)
-                        {
-                            return BlockDynSharedMemBytes<T_KernelFn, T_Spec>{kernelBundle.m_kernelFn, spec}(
-                                executor,
-                                args...);
-                        },
+                        { return BlockDynSharedMemBytes<T_KernelFn, T_Spec>{kernelBundle.m_kernelFn, spec}(args...); },
                         kernelBundle.m_args);
                 }
                 else
@@ -119,20 +109,14 @@ namespace alpaka::onHost
             }
         };
 
-        template<
-            alpaka::concepts::Executor T_Executor,
-            onHost::concepts::ThreadSpec T_ThreadSpec,
-            alpaka::concepts::KernelBundle T_KernelBundle>
+        template<onHost::concepts::ThreadSpec T_ThreadSpec, alpaka::concepts::KernelBundle T_KernelBundle>
         struct HasUserDefinedDynSharedMemBytes : std::true_type
         {
         };
 
-        template<
-            alpaka::concepts::Executor T_Executor,
-            onHost::concepts::ThreadSpec T_ThreadSpec,
-            alpaka::concepts::KernelBundle T_KernelBundle>
-        requires(trait::GetDynSharedMemBytes<T_Executor, T_ThreadSpec, T_KernelBundle>::zeroSharedMemory == true)
-        struct HasUserDefinedDynSharedMemBytes<T_Executor, T_ThreadSpec, T_KernelBundle> : std::false_type
+        template<onHost::concepts::ThreadSpec T_ThreadSpec, alpaka::concepts::KernelBundle T_KernelBundle>
+        requires(trait::GetDynSharedMemBytes<T_ThreadSpec, T_KernelBundle>::zeroSharedMemory == true)
+        struct HasUserDefinedDynSharedMemBytes<T_ThreadSpec, T_KernelBundle> : std::false_type
         {
         };
     } // namespace trait
@@ -167,29 +151,17 @@ namespace alpaka::onHost
             deviceKind::allDevices);
     }
 
-    template<
-        alpaka::concepts::Executor T_Executor,
-        onHost::concepts::ThreadSpec T_ThreadSpec,
-        alpaka::concepts::KernelBundle T_KernelBundle>
-    constexpr uint32_t getDynSharedMemBytes(
-        T_Executor const executor,
-        T_ThreadSpec spec,
-        T_KernelBundle const& kernelBundle)
+    template<onHost::concepts::ThreadSpec T_ThreadSpec, alpaka::concepts::KernelBundle T_KernelBundle>
+    constexpr uint32_t getDynSharedMemBytes(T_ThreadSpec spec, T_KernelBundle const& kernelBundle)
     {
-        return trait::GetDynSharedMemBytes<T_Executor, T_ThreadSpec, T_KernelBundle>{}(executor, spec, kernelBundle);
+        return trait::GetDynSharedMemBytes<T_ThreadSpec, T_KernelBundle>{}(spec, kernelBundle);
     }
 
-    template<
-        alpaka::concepts::Executor T_Executor,
-        onHost::concepts::ThreadSpec T_ThreadSpec,
-        alpaka::concepts::KernelBundle T_KernelBundle>
-    consteval bool hasUserDefinedDynSharedMemBytes(
-        T_Executor const executor,
-        T_ThreadSpec spec,
-        T_KernelBundle const& kernelBundle)
+    template<onHost::concepts::ThreadSpec T_ThreadSpec, alpaka::concepts::KernelBundle T_KernelBundle>
+    consteval bool hasUserDefinedDynSharedMemBytes(T_ThreadSpec spec, T_KernelBundle const& kernelBundle)
     {
-        alpaka::unused(executor, spec, kernelBundle);
-        return trait::HasUserDefinedDynSharedMemBytes<T_Executor, T_ThreadSpec, T_KernelBundle>::value;
+        alpaka::unused(spec, kernelBundle);
+        return trait::HasUserDefinedDynSharedMemBytes<T_ThreadSpec, T_KernelBundle>::value;
     }
 
 } // namespace alpaka::onHost

--- a/test/unit/sharedMem/sharedMem.cpp
+++ b/test/unit/sharedMem/sharedMem.cpp
@@ -160,7 +160,7 @@ struct DynSharedMemTrait
 
 namespace alpaka::onHost::trait
 {
-    template<typename T_Spec>
+    template<concepts::ThreadSpec T_Spec>
     struct BlockDynSharedMemBytes<DynSharedMemTrait, T_Spec>
     {
         BlockDynSharedMemBytes(DynSharedMemTrait const& kernel, T_Spec const& spec)
@@ -168,9 +168,9 @@ namespace alpaka::onHost::trait
             alpaka::unused(kernel, spec);
         }
 
-        uint32_t operator()(auto const executor, auto const&... args) const
+        uint32_t operator()(auto const&... args) const
         {
-            alpaka::unused(executor, args...);
+            alpaka::unused(args...);
             return 32;
         }
     };


### PR DESCRIPTION
fix #540

With PR #527 we forgot to update the dynamic shared memory traits. The executor is now part of the thread specification and is therefore not required as seperate parameter.
Keeping the old interface could lead in mistakes if the executor passed as argument differ from the executor in the thread specification.