### PR TITLE
throw error in constructor of executor if threadspec is unsupported

### DIFF
--- a/include/alpaka/api/host/exec/OmpBlocks.hpp
+++ b/include/alpaka/api/host/exec/OmpBlocks.hpp
@@ -35,14 +35,15 @@ namespace alpaka::onHost
                 , m_numaIdx{numaIdx}
                 , m_setThreadAffinity{setThreadAffinity}
             {
+                if(m_threadBlocking.getNumThreads().product() != 1u)
+                {
+                    throw std::runtime_error("Thread block extent must be 1.");
+                }
             }
 
             void operator()(auto const& kernelBundle, auto const& dict) const
             {
                 using NumThreadsVecType = typename T_ThreadSpec::NumThreadsVecType;
-
-                if(m_threadBlocking.getNumThreads().product() != 1u)
-                    throw std::runtime_error("Thread block extent must be 1.");
 #    pragma omp parallel
                 {
                     if(m_setThreadAffinity)

--- a/include/alpaka/api/host/exec/Serial.hpp
+++ b/include/alpaka/api/host/exec/Serial.hpp
@@ -32,6 +32,10 @@ namespace alpaka::onHost
                 , m_numaIdx{numaIdx}
                 , m_setThreadAffinity{setThreadAffinity}
             {
+                if(m_threadBlocking.getNumThreads().product() != 1u)
+                {
+                    throw std::runtime_error("Thread block extent must be 1.");
+                }
             }
 
             void operator()(auto const& kernelBundle, auto const& dict) const

--- a/include/alpaka/api/host/exec/TbbBlocks.hpp
+++ b/include/alpaka/api/host/exec/TbbBlocks.hpp
@@ -38,13 +38,14 @@ namespace alpaka::onHost
                 , m_numaIdx{numaIdx}
                 , m_setThreadAffinity{setThreadAffinity}
             {
+                if(m_threadBlocking.getNumThreads().product() != 1u)
+                {
+                    throw std::runtime_error("Thread block extent must be 1.");
+                }
             }
 
             void operator()(auto const& kernelBundle, auto const& dict) const
             {
-                if(m_threadBlocking.getNumThreads().product() != 1u)
-                    throw std::runtime_error("Thread block extent must be 1.");
-
                 auto blockCount = m_threadBlocking.getNumBlocks();
 
                 constexpr uint32_t simdWidth


### PR DESCRIPTION
If we define an executor with an incorrect thread spec (for example using a thread spec with multiple threads with a sequential executor) we should throw. 
Currently we throw in the call operator, which when using an async queue, throws the exception, but it is discarded along with the future, so it is not correctly propagated.
We can instead throw in the constructor, before it is handed to the async queue.
Also adds missing exception in serial backend.