### PR TITLE
refactor `onHost::getFrameSpec()`

### DIFF
--- a/docs/snippets/cheatsheet/cheatsheet.cpp
+++ b/docs/snippets/cheatsheet/cheatsheet.cpp
@@ -379,12 +379,14 @@ auto main() -> int
 
         {
             // BEGIN-CHEATSHEET-autoFrameSpec
+            // Provides kernel start parameters sutable for the device and executor
+            onHost::concepts::FrameSpec auto frameSpec = onHost::getFrameSpec(device, exec::anyExecutor, extentMd);
             // DataType is used to optimize the kernel parameters for working on data of this type
-            onHost::concepts::FrameSpec auto frameSpec
-                = onHost::getFrameSpec<DataType>(device, exec::anyExecutor, extentMd);
+            onHost::concepts::FrameSpec auto simdFrameSpec
+                = onHost::getSimdFrameSpec<DataType>(device, exec::anyExecutor, extentMd);
             // END-CHEATSHEET-autoFrameSpec
 
-            unused(frameSpec);
+            unused(frameSpec, simdFrameSpec);
         }
 
         {

--- a/docs/snippets/dataStorage/datastorage_writeable_datasource.cpp
+++ b/docs/snippets/dataStorage/datastorage_writeable_datasource.cpp
@@ -15,7 +15,7 @@ alpaka::onHost::SharedBuffer in = alpaka::onHost::alloc<int>(dev, extents);
 alpaka::onHost::SharedBuffer out = alpaka::onHost::alloc<int>(dev, extents);
 
 alpaka::onHost::concepts::FrameSpec auto frameSpec
-    = alpaka::onHost::getFrameSpec<int>(dev, alpaka::exec::anyExecutor, extents);
+    = alpaka::onHost::getFrameSpec(dev, alpaka::exec::anyExecutor, extents);
 
 // ===== End: main first part =====
 

--- a/docs/snippets/example/050_kernel.cpp
+++ b/docs/snippets/example/050_kernel.cpp
@@ -67,8 +67,7 @@ TEMPLATE_LIST_TEST_CASE("tutorial kernel intro vector add", "[docs]", docs::test
     /* Let alpaka calculate a well-functioning `frameSpec` for you.
      * This assumes that you are using `onAcc::makeIdxMap` in the kernel.
      */
-    onHost::concepts::FrameSpec auto frameSpec
-        = onHost::getFrameSpec<int>(device, exec::anyExecutor, Vec{numElements});
+    onHost::concepts::FrameSpec auto frameSpec = onHost::getFrameSpec(device, exec::anyExecutor, Vec{numElements});
 
     /* Create a kernel object and enqueue it along with the `frameSpec´ and kernel arguments.
      * Depending on how many tasks are still in the queue, the kernel may be executed immediately or after a delay.

--- a/docs/snippets/example/080_multidim.cpp
+++ b/docs/snippets/example/080_multidim.cpp
@@ -65,7 +65,7 @@ TEMPLATE_LIST_TEST_CASE("tutorial multidimensional stencil kernel", "[docs]", do
     onHost::memset(queue, outBuffer, 0x00);
 
     // BEGIN-TUTORIAL-multidimFrameSpec
-    onHost::concepts::FrameSpec auto frameSpec = onHost::getFrameSpec<int>(device, exec::anyExecutor, problemExtents);
+    onHost::concepts::FrameSpec auto frameSpec = onHost::getFrameSpec(device, exec::anyExecutor, problemExtents);
     // END-TUTORIAL-multidimFrameSpec
 
     // BEGIN-TUTORIAL-multidimKernelLaunch

--- a/example/randomInit/src/randomInit.cpp
+++ b/example/randomInit/src/randomInit.cpp
@@ -205,7 +205,7 @@ bool testRandomInitKernels(
     // Frame size
 
     // Launch the 1-dimensional kernel with scalar size
-    auto frameSpec = alpaka::onHost::getFrameSpec<T_Data>(device, computeExec, alpaka::Vec{blockSize});
+    auto frameSpec = alpaka::onHost::getFrameSpec(device, computeExec, alpaka::Vec{blockSize});
 
     // TEST - 1: Philox Generator generates integer random numbers
     std::cout << "- Testing RandomInitKernel with a grid of " << frameSpec << "\n";

--- a/example/randomInit/src/randomInitNormal.hpp
+++ b/example/randomInit/src/randomInitNormal.hpp
@@ -138,7 +138,7 @@ int exampleDispatch(auto const cfg, uint32_t numElements, auto const& mean, auto
     // Allocate output host and device buffers
     auto outArray_h = onHost::alloc<T_Data>(host, numElements);
     auto outArray_d = onHost::allocLike(device, outArray_h);
-    auto frameSpec = onHost::getFrameSpec<T_Data>(device, computeExec, Vec{blockSizeNormal});
+    auto frameSpec = onHost::getFrameSpec(device, computeExec, Vec{blockSizeNormal});
 
     onHost::Queue queue = device.makeQueue();
 

--- a/include/alpaka/api/generic.hpp
+++ b/include/alpaka/api/generic.hpp
@@ -69,8 +69,10 @@ namespace alpaka::internal::generic
         ALPAKA_LOG_FUNCTION(onHost::logger::memory);
 
         auto extents = onHost::getExtents(dest);
-        auto frameSpec
-            = onHost::internal::getFrameSpec<T_Value>(*onHost::internal::getDevice(internalQueue), executor, extents);
+        auto frameSpec = onHost::internal::getSimdFrameSpec<T_Value>(
+            *onHost::internal::getDevice(internalQueue),
+            executor,
+            extents);
 
         ALPAKA_LOG_INFO(
             onHost::logger::memory,

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -323,17 +323,47 @@ namespace alpaka::onHost
 
     /** Provides a frame specification to operate on a given index range
      *
-     * The frame specification will be optimized for SIMD executions in the highest dimension.
-     *
      * @param extents size of the index range
      * @return frame specification
      */
-    template<typename T_DataType, typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
-    inline constexpr auto getFrameSpec(
+    template<typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
+    inline constexpr concepts::FrameSpec auto getFrameSpec(
         Device<T_Api, T_DeviceKind> const& device,
         alpaka::concepts::Executor auto executor,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
-        return internal::getFrameSpec<T_DataType>(*device.get(), executor, extents);
+        if constexpr(executor == exec::anyExecutor)
+        {
+            auto usedExecutor = defaultExecutor(device);
+            return internal::getFrameSpec(*device.get(), usedExecutor, extents);
+        }
+        else
+            return internal::getFrameSpec(*device.get(), executor, extents);
+    }
+
+    /** Provides a frame specification to operate on a given index range
+     *
+     * The frame specification will be optimized for SIMD executions in the highest dimension
+     * for a flat non-hierarchical execution via onAcc::worker::threadsInGrid.
+     * Do not use this functions for kernel using hierarchical thread parallelism, in many cases the frame
+     * specification depends on the outer parallelism in the kernel.
+     *
+     * @tparam T_DataType the data type for which you would like to SIMD optimize
+     * @param extents number of elements for each dimension of the type T_DataType
+     * @return frame specification
+     */
+    template<typename T_DataType, typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
+    inline constexpr concepts::FrameSpec auto getSimdFrameSpec(
+        Device<T_Api, T_DeviceKind> const& device,
+        alpaka::concepts::Executor auto executor,
+        alpaka::concepts::VectorOrScalar auto const& extents)
+    {
+        if constexpr(executor == exec::anyExecutor)
+        {
+            auto usedExecutor = defaultExecutor(device);
+            return internal::getSimdFrameSpec<T_DataType>(*device.get(), usedExecutor, extents);
+        }
+        else
+            return internal::getSimdFrameSpec<T_DataType>(*device.get(), executor, extents);
     }
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/algo/internal/concurrent.hpp
+++ b/include/alpaka/onHost/algo/internal/concurrent.hpp
@@ -49,7 +49,7 @@ namespace alpaka::onHost::internal
         alpaka::concepts::IDataSource auto&&... in)
     {
         Vec const extentMd = extents;
-        auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), exec, extentMd);
+        auto frameSpec = getSimdFrameSpec<T_DataType>(queue.getDevice(), exec, extentMd);
 
         ALPAKA_LOG_INFO(
             onHost::logger::memory,

--- a/include/alpaka/onHost/algo/internal/iota.hpp
+++ b/include/alpaka/onHost/algo/internal/iota.hpp
@@ -58,7 +58,7 @@ namespace alpaka::onHost::internal
         alpaka::concepts::IMdSpan auto&&... inputs)
     {
         Vec const extentMd = extents;
-        auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), exec, extentMd);
+        auto frameSpec = getSimdFrameSpec<T_DataType>(queue.getDevice(), exec, extentMd);
 
         ALPAKA_LOG_INFO(
             onHost::logger::memory,

--- a/include/alpaka/onHost/algo/internal/transform.hpp
+++ b/include/alpaka/onHost/algo/internal/transform.hpp
@@ -89,7 +89,7 @@ namespace alpaka::onHost::internal
     {
         auto extentMd = onHost::getExtents(out);
         using DataType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(out)>;
-        auto frameSpec = getFrameSpec<DataType>(queue.getDevice(), exec, extentMd);
+        auto frameSpec = getSimdFrameSpec<DataType>(queue.getDevice(), exec, extentMd);
 
         ALPAKA_LOG_INFO(
             onHost::logger::memory,

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -142,7 +142,7 @@ namespace alpaka::onHost::internal
     {
         auto extentMd = onHost::getExtents(in0);
         using IndexType = alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(extentMd)>;
-        auto frameSpec = getFrameSpec<T_DataType>(queue.getDevice(), exec, extentMd);
+        auto frameSpec = getSimdFrameSpec<T_DataType>(queue.getDevice(), exec, extentMd);
 
         /* Adjust the launch parameters to not oversubscribe a device too much.
          *

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -485,19 +485,17 @@ namespace alpaka::onHost
             return GetPitches::Op<ALPAKA_TYPEOF(*any.get())>{}(*any.get());
         }
 
-        /** implementation to get a SIMD optimized frame spec
+        /** Provide a frame specification for the given extents
          *
-         * @param internalDevice must be a alpaka internal device implementation
+         * @param internalDevice must be an alpaka internal device implementation
          */
-        template<typename T_DataType>
         inline constexpr auto getFrameSpec(
             auto const& internalDevice,
             alpaka::concepts::Executor auto executor,
             alpaka::concepts::VectorOrScalar auto const& extents)
         {
+            static_assert(executor != exec::anyExecutor, "'exec::anyExecutor' can not be used here");
             Vec extentMd = extents;
-            auto deviceKind = alpaka::internal::getDeviceKind(internalDevice);
-            auto deviceApi = alpaka::internal::getApi(internalDevice);
             using ExtentVecType = ALPAKA_TYPEOF(extentMd);
             // check that all extent dimensions are greater than zero
             ALPAKA_ASSERT((extentMd > ExtentVecType::fill(0u)).reduce(std::logical_and{}));
@@ -507,8 +505,8 @@ namespace alpaka::onHost
             // try to create a specification with a frame size of 512 elements
             IndexType numFrameElements = 512;
             // avoid non-power of two values
-            auto fastDimensionValue = roundDownToPowerOfTwo(std::min(warpSize, extentMd.x()));
-            auto frameExtents = ExtentVecType::fill(1).rAssign(fastDimensionValue);
+            IndexType fastDimensionValue = roundDownToPowerOfTwo(std::min(warpSize, extentMd.x()));
+            ExtentVecType frameExtents = ExtentVecType::fill(1).rAssign(fastDimensionValue);
             numFrameElements /= frameExtents.x();
             // distribute remainder frame elements
             while(numFrameElements > IndexType{1})
@@ -532,12 +530,46 @@ namespace alpaka::onHost
                     break;
                 numFrameElements /= IndexType{2};
             }
+
+            ExtentVecType numFrames = divExZero(extentMd, frameExtents);
+            auto frameSpec = FrameSpec{numFrames, frameExtents, executor};
+            return frameSpec;
+        }
+
+        /** Provides a SIMD optimized frame specification
+         *
+         * The frame specification is optimized for a flat non-hierarchical execution via onAcc::worker::threadsInGrid.
+         *
+         * @tparam T_DataType the data type for which you would like to SIMD optimize
+         * @param internalDevice must be a alpaka internal device implementation
+         */
+        template<typename T_DataType>
+        inline constexpr auto getSimdFrameSpec(
+            auto const& internalDevice,
+            alpaka::concepts::Executor auto executor,
+            alpaka::concepts::VectorOrScalar auto const& extents)
+        {
+            static_assert(executor != exec::anyExecutor, "'exec::anyExecutor' can not be used here");
+            Vec extentMd = extents;
+            auto deviceKind = alpaka::internal::getDeviceKind(internalDevice);
+            auto deviceApi = alpaka::internal::getApi(internalDevice);
+            using ExtentVecType = ALPAKA_TYPEOF(extentMd);
+            // check that all extent dimensions are greater than zero
+            ALPAKA_ASSERT((extentMd > ExtentVecType::fill(0u)).reduce(std::logical_and{}));
+            using IndexType = alpaka::trait::GetValueType_t<ExtentVecType>;
+
+            ExtentVecType frameExtents = getFrameSpec(internalDevice, executor, extents).getFrameExtents();
+
             IndexType elementsPerFrameItem
                 = static_cast<IndexType>(getNumElemPerThread<T_DataType>(deviceApi, deviceKind));
-            alpaka::concepts::Vector auto numFrames
+
+            /* The number of frames depends on an imaginary frame extent where each frame item is computing multiple
+             * elements from the problem extents.
+             */
+            ExtentVecType numFrames
                 = divExZero(extentMd, frameExtents * frameExtents.fill(1).rAssign(elementsPerFrameItem));
             // The frame specification is not required to be a multiple of the extent, it can be smaller.
-            auto frameSpec = FrameSpec{numFrames, frameExtents, executor};
+            FrameSpec frameSpec = FrameSpec{numFrames, frameExtents, executor};
             return frameSpec;
         }
     } // namespace internal

--- a/test/unit/frame/getFrameSpec.cpp
+++ b/test/unit/frame/getFrameSpec.cpp
@@ -47,7 +47,7 @@ void testScalar(auto const& computeDev, alpaka::concepts::Executor auto exec)
 
 
     // test lvalue
-    auto const frameSpec = alpaka::onHost::getFrameSpec<T>(computeDev, exec, testValues);
+    auto const frameSpec = alpaka::onHost::getFrameSpec(computeDev, exec, testValues);
 
     checkFrameSpec(frameSpec, testValues);
 }
@@ -59,7 +59,7 @@ void testVector(auto const& computeDev, alpaka::concepts::Executor auto exec)
     {
         {
             // test lvalue
-            auto const frameSpec = alpaka::onHost::getFrameSpec<T>(computeDev, exec, vec);
+            auto const frameSpec = alpaka::onHost::getFrameSpec(computeDev, exec, vec);
 
             checkFrameSpec(frameSpec, vec);
         }

--- a/test/unit/intrinsic/clz.cpp
+++ b/test/unit/intrinsic/clz.cpp
@@ -55,7 +55,7 @@ TEMPLATE_LIST_TEST_CASE("clz", "[intrinsic][clz]", TestBackends)
     alpaka::onHost::memcpy(queue, devInput, hostInput);
 
     // Define execution parameters
-    auto const frameSpec = alpaka::onHost::getFrameSpec<uint64_t>(devAcc, computeExec, devInput.getExtents());
+    auto const frameSpec = alpaka::onHost::getFrameSpec(devAcc, computeExec, devInput.getExtents());
 
     // Create kernel
     PopcountKernel kernel;

--- a/test/unit/intrinsic/ffs.cpp
+++ b/test/unit/intrinsic/ffs.cpp
@@ -69,7 +69,7 @@ TEMPLATE_LIST_TEST_CASE("ffs", "[intrinsic][ffs]", TestBackends)
     alpaka::onHost::memcpy(queue, devInput, hostInput);
 
     // Define execution parameters
-    auto const frameSpec = alpaka::onHost::getFrameSpec<uint64_t>(devAcc, computeExec, devInput.getExtents());
+    auto const frameSpec = alpaka::onHost::getFrameSpec(devAcc, computeExec, devInput.getExtents());
 
     // Create kernel
     TestKernel kernel;

--- a/test/unit/intrinsic/popc.cpp
+++ b/test/unit/intrinsic/popc.cpp
@@ -62,7 +62,7 @@ TEMPLATE_LIST_TEST_CASE("popcount", "[intrinsic][popc]", TestBackends)
     alpaka::onHost::memcpy(queue, devInput, hostInput);
 
     // Define execution parameters
-    auto const frameSpec = alpaka::onHost::getFrameSpec<uint64_t>(devAcc, computeExec, devInput.getExtents());
+    auto const frameSpec = alpaka::onHost::getFrameSpec(devAcc, computeExec, devInput.getExtents());
 
     // Create kernel
     TestKernel kernel;

--- a/test/unit/mem/alloc.cpp
+++ b/test/unit/mem/alloc.cpp
@@ -35,7 +35,7 @@ void validateAccess(auto device, alpaka::concepts::Executor auto exec, concepts:
     REQUIRE(onHost::isDataAccessible(deviceQueue, deviceAccessibleData) == true);
     onHost::fill(deviceQueue, deviceStatus, 0);
     deviceQueue.enqueue(
-        getFrameSpec<float>(deviceQueue.getDevice(), exec, deviceAccessibleData.getExtents()),
+        getFrameSpec(deviceQueue.getDevice(), exec, deviceAccessibleData.getExtents()),
         KernelBundle{IotaValidate{}, deviceStatus, deviceAccessibleData});
     onHost::memcpy(deviceQueue, hostStatus, deviceStatus);
     onHost::wait(deviceQueue);

--- a/test/unit/mem/allocDeferred.cpp
+++ b/test/unit/mem/allocDeferred.cpp
@@ -39,7 +39,7 @@ void allocDeferredImplicitWait(auto device, auto exec)
         auto sharedBuffer = onHost::allocDeferred<float>(queue0, 10ul);
         onHost::fill(queue0, sharedBuffer, 3.14159265f);
         queue0.enqueue(
-            getFrameSpec<float>(queue0.getDevice(), exec, sharedBuffer.getExtents()),
+            getFrameSpec(queue0.getDevice(), exec, sharedBuffer.getExtents()),
             KernelBundle{RaceCheckKernel{}, dBufferResults, sharedBuffer});
         /* sharedBuffer is detroyed here before the kernel is finshed.
          * If the view is not waiting for all work in the queue enqueued before the destructor of the view is called,
@@ -76,7 +76,7 @@ void allocDeferredExplicitWait(auto device, auto exec)
 
         onHost::fill(queue0, sharedBuffer, 3.14159265f);
         queue0.enqueue(
-            getFrameSpec<float>(queue0.getDevice(), exec, sharedBuffer.getExtents()),
+            getFrameSpec(queue0.getDevice(), exec, sharedBuffer.getExtents()),
             KernelBundle{RaceCheckKernel{}, dBufferResults, sharedBuffer});
         /* sharedBuffer is detroyed here before the kernel is finshed.
          * If the view is not waiting for all work in the queue enqueued before the destructor of the view is called,

--- a/test/unit/mem/keepAlive.cpp
+++ b/test/unit/mem/keepAlive.cpp
@@ -54,7 +54,7 @@ TEMPLATE_LIST_TEST_CASE("keep alive", "", TestApis)
         // enqueue everything in this scope
         auto scopedBuffer = onHost::allocDeferred<int>(queue, N);
 
-        auto framespec = getFrameSpec<int>(device, exec, scopedBuffer.getExtents());
+        auto framespec = getFrameSpec(device, exec, scopedBuffer.getExtents());
 
         // fill scoped buffer
         queue.enqueue(framespec, KernelBundle{IotaKernel{}, scopedBuffer});

--- a/test/unit/rand/uniformReal.cpp
+++ b/test/unit/rand/uniformReal.cpp
@@ -159,7 +159,7 @@ void testCase(HelperPack<T_Engine, T_FP, T_Interval>, uint64_t seed, T_FP minF, 
 
     // ---- launch kernel -------------------------------------------------------
     queue.enqueue(
-        onHost::getFrameSpec<T_FP>(device, exec, Vec{N}),
+        onHost::getFrameSpec(device, exec, Vec{N}),
         KernelBundle{UniformRealKernel<T_Engine, T_FP, T_Interval>{}, devRes.getMdSpan(), seed, minF, maxF});
 
     onHost::memcpy(queue, hostRes, devRes);


### PR DESCRIPTION
- Introduce a new implementation of `getFrameSpec()` which is not performing SIMD optimizations and therfore does not need a data type.
- The old SIMD optimized function is now called `getSimdFrameSpec<DataType>()`
- Update the current places where the functions were used.


**breaking change:** This is a breaking change because places where `getFrameSpec<Type>()` was sued must be changed to `getFrameSpec()`. Only if you really need a SIMD optimized frame specification, you should use `getSimdFrameSpec<DataType>()`.