### PR TITLE
Add function to get default executor

### DIFF
--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -531,13 +531,12 @@ namespace alpaka::onHost
                                && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
-                auto executors = supportedExecutors(getDevice(queue), exec::allExecutors);
                 // avoid that we pass a SharedBuffer and convert non alpaka data views
                 alpaka::concepts::IView<T_Value> auto dataView = makeView(dest);
 
                 alpaka::internal::generic::fill(
                     queue,
-                    std::get<0>(executors),
+                    defaultExecutor(getDevice(queue)),
                     dataView.getSubView(extents),
                     elementValue);
             }

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -179,11 +179,14 @@ namespace alpaka::onHost::internal
             requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
                      && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
         {
-            auto executors = supportedExecutors(getDevice(queue), exec::allExecutors);
             // avoid that we pass a SharedBuffer and convert non alpaka data views
             auto dataView = makeView(dest);
 
-            alpaka::internal::generic::fill(queue, std::get<0>(executors), dataView.getSubView(extents), elementValue);
+            alpaka::internal::generic::fill(
+                queue,
+                defaultExecutor(getDevice(queue)),
+                dataView.getSubView(extents),
+                elementValue);
         }
     };
 

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -700,13 +700,12 @@ namespace alpaka::onHost
                          && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
-                auto executors = supportedExecutors(getDevice(queue), exec::allExecutors);
                 // avoid that we pass a SharedBuffer and convert non alpaka data views
                 auto dataView = makeView(dest);
 
                 alpaka::internal::generic::fill(
                     queue,
-                    std::get<0>(executors),
+                    defaultExecutor(getDevice(queue)),
                     dataView.getSubView(extents),
                     elementValue);
             }

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -114,20 +114,20 @@ namespace alpaka::onHost
                 isFrameSpec_v<ALPAKA_TYPEOF(launchCfg)>
                 && ALPAKA_TYPEOF(launchCfg)::getExecutor() == alpaka::exec::anyExecutor)
             {
-                auto executors
-                    = alpaka::onHost::supportedExecutors(internal::getDevice(*m_queue.get()), exec::allExecutors);
-                FrameSpec frameSpecWithExecutor
-                    = FrameSpec{launchCfg.getNumFrames(), launchCfg.getFrameExtents(), std::get<0>(executors)};
+                FrameSpec frameSpecWithExecutor = FrameSpec{
+                    launchCfg.getNumFrames(),
+                    launchCfg.getFrameExtents(),
+                    alpaka::onHost::defaultExecutor(internal::getDevice(*m_queue.get()))};
                 internal::enqueue(*m_queue.get(), frameSpecWithExecutor, kernelBundle);
             }
             else if constexpr(
                 isThreadSpec_v<ALPAKA_TYPEOF(launchCfg)>
                 && ALPAKA_TYPEOF(launchCfg)::getExecutor() == alpaka::exec::anyExecutor)
             {
-                auto executors
-                    = alpaka::onHost::supportedExecutors(internal::getDevice(*m_queue.get()), exec::allExecutors);
-                ThreadSpec threadSpecWithExecutor
-                    = ThreadSpec{launchCfg.getNumBlocks(), launchCfg.getNumThreads(), std::get<0>(executors)};
+                ThreadSpec threadSpecWithExecutor = ThreadSpec{
+                    launchCfg.getNumBlocks(),
+                    launchCfg.getNumThreads(),
+                    alpaka::onHost::defaultExecutor(internal::getDevice(*m_queue.get()))};
                 internal::enqueue(*m_queue.get(), threadSpecWithExecutor, kernelBundle);
             }
             else

--- a/include/alpaka/onHost/algo/concurrent.hpp
+++ b/include/alpaka/onHost/algo/concurrent.hpp
@@ -51,10 +51,9 @@ namespace alpaka::onHost
     {
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
             internal::concurrent<T_DataType>(
                 queue,
-                std::get<0>(availableExecutors),
+                defaultExecutor(queue.getDevice()),
                 extents,
                 ALPAKA_FORWARD(fn),
                 ALPAKA_FORWARD(inOut)...);
@@ -74,10 +73,9 @@ namespace alpaka::onHost
         auto&& fn,
         alpaka::concepts::IDataSource auto&&... inOut)
     {
-        auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         internal::concurrent<T_DataType>(
             queue,
-            std::get<0>(executor),
+            defaultExecutor(queue.getDevice()),
             extents,
             ALPAKA_FORWARD(fn),
             ALPAKA_FORWARD(inOut)...);

--- a/include/alpaka/onHost/algo/iota.hpp
+++ b/include/alpaka/onHost/algo/iota.hpp
@@ -41,10 +41,9 @@ namespace alpaka::onHost
     {
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
             internal::iota(
                 queue,
-                std::get<0>(availableExecutors),
+                defaultExecutor(queue.getDevice()),
                 onHost::getExtents(out0),
                 initValue,
                 ALPAKA_FORWARD(out0),
@@ -76,10 +75,9 @@ namespace alpaka::onHost
             && std::conjunction_v<
                 std::is_convertible<T_DataType, typename alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(outOther)>>...>)
     {
-        auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         internal::iota<T_DataType>(
             queue,
-            std::get<0>(executor),
+            defaultExecutor(queue.getDevice()),
             onHost::getExtents(out0),
             initValue,
             ALPAKA_FORWARD(out0),

--- a/include/alpaka/onHost/algo/reduce.hpp
+++ b/include/alpaka/onHost/algo/reduce.hpp
@@ -36,10 +36,9 @@ namespace alpaka::onHost
     {
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
             internal::transformReduce(
                 queue,
-                std::get<0>(availableExecutors),
+                defaultExecutor(queue.getDevice()),
                 neutralElement,
                 out,
                 ALPAKA_FORWARD(binaryReduceFn),
@@ -70,8 +69,13 @@ namespace alpaka::onHost
         alpaka::concepts::IDataSource auto&& in)
         requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
     {
-        auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
-        reduce(queue, std::get<0>(executor), neutralElement, out, ALPAKA_FORWARD(binaryReduceFn), ALPAKA_FORWARD(in));
+        reduce(
+            queue,
+            defaultExecutor(queue.getDevice()),
+            neutralElement,
+            out,
+            ALPAKA_FORWARD(binaryReduceFn),
+            ALPAKA_FORWARD(in));
     }
 
     /** @} */

--- a/include/alpaka/onHost/algo/scan.hpp
+++ b/include/alpaka/onHost/algo/scan.hpp
@@ -52,11 +52,10 @@ namespace alpaka::onHost
         auto devAcc = queue.getDevice();
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
             internal::scan<internal::INCLUSIVE_SCAN>(
                 queue,
                 devAcc,
-                std::get<0>(availableExecutors),
+                defaultExecutor(devAcc),
                 buffer,
                 outputVec,
                 inputVec);
@@ -74,13 +73,7 @@ namespace alpaka::onHost
         auto devAcc = queue.getDevice();
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
-            internal::scan<internal::INCLUSIVE_SCAN>(
-                queue,
-                devAcc,
-                std::get<0>(availableExecutors),
-                outputVec,
-                inputVec);
+            internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, defaultExecutor(devAcc), outputVec, inputVec);
         }
         else
             internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, outputVec, inputVec);
@@ -109,14 +102,7 @@ namespace alpaka::onHost
         auto devAcc = queue.getDevice();
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
-            internal::scan<internal::INCLUSIVE_SCAN>(
-                queue,
-                devAcc,
-                std::get<0>(availableExecutors),
-                buffer,
-                dataVec,
-                dataVec);
+            internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, defaultExecutor(devAcc), buffer, dataVec, dataVec);
         }
         else
             internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, buffer, dataVec, dataVec);
@@ -130,8 +116,7 @@ namespace alpaka::onHost
         auto devAcc = queue.getDevice();
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
-            internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, std::get<0>(availableExecutors), dataVec, dataVec);
+            internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, defaultExecutor(devAcc), dataVec, dataVec);
         }
         else
             internal::scan<internal::INCLUSIVE_SCAN>(queue, devAcc, exec, dataVec, dataVec);
@@ -162,11 +147,10 @@ namespace alpaka::onHost
         auto devAcc = queue.getDevice();
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
             internal::scan<internal::EXCLUSIVE_SCAN>(
                 queue,
                 devAcc,
-                std::get<0>(availableExecutors),
+                defaultExecutor(devAcc),
                 buffer,
                 outputVec,
                 inputVec);
@@ -184,13 +168,7 @@ namespace alpaka::onHost
         auto devAcc = queue.getDevice();
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
-            internal::scan<internal::EXCLUSIVE_SCAN>(
-                queue,
-                devAcc,
-                std::get<0>(availableExecutors),
-                outputVec,
-                inputVec);
+            internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, defaultExecutor(devAcc), outputVec, inputVec);
         }
         else
             internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, outputVec, inputVec);
@@ -219,14 +197,7 @@ namespace alpaka::onHost
         auto devAcc = queue.getDevice();
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
-            internal::scan<internal::EXCLUSIVE_SCAN>(
-                queue,
-                devAcc,
-                std::get<0>(availableExecutors),
-                buffer,
-                dataVec,
-                dataVec);
+            internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, defaultExecutor(devAcc), buffer, dataVec, dataVec);
         }
         else
             internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, buffer, dataVec, dataVec);
@@ -240,8 +211,7 @@ namespace alpaka::onHost
         auto devAcc = queue.getDevice();
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
-            internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, std::get<0>(availableExecutors), dataVec, dataVec);
+            internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, defaultExecutor(devAcc), dataVec, dataVec);
         }
         else
             internal::scan<internal::EXCLUSIVE_SCAN>(queue, devAcc, exec, dataVec, dataVec);

--- a/include/alpaka/onHost/algo/transform.hpp
+++ b/include/alpaka/onHost/algo/transform.hpp
@@ -57,10 +57,9 @@ namespace alpaka::onHost
     {
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
             internal::transform(
                 queue,
-                std::get<0>(availableExecutors),
+                defaultExecutor(queue.getDevice()),
                 ALPAKA_FORWARD(out),
                 ALPAKA_FORWARD(fn),
                 ALPAKA_FORWARD(in)...);
@@ -80,8 +79,12 @@ namespace alpaka::onHost
         auto&& fn,
         alpaka::concepts::IDataSource auto&&... in)
     {
-        auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
-        transform(queue, std::get<0>(executor), ALPAKA_FORWARD(out), ALPAKA_FORWARD(fn), ALPAKA_FORWARD(in)...);
+        transform(
+            queue,
+            defaultExecutor(queue.getDevice()),
+            ALPAKA_FORWARD(out),
+            ALPAKA_FORWARD(fn),
+            ALPAKA_FORWARD(in)...);
     }
 
     /** @} */

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -69,10 +69,9 @@ namespace alpaka::onHost
     {
         if constexpr(exec == alpaka::exec::anyExecutor)
         {
-            auto availableExecutors = supportedExecutors(queue.getDevice(), exec::allExecutors);
             internal::transformReduce(
                 queue,
-                std::get<0>(availableExecutors),
+                defaultExecutor(queue.getDevice()),
                 neutralElement,
                 out,
                 ALPAKA_FORWARD(binaryReduceFn),
@@ -104,10 +103,9 @@ namespace alpaka::onHost
         alpaka::concepts::IDataSource auto&&... in)
         requires(std::same_as<DataType, alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>>)
     {
-        auto executor = supportedExecutors(queue.getDevice(), exec::allExecutors);
         transformReduce(
             queue,
-            std::get<0>(executor),
+            defaultExecutor(queue.getDevice()),
             neutralElement,
             out,
             ALPAKA_FORWARD(binaryReduceFn),

--- a/include/alpaka/onHost/trait.hpp
+++ b/include/alpaka/onHost/trait.hpp
@@ -141,6 +141,15 @@ namespace alpaka::onHost
             listOfExecutors);
     }
 
+    /** Select a default executor for the given device.
+     *
+     * Picks the first executor (with the most parallelism) supported by the device out of all known executors.
+     */
+    constexpr auto defaultExecutor(internal::concepts::DeviceHandle auto deviceHandle)
+    {
+        return std::get<0>(supportedExecutors(deviceHandle, exec::allExecutors));
+    }
+
     constexpr auto supportedDevices(auto const api)
     {
         return meta::filter(


### PR DESCRIPTION
- [x] Needs to be rebased after #555 is merged 

Moves the selection of the default executor to its own function and uses it