### PR TITLE
add queue `OmpCollectiveQueue`

### DIFF
--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -173,7 +173,7 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(alpaka::onHost::logger::event);
                 auto thisHandle = this->getSharedPtr();
                 std::lock_guard<std::mutex> lk{queuesGuard};
-                auto newEvent = std::make_shared<cpu::Event<Device>>(std::move(thisHandle), queueWaitFns.size());
+                auto newEvent = std::make_shared<cpu::Event<Device>>(std::move(thisHandle), events.size());
 
                 events.emplace_back(newEvent);
                 return newEvent;

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -66,18 +66,16 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(alpaka::onHost::logger::device);
                 // Host device synchronization - wait on all queues associated with this device.
-                // IMPORTANT: Do not hold queuesGuard across potentially long waits; copy weak refs first.
-                std::vector<std::weak_ptr<cpu::Queue<Device>>> tmpQueues;
+                // IMPORTANT: Do not hold queuesGuard across potentially long waits; copy the list first to avoid to be
+                // able to work on the list without a guard.
+                std::vector<std::function<void()>> tmpQueues;
                 {
                     std::lock_guard<std::mutex> lk{queuesGuard};
-                    tmpQueues = queues; // copy weak_ptr list
+                    tmpQueues = queueWaitFns; // copy weak_ptr list
                 }
-                for(auto& weakQueue : tmpQueues)
+                for(auto& waitFn : tmpQueues)
                 {
-                    if(auto queue = weakQueue.lock())
-                    {
-                        internal::wait(*queue);
-                    }
+                    waitFn();
                 }
             }
 
@@ -91,7 +89,12 @@ namespace alpaka::onHost
             uint32_t m_idx = 0u;
             uint32_t m_cpuGroupIdx = internal::hwloc::allDomains;
             DeviceProperties m_properties;
-            std::vector<std::weak_ptr<cpu::Queue<Device>>> queues;
+            /* Wait function to any created queue
+             * The function should capture the queue only as weak pointer else a queue will never be deleted because
+             * the queue would hold a shared pointer to the device and the device via the wait function a shared
+             * pointer to the queue.
+             */
+            std::vector<std::function<void()>> queueWaitFns;
             std::vector<std::weak_ptr<cpu::Event<Device>>> events;
             std::mutex queuesGuard;
 
@@ -147,11 +150,17 @@ namespace alpaka::onHost
                 constexpr bool isBlocking = kind == queueKind::blocking;
                 auto newQueue = std::make_shared<cpu::Queue<Device>>(
                     std::move(thisHandle),
-                    queues.size(),
+                    queueWaitFns.size(),
                     m_cpuGroupIdx,
                     isBlocking);
 
-                queues.emplace_back(newQueue);
+                std::weak_ptr<cpu::Queue<Device>> weakPtrToQueue = newQueue;
+                queueWaitFns.emplace_back(
+                    [weakPtrToQueue]
+                    {
+                        if(auto queue = weakPtrToQueue.lock())
+                            internal::wait(*queue);
+                    });
                 return newQueue;
             }
 
@@ -162,7 +171,7 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(alpaka::onHost::logger::event);
                 auto thisHandle = this->getSharedPtr();
                 std::lock_guard<std::mutex> lk{queuesGuard};
-                auto newEvent = std::make_shared<cpu::Event<Device>>(std::move(thisHandle), queues.size());
+                auto newEvent = std::make_shared<cpu::Event<Device>>(std::move(thisHandle), queueWaitFns.size());
 
                 events.emplace_back(newEvent);
                 return newEvent;

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -44,6 +44,8 @@ namespace alpaka::onHost
             ~Device()
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::device);
+                // wait for all queues before we destroy the device
+                wait();
             }
 
             Device(Device const&) = delete;

--- a/include/alpaka/api/host/OmpCollectiveQueue.hpp
+++ b/include/alpaka/api/host/OmpCollectiveQueue.hpp
@@ -81,6 +81,7 @@ namespace alpaka::onHost
          * same value. The function is a collective functions and must be called by all threads in the parallel scope.
          *
          * If this function is called outside of an OpenMP parallel section the functor is invoked by the caller only.
+         * This operation is synchronizing all threads within a parallel OpenMP region.
          *
          * @return A copy of the return value from the invocation. The return value must be assignable.
          */
@@ -91,7 +92,7 @@ namespace alpaka::onHost
             {
                 using ReturnType = decltype(ALPAKA_FORWARD(fn)());
 
-                // wrap within a optional in cases the return value has no default constructor
+                // wrap within an optional in cases the return value has no default constructor
                 std::optional<ReturnType> returnValue;
 
 #    pragma omp single copyprivate(returnValue)
@@ -139,6 +140,26 @@ namespace alpaka::onHost
                 return !(*this == other);
             }
 
+            /** Wait for all tasks enqueued before the parallel region. */
+            void waitUntilParentQueueIsEmpty()
+            {
+                auto& pQueue = *parentQueue.get();
+                // wait for all tasks enqueued before the parallel region
+                while(internal::IgnoreVisibility::Op<ParentType>::isQueueBlockingTaskExecuted(pQueue) != 0u)
+                    ;
+            }
+
+            void waitForNonOmpParallelOps()
+            {
+                while(m_numCollectiveTasksExecuted != 0u)
+                    ;
+            }
+
+            /* Each thread in a parallel OpenMP section must increase the counter when participating in an operation
+             * even if it is not actively executing something.
+             */
+            std::atomic<uint32_t> m_numCollectiveTasksExecuted = 0;
+
         private:
             using ParentType = Queue<T_Device>;
             std::shared_ptr<ParentType> parentQueue;
@@ -185,6 +206,92 @@ namespace alpaka::onHost
 
     namespace internal
     {
+        template<typename T_Device>
+        struct IgnoreVisibility::Op<cpu::Queue<T_Device>>
+        {
+            [[nodiscard]] static bool isQueueBlockingTaskExecuted(cpu::Queue<T_Device>& queue)
+            {
+                return queue.m_isBlockingTaskExecuted.load();
+            }
+        };
+
+        namespace omp
+        {
+            template<typename T_Device>
+            inline void invokeSingleNowait(cpu::OmpCollectiveQueue<T_Device>& queue, auto&& fn)
+                requires(std::same_as<std::invoke_result_t<ALPAKA_TYPEOF(fn)>, void>)
+            {
+#    if ALPAKA_OMP
+                if(::omp_in_parallel() != 0)
+                {
+                    queue.waitUntilParentQueueIsEmpty();
+                    ++queue.m_numCollectiveTasksExecuted;
+#        pragma omp single nowait
+                    {
+                        ALPAKA_FORWARD(fn)();
+                    }
+                    --queue.m_numCollectiveTasksExecuted;
+                    return;
+                }
+
+                // wait until all threads within the OpenMP parallel region finished there task
+                queue.waitForNonOmpParallelOps();
+#    endif
+                ALPAKA_FORWARD(fn)();
+            }
+
+            template<typename T_Device>
+            inline auto invokeSingleAndWait(cpu::OmpCollectiveQueue<T_Device>& queue, auto&& fn)
+                requires(std::same_as<std::invoke_result_t<ALPAKA_TYPEOF(fn)>, void>)
+            {
+#    if ALPAKA_OMP
+                if(::omp_in_parallel() != 0)
+                {
+#        pragma omp single
+                    {
+                        queue.waitUntilParentQueueIsEmpty();
+                        ++queue.m_numCollectiveTasksExecuted;
+                        ALPAKA_FORWARD(fn)();
+                        --queue.m_numCollectiveTasksExecuted;
+                    }
+                    return;
+                }
+
+                // wait until all threads within the OpenMP parallel region finished there task
+                queue.waitForNonOmpParallelOps();
+#    endif
+                ALPAKA_FORWARD(fn)();
+            }
+
+            template<typename T_Device>
+            inline auto invokeSingleAndWait(cpu::OmpCollectiveQueue<T_Device>& queue, auto&& fn)
+                requires(!std::same_as<std::invoke_result_t<ALPAKA_TYPEOF(fn)>, void>)
+            {
+#    if ALPAKA_OMP
+                if(::omp_in_parallel() != 0)
+                {
+                    using ReturnType = decltype(ALPAKA_FORWARD(fn)());
+
+                    // wrap within an optional in cases the return value has no default constructor
+                    std::optional<ReturnType> returnValue;
+
+#        pragma omp single copyprivate(returnValue)
+                    {
+                        queue.waitUntilParentQueueIsEmpty();
+                        ++queue.m_numCollectiveTasksExecuted;
+                        returnValue = ALPAKA_FORWARD(fn)();
+                        --queue.m_numCollectiveTasksExecuted;
+                    }
+                    return returnValue.value();
+                }
+
+                // wait until all threads within the OpenMP parallel region finished there task
+                queue.waitForNonOmpParallelOps();
+#    endif
+                return ALPAKA_FORWARD(fn)();
+            }
+        } // namespace omp
+
         template<typename T_Platform>
         struct MakeQueue::Op<cpu::Device<T_Platform>, alpaka::queueKind::OmpCollective>
         {
@@ -196,22 +303,30 @@ namespace alpaka::onHost
 
                 auto newQueue = std::make_shared<cpu::OmpCollectiveQueue<cpu::Device<T_Platform>>>(
                     std::move(queueHandle),
-                    device.queues.size(),
+                    device.queueWaitFns.size(),
                     device.m_numaIdx);
 
-                // we store the parent queue because all real queue implementation is located there
-                device.queues.emplace_back(newQueue->parentQueue);
+                std::weak_ptr<cpu::OmpCollectiveQueue<cpu::Device<T_Platform>>> weakPtrToQueue = newQueue;
+                device.queueWaitFns.emplace_back(
+                    [weakPtrToQueue]
+                    {
+                        if(auto queue = weakPtrToQueue.lock())
+                            internal::wait(*queue);
+                    });
+
                 return newQueue;
             }
         };
 
+        /** OpenMP barrier is used. */
         template<typename T_Device, typename T_Event>
         struct WaitFor::Op<cpu::OmpCollectiveQueue<T_Device>, T_Event>
         {
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, cpu::Event<T_Device>& event) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                omp::invokeSingle(
+                omp::invokeSingleAndWait(
+                    queue,
                     [&]
                     {
                         internal::WaitFor::Op<cpu::Queue<T_Device>, ALPAKA_TYPEOF(event)>{}(*queue.parentQueue, event);
@@ -219,27 +334,32 @@ namespace alpaka::onHost
             }
         };
 
+        /** OpenMP barrier is used. */
         template<typename T_Device>
         struct Wait::Op<cpu::OmpCollectiveQueue<T_Device>>
         {
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                omp::invokeSingle([&] { internal::Wait::Op<cpu::Queue<T_Device>>{}(*queue.parentQueue); });
+                omp::invokeSingleAndWait(
+                    queue,
+                    [&] { internal::Wait::Op<cpu::Queue<T_Device>>{}(*queue.parentQueue); });
             }
         };
 
+        /** OpenMP barrier is used to guarantee all threads in the parallel region seeing the same status.*/
         template<typename T_Device>
         struct IsQueueEmpty::Op<cpu::OmpCollectiveQueue<T_Device>>
         {
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                return omp::invokeSingle([&]
-                                         { internal::IsQueueEmpty::Op<cpu::Queue<T_Device>>{}(*queue.parentQueue); });
+                return omp::invokeSingleAndWait(
+                    [&] { internal::IsQueueEmpty::Op<cpu::Queue<T_Device>>{}(*queue.parentQueue); });
             }
         };
 
+        /** NO OpenMP barrier used. */
         template<typename T_Device, typename T_Task>
         struct internal::Enqueue::HostTaskDeferred<cpu::OmpCollectiveQueue<T_Device>, T_Task>
         {
@@ -247,7 +367,8 @@ namespace alpaka::onHost
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Task const& task) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                omp::invokeSingle(
+                omp::invokeSingleNowait(
+                    queue,
                     [&]
                     {
                         internal::Enqueue::HostTaskDeferred<cpu::Queue<T_Device>, T_Task>{}(*queue.parentQueue, task);
@@ -255,6 +376,7 @@ namespace alpaka::onHost
             }
         };
 
+        /** NO OpenMP barrier used. */
         template<typename T_Device, typename T_Task>
         struct internal::Enqueue::HostTask<cpu::OmpCollectiveQueue<T_Device>, T_Task>
         {
@@ -266,18 +388,21 @@ namespace alpaka::onHost
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Task const& task) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                omp::invokeSingle(
+                omp::invokeSingleNowait(
+                    queue,
                     [&] { internal::Enqueue::HostTask<cpu::Queue<T_Device>, T_Task>{}(*queue.parentQueue, task); });
             }
         };
 
+        /** OpenMP barrier is used. */
         template<typename T_Device, typename T_Event>
         struct Enqueue::Event<cpu::OmpCollectiveQueue<T_Device>, T_Event>
         {
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Event& event) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                omp::invokeSingle(
+                omp::invokeSingleAndWait(
+                    queue,
                     [&] { internal::Enqueue::Event<cpu::Queue<T_Device>, T_Event>{}(*queue.parentQueue, event); });
             }
         };
@@ -308,11 +433,8 @@ namespace alpaka::onHost
 
                 if(::omp_in_parallel() != 0)
                 {
-#    pragma omp master
-                    {
-                        queue.parentQueue->m_mutex.lock();
-                        queue.parentQueue->m_isBlockingTaskExecuted = true;
-                    }
+                    queue.waitUntilParentQueueIsEmpty();
+                    ++queue.m_numCollectiveTasksExecuted;
                     auto deviceKind = alpaka::getDeviceKind(queue.parentQueue->m_device);
 
                     // This queue is not changing the affinity
@@ -324,19 +446,15 @@ namespace alpaka::onHost
                         DictEntry(object::deviceKind, deviceKind),
                         DictEntry(object::exec, threadSpec.getExecutor())};
                     onAcc::Acc acc = makeAcc(threadSpec, queue.parentQueue->m_numaIdx, setThreadAffinity);
-                    // wait that the master thread updated the lock
-#    pragma omp barrier
+
                     acc(kernelBundle, moreLayer);
-                    // wait that all threads finished the execution
-#    pragma omp barrier
-#    pragma omp master
-                    {
-                        queue.parentQueue->m_isBlockingTaskExecuted = false;
-                        queue.parentQueue->m_mutex.unlock();
-                    }
+                    --queue.m_numCollectiveTasksExecuted;
                 }
                 else
                 {
+                    // wait until all threads within the OpenMP parallel region finished there task
+                    while(queue.m_numCollectiveTasksExecuted != 0u)
+                        ;
                     queue.parentQueue->enqueue(threadSpec, kernelBundle);
                 }
             }
@@ -367,11 +485,8 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::queue);
                 if(::omp_in_parallel() != 0)
                 {
-#    pragma omp master
-                    {
-                        queue.parentQueue->m_mutex.lock();
-                        queue.parentQueue->m_isBlockingTaskExecuted = true;
-                    }
+                    queue.waitUntilParentQueueIsEmpty();
+                    ++queue.m_numCollectiveTasksExecuted;
 
                     auto adjustedThreadSpec
                         = internal::adjustThreadSpec(*(queue.parentQueue->m_device), frameSpec, kernelBundle);
@@ -386,21 +501,15 @@ namespace alpaka::onHost
                         DictEntry(object::deviceKind, deviceKind),
                         DictEntry(object::exec, adjustedThreadSpec.getExecutor())};
                     onAcc::Acc acc = makeAcc(adjustedThreadSpec, queue.parentQueue->m_numaIdx, setThreadAffinity);
-                    // wait that the master thread updated the lock
-#    pragma omp barrier
+
                     acc(kernelBundle, moreLayer);
-                    /* Wait that all threads finished the execution to avoid that a participating thread in the kernel
-                     * call already performs the next action, assuming the work in the queue is already done.
-                     */
-#    pragma omp barrier
-#    pragma omp master
-                    {
-                        queue.parentQueue->m_isBlockingTaskExecuted = false;
-                        queue.parentQueue->m_mutex.unlock();
-                    }
+                    --queue.m_numCollectiveTasksExecuted;
                 }
                 else
                 {
+                    // wait until all threads within the OpenMP parallel region finished there task
+                    while(queue.m_numCollectiveTasksExecuted != 0u)
+                        ;
                     queue.parentQueue->enqueue(frameSpec, kernelBundle);
                 }
             }
@@ -417,7 +526,8 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
 
-                omp::invokeSingle(
+                omp::invokeSingleNowait(
+                    queue,
                     [&]
                     {
                         Memcpy::Op<cpu::Queue<T_Device>, T_Dest, T_Source, T_Extents>{}(
@@ -440,7 +550,8 @@ namespace alpaka::onHost
                 auto&& source) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
-                omp::invokeSingle(
+                omp::invokeSingleNowait(
+                    queue,
                     [&]
                     {
                         MemcpyDeviceGlobal::Op<
@@ -462,7 +573,8 @@ namespace alpaka::onHost
                 onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> source) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
-                omp::invokeSingle(
+                omp::invokeSingleNowait(
+                    queue,
                     [&]
                     {
                         internal::MemcpyDeviceGlobal::Op<
@@ -489,7 +601,8 @@ namespace alpaka::onHost
                 T_Extents const& extents) const requires(std::is_same_v<ALPAKA_TYPEOF(dest), T_Dest>)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
-                omp::invokeSingle(
+                omp::invokeSingleNowait(
+                    queue,
                     [&]
                     {
                         internal::Memset::Op<cpu::Queue<T_Device>, T_Dest, T_Extents>{}(
@@ -512,6 +625,9 @@ namespace alpaka::onHost
                 requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
                          && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
             {
+                /* There is no need to wait for queue tasks before the parallel region or if called from outside for
+                 * tasks within the parallel region, this will be done during the kernel call in the fill function.
+                 */
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
                 if(::omp_in_parallel() != 0)
                 {
@@ -541,9 +657,7 @@ namespace alpaka::onHost
             }
         };
 
-        /** The code is a copy of the Alloc::Op with the difference that the memory is allocated and freed
-         * within a queue
-         */
+        /** OpenMP barrier is used. */
         template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
         struct AllocDeferred::Op<T_Type, cpu::OmpCollectiveQueue<T_Device>, T_Extents>
         {
@@ -551,7 +665,8 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
 
-                return omp::invokeSingle(
+                return omp::invokeSingleAndWait(
+                    queue,
                     [&]
                     {
                         return internal::AllocDeferred::Op<T_Type, cpu::Queue<T_Device>, T_Extents>{}(

--- a/include/alpaka/api/host/OmpCollectiveQueue.hpp
+++ b/include/alpaka/api/host/OmpCollectiveQueue.hpp
@@ -1,0 +1,578 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file This contains a special queue implementation for one of our users. All requirements to use this queue are in
+ * this single file, this provides the possibility that the file is copied into the user project and adjusted if
+ * needed.
+ *
+ * @attention This file is **NOT** included with `#include <alpaka/alpaka.hpp>`
+ */
+
+#pragma once
+
+#include "alpaka/api/host/Device.hpp"
+#include "alpaka/api/host/Queue.hpp"
+#include "alpaka/onHost/logger/logger.hpp"
+#include "alpaka/tag.hpp"
+
+#include <optional>
+
+namespace alpaka
+{
+    namespace queueKind
+    {
+        /** Special parallel OpenMP queue which is blocking
+         *
+         * All threads within a parallel section execute all queue methods collectively.
+         * The queue behaves like a blocking queue. Within a parallel OpenMP section all functions except enqueue
+         * kernel will be executed by a single thread only, the result is broadcasted to all threads in the section.
+         * Enqueued kernels will be executed by all threads together. Even within a parallel section each call is
+         * blocking.
+         *
+         * The queue can only be used if the dependency OpenMP is available, e.g. by setting the CMake option
+         * ALPAKA_DEP_OMP=ON or using the required compiler flags to activate OpenMP.
+         */
+        struct OmpCollective : detail::QueueKindBase
+        {
+            static std::string getName()
+            {
+                return "OmpCollective";
+            }
+        };
+
+        /** @copydoc OmpCollective */
+        constexpr auto ompCollective = OmpCollective{};
+    } // namespace queueKind
+} // namespace alpaka
+
+namespace alpaka::onHost
+{
+    namespace omp
+    {
+        /** Special OpenMP invoke.
+         *
+         * If the caller thread is within a parallel OpenMP scope, the functor will be invoked by one thread via `omp
+         * single`. After the call all participating threads will be synced. The function is a collective functions and
+         * must be called by all threads in the parallel scope.
+         *
+         * If this function is called outside of an OpenMP parallel section the functor is invoked by the caller only.
+         * Even if OpenMP is not available the function can be called and will simply invoke the functor.
+         */
+        inline void invokeSingle(auto&& fn) requires(std::same_as<std::invoke_result_t<ALPAKA_TYPEOF(fn)>, void>)
+        {
+#if ALPAKA_OMP
+            if(::omp_in_parallel() != 0)
+            {
+#    pragma omp single
+                {
+                    ALPAKA_FORWARD(fn)();
+                }
+            }
+            else
+#endif
+                ALPAKA_FORWARD(fn)();
+        }
+
+        /** Special OpenMP invoke with return value
+         *
+         * If the caller thread is within a parallel OpenMP scope, the functor will be invoked by one thread via `omp
+         * single`. After the call all participating threads will be synced and all threads will return a copy of the
+         * same value. The function is a collective functions and must be called by all threads in the parallel scope.
+         *
+         * If this function is called outside of an OpenMP parallel section the functor is invoked by the caller only.
+         *
+         * @return A copy of the return value from the invocation. The return value must be assignable.
+         */
+        inline auto invokeSingle(auto&& fn) requires(!std::same_as<std::invoke_result_t<ALPAKA_TYPEOF(fn)>, void>)
+        {
+#if ALPAKA_OMP
+            if(::omp_in_parallel() != 0)
+            {
+                using ReturnType = decltype(ALPAKA_FORWARD(fn)());
+
+                // wrap within a optional in cases the return value has no default constructor
+                std::optional<ReturnType> returnValue;
+
+#    pragma omp single copyprivate(returnValue)
+                {
+                    returnValue = ALPAKA_FORWARD(fn)();
+                }
+                return returnValue.value();
+            }
+#endif
+            return ALPAKA_FORWARD(fn)();
+        }
+    } // namespace omp
+
+#if ALPAKA_OMP
+    namespace cpu
+    {
+        template<typename T_Device>
+        struct OmpCollectiveQueue : std::enable_shared_from_this<OmpCollectiveQueue<T_Device>>
+        {
+        public:
+            OmpCollectiveQueue(internal::concepts::DeviceHandle auto device, uint32_t const idx, uint32_t numIdx)
+                : parentQueue(std::make_shared<Queue<T_Device>>(std::move(device), idx, numIdx, true))
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+            }
+
+            ~OmpCollectiveQueue()
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+            }
+
+            OmpCollectiveQueue(OmpCollectiveQueue const&) = delete;
+            OmpCollectiveQueue& operator=(OmpCollectiveQueue const&) = delete;
+
+            OmpCollectiveQueue(OmpCollectiveQueue&&) = delete;
+            OmpCollectiveQueue& operator=(OmpCollectiveQueue&&) = delete;
+
+            bool operator==(OmpCollectiveQueue const& other) const
+            {
+                return parentQueue == other.parentQueue;
+            }
+
+            bool operator!=(OmpCollectiveQueue const& other) const
+            {
+                return !(*this == other);
+            }
+
+        private:
+            using ParentType = Queue<T_Device>;
+            std::shared_ptr<ParentType> parentQueue;
+
+            friend struct alpaka::internal::GetName;
+
+            std::string getName() const
+            {
+                return std::string("host::OmpCollectiveQueue id=") + std::to_string(parentQueue->m_idx);
+            }
+
+            friend struct alpaka::internal::GetDeviceType;
+
+            auto getDeviceKind() const
+            {
+                return alpaka::internal::getDeviceKind(*parentQueue);
+            }
+
+            auto getDevice() const
+            {
+                return internal::getDevice(*parentQueue);
+            }
+
+            std::shared_ptr<OmpCollectiveQueue> getSharedPtr()
+            {
+                return parentQueue->shared_from_this();
+            }
+
+            friend struct internal::GetNativeHandle;
+            friend struct internal::Enqueue;
+            friend struct internal::IsQueueEmpty;
+            friend struct internal::GetDevice;
+            friend struct internal::Wait;
+            friend struct internal::WaitFor;
+            friend struct internal::Memcpy;
+            friend struct internal::Fill;
+            friend struct internal::MemcpyDeviceGlobal;
+            friend struct internal::Memset;
+            friend struct alpaka::internal::GetApi;
+            friend struct internal::AllocDeferred;
+            friend struct internal::MakeQueue;
+        };
+    } // namespace cpu
+
+    namespace internal
+    {
+        template<typename T_Platform>
+        struct MakeQueue::Op<cpu::Device<T_Platform>, alpaka::queueKind::OmpCollective>
+        {
+            auto operator()(cpu::Device<T_Platform>& device, alpaka::queueKind::OmpCollective) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                auto queueHandle = device.getSharedPtr();
+                std::lock_guard<std::mutex> lk{device.queuesGuard};
+
+                auto newQueue = std::make_shared<cpu::OmpCollectiveQueue<cpu::Device<T_Platform>>>(
+                    std::move(queueHandle),
+                    device.queues.size(),
+                    device.m_numaIdx);
+
+                // we store the parent queue because all real queue implementation is located there
+                device.queues.emplace_back(newQueue->parentQueue);
+                return newQueue;
+            }
+        };
+
+        template<typename T_Device, typename T_Event>
+        struct WaitFor::Op<cpu::OmpCollectiveQueue<T_Device>, T_Event>
+        {
+            void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, cpu::Event<T_Device>& event) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                omp::invokeSingle(
+                    [&]
+                    {
+                        internal::WaitFor::Op<cpu::Queue<T_Device>, ALPAKA_TYPEOF(event)>{}(*queue.parentQueue, event);
+                    });
+            }
+        };
+
+        template<typename T_Device>
+        struct Wait::Op<cpu::OmpCollectiveQueue<T_Device>>
+        {
+            void operator()(cpu::OmpCollectiveQueue<T_Device>& queue) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                omp::invokeSingle([&] { internal::Wait::Op<cpu::Queue<T_Device>>{}(*queue.parentQueue); });
+            }
+        };
+
+        template<typename T_Device>
+        struct IsQueueEmpty::Op<cpu::OmpCollectiveQueue<T_Device>>
+        {
+            void operator()(cpu::OmpCollectiveQueue<T_Device>& queue) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                return omp::invokeSingle([&]
+                                         { internal::IsQueueEmpty::Op<cpu::Queue<T_Device>>{}(*queue.parentQueue); });
+            }
+        };
+
+        template<typename T_Device, typename T_Task>
+        struct internal::Enqueue::HostTaskDeferred<cpu::OmpCollectiveQueue<T_Device>, T_Task>
+        {
+            // same as for Enqueue::HostTask, but not waiting for the task to finish
+            void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Task const& task) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                omp::invokeSingle(
+                    [&]
+                    {
+                        internal::Enqueue::HostTaskDeferred<cpu::Queue<T_Device>, T_Task>{}(*queue.parentQueue, task);
+                    });
+            }
+        };
+
+        template<typename T_Device, typename T_Task>
+        struct internal::Enqueue::HostTask<cpu::OmpCollectiveQueue<T_Device>, T_Task>
+        {
+            /** execute a task in the queue
+             *
+             * @attention Do NOT enqueue a task which captures the queue internally to keep the queue alive as
+             * dependency. In this case the destructure of the queue is not called.
+             */
+            void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Task const& task) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                omp::invokeSingle(
+                    [&] { internal::Enqueue::HostTask<cpu::Queue<T_Device>, T_Task>{}(*queue.parentQueue, task); });
+            }
+        };
+
+        template<typename T_Device, typename T_Event>
+        struct Enqueue::Event<cpu::OmpCollectiveQueue<T_Device>, T_Event>
+        {
+            void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Event& event) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                omp::invokeSingle(
+                    [&] { internal::Enqueue::Event<cpu::Queue<T_Device>, T_Event>{}(*queue.parentQueue, event); });
+            }
+        };
+
+        /** enqueue and execute a kernel
+         *
+         * If this method is called from within a parallel OpenMP section all threads must participate in the
+         * execution of the kernel. The kernel will be executed with the thread spec which is created by adjusting
+         * the frame spec to the kernel bundle. threadSpec and kernelBundle must be the same for all threads in the
+         * OpenMP section. If this method is called from outside a parallel OpenMP section, the kernel will be
+         * enqueued and executed as usual within a blocking queue.
+         */
+        template<
+            typename T_Device,
+            onHost::concepts::ThreadSpec T_ThreadSpec,
+            alpaka::concepts::KernelBundle T_KernelBundle>
+        struct Enqueue::Kernel<cpu::OmpCollectiveQueue<T_Device>, T_ThreadSpec, T_KernelBundle>
+        {
+            void operator()(
+                cpu::OmpCollectiveQueue<T_Device>& queue,
+                T_ThreadSpec const& threadSpec,
+                T_KernelBundle const& kernelBundle) const
+            {
+                static_assert(
+                    ALPAKA_TYPEOF(threadSpec)::getExecutor() != exec::anyExecutor,
+                    "'exec::anyExecutor' can not be used to enqueue an kernel.");
+                ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::queue);
+
+                if(::omp_in_parallel() != 0)
+                {
+#    pragma omp master
+                    {
+                        queue.parentQueue->m_mutex.lock();
+                        queue.parentQueue->m_isBlockingTaskExecuted = true;
+                    }
+                    auto deviceKind = alpaka::getDeviceKind(queue.parentQueue->m_device);
+
+                    // This queue is not changing the affinity
+                    bool setThreadAffinity = false;
+
+                    auto moreLayer = Dict{
+                        DictEntry(object::launchedWidthFrameSpec, std::false_type{}),
+                        DictEntry(object::api, api::host),
+                        DictEntry(object::deviceKind, deviceKind),
+                        DictEntry(object::exec, threadSpec.getExecutor())};
+                    onAcc::Acc acc = makeAcc(threadSpec, queue.parentQueue->m_numaIdx, setThreadAffinity);
+                    // wait that the master thread updated the lock
+#    pragma omp barrier
+                    acc(kernelBundle, moreLayer);
+                    // wait that all threads finished the execution
+#    pragma omp barrier
+#    pragma omp master
+                    {
+                        queue.parentQueue->m_isBlockingTaskExecuted = false;
+                        queue.parentQueue->m_mutex.unlock();
+                    }
+                }
+                else
+                {
+                    queue.parentQueue->enqueue(threadSpec, kernelBundle);
+                }
+            }
+        };
+
+        /** enqueue and execute a kernel
+         *
+         * If this method is called from within a parallel OpenMP section all threads must participate in the
+         * execution of the kernel. The kernel will be executed with the thread spec which is created by adjusting
+         * the frame spec to the kernel bundle. frameSpec and kernelBundle must be the same for all threads in the
+         * OpenMP section. If this method is called from outside a parallel OpenMP section, the kernel will be
+         * enqueued and executed as usual within a blocking queue.
+         */
+        template<
+            typename T_Device,
+            onHost::concepts::FrameSpec T_FrameSpec,
+            alpaka::concepts::KernelBundle T_KernelBundle>
+        struct Enqueue::Kernel<cpu::OmpCollectiveQueue<T_Device>, T_FrameSpec, T_KernelBundle>
+        {
+            void operator()(
+                cpu::OmpCollectiveQueue<T_Device>& queue,
+                T_FrameSpec const& frameSpec,
+                T_KernelBundle const& kernelBundle) const
+            {
+                static_assert(
+                    ALPAKA_TYPEOF(frameSpec)::getExecutor() != exec::anyExecutor,
+                    "'exec::anyExecutor' can not be used to enqueue an kernel.");
+                ALPAKA_LOG_FUNCTION(onHost::logger::kernel + onHost::logger::queue);
+                if(::omp_in_parallel() != 0)
+                {
+#    pragma omp master
+                    {
+                        queue.parentQueue->m_mutex.lock();
+                        queue.parentQueue->m_isBlockingTaskExecuted = true;
+                    }
+
+                    auto adjustedThreadSpec
+                        = internal::adjustThreadSpec(*(queue.parentQueue->m_device), frameSpec, kernelBundle);
+                    auto deviceKind = alpaka::getDeviceKind(queue.parentQueue->m_device);
+
+                    // This queue is not changing the affinity
+                    bool setThreadAffinity = false;
+
+                    auto moreLayer = Dict{
+                        DictEntry(object::launchedWidthFrameSpec, std::true_type{}),
+                        DictEntry(object::api, api::host),
+                        DictEntry(object::deviceKind, deviceKind),
+                        DictEntry(object::exec, adjustedThreadSpec.getExecutor())};
+                    onAcc::Acc acc = makeAcc(adjustedThreadSpec, queue.parentQueue->m_numaIdx, setThreadAffinity);
+                    // wait that the master thread updated the lock
+#    pragma omp barrier
+                    acc(kernelBundle, moreLayer);
+                    /* Wait that all threads finished the execution to avoid that a participating thread in the kernel
+                     * call already performs the next action, assuming the work in the queue is already done.
+                     */
+#    pragma omp barrier
+#    pragma omp master
+                    {
+                        queue.parentQueue->m_isBlockingTaskExecuted = false;
+                        queue.parentQueue->m_mutex.unlock();
+                    }
+                }
+                else
+                {
+                    queue.parentQueue->enqueue(frameSpec, kernelBundle);
+                }
+            }
+        };
+
+        template<typename T_Device, typename T_Dest, typename T_Source, typename T_Extents>
+        struct Memcpy::Op<cpu::OmpCollectiveQueue<T_Device>, T_Dest, T_Source, T_Extents>
+        {
+            void operator()(
+                cpu::OmpCollectiveQueue<T_Device>& queue,
+                auto&& dest,
+                T_Source const& source,
+                T_Extents const& extents) const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+
+                omp::invokeSingle(
+                    [&]
+                    {
+                        Memcpy::Op<cpu::Queue<T_Device>, T_Dest, T_Source, T_Extents>{}(
+                            *queue.parentQueue,
+                            dest,
+                            source,
+                            extents);
+                    });
+            }
+        };
+
+        // copy to device global memory
+        template<typename T_Device, typename T_Source, typename T_Storage, typename T>
+        struct MemcpyDeviceGlobal::
+            Op<cpu::OmpCollectiveQueue<T_Device>, onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>, T_Source>
+        {
+            void operator()(
+                cpu::OmpCollectiveQueue<T_Device>& queue,
+                onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> dest,
+                auto&& source) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+                omp::invokeSingle(
+                    [&]
+                    {
+                        MemcpyDeviceGlobal::Op<
+                            cpu::Queue<T_Device>,
+                            onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>,
+                            T_Source>{}(*queue.parentQueue, dest, source);
+                    });
+            }
+        };
+
+        // copy from device global memory
+        template<typename T_Device, typename T_Dest, typename T_Storage, typename T>
+        struct MemcpyDeviceGlobal::
+            Op<cpu::OmpCollectiveQueue<T_Device>, T_Dest, onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>>
+        {
+            void operator()(
+                cpu::OmpCollectiveQueue<T_Device>& queue,
+                auto&& dest,
+                onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> source) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+                omp::invokeSingle(
+                    [&]
+                    {
+                        internal::MemcpyDeviceGlobal::Op<
+                            cpu::Queue<T_Device>,
+                            T_Dest,
+                            onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>>{}(
+                            *queue.parentQueue,
+                            dest,
+                            source);
+                    });
+            }
+        };
+
+        template<typename T_Device, typename T_Dest, typename T_Extents>
+        struct Memset::Op<cpu::OmpCollectiveQueue<T_Device>, T_Dest, T_Extents>
+        {
+            /** @attention Do not use `requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>` here else gcc 11.X
+             * (tested 11.4 and 11.3) will run into an internal compiler segfault during the evaluation of the
+             * constraints */
+            void operator()(
+                cpu::OmpCollectiveQueue<T_Device>& queue,
+                auto&& dest,
+                uint8_t byteValue,
+                T_Extents const& extents) const requires(std::is_same_v<ALPAKA_TYPEOF(dest), T_Dest>)
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+                omp::invokeSingle(
+                    [&]
+                    {
+                        internal::Memset::Op<cpu::Queue<T_Device>, T_Dest, T_Extents>{}(
+                            *queue.parentQueue,
+                            dest,
+                            byteValue,
+                            extents);
+                    });
+            }
+        };
+
+        template<typename T_Device, typename T_Dest, typename T_Value, typename T_Extents>
+        struct Fill::Op<cpu::OmpCollectiveQueue<T_Device>, T_Dest, T_Value, T_Extents>
+        {
+            void operator()(
+                cpu::OmpCollectiveQueue<T_Device>& queue,
+                auto&& dest,
+                T_Value elementValue,
+                T_Extents const& extents) const
+                requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
+                         && std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+                if(::omp_in_parallel() != 0)
+                {
+                    ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+                    auto executors = supportedExecutors(getDevice(queue), exec::allExecutors);
+                    // avoid that we pass a SharedBuffer and convert non alpaka data views
+                    alpaka::concepts::IView<T_Value> auto dataView = makeView(dest);
+
+                    /* All threads in the OpenMP using the generic fill which is enqueuing a kernel into
+                     * cpu::OmpCollectiveQueue. This guarantee that the fill kernel is suing only those threads which
+                     * are in the parallel section.
+                     */
+                    alpaka::internal::generic::fill(
+                        queue,
+                        std::get<0>(executors),
+                        dataView.getSubView(extents),
+                        elementValue);
+                }
+                else
+                {
+                    internal::Fill::Op<cpu::Queue<T_Device>, T_Dest, T_Value, T_Extents>{}(
+                        *queue.parentQueue,
+                        dest,
+                        elementValue,
+                        extents);
+                }
+            }
+        };
+
+        /** The code is a copy of the Alloc::Op with the difference that the memory is allocated and freed
+         * within a queue
+         */
+        template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
+        struct AllocDeferred::Op<T_Type, cpu::OmpCollectiveQueue<T_Device>, T_Extents>
+        {
+            auto operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Extents const& extents) const
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
+
+                return omp::invokeSingle(
+                    [&]
+                    {
+                        return internal::AllocDeferred::Op<T_Type, cpu::Queue<T_Device>, T_Extents>{}(
+                            *queue.parentQueue,
+                            extents);
+                    });
+            }
+        };
+    } // namespace internal
+} // namespace alpaka::onHost
+
+namespace alpaka::internal
+{
+    template<typename T_Device>
+    struct GetApi::Op<onHost::cpu::OmpCollectiveQueue<T_Device>>
+    {
+        inline constexpr auto operator()(auto&& queue) const
+        {
+            return alpaka::getApi(queue.parentQueue->m_device);
+        }
+    };
+#endif
+
+} // namespace alpaka::internal

--- a/include/alpaka/api/host/OmpCollectiveQueue.hpp
+++ b/include/alpaka/api/host/OmpCollectiveQueue.hpp
@@ -22,13 +22,23 @@ namespace alpaka
 {
     namespace queueKind
     {
-        /** Special parallel OpenMP queue which is blocking
+        /** Special parallel OpenMP queue
          *
-         * All threads within a parallel section execute all queue methods collectively.
-         * The queue behaves like a blocking queue. Within a parallel OpenMP section all functions except enqueue
-         * kernel will be executed by a single thread only, the result is broadcasted to all threads in the section.
-         * Enqueued kernels will be executed by all threads together. Even within a parallel section each call is
-         * blocking.
+         * If this queue is used outside of an OpenMP parallel region is behaving like a blocking queue.
+         * If it is used within an OpenMP parallel region it has special behaviors.
+         *   - All threads within a parallel section execute must call methods collectively.
+         *   - operations wait for tasks enqueued outside the parallel region
+         *   - enqueueing a kernel, memcopy, memset or fill:
+         *         - if kernel: all threads execute the kernel collectively
+         *         - there is no barrier before or after the kernel execution
+         *         - take care calling two consecutive kernel, memcopy, memset or fill can lead into a data race
+         *   - wait operations: all threads will wait and see the same queue state
+         *   - enqueueHostFnDeferred: all threads wait before the operation is executed
+         *   - isEmpty: all threads wait to see the same state
+         *   - allocDeferred: all threads wait and get the same value
+         *
+         * Operating on some queue handle in parallel from within and outside the OpenMP parallel region results in
+         * undefined behavior.
          *
          * The queue can only be used if the dependency OpenMP is available, e.g. by setting the CMake option
          * ALPAKA_DEP_OMP=ON or using the required compiler flags to activate OpenMP.
@@ -109,6 +119,10 @@ namespace alpaka::onHost
 #if ALPAKA_OMP
     namespace cpu
     {
+        /** Special OpenMP parallel queue
+         *
+         * @copydetails alpaka::queueKind::OmpCollective
+         */
         template<typename T_Device>
         struct OmpCollectiveQueue : std::enable_shared_from_this<OmpCollectiveQueue<T_Device>>
         {
@@ -185,7 +199,7 @@ namespace alpaka::onHost
 
             std::shared_ptr<OmpCollectiveQueue> getSharedPtr()
             {
-                return parentQueue->shared_from_this();
+                return this->shared_from_this();
             }
 
             friend struct internal::GetNativeHandle;
@@ -217,16 +231,19 @@ namespace alpaka::onHost
 
         namespace omp
         {
+            /** One thread is invoking the function.
+             *
+             * For internal usage only. The function is taking care that the queue is correctly bookkeeping internally.
+             */
             template<typename T_Device>
             inline void invokeSingleNowait(cpu::OmpCollectiveQueue<T_Device>& queue, auto&& fn)
                 requires(std::same_as<std::invoke_result_t<ALPAKA_TYPEOF(fn)>, void>)
             {
-#    if ALPAKA_OMP
                 if(::omp_in_parallel() != 0)
                 {
                     queue.waitUntilParentQueueIsEmpty();
                     ++queue.m_numCollectiveTasksExecuted;
-#        pragma omp single nowait
+#    pragma omp single nowait
                     {
                         ALPAKA_FORWARD(fn)();
                     }
@@ -236,18 +253,22 @@ namespace alpaka::onHost
 
                 // wait until all threads within the OpenMP parallel region finished there task
                 queue.waitForNonOmpParallelOps();
-#    endif
                 ALPAKA_FORWARD(fn)();
             }
 
+            /** One thread is invoking the function and the return value is broadcast if it is non-void.
+             *
+             * For internal usage only. The function is taking care that the queue is correctly bookkeeping internally.
+             *
+             * @{
+             */
             template<typename T_Device>
             inline auto invokeSingleAndWait(cpu::OmpCollectiveQueue<T_Device>& queue, auto&& fn)
                 requires(std::same_as<std::invoke_result_t<ALPAKA_TYPEOF(fn)>, void>)
             {
-#    if ALPAKA_OMP
                 if(::omp_in_parallel() != 0)
                 {
-#        pragma omp single
+#    pragma omp single
                     {
                         queue.waitUntilParentQueueIsEmpty();
                         ++queue.m_numCollectiveTasksExecuted;
@@ -259,7 +280,6 @@ namespace alpaka::onHost
 
                 // wait until all threads within the OpenMP parallel region finished there task
                 queue.waitForNonOmpParallelOps();
-#    endif
                 ALPAKA_FORWARD(fn)();
             }
 
@@ -267,7 +287,6 @@ namespace alpaka::onHost
             inline auto invokeSingleAndWait(cpu::OmpCollectiveQueue<T_Device>& queue, auto&& fn)
                 requires(!std::same_as<std::invoke_result_t<ALPAKA_TYPEOF(fn)>, void>)
             {
-#    if ALPAKA_OMP
                 if(::omp_in_parallel() != 0)
                 {
                     using ReturnType = decltype(ALPAKA_FORWARD(fn)());
@@ -275,7 +294,7 @@ namespace alpaka::onHost
                     // wrap within an optional in cases the return value has no default constructor
                     std::optional<ReturnType> returnValue;
 
-#        pragma omp single copyprivate(returnValue)
+#    pragma omp single copyprivate(returnValue)
                     {
                         queue.waitUntilParentQueueIsEmpty();
                         ++queue.m_numCollectiveTasksExecuted;
@@ -287,9 +306,10 @@ namespace alpaka::onHost
 
                 // wait until all threads within the OpenMP parallel region finished there task
                 queue.waitForNonOmpParallelOps();
-#    endif
                 return ALPAKA_FORWARD(fn)();
             }
+
+            /** @} */
         } // namespace omp
 
         template<typename T_Platform>
@@ -325,7 +345,7 @@ namespace alpaka::onHost
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, cpu::Event<T_Device>& event) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                omp::invokeSingleAndWait(
+                internal::omp::invokeSingleAndWait(
                     queue,
                     [&]
                     {
@@ -341,7 +361,7 @@ namespace alpaka::onHost
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                omp::invokeSingleAndWait(
+                internal::omp::invokeSingleAndWait(
                     queue,
                     [&] { internal::Wait::Op<cpu::Queue<T_Device>>{}(*queue.parentQueue); });
             }
@@ -354,12 +374,12 @@ namespace alpaka::onHost
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                return omp::invokeSingleAndWait(
+                return internal::omp::invokeSingleAndWait(
                     [&] { internal::IsQueueEmpty::Op<cpu::Queue<T_Device>>{}(*queue.parentQueue); });
             }
         };
 
-        /** NO OpenMP barrier used. */
+        /** Pre OpenMP barrier is used and operation is executed without barrier at the end */
         template<typename T_Device, typename T_Task>
         struct internal::Enqueue::HostTaskDeferred<cpu::OmpCollectiveQueue<T_Device>, T_Task>
         {
@@ -367,7 +387,13 @@ namespace alpaka::onHost
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Task const& task) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                omp::invokeSingleNowait(
+
+                // ensure that e.g. SharedBuffer::keepAlive() works as expected
+                if(::omp_in_parallel() != 0)
+                {
+#    pragma omp barrier
+                }
+                internal::omp::invokeSingleNowait(
                     queue,
                     [&]
                     {
@@ -388,20 +414,25 @@ namespace alpaka::onHost
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Task const& task) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                omp::invokeSingleNowait(
+                internal::omp::invokeSingleNowait(
                     queue,
                     [&] { internal::Enqueue::HostTask<cpu::Queue<T_Device>, T_Task>{}(*queue.parentQueue, task); });
             }
         };
 
-        /** OpenMP barrier is used. */
+        /** Pre OpenMP barrier is used and operation is executed without barrier at the end */
         template<typename T_Device, typename T_Event>
         struct Enqueue::Event<cpu::OmpCollectiveQueue<T_Device>, T_Event>
         {
             void operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Event& event) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                omp::invokeSingleAndWait(
+                // ensure that e.g. SharedBuffer::keepAlive() works as expected
+                if(::omp_in_parallel() != 0)
+                {
+#    pragma omp barrier
+                }
+                internal::omp::invokeSingleNowait(
                     queue,
                     [&] { internal::Enqueue::Event<cpu::Queue<T_Device>, T_Event>{}(*queue.parentQueue, event); });
             }
@@ -415,15 +446,13 @@ namespace alpaka::onHost
          * OpenMP section. If this method is called from outside a parallel OpenMP section, the kernel will be
          * enqueued and executed as usual within a blocking queue.
          */
-        template<
-            typename T_Device,
-            onHost::concepts::ThreadSpec T_ThreadSpec,
-            alpaka::concepts::KernelBundle T_KernelBundle>
-        struct Enqueue::Kernel<cpu::OmpCollectiveQueue<T_Device>, T_ThreadSpec, T_KernelBundle>
+        template<typename T_Device, alpaka::concepts::KernelBundle T_KernelBundle, typename... T_ThreadSpecArgs>
+        struct Enqueue::
+            Kernel<cpu::OmpCollectiveQueue<T_Device>, onHost::ThreadSpec<T_ThreadSpecArgs...>, T_KernelBundle>
         {
             void operator()(
                 cpu::OmpCollectiveQueue<T_Device>& queue,
-                T_ThreadSpec const& threadSpec,
+                onHost::ThreadSpec<T_ThreadSpecArgs...> const& threadSpec,
                 T_KernelBundle const& kernelBundle) const
             {
                 static_assert(
@@ -468,15 +497,13 @@ namespace alpaka::onHost
          * OpenMP section. If this method is called from outside a parallel OpenMP section, the kernel will be
          * enqueued and executed as usual within a blocking queue.
          */
-        template<
-            typename T_Device,
-            onHost::concepts::FrameSpec T_FrameSpec,
-            alpaka::concepts::KernelBundle T_KernelBundle>
-        struct Enqueue::Kernel<cpu::OmpCollectiveQueue<T_Device>, T_FrameSpec, T_KernelBundle>
+        template<typename T_Device, alpaka::concepts::KernelBundle T_KernelBundle, typename... T_FrameSpecArgs>
+        struct Enqueue::
+            Kernel<cpu::OmpCollectiveQueue<T_Device>, onHost::FrameSpec<T_FrameSpecArgs...>, T_KernelBundle>
         {
             void operator()(
                 cpu::OmpCollectiveQueue<T_Device>& queue,
-                T_FrameSpec const& frameSpec,
+                onHost::FrameSpec<T_FrameSpecArgs...> const& frameSpec,
                 T_KernelBundle const& kernelBundle) const
             {
                 static_assert(
@@ -515,6 +542,7 @@ namespace alpaka::onHost
             }
         };
 
+        /** NO OpenMP barrier used. */
         template<typename T_Device, typename T_Dest, typename T_Source, typename T_Extents>
         struct Memcpy::Op<cpu::OmpCollectiveQueue<T_Device>, T_Dest, T_Source, T_Extents>
         {
@@ -539,7 +567,7 @@ namespace alpaka::onHost
             }
         };
 
-        // copy to device global memory
+        /** NO OpenMP barrier used. */
         template<typename T_Device, typename T_Source, typename T_Storage, typename T>
         struct MemcpyDeviceGlobal::
             Op<cpu::OmpCollectiveQueue<T_Device>, onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>, T_Source>
@@ -550,7 +578,7 @@ namespace alpaka::onHost
                 auto&& source) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
-                omp::invokeSingleNowait(
+                internal::omp::invokeSingleNowait(
                     queue,
                     [&]
                     {
@@ -562,7 +590,7 @@ namespace alpaka::onHost
             }
         };
 
-        // copy from device global memory
+        /** NO OpenMP barrier used. */
         template<typename T_Device, typename T_Dest, typename T_Storage, typename T>
         struct MemcpyDeviceGlobal::
             Op<cpu::OmpCollectiveQueue<T_Device>, T_Dest, onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T>>
@@ -573,7 +601,7 @@ namespace alpaka::onHost
                 onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> source) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
-                omp::invokeSingleNowait(
+                internal::omp::invokeSingleNowait(
                     queue,
                     [&]
                     {
@@ -588,6 +616,7 @@ namespace alpaka::onHost
             }
         };
 
+        /** NO OpenMP barrier used. */
         template<typename T_Device, typename T_Dest, typename T_Extents>
         struct Memset::Op<cpu::OmpCollectiveQueue<T_Device>, T_Dest, T_Extents>
         {
@@ -601,7 +630,7 @@ namespace alpaka::onHost
                 T_Extents const& extents) const requires(std::is_same_v<ALPAKA_TYPEOF(dest), T_Dest>)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
-                omp::invokeSingleNowait(
+                internal::omp::invokeSingleNowait(
                     queue,
                     [&]
                     {
@@ -614,6 +643,7 @@ namespace alpaka::onHost
             }
         };
 
+        /** NO OpenMP barrier used. */
         template<typename T_Device, typename T_Dest, typename T_Value, typename T_Extents>
         struct Fill::Op<cpu::OmpCollectiveQueue<T_Device>, T_Dest, T_Value, T_Extents>
         {
@@ -665,7 +695,7 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
 
-                return omp::invokeSingleAndWait(
+                return internal::omp::invokeSingleAndWait(
                     queue,
                     [&]
                     {

--- a/include/alpaka/api/host/OmpCollectiveQueue.hpp
+++ b/include/alpaka/api/host/OmpCollectiveQueue.hpp
@@ -324,7 +324,7 @@ namespace alpaka::onHost
                 auto newQueue = std::make_shared<cpu::OmpCollectiveQueue<cpu::Device<T_Platform>>>(
                     std::move(queueHandle),
                     device.queueWaitFns.size(),
-                    device.m_numaIdx);
+                    device.m_cpuGroupIdx);
 
                 std::weak_ptr<cpu::OmpCollectiveQueue<cpu::Device<T_Platform>>> weakPtrToQueue = newQueue;
                 device.queueWaitFns.emplace_back(

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -273,6 +273,7 @@ namespace alpaka::onHost
             friend struct internal::Memset;
             friend struct alpaka::internal::GetApi;
             friend struct internal::AllocDeferred;
+            friend struct internal::IgnoreVisibility;
         };
     } // namespace cpu
 

--- a/include/alpaka/api/host/exec/OmpBlocks.hpp
+++ b/include/alpaka/api/host/exec/OmpBlocks.hpp
@@ -30,12 +30,12 @@ namespace alpaka::onHost
         template<onHost::concepts::ThreadSpec T_ThreadSpec>
         struct OmpBlocks
         {
-            constexpr OmpBlocks(T_ThreadSpec threadBlocking, uint32_t numaIdx, bool setThreadAffinity)
-                : m_threadBlocking{std::move(threadBlocking)}
+            constexpr OmpBlocks(T_ThreadSpec threadSpec, uint32_t numaIdx, bool setThreadAffinity)
+                : m_threadSpec{std::move(threadSpec)}
                 , m_numaIdx{numaIdx}
                 , m_setThreadAffinity{setThreadAffinity}
             {
-                if(m_threadBlocking.getNumThreads().product() != 1u)
+                if(m_threadSpec.getNumThreads().product() != 1u)
                 {
                     throw std::runtime_error("Thread block extent must be 1.");
                 }
@@ -44,19 +44,32 @@ namespace alpaka::onHost
             void operator()(auto const& kernelBundle, auto const& dict) const
             {
                 using NumThreadsVecType = typename T_ThreadSpec::NumThreadsVecType;
-#    pragma omp parallel
+
+                bool shouldSetThreadAffinity = m_setThreadAffinity;
+
+                /* Do not change the affinity if we are executed within a OpenMP parallel section, the user should keep
+                 * the control over it.
+                 */
+                if(::omp_in_parallel() != 0)
+                    shouldSetThreadAffinity = false;
+
+                auto fn = [&kernelBundle,
+                           &dict,
+                           threadSpec = m_threadSpec,
+                           numaIdx = m_numaIdx,
+                           setThreadAffinity = shouldSetThreadAffinity]()
                 {
-                    if(m_setThreadAffinity)
-                        internal::hwloc::setThreadAffinity(m_numaIdx);
+                    if(setThreadAffinity)
+                        internal::hwloc::setThreadAffinity(numaIdx);
 
                     // copy from num blocks to derive correct index type
-                    auto blockIdx = m_threadBlocking.getNumBlocks();
+                    auto blockIdx = threadSpec.getNumBlocks();
                     constexpr uint32_t simdWidth
                         = alpaka::getArchSimdWidth<uint8_t>(api::host, ALPAKA_TYPEOF(dict[object::deviceKind]){});
                     auto blockSharedMem = onAcc::cpu::SingleThreadStaticShared<simdWidth>{};
 
                     // dynamic shared mem
-                    uint32_t blockDynSharedMemBytes = onHost::getDynSharedMemBytes(m_threadBlocking, kernelBundle);
+                    uint32_t blockDynSharedMemBytes = onHost::getDynSharedMemBytes(threadSpec, kernelBundle);
                     auto const blockDynSharedMemEntry = DictEntry{layer::dynShared, std::ref(blockSharedMem)};
                     auto const blockDynSharedMemBytesEntry
                         = DictEntry{object::dynSharedMemBytes, std::ref(blockDynSharedMemBytes)};
@@ -68,7 +81,7 @@ namespace alpaka::onHost
                         dict,
                         Dict{blockDynSharedMemEntry, blockDynSharedMemBytesEntry});
 
-                    auto blockCount = m_threadBlocking.getNumBlocks();
+                    auto blockCount = threadSpec.getNumBlocks();
 
                     auto const blockLayerEntry = DictEntry{
                         layer::block,
@@ -90,10 +103,24 @@ namespace alpaka::onHost
                         kernelBundle(acc);
                         blockSharedMem.reset();
                     }
+                };
+
+                if(::omp_in_parallel() != 0)
+                {
+                    /* we are already in a OpenMP parllel section, do not start a new section to avoid nested
+                     * parallelism which is typical slow
+                     */
+                    fn();
+                }
+                else
+                {
+#    pragma omp parallel
+                    fn();
                 }
             }
 
-            T_ThreadSpec m_threadBlocking;
+        private:
+            T_ThreadSpec m_threadSpec;
             uint32_t m_numaIdx;
             bool m_setThreadAffinity;
         };

--- a/include/alpaka/api/host/exec/OmpBlocks.hpp
+++ b/include/alpaka/api/host/exec/OmpBlocks.hpp
@@ -41,6 +41,15 @@ namespace alpaka::onHost
                 }
             }
 
+            /** Execute the kernel bundle with OpenMP.
+             *
+             * @attention If this method is called from within an existing OpenMP parallel scope the function must be
+             * called collectivly. All existing threads will execute the kernel bundle together and there will be no
+             * thread synchronization after the function call.
+             *
+             * If the function is called from without beeing in a parallel OpenMP scope a OpenMP parallel for loop will
+             * be used for exection.
+             */
             void operator()(auto const& kernelBundle, auto const& dict) const
             {
                 using NumThreadsVecType = typename T_ThreadSpec::NumThreadsVecType;
@@ -107,8 +116,10 @@ namespace alpaka::onHost
 
                 if(::omp_in_parallel() != 0)
                 {
-                    /* we are already in a OpenMP parllel section, do not start a new section to avoid nested
-                     * parallelism which is typical slow
+                    /* We are already in a OpenMP parllel section, do not start a new section to avoid nested
+                     * parallelism which is typical slow.
+                     * There is no synchronization after the function execution happen, the caller is responsible for
+                     * it.
                      */
                     fn();
                 }

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -495,6 +495,21 @@ namespace alpaka::onHost
             return GetPitches::Op<ALPAKA_TYPEOF(*any.get())>{}(*any.get());
         }
 
+        /** Class to get access even if the visibility is private or protected.
+         *
+         * In the internal implementations of alpaka most classes does not expose their members to avoid that the user
+         * can easily use it in there code. Nevertheless, sometimes it is useful to ignore the visibility to simplify
+         * the implementation of function interfaces. If the class you want to access defines IgnoreVisibility as
+         * friend you can implement any data/function access to the class.
+         *
+         * @attention Do not make strong use of this method!
+         */
+        struct IgnoreVisibility
+        {
+            template<typename T_Any>
+            struct Op;
+        };
+
         /** Provide a frame specification for the given extents
          *
          * @param internalDevice must be an alpaka internal device implementation

--- a/test/unit/queue/ompCollectiveQueue.cpp
+++ b/test/unit/queue/ompCollectiveQueue.cpp
@@ -1,0 +1,204 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/** This test is testing the special queue OmpCollectiveQueue.
+ *
+ * The queue is **NOT** part of official alpaka, therefore is must be included separately.
+ * The test is skipped if alpaka tests are build without OpenMP support.
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/api/host/OmpCollectiveQueue.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <vector>
+
+
+using namespace alpaka;
+
+// We test only the executor cpuOmpBlocks because we use the special queue OmpCollectiveQueue
+using TestBackends
+    = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, std::make_tuple(exec::cpuOmpBlocks)))>;
+
+#if ALPAKA_OMP
+/** The number of threads used for the OpenMP parallel section */
+constexpr uint32_t numOmpThreads = 3;
+
+// used to validate the ompCollective queue indide of a parallel section
+struct KernelND
+{
+    ALPAKA_FN_ACC void operator()(auto const& acc, auto out, auto counter) const
+    {
+        uint32_t ompThreadIdx = omp_get_thread_num();
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
+        {
+            out[i] = ompThreadIdx;
+            onAcc::atomicAdd(acc, &counter[i], 1u);
+        }
+    }
+};
+
+// used to validate the ompCollective queue outside of a parallel section
+struct IotaKernelND
+{
+    ALPAKA_FN_ACC void operator()(auto const& acc, auto out, auto counter) const
+    {
+        for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
+        {
+            out[i] = i;
+            onAcc::atomicAdd(acc, &counter[i], 1u);
+        }
+    }
+};
+
+// test the queue ompCollective within a parallel section
+void testCombinationOmpParallel(auto queue, auto exec, concepts::Vector auto extents)
+{
+    auto hBuff = onHost::allocHost<uint32_t>(extents);
+
+    // take care invokeSingle can be called outside of a OpenMP parallel section
+    auto hBuffCounter = onHost::omp::invokeSingle([&] { return onHost::allocHostLike(hBuff); });
+
+    // Test as many as possible queue methods within the parallel section, because all of them have a special
+    // implementation.
+#    pragma omp parallel num_threads(numOmpThreads)
+    {
+        /* Any non queue function can be call as lambda via the invoke helper method.
+         * After the kernel call the buffer contains the index of the thread which accessed the corresponding element.
+         */
+        auto dBuff = onHost::omp::invokeSingle([&] { return onHost::alloc<uint32_t>(queue.getDevice(), extents); });
+
+        auto dBuffCounter = onHost::allocDeferred<uint32_t>(queue, extents);
+        // wait is not required because the queue is blocking but let us test the interface
+        onHost::wait(queue);
+
+        onHost::fill(queue, dBuff, 0u);
+        onHost::memset(queue, dBuffCounter, 0u);
+
+        auto numFrames = ALPAKA_TYPEOF(extents)::fill(1);
+        /* we need as many blocks as we have numOmpThreads threads to guarantee each thread is executing at least one
+         * element. This is required for our validation.
+         */
+        numFrames.x() = numOmpThreads;
+        queue.enqueue(
+            onHost::FrameSpec{numFrames, ALPAKA_TYPEOF(extents)::fill(1), exec},
+            KernelBundle{KernelND{}, dBuff, dBuffCounter});
+
+        onHost::memcpy(queue, hBuff, dBuff);
+        onHost::memcpy(queue, hBuffCounter, dBuffCounter);
+        // no wait is performed because the queue is blocking
+    }
+
+    // Use REQUIRE instead of CHECK to avoid spamming the output if the results are wrong.
+    // we create a histogram to check that all threads are used
+    std::vector<uint32_t> threadCounter(numOmpThreads, 0u);
+    meta::ndLoopIncIdx(
+        extents,
+        [&](auto idx)
+        {
+            threadCounter[hBuff[idx]]++;
+            // fail if more or less than one invocation on the same data item is detected
+            REQUIRE(1u == hBuffCounter[idx]);
+        });
+    // Each thread should be used by the kernel at least once
+    for(auto const& count : threadCounter)
+        REQUIRE(count != 0u);
+}
+
+// test the queue ompCollective outside of a parallel section
+void testCombinationNoParallel(auto queue, auto exec, concepts::Vector auto extents)
+{
+    auto dBuff = onHost::alloc<ALPAKA_TYPEOF(extents)>(queue.getDevice(), extents);
+    auto dBuffCounter = onHost::alloc<uint32_t>(queue.getDevice(), extents);
+
+    auto hBuff = onHost::allocHostLike(dBuff);
+    auto hBuffCounter = onHost::allocHostLike(dBuffCounter);
+
+    onHost::memset(queue, dBuff, 0u);
+    onHost::memset(queue, dBuffCounter, 0u);
+
+    queue.enqueue(
+        onHost::FrameSpec{extents, ALPAKA_TYPEOF(extents)::fill(1), exec},
+        KernelBundle{IotaKernelND{}, dBuff, dBuffCounter});
+    onHost::memcpy(queue, hBuff, dBuff);
+    onHost::memcpy(queue, hBuffCounter, dBuffCounter);
+
+    // Use REQUIRE instead of CHECK to avoid spamming the output if the results are wrong.
+    meta::ndLoopIncIdx(
+        extents,
+        [&](auto idx)
+        {
+            REQUIRE(idx == hBuff[idx]);
+            // fail if more or less than one invocation on the same data item is detected
+            REQUIRE(1u == hBuffCounter[idx]);
+        });
+}
+
+template<typename Queue, typename Exec, typename Extent>
+void runTest(Queue& queue, Exec exec, Extent const& bufferExtents)
+{
+    DYNAMIC_SECTION(
+        "OpenMP within parallel section: exec=" << onHost::demangledName(exec) << ", extent=" << bufferExtents)
+    {
+        // we need at least numOmpThreads elements to guarantee that each thread is executing at least one element.
+        CHECK(bufferExtents.product() >= numOmpThreads);
+        testCombinationOmpParallel(queue, exec, bufferExtents);
+    }
+    DYNAMIC_SECTION("No OpenMP section: exec=" << onHost::demangledName(exec) << ", extent=" << bufferExtents)
+    {
+        // we need at least numOmpThreads elements to guarantee that each thread is executing at least one element.
+        CHECK(bufferExtents.product() >= numOmpThreads);
+        testCombinationNoParallel(queue, exec, bufferExtents);
+    }
+}
+
+/** The test is testing the queue ompCollective once within a parallel OpenMP section and once outside.
+ *  In both cases it must behave like a blocking queue.
+ */
+TEMPLATE_LIST_TEST_CASE("OmpCollectiveQueue", "[queue][OmpCollectiveQueue]", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceSpec = cfg[object::deviceSpec];
+    auto exec = cfg[object::exec];
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        SUCCEED("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    INFO("api=" << deviceSpec.getApi().getName());
+    INFO("device=" << device.getName());
+    INFO("executor=" << exec.getName());
+
+    onHost::Queue queue = device.makeQueue(queueKind::ompCollective);
+
+    auto extents = std::make_tuple(
+        // 1D
+        Vec{numOmpThreads},
+        Vec{997u},
+        // 2D
+        Vec{2u, 3u},
+        Vec{101u, 103u},
+        // 3D
+        Vec{2u, 3u, 5u},
+        Vec{43u, 47u, 53u},
+        // 4D
+        Vec{2u, 3u, 5u, 7u},
+        Vec{47u, 43u, 17u, 13u});
+
+    std::apply([&](auto const&... extent) { (runTest(queue, exec, extent), ...); }, extents);
+}
+#else
+TEST_CASE("OmpCollectiveQueue", "[queue][OmpCollectiveQueue]")
+{
+    WARN("no OpenMP available: Disable OmpCollectiveQueue test");
+    SUCCEED("SKIP OmpCollectiveQueue test");
+}
+#endif

--- a/test/unit/queue/ompCollectiveQueue.cpp
+++ b/test/unit/queue/ompCollectiveQueue.cpp
@@ -73,12 +73,12 @@ void testCombinationOmpParallel(auto queue, auto exec, concepts::Vector auto ext
         auto dBuff = onHost::omp::invokeSingle([&] { return onHost::alloc<uint32_t>(queue.getDevice(), extents); });
 
         auto dBuffCounter = onHost::allocDeferred<uint32_t>(queue, extents);
-        // wait is not required because the queue is blocking but let us test the interface
-        onHost::wait(queue);
 
         onHost::fill(queue, dBuff, 0u);
         onHost::memset(queue, dBuffCounter, 0u);
 
+        // wait is required because memset and fill are non-blocking and concurrent
+        onHost::wait(queue);
         auto numFrames = ALPAKA_TYPEOF(extents)::fill(1);
         /* we need as many blocks as we have numOmpThreads threads to guarantee each thread is executing at least one
          * element. This is required for our validation.
@@ -87,6 +87,9 @@ void testCombinationOmpParallel(auto queue, auto exec, concepts::Vector auto ext
         queue.enqueue(
             onHost::FrameSpec{numFrames, ALPAKA_TYPEOF(extents)::fill(1), exec},
             KernelBundle{KernelND{}, dBuff, dBuffCounter});
+
+        // wait is required because kernel enqueue is non-blocking and concurrent
+        onHost::wait(queue);
 
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::memcpy(queue, hBuffCounter, dBuffCounter);

--- a/test/unit/queue/ompCollectiveQueue.cpp
+++ b/test/unit/queue/ompCollectiveQueue.cpp
@@ -33,7 +33,11 @@ struct KernelND
 {
     ALPAKA_FN_ACC void operator()(auto const& acc, auto out, auto counter) const
     {
+#    if ALPAKA_COMP_NVCC && ALPAKA_ARCH_PTX
+        uint32_t ompThreadIdx = 0;
+#    else
         uint32_t ompThreadIdx = omp_get_thread_num();
+#    endif
         for(auto i : onAcc::makeIdxMap(acc, onAcc::worker::threadsInGrid, IdxRange{out.getExtents()}))
         {
             out[i] = ompThreadIdx;
@@ -63,8 +67,9 @@ void testCombinationOmpParallel(auto queue, auto exec, concepts::Vector auto ext
     // take care invokeSingle can be called outside of a OpenMP parallel section
     auto hBuffCounter = onHost::omp::invokeSingle([&] { return onHost::allocHostLike(hBuff); });
 
-    // Test as many as possible queue methods within the parallel section, because all of them have a special
-    // implementation.
+    /* Test as many as possible queue methods within the parallel section, because all of them have a special
+     * implementation.
+     */
 #    pragma omp parallel num_threads(numOmpThreads)
     {
         /* Any non queue function can be call as lambda via the invoke helper method.
@@ -80,7 +85,7 @@ void testCombinationOmpParallel(auto queue, auto exec, concepts::Vector auto ext
         // wait is required because memset and fill are non-blocking and concurrent
         onHost::wait(queue);
         auto numFrames = ALPAKA_TYPEOF(extents)::fill(1);
-        /* we need as many blocks as we have numOmpThreads threads to guarantee each thread is executing at least one
+        /* We need as frames blocks as we have numOmpThreads threads to guarantee each thread is executing at least one
          * element. This is required for our validation.
          */
         numFrames.x() = numOmpThreads;
@@ -93,11 +98,13 @@ void testCombinationOmpParallel(auto queue, auto exec, concepts::Vector auto ext
 
         onHost::memcpy(queue, hBuff, dBuff);
         onHost::memcpy(queue, hBuffCounter, dBuffCounter);
-        // no wait is performed because the queue is blocking
     }
+    // we need to wait because memcpy within the parallel region will not block
+    onHost::wait(queue);
 
-    // Use REQUIRE instead of CHECK to avoid spamming the output if the results are wrong.
-    // we create a histogram to check that all threads are used
+    /* Use REQUIRE instead of CHECK to avoid spamming the output if the results are wrong.
+     * we create a histogram to check that all threads are used.
+     */
     std::vector<uint32_t> threadCounter(numOmpThreads, 0u);
     meta::ndLoopIncIdx(
         extents,
@@ -112,7 +119,7 @@ void testCombinationOmpParallel(auto queue, auto exec, concepts::Vector auto ext
         REQUIRE(count != 0u);
 }
 
-// test the queue ompCollective outside of a parallel section
+// test the queue ompCollective outside a parallel section
 void testCombinationNoParallel(auto queue, auto exec, concepts::Vector auto extents)
 {
     auto dBuff = onHost::alloc<ALPAKA_TYPEOF(extents)>(queue.getDevice(), extents);
@@ -122,7 +129,12 @@ void testCombinationNoParallel(auto queue, auto exec, concepts::Vector auto exte
     auto hBuffCounter = onHost::allocHostLike(dBuffCounter);
 
     onHost::memset(queue, dBuff, 0u);
-    onHost::memset(queue, dBuffCounter, 0u);
+    onHost::fill(queue, dBuffCounter, 0u);
+
+    /* This wait is not required because the queue ompCollective is blocking but for testing that wait is callable this
+     * is important.
+     */
+    onHost::wait(queue);
 
     queue.enqueue(
         onHost::FrameSpec{extents, ALPAKA_TYPEOF(extents)::fill(1), exec},

--- a/test/unit/queue/ompCollectiveQueue.cpp
+++ b/test/unit/queue/ompCollectiveQueue.cpp
@@ -11,6 +11,7 @@
 #include <alpaka/alpaka.hpp>
 #include <alpaka/api/host/OmpCollectiveQueue.hpp>
 
+#include <alpakaTest/deviceHelper.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
@@ -176,22 +177,9 @@ void runTest(Queue& queue, Exec exec, Extent const& bufferExtents)
  */
 TEMPLATE_LIST_TEST_CASE("OmpCollectiveQueue", "[queue][OmpCollectiveQueue]", TestBackends)
 {
-    auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
-
-    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
-    if(!devSelector.isAvailable())
-    {
-        SUCCEED("No device available for " << deviceSpec.getName());
-        return;
-    }
-
-    onHost::Device device = devSelector.makeDevice(0);
-    INFO("api=" << deviceSpec.getApi().getName());
-    INFO("device=" << device.getName());
-    INFO("executor=" << exec.getName());
-
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue(queueKind::ompCollective);
 
     auto extents = std::make_tuple(


### PR DESCRIPTION
Add a special queue for OpenMP environments that supports thread collective kernel invocations from within an OpenMP parallel section.

The queue is not included if you include `alpaka/alpaka.hpp`, this feature is required to be included explicitly.


CC: @krzikalla


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenMP-aware collective host queue mode to coordinate queue operations consistently across participating threads, including OpenMP single/broadcast invocation support.
* **Bug Fixes**
  * Improved host device/queue teardown and wait behavior to ensure pending work completes reliably without holding internal locks during long waits.
  * Refined OpenMP execution to avoid nested parallel regions and to keep collective enqueue/wait state consistent across threads.
* **Tests**
  * Added unit tests covering collective queue behavior both inside and outside OpenMP parallel regions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->