### PR TITLE
Add `alpaka_DOCS=ON` to CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,8 @@
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "alpaka_TESTS": "ON",
         "alpaka_EXAMPLES": "ON",
-        "alpaka_BENCHMARKS": "ON"
+        "alpaka_BENCHMARKS": "ON",
+        "alpaka_DOCS": "ON"
       }
     },
     {


### PR DESCRIPTION
Activate documentation snippet compilation for the CMake presets.
I assume we missed it in the past.