### PR TITLE
add math and atomic tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /docs/doxygen
 /docs/doxygen_dev
 /docs/cheatsheet/cheatsheet.pdf
-/docs/_generated/
+/docs/source/_generated/
 
 **/build*/
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /docs/doxygen
 /docs/doxygen_dev
 /docs/cheatsheet/cheatsheet.pdf
+/docs/_generated/
 
 **/build*/
 

--- a/docs/snippets/example/140_math.cpp
+++ b/docs/snippets/example/140_math.cpp
@@ -1,0 +1,92 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: ISC
+ */
+
+#include "docsTest.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <cmath>
+
+using namespace alpaka;
+
+// BEGIN-TUTORIAL-mathKernel
+struct TrigIdentityKernel
+{
+    ALPAKA_FN_ACC void operator()(
+        onAcc::concepts::Acc auto const& acc,
+        concepts::IMdSpan<float> auto out,
+        concepts::IDataSource<float> auto const& angles) const
+    {
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{angles.getExtents()}))
+        {
+            float sine{};
+            float cosine{};
+            math::sincos(angles[i], sine, cosine);
+            out[i] = math::fma(sine, sine, cosine * cosine);
+        }
+    }
+};
+
+// END-TUTORIAL-mathKernel
+
+// BEGIN-TUTORIAL-rsqrtKernel
+struct DistanceKernel
+{
+    ALPAKA_FN_ACC void operator()(
+        onAcc::concepts::Acc auto const& acc,
+        concepts::IMdSpan<float> auto out,
+        concepts::IDataSource<float> auto const& input) const
+    {
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{input.getExtents()}))
+        {
+            auto const squaredLength = math::fma(input[i], input[i], 1.0f);
+            out[i] = math::rsqrt(squaredLength);
+        }
+    }
+};
+
+// END-TUTORIAL-rsqrtKernel
+
+TEMPLATE_LIST_TEST_CASE("tutorial math functions on device", "[docs]", docs::test::TestBackends)
+{
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue();
+
+    std::array<float, 4u> hostAngles{0.0f, 0.5f, 1.0f, 1.5f};
+    std::array<float, 4u> hostTrig{};
+    std::array<float, 4u> hostInvLen{};
+
+    auto angleBuffer = onHost::allocLike(device, hostAngles);
+    auto trigBuffer = onHost::allocLike(device, hostAngles);
+    auto invLenBuffer = onHost::allocLike(device, hostAngles);
+
+    onHost::memcpy(queue, angleBuffer, hostAngles);
+
+    onHost::concepts::FrameSpec auto frameSpec = onHost::FrameSpec{1u, 64u};
+    queue.enqueue(frameSpec, KernelBundle{TrigIdentityKernel{}, trigBuffer, angleBuffer});
+    queue.enqueue(frameSpec, KernelBundle{DistanceKernel{}, invLenBuffer, angleBuffer});
+
+    onHost::memcpy(queue, hostTrig, trigBuffer);
+    onHost::memcpy(queue, hostInvLen, invLenBuffer);
+    onHost::wait(queue);
+
+    for(auto value : hostTrig)
+    {
+        CHECK(value == Catch::Approx(1.0f).margin(5e-6f));
+    }
+
+    for(size_t i = 0; i < hostAngles.size(); ++i)
+    {
+        auto expected = 1.0f / std::sqrt(hostAngles[i] * hostAngles[i] + 1.0f);
+        CHECK(hostInvLen[i] == Catch::Approx(expected).margin(5e-6f));
+    }
+}

--- a/docs/snippets/example/150_atomics.cpp
+++ b/docs/snippets/example/150_atomics.cpp
@@ -1,0 +1,64 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: ISC
+ */
+
+#include "docsTest.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+
+using namespace alpaka;
+
+// BEGIN-TUTORIAL-atomicKernel
+struct HistogramKernel
+{
+    ALPAKA_FN_ACC void operator()(
+        onAcc::concepts::Acc auto const& acc,
+        concepts::IDataSource auto const& input,
+        concepts::IMdSpan auto bins) const
+    {
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{input.getExtents()}))
+        {
+            auto const bin = input[i];
+            onAcc::atomicAdd(acc, &bins[bin], 1u, onAcc::scope::device);
+        }
+    }
+};
+
+// END-TUTORIAL-atomicKernel
+
+TEMPLATE_LIST_TEST_CASE("tutorial atomics histogram", "[docs]", docs::test::TestBackends)
+{
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue();
+
+    std::array<uint32_t, 12u> hostInput{0u, 1u, 0u, 2u, 3u, 0u, 1u, 2u, 2u, 3u, 3u, 3u};
+    std::array<uint32_t, 4u> hostBins{};
+
+    auto inputBuffer = onHost::allocLike(device, hostInput);
+    auto binsBuffer = onHost::alloc<uint32_t>(device, Vec{4u});
+
+    onHost::memcpy(queue, inputBuffer, hostInput);
+    onHost::memset(queue, binsBuffer, 0x00);
+
+    // BEGIN-TUTORIAL-atomicLaunch
+    onHost::concepts::FrameSpec auto frameSpec
+        = onHost::FrameSpec{divExZero(static_cast<uint32_t>(hostInput.size()), 64u), 64u};
+    queue.enqueue(frameSpec, KernelBundle{HistogramKernel{}, inputBuffer, binsBuffer});
+    // END-TUTORIAL-atomicLaunch
+
+    onHost::memcpy(queue, hostBins, binsBuffer);
+    onHost::wait(queue);
+
+    CHECK(hostBins[0] == 3u);
+    CHECK(hostBins[1] == 2u);
+    CHECK(hostBins[2] == 3u);
+    CHECK(hostBins[3] == 4u);
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,10 +12,12 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 from sphinx_helper.single_header import generate_single_header
 from sphinx_helper.utils import on_rtd
 from sphinx_helper.doxygen import generate_doxygen
+from sphinx_helper.math_function_families import generate_math_function_families
 
 def setup(app):
     # Doxygen XML must exist before Sphinx/Breathe reads the documents.
     app.connect('builder-inited', generate_doxygen)
+    app.connect('builder-inited', generate_math_function_families)
     app.connect('build-finished', generate_single_header)
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -71,6 +71,8 @@ Individual chapters are based on the information of the chapters before.
    tutorial/kernelParallelism.rst
    tutorial/synchronization.rst
    tutorial/sharedMemory.rst
+   tutorial/math.rst
+   tutorial/atomics.rst
 
 .. toctree::
    :caption: Advanced

--- a/docs/source/sphinx_helper/math_function_families.py
+++ b/docs/source/sphinx_helper/math_function_families.py
@@ -1,0 +1,64 @@
+"""Generate the math function reference block used by the tutorials."""
+
+from __future__ import annotations
+
+import pathlib
+import xml.etree.ElementTree as ET
+
+DOXYGEN_NAMESPACE_PAGE = "../doxygen/namespacealpaka_1_1math.html"
+
+
+def _load_function_data(xml_file_path: pathlib.Path) -> dict[str, tuple[str, int]]:
+    root = ET.parse(xml_file_path).getroot()
+
+    function_data: dict[str, tuple[str, int]] = {}
+    for member in root.findall(".//memberdef[@kind='function']"):
+        function_name = member.findtext("name")
+        member_id = member.get("id")
+        if function_name and member_id:
+            anchor = member_id.rsplit("_1", maxsplit=1)[-1]
+            function_data[function_name] = (f"{DOXYGEN_NAMESPACE_PAGE}#{anchor}", len(member.findall("param")))
+
+    return function_data
+
+
+def _group_functions(
+        function_data: dict[str, tuple[str, int]]
+) -> dict[str, list[str]]:
+    grouped_functions: dict[str, list[str]] = {
+        "Unary Functions": [],
+        "Binary Functions": [],
+        "Other Functions": [],
+    }
+
+    for function_name, (_, param_count) in sorted(function_data.items()):
+        if param_count == 1:
+            grouped_functions["Unary Functions"].append(function_name)
+        elif param_count == 2:
+            grouped_functions["Binary Functions"].append(function_name)
+        else:
+            grouped_functions["Other Functions"].append(function_name)
+
+    return grouped_functions
+
+
+def generate_math_function_families(app) -> None:
+    """Create the generated RST snippet referenced by the math tutorial."""
+
+    output_path = pathlib.Path(app.srcdir, "_generated", "math_function_families.rst")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    xml_file_path = pathlib.Path(app.confdir).parent / pathlib.Path("doxygen", "xml", "namespacealpaka_1_1math.xml")
+
+    function_data = _load_function_data(xml_file_path)
+    grouped_functions = _group_functions(function_data)
+
+    lines: list[str] = []
+
+    for title, functions in grouped_functions.items():
+        if not functions:
+            continue
+        lines.extend(["", title, "-" * len(title), ""])
+        rendered_functions = [f"`{function_name} <{function_data[function_name][0]}>`_" for function_name in functions]
+        lines.append(", ".join(rendered_functions))
+
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/docs/source/tutorial/atomics.rst
+++ b/docs/source/tutorial/atomics.rst
@@ -2,18 +2,14 @@ Atomics
 =======
 
 Atomics are the tool you reach for when several workers may update the same memory location.
-Typical examples are histograms, counters, sparse assembly, work lists, and some reductions.
-
-When to Use Atomics
--------------------
-
 Use an atomic operation only when two or more workers can hit the same location at the same time.
-If every output element is written exactly once, atomics are usually unnecessary and slower than a plain store.
+Atomics have performance disadvantages, so they should be used only when necessary.
+Typical examples are histograms, counters, sparse assembly, work lists, and some reductions.
 
 Histogram
 ---------
 
-Histograms are a typical example because many input elements may contribute to the same bin.
+`Histograms <https://en.wikipedia.org/wiki/Histogram>`_ are a typical example because many input elements may contribute to the same bin.
 That means a direct ``bins[bin] += 1`` would create a data race.
 
   .. literalinclude:: ../../snippets/example/150_atomics.cpp
@@ -62,14 +58,14 @@ If you are accumulating into shared memory or another block-private structure, b
 If all blocks may update the same global counter, histogram bin, or reduction output, you need device scope.
 
 *alpaka* provides operations such as ``atomicAdd``, ``atomicMin``, ``atomicMax``, ``atomicExch``, and ``atomicCas``.
-For a first encounter, ``atomicAdd`` with the default device scope is the easiest one to reason about.
+You can find a complete list of all available atomic operations in the `Doxygen documentation <../doxygen/namespacealpaka_1_1onAcc.html>`_.
 
 Common Mistakes
 ---------------
 
-- Using atomics for data that is actually written exactly once.
 - Choosing device scope when block-local scope would be enough.
-- Mixing atomics and non-atomic accesses to the same location without a clear protocol. This leads to data races.
+- Mixing atomics and non-atomic accesses to the same location without a clear code structure. This leads to data races.
+  Try to reuse common and well-known software pattern and idioms.
 - Trying to use atomics as a substitute to synchronize threads.
 
 Complete Source File

--- a/docs/source/tutorial/atomics.rst
+++ b/docs/source/tutorial/atomics.rst
@@ -1,0 +1,90 @@
+Atomics
+=======
+
+Atomics are the tool you reach for when several workers may update the same memory location.
+Typical examples are histograms, counters, sparse assembly, work lists, and some reductions.
+
+When to Use Atomics
+-------------------
+
+Use an atomic operation only when two or more workers can hit the same location at the same time.
+If every output element is written exactly once, atomics are usually unnecessary and slower than a plain store.
+
+Histogram
+---------
+
+Histograms are a typical example because many input elements may contribute to the same bin.
+That means a direct ``bins[bin] += 1`` would create a data race.
+
+  .. literalinclude:: ../../snippets/example/150_atomics.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-atomicKernel
+    :end-before: END-TUTORIAL-atomicKernel
+    :dedent:
+
+Launching the Atomic Kernel
+---------------------------
+
+  .. literalinclude:: ../../snippets/example/150_atomics.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-atomicLaunch
+    :end-before: END-TUTORIAL-atomicLaunch
+    :dedent:
+
+Common problems where atomics are useful:
+
+- accumulate a global count,
+- build a histogram,
+- count errors or events,
+- update a minimum or maximum,
+- or implement a simple unordered reduction.
+
+Atomic Scope
+------------
+
+The atomic helpers in *alpaka* have an optional scope parameter.
+In practice, the shape looks like this:
+
+- ``onAcc::atomicAdd(acc, ptr, value)``
+- ``onAcc::atomicAdd(acc, ptr, value, onAcc::scope::block)``
+- ``onAcc::atomicAdd(acc, ptr, value, onAcc::scope::device)``
+
+If you do not pass a scope, the default is ``onAcc::scope::device``.
+
+This is useful because not every algorithm needs the same visibility:
+
+- ``scope::block`` means the atomic operation only needs to be coherent for threads in the same block.
+- ``scope::device`` means the atomic operation must work across the whole device.
+
+Many algorithms only need block-local coordination.
+Even on device global memory using the block scope can be enough if the algorithm guarantees that only threads of the same block can update the same data chunk.
+If you are accumulating into shared memory or another block-private structure, block scope expresses the real requirement more precisely.
+If all blocks may update the same global counter, histogram bin, or reduction output, you need device scope.
+
+*alpaka* provides operations such as ``atomicAdd``, ``atomicMin``, ``atomicMax``, ``atomicExch``, and ``atomicCas``.
+For a first encounter, ``atomicAdd`` with the default device scope is the easiest one to reason about.
+
+Common Mistakes
+---------------
+
+- Using atomics for data that is actually written exactly once.
+- Choosing device scope when block-local scope would be enough.
+- Mixing atomics and non-atomic accesses to the same location without a clear protocol. This leads to data races.
+- Trying to use atomics as a substitute to synchronize threads.
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>150_atomics.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/150_atomics.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>
+   <br/>

--- a/docs/source/tutorial/math.rst
+++ b/docs/source/tutorial/math.rst
@@ -2,8 +2,10 @@ Math Functions
 ==============
 
 Inside kernels, prefer ``alpaka::math`` over calling backend-specific math APIs or C++ `std` math functions directly.
-That keeps the code portable across the API's ``host``, ``cuda``, ``hip``, and ``oneApi``.
-*alpaka*'s math functions can also be used outside of kernels on the host side.
+*alpaka* provides a wide range of mathematical functions in the `alpaka::math <../doxygen/namespacealpaka_1_1math.html>`_ namespace.
+These enable a portable codebase while delivering the best possible performance for the data types used.
+To this end, *alpaka* uses the native math functions of the :ref:`api` (e.g., CUDA built-in math functions) with which a kernel is executed, whenever available.
+*alpaka* math functions can also be used in host code outside of kernels.
 
 Element-wise Math
 -----------------

--- a/docs/source/tutorial/math.rst
+++ b/docs/source/tutorial/math.rst
@@ -1,0 +1,50 @@
+Math Functions
+==============
+
+Inside kernels, prefer ``alpaka::math`` over calling backend-specific math APIs or C++ `std` math functions directly.
+That keeps the code portable across the API's ``host``, ``cuda``, ``hip``, and ``oneApi``.
+*alpaka*'s math functions can also be used outside of kernels on the host side.
+
+Element-wise Math
+-----------------
+
+The example is similar to the vector addition, iterate over the data with ``makeIdxMap`` and call math functions on each element.
+
+  .. literalinclude:: ../../snippets/example/140_math.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-mathKernel
+    :end-before: END-TUTORIAL-mathKernel
+    :dedent:
+
+Distance-like Computations
+--------------------------
+
+Reciprocal square root is another common operation in physics, graphics, and geometry kernels.
+
+  .. literalinclude:: ../../snippets/example/140_math.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-rsqrtKernel
+    :end-before: END-TUTORIAL-rsqrtKernel
+    :dedent:
+
+Available Function Families
+---------------------------
+
+.. include:: ../_generated/math_function_families.rst
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>140_math.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/140_math.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>
+   <br/>


### PR DESCRIPTION
- add tutorials sections
- add helper script to list math functions in the documentation


note: I tried using breath to list the math functions. It was looking horrible, therefore I decided to keep the xml parsing, which allows linking the math functions directly to the user documentation and avoid showing the full signature of each function.