### PR TITLE
Refactor the way of defining the user functor equivalant atomic for

### DIFF
--- a/include/alpaka/onAcc/atomic.hpp
+++ b/include/alpaka/onAcc/atomic.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/api/api.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/core/common.hpp"
+#include "alpaka/onAcc/Acc.hpp"
 #include "alpaka/onAcc/atomicOp.hpp"
 #include "alpaka/onAcc/internal/interface.hpp"
 #include "alpaka/onAcc/scope.hpp"
@@ -183,22 +184,32 @@ namespace alpaka::onAcc
         return atomicOp<AtomicCas>(acc, addr, compare, value, hier);
     }
 
-    namespace trait
+    namespace atomic
     {
-
-        template<typename T_Functor>
-        struct FunctorToAtomicOp;
-
-        template<>
-        struct FunctorToAtomicOp<std::plus<>>
-
+        /** Defines the equivalent of an atomic invoke for user defined functors.
+         *
+         * This function can be specialized within the namespace of the user functor type and will be found via ADL.
+         * Typically, this functor is used within the reduce and transformReduce algorithm.
+         * The implementation must implement the functor equivalent atomic function.
+         *
+         * @param fn non-atomic user functor
+         * @param inOut pointer to the values which is updated
+         * @param args arguments normally forwarded to the user functor
+         */
+        ALPAKA_FN_ACC void atomicInvoke(auto&& fn, concepts::Acc auto const& acc, auto* inOut, auto&&... args)
         {
-            using type = alpaka::onAcc::AtomicAdd;
-        };
-    } // namespace trait
+            alpaka::unused(fn, acc, inOut, args...);
+            static_assert(
+                false,
+                "You must specialize atomicInvoke() for your functor. Best place the overload in the namespace of the "
+                "functor, it will be found by ADL.");
+        }
 
-    // Add more functors as needed
-    template<typename T_Functor>
-    using FunctorToAtomicOp_t = typename trait::FunctorToAtomicOp<std::decay_t<T_Functor>>::type;
+        template<typename T>
+        ALPAKA_FN_ACC void atomicInvoke(std::plus<T>, concepts::Acc auto const& acc, auto* inOut, auto&&... args)
+        {
+            atomicAdd(acc, inOut, ALPAKA_FORWARD(args)...);
+        }
+    } // namespace atomic
 
 } // namespace alpaka::onAcc

--- a/include/alpaka/onAcc/atomic.hpp
+++ b/include/alpaka/onAcc/atomic.hpp
@@ -198,9 +198,9 @@ namespace alpaka::onAcc
          */
         ALPAKA_FN_ACC void atomicInvoke(auto&& fn, concepts::Acc auto const& acc, auto* inOut, auto&&... args)
         {
-            alpaka::unused(fn, acc, inOut, args...);
+            alpaka::unused(acc, inOut, args...);
             static_assert(
-                false,
+                sizeof(ALPAKA_TYPEOF(fn)) && false,
                 "You must specialize atomicInvoke() for your functor. Best place the overload in the namespace of the "
                 "functor, it will be found by ADL.");
         }

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -116,18 +116,21 @@ namespace alpaka::onHost::internal
             // Atomic update of the global result
             if(laneIdInBlock == 0)
             {
-                if constexpr(requires { typename ALPAKA_TYPEOF(reduceFunc)::Functor; })
+                using alpaka::onAcc::atomic::atomicInvoke;
+                if constexpr(
+                    alpaka::concepts::SpecializationOf<ALPAKA_TYPEOF(reduceFunc), ScalarFunc>
+                    || alpaka::concepts::SpecializationOf<ALPAKA_TYPEOF(reduceFunc), StencilFunc>)
                 {
-                    // Handle wrapped reduce functors e.g. ScalarFunc
+                    // Handle wrapped reduce functors e.g. ScalarFunc or StencilFunc
                     using ReduceFunctor = typename ALPAKA_TYPEOF(reduceFunc)::Functor;
-                    using BinaryAtomicOp = onAcc::FunctorToAtomicOp_t<ReduceFunctor>;
-                    alpaka::onAcc::atomicOp<BinaryAtomicOp>(acc, output.data(), dynS[laneIdInBlock]);
+                    atomicInvoke(
+                        static_cast<ReduceFunctor const&>(reduceFunc),
+                        acc,
+                        output.data(),
+                        dynS[laneIdInBlock]);
                 }
                 else
-                {
-                    using BinaryAtomicOp = onAcc::FunctorToAtomicOp_t<ALPAKA_TYPEOF(reduceFunc)>;
-                    alpaka::onAcc::atomicOp<BinaryAtomicOp>(acc, output.data(), dynS[laneIdInBlock]);
-                }
+                    atomicInvoke(reduceFunc, acc, output.data(), dynS[laneIdInBlock]);
             }
         }
 

--- a/include/alpaka/onHost/algo/reduce.hpp
+++ b/include/alpaka/onHost/algo/reduce.hpp
@@ -20,8 +20,7 @@ namespace alpaka::onHost
      * @param binaryReduceFn Reduce binary functor, the functor operation must be transitive and commutative.
      *   The atomic operation atomic::atomicInvoke(ReduceFnType, onAcc::concepts::Acc, auto* destination,auto source)
      * must be overloaded. The functor execution order is not specified. The functor should support Simd packages, if
-     * not you can enforce the element wise execution by wrapping into
-     *   @see ScalarFunc.
+     * not you can enforce the element wise execution by wrapping into ScalarFunc.
      * @param in The input data which should be reduced.
      *
      * @{
@@ -59,7 +58,7 @@ namespace alpaka::onHost
     }
 
     /**
-     * A available default executor will be selected automaticlally. The default executor is a executor with most
+     * A available default executor will be selected automatically. The default executor is a executor with most
      * parallelism/performance.
      */
     template<typename DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>

--- a/include/alpaka/onHost/algo/reduce.hpp
+++ b/include/alpaka/onHost/algo/reduce.hpp
@@ -18,9 +18,9 @@ namespace alpaka::onHost
      * @param out MdSpan for the result. The value_type must be equal to neutralElement and the result of the binary
      * reduce functor type. The result is written to the first element of the output data.
      * @param binaryReduceFn Reduce binary functor, the functor operation must be transitive and commutative.
-     *   The atomic trait alpaka::onAcc::trait::FunctorToAtomicOp<> must be specialized.
-     *   The functor execution order is not specified.
-     *   The functor should support Simd packages, if not you can enforce the element wise execution by wrapping into
+     *   The atomic operation atomic::atomicInvoke(ReduceFnType, onAcc::concepts::Acc, auto* destination,auto source)
+     * must be overloaded. The functor execution order is not specified. The functor should support Simd packages, if
+     * not you can enforce the element wise execution by wrapping into
      *   @see ScalarFunc.
      * @param in The input data which should be reduced.
      *

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -26,9 +26,9 @@ namespace alpaka::onHost
      * @param out MdSpan for the result. The value_type must be equal to neutralElement and the result of the binary
      * reduce functor type. The result is written to the first element of the output data.
      * @param binaryReduceFn Reduce binary functor, the functor operation must be transitive and commutative.
-     *   The atomic trait alpaka::onAcc::trait::FunctorToAtomicOp<> must be specialized.
-     *   The functor execution order is not specified.
-     *   The functor should support Simd packages, if not you can enforce the element wise execution by wrapping into
+     *   The atomic operation atomic::atomicInvoke(ReduceFnType, onAcc::concepts::Acc, auto* destination,auto source)
+     * must be overloaded. The functor execution order is not specified. The functor should support Simd packages, if
+     * not you can enforce the element wise execution by wrapping into
      *   @see ScalarFunc.
      * @param transformFn The function to apply to each element of the input data.
      *   The functor should support Simd packages. If not you can enforce the element wise execution by wrapping into

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -32,8 +32,8 @@ namespace alpaka::onHost
      *   @see ScalarFunc.
      * @param transformFn The function to apply to each element of the input data.
      *   The functor should support Simd packages. If not you can enforce the element wise execution by wrapping into
-     * @see ScalarFunc. If you would like to support stencil executions wrapp fn into @see StencilFunc. StencilFunc is
-     * getting all arguments as @see SimdPtr. If StencilFunc is used you should take care to not read outside of valid
+     * ScalarFunc. If you would like to support stencil executions wrapp fn into StencilFunc. StencilFunc is
+     * getting all arguments as SimdPtr. If StencilFunc is used you should take care to not read outside of valid
      * memory ranges by using sub-views to your input and output data. Optionally a transformFn can have an accelerator
      * as first argument.
      * @param in The input data to transform, all input data is passed to fn. transformFn must support as many

--- a/test/unit/algorithm/reduce.cpp
+++ b/test/unit/algorithm/reduce.cpp
@@ -16,35 +16,44 @@ using namespace alpaka;
 
 using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
-// This functor des not support Simd and must be wrapped by @see ScalarFunc
-struct MinValue
+namespace myTest
 {
-    constexpr auto operator()(auto const& a, auto const& b) const
+    // This functor des not support Simd and must be wrapped by @see ScalarFunc
+    struct MinValue
     {
-        return math::min(a, b);
-    }
-};
+        constexpr auto operator()(auto const& a, auto const& b) const
+        {
+            return math::min(a, b);
+        }
+    };
 
-template<>
-struct alpaka::onAcc::trait::FunctorToAtomicOp<MinValue>
-{
-    using type = alpaka::onAcc::AtomicMin;
-};
-
-// This functor des not support Simd and must be wrapped by @see ScalarFunc
-struct MaxValue
-{
-    constexpr auto operator()(auto const& a, auto const& b) const
+    ALPAKA_FN_ACC void atomicInvoke(
+        MinValue const&,
+        alpaka::onAcc::concepts::Acc auto const& acc,
+        auto* dest,
+        auto const src)
     {
-        return math::max(a, b);
+        onAcc::atomicMin(acc, dest, src);
     }
-};
 
-template<>
-struct alpaka::onAcc::trait::FunctorToAtomicOp<MaxValue>
-{
-    using type = alpaka::onAcc::AtomicMax;
-};
+    // This functor des not support Simd and must be wrapped by @see ScalarFunc
+    struct MaxValue
+    {
+        constexpr auto operator()(auto const& a, auto const& b) const
+        {
+            return math::max(a, b);
+        }
+    };
+
+    ALPAKA_FN_ACC void atomicInvoke(
+        MaxValue const&,
+        alpaka::onAcc::concepts::Acc auto const& acc,
+        auto* dest,
+        auto const src)
+    {
+        onAcc::atomicMax(acc, dest, src);
+    }
+} // namespace myTest
 
 struct TestWithMdSpan
 {
@@ -144,8 +153,16 @@ TEMPLATE_LIST_TEST_CASE("reduce", "", TestBackends)
     // This list is not directly defined within the function TestWithMdSpan due to nvcc compile issues.
     auto setups = std::make_tuple(
         std::make_tuple(DataType{0}, std::plus{}, std::plus{}, TestWithMdSpan{}),
-        std::make_tuple(std::numeric_limits<DataType>::max(), ScalarFunc{MinValue{}}, MinValue{}, TestWithMdSpan{}),
-        std::make_tuple(std::numeric_limits<DataType>::min(), ScalarFunc{MaxValue{}}, MaxValue{}, TestWithMdSpan{}));
+        std::make_tuple(
+            std::numeric_limits<DataType>::max(),
+            ScalarFunc{myTest::MinValue{}},
+            myTest::MinValue{},
+            TestWithMdSpan{}),
+        std::make_tuple(
+            std::numeric_limits<DataType>::min(),
+            ScalarFunc{myTest::MaxValue{}},
+            myTest::MaxValue{},
+            TestWithMdSpan{}));
 
     // different extents for testing
     auto extentMdList
@@ -208,11 +225,15 @@ TEMPLATE_LIST_TEST_CASE("reduce generator", "", TestBackends)
     // This list is not directly defined within the function TestWithGenerator due to nvcc compile issues.
     auto setup = std::make_tuple(
         std::make_tuple(DataType{0}, std::plus{}, std::plus{}, TestWithGenerator{}),
-        std::make_tuple(std::numeric_limits<DataType>::max(), ScalarFunc{MinValue{}}, MinValue{}, TestWithGenerator{}),
+        std::make_tuple(
+            std::numeric_limits<DataType>::max(),
+            ScalarFunc{myTest::MinValue{}},
+            myTest::MinValue{},
+            TestWithGenerator{}),
         std::make_tuple(
             std::numeric_limits<DataType>::min(),
-            ScalarFunc{MaxValue{}},
-            MaxValue{},
+            ScalarFunc{myTest::MaxValue{}},
+            myTest::MaxValue{},
             TestWithGenerator{}));
 
     // different extents for testing

--- a/test/unit/algorithm/reduce.cpp
+++ b/test/unit/algorithm/reduce.cpp
@@ -18,7 +18,7 @@ using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDe
 
 namespace myTest
 {
-    // This functor des not support Simd and must be wrapped by @see ScalarFunc
+    // This functor des not support Simd and must be wrapped by ScalarFunc
     struct MinValue
     {
         constexpr auto operator()(auto const& a, auto const& b) const
@@ -36,7 +36,7 @@ namespace myTest
         onAcc::atomicMin(acc, dest, src);
     }
 
-    // This functor des not support Simd and must be wrapped by @see ScalarFunc
+    // This functor des not support Simd and must be wrapped by ScalarFunc
     struct MaxValue
     {
         constexpr auto operator()(auto const& a, auto const& b) const

--- a/test/unit/algorithm/transformReduce.cpp
+++ b/test/unit/algorithm/transformReduce.cpp
@@ -61,20 +61,26 @@ struct ScalarOpWithAcc
     }
 };
 
-// This functor des not support Simd and must be wrapped by @see ScalarFunc
-struct MinValue
+namespace myTest
 {
-    constexpr auto operator()(auto const& a, auto const& b) const
+    // This functor des not support Simd and must be wrapped by @see ScalarFunc
+    struct MinValue
     {
-        return math::min(a, b);
-    }
-};
+        constexpr auto operator()(auto const& a, auto const& b) const
+        {
+            return math::min(a, b);
+        }
+    };
 
-template<>
-struct alpaka::onAcc::trait::FunctorToAtomicOp<MinValue>
-{
-    using type = alpaka::onAcc::AtomicMin;
-};
+    ALPAKA_FN_ACC void atomicInvoke(
+        MinValue const&,
+        alpaka::onAcc::concepts::Acc auto const& acc,
+        auto* dest,
+        auto const src)
+    {
+        onAcc::atomicMin(acc, dest, src);
+    }
+} // namespace myTest
 
 struct TestWithMdSpan
 {
@@ -224,7 +230,7 @@ TEMPLATE_LIST_TEST_CASE("transformReduce", "", TestBackends)
             TestWithMdSpan{}),
         std::make_tuple(
             std::numeric_limits<DataType>::max(),
-            std::make_pair(ScalarFunc{MinValue{}}, MinValue{}),
+            std::make_pair(ScalarFunc{myTest::MinValue{}}, myTest::MinValue{}),
             // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
             std::make_pair(std::plus{}, std::plus{}),
             TestWithMdSpan{}));
@@ -352,7 +358,7 @@ TEMPLATE_LIST_TEST_CASE("transformReduce generator", "", TestBackends)
             TestWithGenerator{}),
         std::make_tuple(
             std::numeric_limits<DataType>::max(),
-            std::make_pair(ScalarFunc{MinValue{}}, MinValue{}),
+            std::make_pair(ScalarFunc{myTest::MinValue{}}, myTest::MinValue{}),
             // we use variable.load() in the functor therefore we need to wrap the functor as StencilFunc
             std::make_pair(std::plus{}, std::plus{}),
             TestWithGenerator{}));

--- a/test/unit/algorithm/transformReduce.cpp
+++ b/test/unit/algorithm/transformReduce.cpp
@@ -63,7 +63,7 @@ struct ScalarOpWithAcc
 
 namespace myTest
 {
-    // This functor des not support Simd and must be wrapped by @see ScalarFunc
+    // This functor des not support Simd and must be wrapped by ScalarFunc
     struct MinValue
     {
         constexpr auto operator()(auto const& a, auto const& b) const


### PR DESCRIPTION
algorithms

The `onHost` reduce algorithms requires a definition how the processed type with the reduce functor can be expressed as atomic functions. This is currently a requirement by the algorithms. The old way was to define the atomic operation type only. This is not generic enouph to provide support for structured types or user defined types.
By switching to a function the user must spezialize it is now possible to work with complex reduction functors and types.

This is the required change if it was already used in the user code

```C++
namespace alpaka::onAcc::trait
{
  template<> 
  struct FunctorToAtomicOp<std::plus<>>{
         using type = alpaka::onAcc::AtomicAdd;
  };
}
```

must be changed to , in the namespace `alapka::onAcc::atomic` or in the namespace of the functor definition.

```C++
template<typename T>
ALPAKA_FN_ACC void atomicInvoke(std::plus<T> fn, concepts::Acc auto const& acc, auto* inOut, auto&&... args)
{
    atomicAdd(acc, inOut, ALPAKA_FORWARD(args)...);
}
```
