### PR TITLE
optimze compile time of alpaka

### DIFF
--- a/include/alpaka/KernelBundle.hpp
+++ b/include/alpaka/KernelBundle.hpp
@@ -9,7 +9,6 @@
 #include "alpaka/core/RemoveRestrict.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/config.hpp"
-#include "alpaka/onHost/demangledName.hpp"
 #include "alpaka/trait.hpp"
 #include "alpaka/utility.hpp"
 

--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -31,9 +31,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <iostream>
+#include <iosfwd>
 #include <ranges>
 #include <sstream>
+#include <string>
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/SimdMask.hpp
+++ b/include/alpaka/SimdMask.hpp
@@ -31,9 +31,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <iostream>
+#include <iosfwd>
 #include <ranges>
 #include <sstream>
+#include <string>
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -13,9 +13,10 @@
 #include <array>
 #include <concepts>
 #include <cstdint>
-#include <iostream>
+#include <iosfwd>
 #include <ranges>
 #include <sstream>
+#include <string>
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -8,7 +8,6 @@
 #include "alpaka/Simd.hpp"
 #include "alpaka/SimdWhereExpr.hpp"
 #include "alpaka/UniqueId.hpp"
-#include "alpaka/Vec.hpp"
 #include "alpaka/api/api.hpp"
 #include "alpaka/api/cpu.hpp"
 #include "alpaka/api/cuda/warp.hpp"

--- a/include/alpaka/api/host/Api.hpp
+++ b/include/alpaka/api/host/Api.hpp
@@ -5,13 +5,12 @@
 #pragma once
 
 #include "alpaka/api/host/cpuArchSize.hpp"
-#include "alpaka/api/host/hwloc/hwlocConfig.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/concepts.hpp"
 #include "alpaka/mem/trait.hpp"
 #include "alpaka/onHost/trait.hpp"
 
-#include <sstream>
+#include <string>
 
 namespace alpaka
 {

--- a/include/alpaka/onHost/DeviceSpec.hpp
+++ b/include/alpaka/onHost/DeviceSpec.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/api/api.hpp"
+#include "alpaka/api/host/hwloc/hwlocConfig.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/tag.hpp"
 

--- a/include/alpaka/onHost/Handle.hpp
+++ b/include/alpaka/onHost/Handle.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <iostream>
 #include <memory>
+#include <mutex>
 #include <type_traits>
 
 namespace alpaka::onHost

--- a/include/alpaka/onHost/demangledName.hpp
+++ b/include/alpaka/onHost/demangledName.hpp
@@ -6,7 +6,6 @@
 
 #include "alpaka/core/config.hpp"
 
-#include <regex>
 #include <source_location>
 #include <string>
 #include <string_view>
@@ -64,18 +63,46 @@ namespace alpaka::onHost
      */
     inline std::string simplifyFunctionSignature(std::string const& deName)
     {
-        // 1. Remove the type assignments in template parameters (e.g., T_DeviceKind = ...)
-        std::string simplified = std::regex_replace(deName, std::regex("<[^>]*=\\s*[^>]*>"), "<...>");
+        std::string simplified;
+        simplified.reserve(deName.size());
 
-        // 2. Remove redundant occurrences of "alpaka::" within the template arguments (keep it once)
-        simplified = std::regex_replace(simplified, std::regex("alpaka::(?![A-Za-z0-9_]+<)"), "");
+        int templateDepth = 0;
+        // Simplify nested templates by removing template arguments, e.g., <...>
+        for(char const c : deName)
+        {
+            if(c == '<')
+            {
+                if(templateDepth++ == 0)
+                    simplified += "<...>";
+                continue;
+            }
+            if(c == '>')
+            {
+                if(templateDepth > 0)
+                {
+                    --templateDepth;
+                    continue;
+                }
+            }
+            if(templateDepth > 0)
+                continue;
+            simplified += c;
+        }
 
-        // 3. Simplify nested templates by removing template arguments, e.g., <...>
-        simplified = std::regex_replace(simplified, std::regex("<[^>]*>"), "<...>");
-
-        // 4. Optionally remove remaining `alpaka::` namespaces if desired
-        simplified = std::regex_replace(simplified, std::regex("^(alpaka::)+"), "");
-
+        // Remove "alpaka::" from the signatures
+        std::string withoutAlpaka;
+        withoutAlpaka.reserve(simplified.size());
+        constexpr std::string_view alpakaNamespace = "alpaka::";
+        for(size_t i = 0; i < simplified.size();)
+        {
+            if(simplified.compare(i, alpakaNamespace.size(), alpakaNamespace) == 0)
+            {
+                i += alpakaNamespace.size();
+                continue;
+            }
+            withoutAlpaka += simplified[i++];
+        }
+        simplified = std::move(withoutAlpaka);
         return simplified;
     }
 


### PR DESCRIPTION
Optimize includes to reduce the compile time by around 12%. The biggest improve came from removing `#include <regex>` by manual parsing.
Change the implementation of `simplifyFunctionSignature()`, due to the manuel parsing some issues with the shortening are fixed and the compile time improved a lot.