### PR TITLE
remove `onAcc::Atomic*` functors

### DIFF
--- a/docs/snippets/cheatsheet/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet/cheatsheet.cpp
@@ -108,10 +108,10 @@ struct KernelWait
 
         int* ptr = nullptr;
         // BEGIN-CHEATSHEET-atomicAdd
-        // Operation: onAcc::AtomicAdd, onAcc::AtomicSub, onAcc::AtomicMin, onAcc::AtomicMax, onAcc::AtomicExch,
-        //            onAcc::AtomicInc, onAcc::AtomicDec, onAcc::AtomicAnd, onAcc::AtomicOr, onAcc::AtomicXor,
-        //            onAcc::AtomicCas
-        using Operation = onAcc::AtomicAdd;
+        // Operation: operation::Add, operation::Sub, operation::Min, operation::Max, operation::Exch,
+        //            operation::Inc, operation::Dec, operation::And, operation::Or, operation::Xor,
+        //            operation::Cas
+        using Operation = operation::Add;
         auto result = atomicOp<Operation>(acc, ptr, 1);
         // Also dedicated functions available, e.g.:
         auto old = onAcc::atomicAdd(acc, ptr, 1);

--- a/include/alpaka/api/host/atomic.hpp
+++ b/include/alpaka/api/host/atomic.hpp
@@ -6,9 +6,9 @@
 
 #include "alpaka/api/host/tag.hpp"
 #include "alpaka/core/config.hpp"
-#include "alpaka/onAcc/atomicOp.hpp"
 #include "alpaka/onAcc/internal/interface.hpp"
 #include "alpaka/onAcc/scope.hpp"
+#include "alpaka/operation.hpp"
 
 #include <array>
 #include <atomic>
@@ -54,9 +54,9 @@ namespace alpaka::onAcc
 
     namespace internalCompute
     {
-        //! The CPU accelerators AtomicAdd.
+        //! The CPU accelerators operation::Add.
         template<typename T, typename T_Scope>
-        struct Atomic::Op<AtomicAdd, internal::StlAtomic, T, T_Scope>
+        struct Atomic::Op<operation::Add, internal::StlAtomic, T, T_Scope>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -66,9 +66,9 @@ namespace alpaka::onAcc
             }
         };
 
-        //! The CPU accelerators AtomicSub.
+        //! The CPU accelerators operation::Sub.
         template<typename T, typename T_Scope>
-        struct Atomic::Op<AtomicSub, internal::StlAtomic, T, T_Scope>
+        struct Atomic::Op<alpaka::operation::Sub, internal::StlAtomic, T, T_Scope>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -78,9 +78,9 @@ namespace alpaka::onAcc
             }
         };
 
-        //! The CPU accelerators AtomicMin.
+        //! The CPU accelerators operation::Min.
         template<typename T, typename T_Scope>
-        struct Atomic::Op<AtomicMin, internal::StlAtomic, T, T_Scope>
+        struct Atomic::Op<alpaka::operation::Min, internal::StlAtomic, T, T_Scope>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -98,9 +98,9 @@ namespace alpaka::onAcc
             }
         };
 
-        //! The CPU accelerators AtomicMax.
+        //! The CPU accelerators operation::Max.
         template<typename T, typename T_Scope>
-        struct Atomic::Op<AtomicMax, internal::StlAtomic, T, T_Scope>
+        struct Atomic::Op<alpaka::operation::Max, internal::StlAtomic, T, T_Scope>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -118,9 +118,9 @@ namespace alpaka::onAcc
             }
         };
 
-        //! The CPU accelerators AtomicExch.
+        //! The CPU accelerators operation::Exch.
         template<typename T, typename T_Scope>
-        struct Atomic::Op<AtomicExch, internal::StlAtomic, T, T_Scope>
+        struct Atomic::Op<alpaka::operation::Exch, internal::StlAtomic, T, T_Scope>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -136,9 +136,9 @@ namespace alpaka::onAcc
             }
         };
 
-        //! The CPU accelerators AtomicInc.
+        //! The CPU accelerators operation::Inc.
         template<typename T, typename T_Scope>
-        struct Atomic::Op<AtomicInc, internal::StlAtomic, T, T_Scope>
+        struct Atomic::Op<alpaka::operation::Inc, internal::StlAtomic, T, T_Scope>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -154,9 +154,9 @@ namespace alpaka::onAcc
             }
         };
 
-        //! The CPU accelerators AtomicDec.
+        //! The CPU accelerators operation::Dec.
         template<typename T, typename T_Scope>
-        struct Atomic::Op<AtomicDec, internal::StlAtomic, T, T_Scope>
+        struct Atomic::Op<alpaka::operation::Dec, internal::StlAtomic, T, T_Scope>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -172,9 +172,9 @@ namespace alpaka::onAcc
             }
         };
 
-        //! The CPU accelerators AtomicAnd.
+        //! The CPU accelerators operation::And.
         template<typename T, typename T_Scope>
-        struct Atomic::Op<AtomicAnd, internal::StlAtomic, T, T_Scope>
+        struct Atomic::Op<alpaka::operation::And, internal::StlAtomic, T, T_Scope>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -184,9 +184,9 @@ namespace alpaka::onAcc
             }
         };
 
-        //! The CPU accelerators AtomicOr.
+        //! The CPU accelerators operation::Or.
         template<typename T, typename T_Scope>
-        struct Atomic::Op<AtomicOr, internal::StlAtomic, T, T_Scope>
+        struct Atomic::Op<alpaka::operation::Or, internal::StlAtomic, T, T_Scope>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -196,9 +196,9 @@ namespace alpaka::onAcc
             }
         };
 
-        //! The CPU accelerators AtomicXor.
+        //! The CPU accelerators operation::Xor.
         template<typename T, typename T_Scope>
-        struct Atomic::Op<AtomicXor, internal::StlAtomic, T, T_Scope>
+        struct Atomic::Op<alpaka::operation::Xor, internal::StlAtomic, T, T_Scope>
         {
             ALPAKA_FN_HOST static auto atomicOp(internal::StlAtomic const&, T* const addr, T const& value) -> T
             {
@@ -208,9 +208,9 @@ namespace alpaka::onAcc
             }
         };
 
-        //! The CPU accelerators AtomicCas.
+        //! The CPU accelerators operation::Cas.
         template<typename T, typename T_Scope>
-        struct Atomic::Op<AtomicCas, internal::StlAtomic, T, T_Scope>
+        struct Atomic::Op<alpaka::operation::Cas, internal::StlAtomic, T, T_Scope>
         {
             ALPAKA_FN_HOST static auto atomicOp(
                 internal::StlAtomic const&,

--- a/include/alpaka/api/syclGeneric/atomic.hpp
+++ b/include/alpaka/api/syclGeneric/atomic.hpp
@@ -6,9 +6,9 @@
 
 #include "alpaka/api/syclGeneric/tag.hpp"
 #include "alpaka/core/config.hpp"
-#include "alpaka/onAcc/atomicOp.hpp"
 #include "alpaka/onAcc/internal/interface.hpp"
 #include "alpaka/onAcc/scope.hpp"
+#include "alpaka/operation.hpp"
 
 #if ALPAKA_LANG_SYCL
 
@@ -72,7 +72,7 @@ namespace alpaka::onAcc::internalCompute
     // Add.
     //! The SYCL accelerator atomic operation.
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicAdd, onAcc::internal::SyclAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::Add, onAcc::internal::SyclAtomic, T, T_Scope>
     {
         static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "SYCL atomics do not support this type");
 
@@ -85,7 +85,7 @@ namespace alpaka::onAcc::internalCompute
     // Sub.
     //! The SYCL accelerator atomic operation.
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicSub, onAcc::internal::SyclAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::Sub, onAcc::internal::SyclAtomic, T, T_Scope>
     {
         static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "SYCL atomics do not support this type");
 
@@ -98,7 +98,7 @@ namespace alpaka::onAcc::internalCompute
     // Min.
     //! The SYCL accelerator atomic operation.
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicMin, onAcc::internal::SyclAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::Min, onAcc::internal::SyclAtomic, T, T_Scope>
     {
         static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "SYCL atomics do not support this type");
 
@@ -111,7 +111,7 @@ namespace alpaka::onAcc::internalCompute
     // Max.
     //! The SYCL accelerator atomic operation.
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicMax, onAcc::internal::SyclAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::Max, onAcc::internal::SyclAtomic, T, T_Scope>
     {
         static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "SYCL atomics do not support this type");
 
@@ -124,7 +124,7 @@ namespace alpaka::onAcc::internalCompute
     // Exch.
     //! The SYCL accelerator atomic operation.
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicExch, onAcc::internal::SyclAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::Exch, onAcc::internal::SyclAtomic, T, T_Scope>
     {
         static_assert(
             (std::is_integral_v<T> || std::is_floating_point_v<T>) and (sizeof(T) == 4 || sizeof(T) == 8),
@@ -139,7 +139,7 @@ namespace alpaka::onAcc::internalCompute
     // Inc.
     //! The SYCL accelerator atomic operation.
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicInc, onAcc::internal::SyclAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::Inc, onAcc::internal::SyclAtomic, T, T_Scope>
     {
         static_assert(
             std::is_unsigned_v<T> && (sizeof(T) == 4 || sizeof(T) == 8),
@@ -156,7 +156,7 @@ namespace alpaka::onAcc::internalCompute
     // Dec.
     //! The SYCL accelerator atomic operation.
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicDec, onAcc::internal::SyclAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::Dec, onAcc::internal::SyclAtomic, T, T_Scope>
     {
         static_assert(
             std::is_unsigned_v<T> && (sizeof(T) == 4 || sizeof(T) == 8),
@@ -173,7 +173,7 @@ namespace alpaka::onAcc::internalCompute
     // And.
     //! The SYCL accelerator atomic operation.
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicAnd, onAcc::internal::SyclAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::And, onAcc::internal::SyclAtomic, T, T_Scope>
     {
         static_assert(std::is_integral_v<T>, "Bitwise operations only supported for integral types.");
 
@@ -186,7 +186,7 @@ namespace alpaka::onAcc::internalCompute
     // Or.
     //! The SYCL accelerator atomic operation.
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicOr, onAcc::internal::SyclAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::Or, onAcc::internal::SyclAtomic, T, T_Scope>
     {
         static_assert(std::is_integral_v<T>, "Bitwise operations only supported for integral types.");
 
@@ -199,7 +199,7 @@ namespace alpaka::onAcc::internalCompute
     // Xor.
     //! The SYCL accelerator atomic operation.
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicXor, onAcc::internal::SyclAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::Xor, onAcc::internal::SyclAtomic, T, T_Scope>
     {
         static_assert(std::is_integral_v<T>, "Bitwise operations only supported for integral types.");
 
@@ -212,7 +212,7 @@ namespace alpaka::onAcc::internalCompute
     // Cas.
     //! The SYCL accelerator atomic operation.
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicCas, onAcc::internal::SyclAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::Cas, onAcc::internal::SyclAtomic, T, T_Scope>
     {
         static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "SYCL atomics do not support this type");
 

--- a/include/alpaka/api/unifiedCudaHip/atomic.hpp
+++ b/include/alpaka/api/unifiedCudaHip/atomic.hpp
@@ -8,9 +8,9 @@
 #include "alpaka/api/unifiedCudaHip/tag.hpp"
 #include "alpaka/core/Unreachable.hpp"
 #include "alpaka/core/config.hpp"
-#include "alpaka/onAcc/atomicOp.hpp"
 #include "alpaka/onAcc/internal/interface.hpp"
 #include "alpaka/onAcc/scope.hpp"
+#include "alpaka/operation.hpp"
 
 #include <limits>
 #include <type_traits>
@@ -82,7 +82,7 @@ namespace alpaka::onAcc::internalCompute
                     assumed = old;
                     T v = *(reinterpret_cast<T*>(&assumed));
                     TOp{}(&v, value);
-                    using Cas = Atomic::Op<AtomicCas, internal::CudaHipAtomic, EmulatedType, T_Scope>;
+                    using Cas = Atomic::Op<alpaka::operation::Cas, internal::CudaHipAtomic, EmulatedType, T_Scope>;
                     old = Cas::atomicOp(ctx, addressAsIntegralType, assumed, reinterpretValue(v));
                     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
                 } while(assumed != old);
@@ -90,9 +90,9 @@ namespace alpaka::onAcc::internalCompute
             }
         };
 
-        //! Emulate AtomicCas with equivalent unisigned integral type
+        //! Emulate operation::Cas with equivalent unisigned integral type
         template<typename T, typename T_Scope>
-        struct EmulateAtomic<AtomicCas, internal::CudaHipAtomic, T, T_Scope> : private EmulationBase
+        struct EmulateAtomic<alpaka::operation::Cas, internal::CudaHipAtomic, T, T_Scope> : private EmulationBase
         {
             static __device__ auto atomic(
                 internal::CudaHipAtomic const ctx,
@@ -105,30 +105,34 @@ namespace alpaka::onAcc::internalCompute
                 EmulatedType reinterpretedCompare = reinterpretValue(compare);
                 EmulatedType reinterpretedValue = reinterpretValue(value);
 
-                auto old = Atomic::Op<AtomicCas, internal::CudaHipAtomic, EmulatedType, T_Scope>::atomicOp(
-                    ctx,
-                    addressAsIntegralType,
-                    reinterpretedCompare,
-                    reinterpretedValue);
+                auto old
+                    = Atomic::Op<alpaka::operation::Cas, internal::CudaHipAtomic, EmulatedType, T_Scope>::atomicOp(
+                        ctx,
+                        addressAsIntegralType,
+                        reinterpretedCompare,
+                        reinterpretedValue);
 
                 return *(reinterpret_cast<T*>(&old));
             }
         };
 
-        //! Emulate AtomicSub with atomicAdd
+        //! Emulate operation::Sub with atomicAdd
         template<typename T, typename T_Scope>
-        struct EmulateAtomic<AtomicSub, internal::CudaHipAtomic, T, T_Scope>
+        struct EmulateAtomic<alpaka::operation::Sub, internal::CudaHipAtomic, T, T_Scope>
         {
             static __device__ auto atomic(internal::CudaHipAtomic const ctx, T* const addr, T const& value) -> T
             {
-                return Atomic::Op<AtomicAdd, internal::CudaHipAtomic, T, T_Scope>::atomicOp(ctx, addr, -value);
+                return Atomic::Op<alpaka::operation::Add, internal::CudaHipAtomic, T, T_Scope>::atomicOp(
+                    ctx,
+                    addr,
+                    -value);
             }
         };
 
-        //! AtomicDec can not be implemented for floating point types!
+        //! operation::Dec can not be implemented for floating point types!
         template<typename T, typename T_Scope>
         struct EmulateAtomic<
-            AtomicDec,
+            operation::Dec,
             internal::CudaHipAtomic,
             T,
             T_Scope,
@@ -136,15 +140,17 @@ namespace alpaka::onAcc::internalCompute
         {
             static __device__ auto atomic(internal::CudaHipAtomic const&, T* const, T const&) -> T
             {
-                static_assert(!sizeof(T), "EmulateAtomic<AtomicDec> is not supported for floating point data types!");
+                static_assert(
+                    !sizeof(T),
+                    "EmulateAtomic<alpaka::operation::Dec> is not supported for floating point data types!");
                 return T{};
             }
         };
 
-        //! AtomicInc can not be implemented for floating point types!
+        //! operation::Inc can not be implemented for floating point types!
         template<typename T, typename T_Scope>
         struct EmulateAtomic<
-            AtomicInc,
+            operation::Inc,
             internal::CudaHipAtomic,
             T,
             T_Scope,
@@ -152,15 +158,17 @@ namespace alpaka::onAcc::internalCompute
         {
             static __device__ auto atomic(internal::CudaHipAtomic const&, T* const, T const&) -> T
             {
-                static_assert(!sizeof(T), "EmulateAtomic<AtomicInc> is not supported for floating point data types!");
+                static_assert(
+                    !sizeof(T),
+                    "EmulateAtomic<alpaka::operation::Inc> is not supported for floating point data types!");
                 return T{};
             }
         };
 
-        //! AtomicAnd can not be implemented for floating point types!
+        //! operation::And can not be implemented for floating point types!
         template<typename T, typename T_Scope>
         struct EmulateAtomic<
-            AtomicAnd,
+            operation::And,
             internal::CudaHipAtomic,
             T,
             T_Scope,
@@ -168,15 +176,17 @@ namespace alpaka::onAcc::internalCompute
         {
             static __device__ auto atomic(internal::CudaHipAtomic const&, T* const, T const&) -> T
             {
-                static_assert(!sizeof(T), "EmulateAtomic<AtomicAnd> is not supported for floating point data types!");
+                static_assert(
+                    !sizeof(T),
+                    "EmulateAtomic<alpaka::operation::And> is not supported for floating point data types!");
                 return T{};
             }
         };
 
-        //! AtomicOr can not be implemented for floating point types!
+        //! operation::Or can not be implemented for floating point types!
         template<typename T, typename T_Scope>
         struct EmulateAtomic<
-            AtomicOr,
+            operation::Or,
             internal::CudaHipAtomic,
             T,
             T_Scope,
@@ -184,15 +194,17 @@ namespace alpaka::onAcc::internalCompute
         {
             static __device__ auto atomic(internal::CudaHipAtomic const&, T* const, T const&) -> T
             {
-                static_assert(!sizeof(T), "EmulateAtomic<AtomicOr> is not supported for floating point data types!");
+                static_assert(
+                    !sizeof(T),
+                    "EmulateAtomic<alpaka::operation::Or> is not supported for floating point data types!");
                 return T{};
             }
         };
 
-        //! AtomicXor can not be implemented for floating point types!
+        //! operation::Xor can not be implemented for floating point types!
         template<typename T, typename T_Scope>
         struct EmulateAtomic<
-            AtomicXor,
+            operation::Xor,
             internal::CudaHipAtomic,
             T,
             T_Scope,
@@ -200,7 +212,9 @@ namespace alpaka::onAcc::internalCompute
         {
             static __device__ auto atomic(internal::CudaHipAtomic const&, T* const, T const&) -> T
             {
-                static_assert(!sizeof(T), "EmulateAtomic<AtomicXor> is not supported for floating point data types!");
+                static_assert(
+                    !sizeof(T),
+                    "EmulateAtomic<alpaka::operation::Xor> is not supported for floating point data types!");
                 return T{};
             }
         };
@@ -248,7 +262,7 @@ namespace alpaka::onAcc::internalCompute
     };
 
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicCas, internal::CudaHipAtomic, T, T_Scope>
+    struct Atomic::Op<alpaka::operation::Cas, internal::CudaHipAtomic, T, T_Scope>
     {
         static __device__ auto atomicOp(
             [[maybe_unused]] internal::CudaHipAtomic const ctx,
@@ -258,32 +272,33 @@ namespace alpaka::onAcc::internalCompute
         {
             static_assert(
                 sizeof(T) == 4u || sizeof(T) == 8u,
-                "atomicOp<AtomicCas, internal::CudaHipAtomic, T>(atomic, addr, compare, value) is not "
+                "atomicOp<alpaka::operation::Cas, internal::CudaHipAtomic, T>(atomic, addr, compare, value) is not "
                 "supported! Only 64 and "
                 "32bit atomics are supported.");
 
-            if constexpr(::AlpakaBuiltInAtomic<AtomicCas, T, T_Scope>::value)
-                return ::AlpakaBuiltInAtomic<AtomicCas, T, T_Scope>::atomic(addr, compare, value);
+            if constexpr(::AlpakaBuiltInAtomic<alpaka::operation::Cas, T, T_Scope>::value)
+                return ::AlpakaBuiltInAtomic<alpaka::operation::Cas, T, T_Scope>::atomic(addr, compare, value);
 
             else if constexpr(std::is_same_v<unsigned long int, T>)
             {
-                if constexpr(sizeof(T) == 4u && ::AlpakaBuiltInAtomic<AtomicCas, unsigned int, T_Scope>::value)
-                    return ::AlpakaBuiltInAtomic<AtomicCas, unsigned int, T_Scope>::atomic(
+                if constexpr(
+                    sizeof(T) == 4u && ::AlpakaBuiltInAtomic<alpaka::operation::Cas, unsigned int, T_Scope>::value)
+                    return ::AlpakaBuiltInAtomic<alpaka::operation::Cas, unsigned int, T_Scope>::atomic(
                         reinterpret_cast<unsigned int*>(addr),
                         static_cast<unsigned int>(compare),
                         static_cast<unsigned int>(value));
                 else if constexpr(
                     sizeof(T) == 8u
-                    && ::AlpakaBuiltInAtomic<AtomicCas, unsigned long long int, T_Scope>::value) // LP64
+                    && ::AlpakaBuiltInAtomic<alpaka::operation::Cas, unsigned long long int, T_Scope>::value) // LP64
                 {
-                    return ::AlpakaBuiltInAtomic<AtomicCas, unsigned long long int, T_Scope>::atomic(
+                    return ::AlpakaBuiltInAtomic<alpaka::operation::Cas, unsigned long long int, T_Scope>::atomic(
                         reinterpret_cast<unsigned long long int*>(addr),
                         static_cast<unsigned long long int>(compare),
                         static_cast<unsigned long long int>(value));
                 }
             }
 
-            return detail::EmulateAtomic<AtomicCas, internal::CudaHipAtomic, T, T_Scope>::atomic(
+            return detail::EmulateAtomic<alpaka::operation::Cas, internal::CudaHipAtomic, T, T_Scope>::atomic(
                 ctx,
                 addr,
                 compare,

--- a/include/alpaka/api/unifiedCudaHip/atomicBuiltIn.hpp
+++ b/include/alpaka/api/unifiedCudaHip/atomicBuiltIn.hpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "alpaka/core/config.hpp"
-#include "alpaka/onAcc/atomicOp.hpp"
 #include "alpaka/onAcc/scope.hpp"
+#include "alpaka/operation.hpp"
 #include "alpaka/utility.hpp"
 
 #include <type_traits>
@@ -50,7 +50,7 @@ inline namespace alpakaGlobal
     // Cas.
     template<typename T, typename T_Scope>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicCas,
+        alpaka::operation::Cas,
         T,
         T_Scope,
         typename std::void_t<
@@ -65,7 +65,7 @@ inline namespace alpakaGlobal
 
     template<typename T>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicCas,
+        alpaka::operation::Cas,
         T,
         alpaka::onAcc::scope::Block,
         typename std::void_t<decltype(atomicCAS_block(
@@ -82,7 +82,7 @@ inline namespace alpakaGlobal
     // Add.
     template<typename T, typename T_Scope>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicAdd,
+        alpaka::operation::Add,
         T,
         T_Scope,
         typename std::void_t<decltype(atomicAdd(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -96,7 +96,7 @@ inline namespace alpakaGlobal
 
     template<typename T>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicAdd,
+        alpaka::operation::Add,
         T,
         alpaka::onAcc::scope::Block,
         typename std::void_t<decltype(atomicAdd_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -113,7 +113,7 @@ inline namespace alpakaGlobal
     // call the buildin method and instead use the atomicCAS emulation. For details see:
     // https://github.com/alpaka-group/alpaka/issues/1657
     template<>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicAdd, float, alpaka::onAcc::scope::Block> : std::false_type
+    struct AlpakaBuiltInAtomic<alpaka::operation::Add, float, alpaka::onAcc::scope::Block> : std::false_type
     {
     };
 #    endif
@@ -122,7 +122,7 @@ inline namespace alpakaGlobal
 
     template<typename T, typename T_Scope>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicSub,
+        alpaka::operation::Sub,
         T,
         T_Scope,
         typename std::void_t<decltype(atomicSub(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -136,7 +136,7 @@ inline namespace alpakaGlobal
 
     template<typename T>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicSub,
+        alpaka::operation::Sub,
         T,
         alpaka::onAcc::scope::Block,
         typename std::void_t<decltype(atomicSub_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -151,7 +151,7 @@ inline namespace alpakaGlobal
     // Min.
     template<typename T, typename T_Scope>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicMin,
+        alpaka::operation::Min,
         T,
         T_Scope,
         typename std::void_t<decltype(atomicMin(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -165,7 +165,7 @@ inline namespace alpakaGlobal
 
     template<typename T>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicMin,
+        alpaka::operation::Min,
         T,
         alpaka::onAcc::scope::Block,
         typename std::void_t<decltype(atomicMin_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -180,33 +180,33 @@ inline namespace alpakaGlobal
 // disable HIP atomicMin: see https://github.com/ROCm-Developer-Tools/hipamd/pull/40
 #    if (ALPAKA_LANG_HIP)
     template<typename T_Scope>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMin, float, T_Scope> : std::false_type
+    struct AlpakaBuiltInAtomic<alpaka::operation::Min, float, T_Scope> : std::false_type
     {
     };
 
     template<>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMin, float, alpaka::onAcc::scope::Block> : std::false_type
+    struct AlpakaBuiltInAtomic<alpaka::operation::Min, float, alpaka::onAcc::scope::Block> : std::false_type
     {
     };
 
     template<typename T_Scope>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMin, double, T_Scope> : std::false_type
+    struct AlpakaBuiltInAtomic<alpaka::operation::Min, double, T_Scope> : std::false_type
     {
     };
 
     template<>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMin, double, alpaka::onAcc::scope::Block> : std::false_type
+    struct AlpakaBuiltInAtomic<alpaka::operation::Min, double, alpaka::onAcc::scope::Block> : std::false_type
     {
     };
 
 #        if !__has_builtin(__hip_atomic_compare_exchange_strong)
     template<typename T_Scope>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMin, unsigned long long, T_Scope> : std::false_type
+    struct AlpakaBuiltInAtomic<alpaka::operation::Min, unsigned long long, T_Scope> : std::false_type
     {
     };
 
     template<>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMin, unsigned long long, alpaka::onAcc::scope::Block>
+    struct AlpakaBuiltInAtomic<alpaka::operation::Min, unsigned long long, alpaka::onAcc::scope::Block>
         : std::false_type
     {
     };
@@ -217,7 +217,7 @@ inline namespace alpakaGlobal
 
     template<typename T, typename T_Scope>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicMax,
+        alpaka::operation::Max,
         T,
         T_Scope,
         typename std::void_t<decltype(atomicMax(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -231,7 +231,7 @@ inline namespace alpakaGlobal
 
     template<typename T>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicMax,
+        alpaka::operation::Max,
         T,
         alpaka::onAcc::scope::Block,
         typename std::void_t<decltype(atomicMax_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -246,33 +246,33 @@ inline namespace alpakaGlobal
     // disable HIP atomicMax: see https://github.com/ROCm-Developer-Tools/hipamd/pull/40
 #    if (ALPAKA_LANG_HIP)
     template<typename T_Scope>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMax, float, T_Scope> : std::false_type
+    struct AlpakaBuiltInAtomic<alpaka::operation::Max, float, T_Scope> : std::false_type
     {
     };
 
     template<>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMax, float, alpaka::onAcc::scope::Block> : std::false_type
+    struct AlpakaBuiltInAtomic<alpaka::operation::Max, float, alpaka::onAcc::scope::Block> : std::false_type
     {
     };
 
     template<typename T_Scope>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMax, double, T_Scope> : std::false_type
+    struct AlpakaBuiltInAtomic<alpaka::operation::Max, double, T_Scope> : std::false_type
     {
     };
 
     template<>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMax, double, alpaka::onAcc::scope::Block> : std::false_type
+    struct AlpakaBuiltInAtomic<alpaka::operation::Max, double, alpaka::onAcc::scope::Block> : std::false_type
     {
     };
 
 #        if !__has_builtin(__hip_atomic_compare_exchange_strong)
     template<typename T_Scope>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMax, unsigned long long, T_Scope> : std::false_type
+    struct AlpakaBuiltInAtomic<alpaka::operation::Max, unsigned long long, T_Scope> : std::false_type
     {
     };
 
     template<>
-    struct AlpakaBuiltInAtomic<alpaka::onAcc::AtomicMax, unsigned long long, alpaka::onAcc::scope::Block>
+    struct AlpakaBuiltInAtomic<alpaka::operation::Max, unsigned long long, alpaka::onAcc::scope::Block>
         : std::false_type
     {
     };
@@ -284,7 +284,7 @@ inline namespace alpakaGlobal
 
     template<typename T, typename T_Scope>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicExch,
+        alpaka::operation::Exch,
         T,
         T_Scope,
         typename std::void_t<decltype(atomicExch(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -298,7 +298,7 @@ inline namespace alpakaGlobal
 
     template<typename T>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicExch,
+        alpaka::operation::Exch,
         T,
         alpaka::onAcc::scope::Block,
         typename std::void_t<decltype(atomicExch_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -314,7 +314,7 @@ inline namespace alpakaGlobal
 
     template<typename T, typename T_Scope>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicInc,
+        alpaka::operation::Inc,
         T,
         T_Scope,
         typename std::void_t<decltype(atomicInc(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -328,7 +328,7 @@ inline namespace alpakaGlobal
 
     template<typename T>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicInc,
+        alpaka::operation::Inc,
         T,
         alpaka::onAcc::scope::Block,
         typename std::void_t<decltype(atomicInc_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -344,7 +344,7 @@ inline namespace alpakaGlobal
 
     template<typename T, typename T_Scope>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicDec,
+        alpaka::operation::Dec,
         T,
         T_Scope,
         typename std::void_t<decltype(atomicDec(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -358,7 +358,7 @@ inline namespace alpakaGlobal
 
     template<typename T>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicDec,
+        alpaka::operation::Dec,
         T,
         alpaka::onAcc::scope::Block,
         typename std::void_t<decltype(atomicDec_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -374,7 +374,7 @@ inline namespace alpakaGlobal
 
     template<typename T, typename T_Scope>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicAnd,
+        alpaka::operation::And,
         T,
         T_Scope,
         typename std::void_t<decltype(atomicAnd(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -388,7 +388,7 @@ inline namespace alpakaGlobal
 
     template<typename T>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicAnd,
+        alpaka::operation::And,
         T,
         alpaka::onAcc::scope::Block,
         typename std::void_t<decltype(atomicAnd_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -404,7 +404,7 @@ inline namespace alpakaGlobal
 
     template<typename T, typename T_Scope>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicOr,
+        alpaka::operation::Or,
         T,
         T_Scope,
         typename std::void_t<decltype(atomicOr(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -418,7 +418,7 @@ inline namespace alpakaGlobal
 
     template<typename T>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicOr,
+        alpaka::operation::Or,
         T,
         alpaka::onAcc::scope::Block,
         typename std::void_t<decltype(atomicOr_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -434,7 +434,7 @@ inline namespace alpakaGlobal
 
     template<typename T, typename T_Scope>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicXor,
+        alpaka::operation::Xor,
         T,
         T_Scope,
         typename std::void_t<decltype(atomicXor(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
@@ -448,7 +448,7 @@ inline namespace alpakaGlobal
 
     template<typename T>
     struct AlpakaBuiltInAtomic<
-        alpaka::onAcc::AtomicXor,
+        alpaka::operation::Xor,
         T,
         alpaka::onAcc::scope::Block,
         typename std::void_t<decltype(atomicXor_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>

--- a/include/alpaka/onAcc/atomic.hpp
+++ b/include/alpaka/onAcc/atomic.hpp
@@ -8,9 +8,9 @@
 #include "alpaka/api/trait.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/onAcc/Acc.hpp"
-#include "alpaka/onAcc/atomicOp.hpp"
 #include "alpaka/onAcc/internal/interface.hpp"
 #include "alpaka/onAcc/scope.hpp"
+#include "alpaka/operation.hpp"
 
 #include <type_traits>
 
@@ -65,7 +65,7 @@ namespace alpaka::onAcc
     template<typename T, typename T_Scope = scope::Device>
     constexpr auto atomicAdd(auto const& acc, T* const addr, T const& value, T_Scope const hier = T_Scope()) -> T
     {
-        return atomicOp<AtomicAdd>(acc, addr, value, hier);
+        return atomicOp<operation::Add>(acc, addr, value, hier);
     }
 
     //! Executes an atomic sub operation.
@@ -76,7 +76,7 @@ namespace alpaka::onAcc
     template<typename T, typename T_Scope = scope::Device>
     constexpr auto atomicSub(auto const& acc, T* const addr, T const& value, T_Scope const hier = T_Scope()) -> T
     {
-        return atomicOp<AtomicSub>(acc, addr, value, hier);
+        return atomicOp<operation::Sub>(acc, addr, value, hier);
     }
 
     //! Executes an atomic min operation.
@@ -87,7 +87,7 @@ namespace alpaka::onAcc
     template<typename T, typename T_Scope = scope::Device>
     constexpr auto atomicMin(auto const& acc, T* const addr, T const& value, T_Scope const hier = T_Scope()) -> T
     {
-        return atomicOp<AtomicMin>(acc, addr, value, hier);
+        return atomicOp<operation::Min>(acc, addr, value, hier);
     }
 
     //! Executes an atomic max operation.
@@ -98,7 +98,7 @@ namespace alpaka::onAcc
     template<typename T, typename T_Scope = scope::Device>
     constexpr auto atomicMax(auto const& acc, T* const addr, T const& value, T_Scope const hier = T_Scope()) -> T
     {
-        return atomicOp<AtomicMax>(acc, addr, value, hier);
+        return atomicOp<operation::Max>(acc, addr, value, hier);
     }
 
     //! Executes an atomic exchange operation.
@@ -109,7 +109,7 @@ namespace alpaka::onAcc
     template<typename T, typename T_Scope = scope::Device>
     constexpr auto atomicExch(auto const& acc, T* const addr, T const& value, T_Scope const hier = T_Scope()) -> T
     {
-        return atomicOp<AtomicExch>(acc, addr, value, hier);
+        return atomicOp<operation::Exch>(acc, addr, value, hier);
     }
 
     //! Executes an atomic increment operation.
@@ -120,7 +120,7 @@ namespace alpaka::onAcc
     template<typename T, typename T_Scope = scope::Device>
     constexpr auto atomicInc(auto const& acc, T* const addr, T const& value, T_Scope const hier = T_Scope()) -> T
     {
-        return atomicOp<AtomicInc>(acc, addr, value, hier);
+        return atomicOp<operation::Inc>(acc, addr, value, hier);
     }
 
     //! Executes an atomic decrement operation.
@@ -131,7 +131,7 @@ namespace alpaka::onAcc
     template<typename T, typename T_Scope = scope::Device>
     constexpr auto atomicDec(auto const& acc, T* const addr, T const& value, T_Scope const hier = T_Scope()) -> T
     {
-        return atomicOp<AtomicDec>(acc, addr, value, hier);
+        return atomicOp<operation::Dec>(acc, addr, value, hier);
     }
 
     //! Executes an atomic and operation.
@@ -142,7 +142,7 @@ namespace alpaka::onAcc
     template<typename T, typename T_Scope = scope::Device>
     constexpr auto atomicAnd(auto const& acc, T* const addr, T const& value, T_Scope const hier = T_Scope()) -> T
     {
-        return atomicOp<AtomicAnd>(acc, addr, value, hier);
+        return atomicOp<operation::And>(acc, addr, value, hier);
     }
 
     //! Executes an atomic or operation.
@@ -153,7 +153,7 @@ namespace alpaka::onAcc
     template<typename T, typename T_Scope = scope::Device>
     constexpr auto atomicOr(auto const& acc, T* const addr, T const& value, T_Scope const hier = T_Scope()) -> T
     {
-        return atomicOp<AtomicOr>(acc, addr, value, hier);
+        return atomicOp<operation::Or>(acc, addr, value, hier);
     }
 
     //! Executes an atomic xor operation.
@@ -164,7 +164,7 @@ namespace alpaka::onAcc
     template<typename T, typename T_Scope = scope::Device>
     constexpr auto atomicXor(auto const& acc, T* const addr, T const& value, T_Scope const hier = T_Scope()) -> T
     {
-        return atomicOp<AtomicXor>(acc, addr, value, hier);
+        return atomicOp<operation::Xor>(acc, addr, value, hier);
     }
 
     //! Executes an atomic compare-and-swap operation.
@@ -181,7 +181,7 @@ namespace alpaka::onAcc
         T const& value,
         T_Scope const hier = T_Scope()) -> T
     {
-        return atomicOp<AtomicCas>(acc, addr, compare, value, hier);
+        return atomicOp<operation::Cas>(acc, addr, compare, value, hier);
     }
 
     namespace atomic

--- a/include/alpaka/onAcc/internal/atomic.hpp
+++ b/include/alpaka/onAcc/internal/atomic.hpp
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "alpaka/onAcc/atomicOp.hpp"
 #include "alpaka/onAcc/internal/interface.hpp"
+#include "alpaka/operation.hpp"
 
 namespace alpaka::onAcc::internal
 {
@@ -30,11 +30,11 @@ namespace alpaka::onAcc::internalCompute
     };
 
     template<typename T, typename T_Scope>
-    struct Atomic::Op<AtomicCas, internal::NonAtomic, T, T_Scope>
+    struct Atomic::Op<operation::Cas, internal::NonAtomic, T, T_Scope>
     {
         static auto atomicOp(internal::NonAtomic const&, T* const addr, T const& compare, T const& value) -> T
         {
-            return AtomicCas{}(addr, compare, value);
+            return operation::Cas{}(addr, compare, value);
         }
     };
 } // namespace alpaka::onAcc::internalCompute

--- a/include/alpaka/operation.hpp
+++ b/include/alpaka/operation.hpp
@@ -10,10 +10,16 @@
 #include <algorithm>
 #include <type_traits>
 
-namespace alpaka::onAcc
+/** Contains functors with operation following the atomic operation semantics.
+ *
+ * @attention The operations itself are not atomic, only the argument interface follows corresponding atomic
+ * operations. The argument updated is always hand in as pointer.
+ *
+ */
+namespace alpaka::operation
 {
     //! The addition function object.
-    struct AtomicAdd
+    struct Add
     {
         //! \return The old value of addr.
         template<typename T>
@@ -34,7 +40,7 @@ namespace alpaka::onAcc
     };
 
     //! The subtraction function object.
-    struct AtomicSub
+    struct Sub
     {
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -56,7 +62,7 @@ namespace alpaka::onAcc
     };
 
     //! The minimum function object.
-    struct AtomicMin
+    struct Min
     {
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -71,7 +77,7 @@ namespace alpaka::onAcc
     };
 
     //! The maximum function object.
-    struct AtomicMax
+    struct Max
     {
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -86,7 +92,7 @@ namespace alpaka::onAcc
     };
 
     //! The exchange function object.
-    struct AtomicExch
+    struct Exch
     {
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -101,7 +107,7 @@ namespace alpaka::onAcc
     };
 
     //! The increment function object.
-    struct AtomicInc
+    struct Inc
     {
         //! Increments up to value, then reset to 0.
         //!
@@ -118,7 +124,7 @@ namespace alpaka::onAcc
     };
 
     //! The decrement function object.
-    struct AtomicDec
+    struct Dec
     {
         //! Decrement down to 0, then reset to value.
         //!
@@ -135,7 +141,7 @@ namespace alpaka::onAcc
     };
 
     //! The and function object.
-    struct AtomicAnd
+    struct And
     {
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -150,7 +156,7 @@ namespace alpaka::onAcc
     };
 
     //! The or function object.
-    struct AtomicOr
+    struct Or
     {
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -165,7 +171,7 @@ namespace alpaka::onAcc
     };
 
     //! The exclusive or function object.
-    struct AtomicXor
+    struct Xor
     {
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -180,9 +186,9 @@ namespace alpaka::onAcc
     };
 
     //! The compare and swap function object.
-    struct AtomicCas
+    struct Cas
     {
-        //! AtomicCas for non floating point values
+        //! Cas for non floating point values
         // \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename T, std::enable_if_t<!std::is_floating_point_v<T>, bool> = true>
@@ -196,13 +202,13 @@ namespace alpaka::onAcc
             return old;
         }
 
-        //! AtomicCas for floating point values
+        //! Cas for floating point values
         // \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
         ALPAKA_FN_HOST_ACC auto operator()(T* addr, T const& compare, T const& value) const -> T
         {
-            static_assert(sizeof(T) == 4u || sizeof(T) == 8u, "AtomicCas is supporting only 32bit and 64bit values!");
+            static_assert(sizeof(T) == 4u || sizeof(T) == 8u, "Cas is supporting only 32bit and 64bit values!");
             // Type to reinterpret too to perform the bit comparison
             using BitType = std::conditional_t<sizeof(T) == 4u, unsigned int, unsigned long long>;
 
@@ -228,4 +234,4 @@ namespace alpaka::onAcc
             return old;
         }
     };
-} // namespace alpaka::onAcc
+} // namespace alpaka::operation

--- a/test/unit/atomic/atomic.cpp
+++ b/test/unit/atomic/atomic.cpp
@@ -113,7 +113,7 @@ constexpr auto testAtomicCas(TAcc const& acc, bool* success, T& operand, T opera
         {
             operand = operandOrig;
             T const ret
-                = alpaka::onAcc::atomicOp<alpaka::onAcc::AtomicCas>(acc, &operand, compare, value, T_AtomicScope{});
+                = alpaka::onAcc::atomicOp<alpaka::operation::Cas>(acc, &operand, compare, value, T_AtomicScope{});
             ALPAKA_CHECK(*success, equals(operandOrig, ret));
             ALPAKA_CHECK(*success, equals(operand, reference));
         }
@@ -132,7 +132,7 @@ constexpr auto testAtomicCas(TAcc const& acc, bool* success, T& operand, T opera
         {
             operand = operandOrig;
             T const ret
-                = alpaka::onAcc::atomicOp<alpaka::onAcc::AtomicCas>(acc, &operand, compare, value, T_AtomicScope{});
+                = alpaka::onAcc::atomicOp<alpaka::operation::Cas>(acc, &operand, compare, value, T_AtomicScope{});
             ALPAKA_CHECK(*success, equals(operandOrig, ret));
             ALPAKA_CHECK(*success, equals(operand, reference));
         }

--- a/test/unit/atomic/atomicHelpers.hpp
+++ b/test/unit/atomic/atomicHelpers.hpp
@@ -23,7 +23,7 @@
 #define ALPAKA_MAKE_ATOMIC_TEST_FUNCTOR(OpName)                                                                       \
     struct OpName                                                                                                     \
     {                                                                                                                 \
-        using Op = alpaka::onAcc::Atomic##OpName;                                                                     \
+        using Op = alpaka::operation::OpName;                                                                         \
                                                                                                                       \
         static constexpr auto atomic(auto&&... args)                                                                  \
         {                                                                                                             \


### PR DESCRIPTION
The functors `onAcc::Atomic*` was taken over from alpaka mainline, the issue with them is that they are not atomic and the name is missleading. In alpaka mainline users tried to use them to perfrom atomic operations.

This refactoring is moving them into `alpaka::operator` to marke tha they are usable on `onHost` and `onAcc`.
A documentation string of the namespace adn by removing `Atomic` from the name the missinterpretation should not happen again.