### PR TITLE
refactor `onAcc::SimdAlgo::transformReduce()`

### DIFF
--- a/benchmark/HACCmk/src/main_alpaka.cpp
+++ b/benchmark/HACCmk/src/main_alpaka.cpp
@@ -80,21 +80,21 @@ namespace haccmkAlpaka
                     move,
                     std::plus{},
                     [&](auto const&,
-                        concepts::SimdPtr auto&& simd_xx1,
-                        concepts::SimdPtr auto&& simd_yy1,
-                        concepts::SimdPtr auto&& simd_zz1,
-                        concepts::SimdPtr auto&& simd_mass1) constexpr
+                        concepts::Simd auto const& simd_xx1,
+                        concepts::Simd auto const& simd_yy1,
+                        concepts::Simd auto const& simd_zz1,
+                        concepts::Simd auto const& simd_mass1) constexpr
                     {
-                        concepts::Simd auto dxc = simd_xx1.load() - xxi;
-                        concepts::Simd auto dyc = simd_yy1.load() - yyi;
-                        concepts::Simd auto dzc = simd_zz1.load() - zzi;
+                        concepts::Simd auto dxc = simd_xx1 - xxi;
+                        concepts::Simd auto dyc = simd_yy1 - yyi;
+                        concepts::Simd auto dzc = simd_zz1 - zzi;
 
                         concepts::Simd auto r2 = dxc * dxc + dyc * dyc + dzc * dzc;
 
-                        using SimdType = ALPAKA_TYPEOF(simd_mass1.load());
+                        using SimdType = ALPAKA_TYPEOF(simd_mass1);
                         concepts::Simd auto m = SimdType::fill(0.f);
 
-                        where(r2 < fsrrmax2, m) = simd_mass1.load();
+                        where(r2 < fsrrmax2, m) = simd_mass1;
 
                         alpaka::concepts::Simd auto tmp = r2 + mp_rsm2;
                         concepts::Simd auto bar = alpaka::math::sqrt(tmp);

--- a/include/alpaka/onAcc/SimdAlgo.hpp
+++ b/include/alpaka/onAcc/SimdAlgo.hpp
@@ -165,9 +165,16 @@ namespace alpaka::onAcc
          *            All other MdSpan objects must have at least the same number of elements.
          *
          * @param neutralElement the neutral element for the reduction operation
-         * @param reduceFunc the binary reduction operation to be executed, e.g. std::plus
-         * @param transformFunc n-nary functor to be executed, values of all containers will be passed to the functor
-         * as arguments. If the result of this functor is a structured value providing an overload to simdize the type
+         * @param reduceFunc The binary reduction operation to be executed, e.g. std::plus. The functor should support
+         * Simd packages.
+         * @param transformFunc N-nary functor to be executed, values of all containers will be passed to the functor
+         * as arguments. The functor should support Simd packages. If not you can enforce the element wise execution by
+         * wrapping into
+         * @see ScalarFunc. If you would like to support stencil executions wrapp fn into @see StencilFunc. StencilFunc
+         * is getting all arguments as @see SimdPtr. If StencilFunc is used you should take care to not read outside of
+         * valid memory ranges by using sub-views to your input and output data. Optionally a transformFn can have an
+         * accelerator as first argument.
+         * If the result of this functor is a structured value providing an overload to simdize the type
          * can improve the performance see alpaka::makeSimdized.
          * @param data0 the first data to be processed
          * @param dataN the remaining data to be processed

--- a/include/alpaka/onAcc/SimdAlgo.hpp
+++ b/include/alpaka/onAcc/SimdAlgo.hpp
@@ -170,8 +170,8 @@ namespace alpaka::onAcc
          * @param transformFunc N-nary functor to be executed, values of all containers will be passed to the functor
          * as arguments. The functor should support Simd packages. If not you can enforce the element wise execution by
          * wrapping into
-         * @see ScalarFunc. If you would like to support stencil executions wrapp fn into @see StencilFunc. StencilFunc
-         * is getting all arguments as @see SimdPtr. If StencilFunc is used you should take care to not read outside of
+         * ScalarFunc. If you would like to support stencil executions wrapp fn into StencilFunc. StencilFunc
+         * is getting all arguments as SimdPtr. If StencilFunc is used you should take care to not read outside of
          * valid memory ranges by using sub-views to your input and output data. Optionally a transformFn can have an
          * accelerator as first argument.
          * If the result of this functor is a structured value providing an overload to simdize the type

--- a/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
+++ b/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
@@ -42,6 +42,7 @@ namespace alpaka::onAcc::internal
         {
             auto numElements = typename ALPAKA_TYPEOF(extents)::UniVec{extents};
             using ValueType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(data0)>;
+            decltype(auto) transformFunc = wrapTransformFunc(ALPAKA_FORWARD(func));
 
             constexpr auto simdCfg = T_Parent::template calcSimdPackConfig<ValueType>(
                 ALPAKA_TYPEOF(acc.getApi()){},
@@ -58,7 +59,7 @@ namespace alpaka::onAcc::internal
                     numElements,
                     neutralElement,
                     ALPAKA_FORWARD(reduceFunc),
-                    ALPAKA_FORWARD(func),
+                    transformFunc,
                     ALPAKA_FORWARD(data0),
                     ALPAKA_FORWARD(dataN)...);
             }
@@ -79,8 +80,9 @@ namespace alpaka::onAcc::internal
             {
                 simdizedReducedValue = reduceFunc(
                     simdizedReducedValue,
-                    func(
+                    callFunctor(
                         acc,
+                        transformFunc,
                         SimdPtr{data0, idx, T_MemAlignment{}, CVec<uint32_t, 1u>{}},
                         SimdPtr{dataN, idx, T_MemAlignment{}, CVec<uint32_t, 1u>{}}...));
             }
@@ -94,6 +96,52 @@ namespace alpaka::onAcc::internal
         }
 
     private:
+        template<uint32_t... T_idx>
+        ALPAKA_FN_INLINE ALPAKA_FN_ACC static constexpr auto loadAncExecuteScalarOp(
+            std::integer_sequence<uint32_t, T_idx...>,
+            auto&& op,
+            auto const& acc,
+            auto&& func,
+            auto&&... data)
+        {
+            return Simd{op(CVec<uint32_t, T_idx>{}, acc, ALPAKA_FORWARD(func), ALPAKA_FORWARD(data)...)...};
+        }
+
+        ALPAKA_FN_INLINE ALPAKA_FN_ACC static constexpr decltype(auto) wrapTransformFunc(auto&& transformFunc)
+        {
+            if constexpr(isSpecializationOf_v<ALPAKA_TYPEOF(transformFunc), StencilFunc>)
+            {
+                return ALPAKA_FORWARD(transformFunc);
+            }
+            else if constexpr(isSpecializationOf_v<ALPAKA_TYPEOF(transformFunc), ScalarFunc>)
+            {
+                return [transformFunc = ALPAKA_FORWARD(transformFunc)](
+                           onAcc::concepts::Acc auto const& acc,
+                           alpaka::concepts::SimdPtr auto&& inPtr0,
+                           alpaka::concepts::SimdPtr auto const&... inPtr) constexpr
+                {
+                    return loadAncExecuteScalarOp(
+                        std::make_integer_sequence<uint32_t, ALPAKA_TYPEOF(inPtr0)::width()>{},
+                        [](alpaka::concepts::CVector auto idx,
+                           auto const& acc,
+                           auto&& func,
+                           alpaka::concepts::Simd auto const&... data) constexpr
+                        { return callFunctor(acc, func, data[idx.x()]...); },
+                        acc,
+                        transformFunc,
+                        inPtr0.load(),
+                        inPtr.load()...);
+                };
+            }
+            else
+            {
+                return [transformFunc = ALPAKA_FORWARD(transformFunc)](
+                           onAcc::concepts::Acc auto const& acc,
+                           alpaka::concepts::SimdPtr auto&&... inPtr) constexpr
+                { return callFunctor(acc, transformFunc, inPtr.load()...); };
+            }
+        }
+
         template<alpaka::concepts::Alignment T_MemAlignment, uint32_t T_width>
         ALPAKA_FN_INLINE static constexpr auto executeDoTransform(
             concepts::Acc auto const& acc,
@@ -101,7 +149,7 @@ namespace alpaka::onAcc::internal
             auto&& func,
             alpaka::concepts::IDataSource auto&&... data)
         {
-            return func(acc, SimdPtr{ALPAKA_FORWARD(data), dataIdx, T_MemAlignment{}, CVec<uint32_t, T_width>{}}...);
+            return callFunctor(acc, func, SimdPtr{data, dataIdx, T_MemAlignment{}, CVec<uint32_t, T_width>{}}...);
         }
 
         /** advance the iterator T_repeat times
@@ -152,16 +200,12 @@ namespace alpaka::onAcc::internal
                         executeDoTransform<T_MemAlignment, T_width>(
                             acc,
                             std::get<0>(std::make_tuple(dataIdx...)),
-                            ALPAKA_FORWARD(func),
-                            ALPAKA_FORWARD(data)...));
+                            func,
+                            data...));
                     auto results = Simd<ComponentType, std::tuple_size_v<ALPAKA_TYPEOF(ids)>>{
-                        executeDoTransform<T_MemAlignment, T_width>(
-                            acc,
-                            dataIdx,
-                            ALPAKA_FORWARD(func),
-                            ALPAKA_FORWARD(data)...)...};
+                        executeDoTransform<T_MemAlignment, T_width>(acc, dataIdx, func, data...)...};
 
-                    return results.reduce(ALPAKA_FORWARD(reduceFunc));
+                    return results.reduce(reduceFunc);
                 },
                 ids);
         }
@@ -191,11 +235,7 @@ namespace alpaka::onAcc::internal
                 {
                     ((result = reduceFn(
                           result,
-                          executeDoTransform<T_MemAlignment, T_width>(
-                              acc,
-                              dataIdx,
-                              ALPAKA_FORWARD(transformFn),
-                              ALPAKA_FORWARD(data)...))),
+                          executeDoTransform<T_MemAlignment, T_width>(acc, dataIdx, transformFn, data...))),
                      ...);
                 },
                 ids);
@@ -222,10 +262,10 @@ namespace alpaka::onAcc::internal
                         acc,
                         iter,
                         std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
-                        ALPAKA_FORWARD(reduceFn),
-                        ALPAKA_FORWARD(transformFn),
-                        ALPAKA_FORWARD(data0),
-                        ALPAKA_FORWARD(dataN)...));
+                        reduceFn,
+                        transformFn,
+                        data0,
+                        dataN...));
             }
             else
             {
@@ -234,10 +274,10 @@ namespace alpaka::onAcc::internal
                     iter,
                     std::make_integer_sequence<uint32_t, T_numSimdPerFnCall>{},
                     tmpReturn,
-                    ALPAKA_FORWARD(reduceFn),
-                    ALPAKA_FORWARD(transformFn),
-                    ALPAKA_FORWARD(data0),
-                    ALPAKA_FORWARD(dataN)...);
+                    reduceFn,
+                    transformFn,
+                    data0,
+                    dataN...);
             }
         }
 
@@ -433,8 +473,9 @@ namespace alpaka::onAcc::internal
                     asParent().getTraversePolicy(),
                     asParent().getIdxLayoutPolicy()))
             {
-                auto transformResult = func(
+                auto transformResult = callFunctor(
                     acc,
+                    func,
                     SimdPtr{data0, idx, T_MemAlignment{}, CVec<uint32_t, 1u>{}},
                     SimdPtr{dataN, idx, T_MemAlignment{}, CVec<uint32_t, 1u>{}}...);
 

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-
-#include "alpaka/Simd.hpp"
 #include "alpaka/Vec.hpp"
 #include "alpaka/api/util.hpp"
 #include "alpaka/core/common.hpp"
@@ -74,15 +72,11 @@ namespace alpaka::onHost::internal
                         alpaka::onAcc::WorkerGroup{chunkIdx + elemIdxInChunk, chunkDataExtent}};
 
                     // reduce functor with simd package support
-                    callTransformFn(
-                        acc,
-                        allThreads,
-                        extentMd,
-                        neutralElement,
-                        tbSum[elemIdxInChunk],
-                        reduceFunc,
-                        transformFunc,
-                        ALPAKA_FORWARD(inputs)...);
+                    auto reducedValue
+                        = allThreads
+                              .transformReduce(acc, extentMd, neutralElement, reduceFunc, transformFunc, inputs...);
+                    auto& tbSumRef = tbSum[elemIdxInChunk];
+                    tbSumRef = reduceFunc(tbSumRef, reducedValue);
                 }
             }
 
@@ -131,81 +125,6 @@ namespace alpaka::onHost::internal
                 }
                 else
                     atomicInvoke(reduceFunc, acc, output.data(), dynS[laneIdInBlock]);
-            }
-        }
-
-        template<uint32_t... T_idx>
-        ALPAKA_FN_INLINE ALPAKA_FN_ACC static constexpr auto loadAncExecuteScalarOp(
-            std::integer_sequence<uint32_t, T_idx...>,
-            auto&& op,
-            auto const& acc,
-            auto&& func,
-            auto&&... data)
-
-        {
-            return Simd{op(CVec<uint32_t, T_idx>{}, acc, ALPAKA_FORWARD(func), ALPAKA_FORWARD(data)...)...};
-        }
-
-        ALPAKA_FN_INLINE ALPAKA_FN_ACC static constexpr void callTransformFn(
-            auto const& acc,
-            auto const& allThreads,
-            alpaka::concepts::Vector auto const& extentMd,
-            auto const& neutralElement,
-            auto& result,
-            auto&& reduceFunc,
-            auto&& transformFunc,
-            alpaka::concepts::IDataSource auto&&... inputs)
-        {
-            // Use the generic transformFunc and the variant reduceFunc
-            if constexpr(isSpecializationOf_v<ALPAKA_TYPEOF(transformFunc), StencilFunc>)
-            {
-                auto reducedValue = allThreads.transformReduce(
-                    acc,
-                    extentMd,
-                    neutralElement,
-                    ALPAKA_FORWARD(reduceFunc),
-                    [&](auto const& acc, alpaka::concepts::SimdPtr auto&&... in)
-                    { return callFunctor(acc, transformFunc, ALPAKA_FORWARD(in)...); },
-                    ALPAKA_FORWARD(inputs)...);
-                result = reduceFunc(result, reducedValue);
-            }
-            else if constexpr(isSpecializationOf_v<ALPAKA_TYPEOF(transformFunc), ScalarFunc>)
-            {
-                auto reducedValue = allThreads.transformReduce(
-                    acc,
-                    extentMd,
-                    neutralElement,
-                    ALPAKA_FORWARD(reduceFunc),
-                    [&](auto const& acc,
-                        alpaka::concepts::SimdPtr auto&& inPtr0,
-                        alpaka::concepts::SimdPtr auto const&... inPtr) constexpr
-                    {
-                        return loadAncExecuteScalarOp(
-                            std::make_integer_sequence<uint32_t, ALPAKA_TYPEOF(inPtr0)::width()>{},
-                            [](alpaka::concepts::CVector auto idx,
-                               auto const& acc,
-                               auto&& func,
-                               alpaka::concepts::Simd auto&&... data) constexpr
-                            { return callFunctor(acc, func, data[idx.x()]...); },
-                            acc,
-                            transformFunc,
-                            inPtr0.load(),
-                            inPtr.load()...);
-                    },
-                    ALPAKA_FORWARD(inputs)...);
-                result = reduceFunc(result, reducedValue);
-            }
-            else
-            {
-                auto reducedValue = allThreads.transformReduce(
-                    acc,
-                    extentMd,
-                    neutralElement,
-                    ALPAKA_FORWARD(reduceFunc),
-                    [&transformFunc](auto const& acc, alpaka::concepts::SimdPtr auto&&... inPtr)
-                    { return callFunctor(acc, transformFunc, inPtr.load()...); },
-                    ALPAKA_FORWARD(inputs)...);
-                result = reduceFunc(result, reducedValue);
             }
         }
     };

--- a/test/unit/algorithm/transformReduce.cpp
+++ b/test/unit/algorithm/transformReduce.cpp
@@ -369,3 +369,174 @@ TEMPLATE_LIST_TEST_CASE("transformReduce generator", "", TestBackends)
 
     std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, setups), ...); }, extentMdList);
 }
+
+struct OnAccTransformReduceKernel
+{
+    ALPAKA_FN_ACC void operator()(
+        auto const& acc,
+        alpaka::concepts::IMdSpan auto out,
+        auto const& extentMd,
+        auto const& neutralElement,
+        auto const& reduceFunc,
+        auto const& transformFunc,
+        auto const&... inputs) const
+    {
+        auto simdGrid = onAcc::SimdAlgo{onAcc::WorkerGroup{extentMd.fill(0), extentMd.fill(1)}};
+        out[0u] = simdGrid.transformReduce(acc, extentMd, neutralElement, reduceFunc, transformFunc, inputs...);
+    }
+};
+
+struct TestOnAccWithMdSpan
+{
+    template<typename T_DataType>
+    static void executeTest(
+        concepts::Executor auto exec,
+        auto const& computeQueue,
+        auto const setup,
+        concepts::Vector auto extentMd)
+    {
+        INFO(
+            "run onAcc reduce(func) : " << onHost::demangledName(std::get<1>(setup).second) << "("
+                                        << onHost::demangledName(std::get<2>(setup).second) << ")");
+
+        auto computeDev = computeQueue.getDevice();
+        using DataType = T_DataType;
+        using OutDataType = ALPAKA_TYPEOF(std::get<0>(setup));
+        onHost::SharedBuffer computeBufferOut = onHost::alloc<OutDataType>(computeDev, 1u);
+        onHost::SharedBuffer computeBufferIn0 = onHost::alloc<DataType>(computeDev, extentMd);
+        onHost::SharedBuffer computeBufferIn1 = onHost::allocLike(computeDev, computeBufferIn0);
+        onHost::SharedBuffer hostBufferIota = onHost::allocHostLike(computeBufferIn0);
+        onHost::SharedBuffer hostBufferOut = onHost::allocHostLike(computeBufferOut);
+
+        DataType iotaCounter = 0;
+        for(auto& value : hostBufferIota)
+        {
+            value = iotaCounter;
+            ++iotaCounter;
+        }
+
+        onHost::memcpy(computeQueue, computeBufferIn0, hostBufferIota);
+        onHost::memcpy(computeQueue, computeBufferIn1, hostBufferIota);
+
+        onHost::wait(computeQueue);
+        auto const beginT = std::chrono::high_resolution_clock::now();
+
+        computeQueue.enqueue(
+            onHost::FrameSpec{1u, 1u, exec},
+            KernelBundle{
+                OnAccTransformReduceKernel{},
+                computeBufferOut,
+                extentMd,
+                std::get<0>(setup),
+                std::get<1>(setup).first,
+                std::get<2>(setup).first,
+                computeBufferIn0,
+                computeBufferIn1});
+
+        onHost::wait(computeQueue);
+        auto const endT = std::chrono::high_resolution_clock::now();
+        UNSCOPED_INFO(
+            "Time for onAcc transform reduce: " << std::chrono::duration<double>(endT - beginT).count()
+                                                << "s data size: " << hostBufferIota.getExtents());
+
+        onHost::memcpy(computeQueue, hostBufferOut, computeBufferOut);
+        onHost::wait(computeQueue);
+
+        DataType refIotaCounter = 0;
+        auto result = std::get<0>(setup);
+        meta::ndLoopIncIdx(
+            extentMd,
+            [&](auto idx)
+            {
+                alpaka::unused(idx);
+                result = std::get<1>(setup).second(result, std::get<2>(setup).second(refIotaCounter, refIotaCounter));
+                ++refIotaCounter;
+            });
+        CHECK(*hostBufferOut.data() == result);
+    }
+};
+
+template<typename T_DataType>
+void prepareOnAccTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
+{
+    using DataType = T_DataType;
+
+    auto deviceSpec = cfg[object::deviceSpec];
+    alpaka::concepts::Executor auto exec = cfg[object::exec];
+
+    auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!computeDevSelector.isAvailable())
+    {
+        SUCCEED("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    onHost::Device computeDev = computeDevSelector.makeDevice(0);
+
+    INFO("device spec: " << getName(deviceSpec));
+    INFO("device name: " << computeDev.getName());
+    INFO("executor   : " << exec.getName());
+
+    onHost::Queue computeQueue = computeDev.makeQueue();
+
+    std::apply(
+        [&](auto const&... setup)
+        { (std::get<3>(setup).template executeTest<DataType>(exec, computeQueue, setup, extentMd), ...); },
+        setupTuple);
+}
+
+TEMPLATE_LIST_TEST_CASE("onAcc transformReduce", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    using DataType = int;
+
+    auto setups = std::make_tuple(
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(std::plus{}, std::plus{}),
+            TestOnAccWithMdSpan{}),
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(StencilFunc{StencilAdd{}}, std::plus{}),
+            TestOnAccWithMdSpan{}),
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(StencilFunc{StencilAddWithAcc{}}, std::plus{}),
+            TestOnAccWithMdSpan{}),
+        std::make_tuple(
+            size_t{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(
+                AddUpCastWithAcc{},
+                [](DataType const& a, DataType const& b) { return static_cast<size_t>(a + b); }),
+            TestOnAccWithMdSpan{}),
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(
+                ScalarFunc{[] ALPAKA_FN_ACC(DataType const& a, DataType const& b)
+                           { return math::min(a + DataType{1}, b); }},
+                [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); }),
+            TestOnAccWithMdSpan{}),
+        std::make_tuple(
+            DataType{0},
+            std::make_pair(std::plus{}, std::plus{}),
+            std::make_pair(
+                ScalarFunc{ScalarOpWithAcc{}},
+                [](DataType const& a, DataType const& b) { return a * DataType{2} + b; }),
+            TestOnAccWithMdSpan{}),
+        std::make_tuple(
+            std::numeric_limits<DataType>::max(),
+            std::make_pair(ScalarFunc{myTest::MinValue{}}, myTest::MinValue{}),
+            std::make_pair(std::plus{}, std::plus{}),
+            TestOnAccWithMdSpan{}));
+
+    auto extentMdList
+        = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
+
+    std::apply([&](auto... extents) { (prepareOnAccTest<DataType>(cfg, extents, setups), ...); }, extentMdList);
+}


### PR DESCRIPTION
Unify the `transformReduce()` functionality from `onHost` and the in-kernel equivalent.
This is a **breaking change** but is making typical code simpler, because the user does not need to deal with `SimdPtr`.
`SimpPtr` is interesting for stencil operations but often not required for typical transform operations.

- provide the usage of `StencilFunc` and `ScalarFunc` functionality from `onHost::transformReduce()` to the in-kernel variant.
- add test for `onAcc` interface
- update HACCmk to take new interface into account
- remove the overuse of `std::forward()`, it should not be used when a universal reference is used multiple times, e.g. in a loop