### PR TITLE
fix `SimdPtr` shift operator

### DIFF
--- a/include/alpaka/SimdPtr.hpp
+++ b/include/alpaka/SimdPtr.hpp
@@ -81,22 +81,23 @@ namespace alpaka
          *
          * @{
          */
-        constexpr auto operator[](alpaka::concepts::IndexVec<IdxType, T_MdSpan::dim()> auto const& idx) const
+        constexpr auto operator[](
+            alpaka::concepts::IndexVec<typename IdxType::type, T_MdSpan::dim()> auto const& idx) const
         {
             constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(value_type));
             constexpr auto align = Alignment<valueAlignment>{};
-            return SimdPtr<T_MdSpan, T_IdxType, ALPAKA_TYPEOF(align), T_SimdWidth>{
+            return SimdPtr<T_MdSpan, IdxType, ALPAKA_TYPEOF(align), T_SimdWidth>{
                 static_cast<T_MdSpan>(*this),
                 idx + m_idx,
                 align,
                 T_SimdWidth{}};
         }
 
-        constexpr auto operator[](alpaka::concepts::IndexVec<IdxType, T_MdSpan::dim()> auto const& idx)
+        constexpr auto operator[](alpaka::concepts::IndexVec<typename IdxType::type, T_MdSpan::dim()> auto const& idx)
         {
             constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(value_type));
             constexpr auto align = Alignment<valueAlignment>{};
-            return SimdPtr<T_MdSpan, T_IdxType, ALPAKA_TYPEOF(align), T_SimdWidth>{
+            return SimdPtr<T_MdSpan, IdxType, ALPAKA_TYPEOF(align), T_SimdWidth>{
                 static_cast<T_MdSpan>(*this),
                 idx + m_idx,
                 align,


### PR DESCRIPTION
With #460 we broke the shift/stencil operator for `SimdPtr`.

A test case for the stencil access is in work but will not be part of this PR.
I am also evaluating if the `IdxType` in the template signature is required or if it is anyway, if not I will remove it in a separate PR.