### PR TITLE
add stencil transform test

### DIFF
--- a/include/alpaka/SimdPtr.hpp
+++ b/include/alpaka/SimdPtr.hpp
@@ -81,9 +81,15 @@ namespace alpaka
          *
          * @{
          */
-        constexpr alpaka::concepts::SimdPtr auto operator[](
-            alpaka::concepts::IndexVec<typename IdxType::type, T_MdSpan::dim()> auto const& idx) const
+        constexpr alpaka::concepts::SimdPtr auto operator[](auto const& idx) const
         {
+            /* Do not use concepts::IndexVec as concept in the function signature else nvcc (tested 12.X -> 13.0)
+             * segfaults during compile.
+             */
+            static_assert(
+                alpaka::concepts::IndexVec<ALPAKA_TYPEOF(idx), typename IdxType::type, T_MdSpan::dim()>,
+                "The dimension of idx must match the encapsulated MdSpan dimension and the index type of idx must be "
+                "lossless castable to the MdSpan index type");
             constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(value_type));
             constexpr auto align = Alignment<valueAlignment>{};
             return SimdPtr<T_MdSpan, IdxType, ALPAKA_TYPEOF(align), T_SimdWidth>{
@@ -93,9 +99,15 @@ namespace alpaka
                 T_SimdWidth{}};
         }
 
-        constexpr alpaka::concepts::SimdPtr auto operator[](
-            alpaka::concepts::IndexVec<typename IdxType::type, T_MdSpan::dim()> auto const& idx)
+        constexpr alpaka::concepts::SimdPtr auto operator[](auto const& idx)
         {
+            /* Do not use concepts::IndexVec as concept in the function signature else nvcc (tested 12.X -> 13.0)
+             * segfaults during compile.
+             */
+            static_assert(
+                alpaka::concepts::IndexVec<ALPAKA_TYPEOF(idx), typename IdxType::type, T_MdSpan::dim()>,
+                "The dimension of idx must match the encapsulated MdSpan dimension and the index type of idx must be "
+                "lossless castable to the MdSpan index type");
             constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(value_type));
             constexpr auto align = Alignment<valueAlignment>{};
             return SimdPtr<T_MdSpan, IdxType, ALPAKA_TYPEOF(align), T_SimdWidth>{

--- a/include/alpaka/SimdPtr.hpp
+++ b/include/alpaka/SimdPtr.hpp
@@ -81,7 +81,7 @@ namespace alpaka
          *
          * @{
          */
-        constexpr auto operator[](
+        constexpr alpaka::concepts::SimdPtr auto operator[](
             alpaka::concepts::IndexVec<typename IdxType::type, T_MdSpan::dim()> auto const& idx) const
         {
             constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(value_type));
@@ -93,7 +93,8 @@ namespace alpaka
                 T_SimdWidth{}};
         }
 
-        constexpr auto operator[](alpaka::concepts::IndexVec<typename IdxType::type, T_MdSpan::dim()> auto const& idx)
+        constexpr alpaka::concepts::SimdPtr auto operator[](
+            alpaka::concepts::IndexVec<typename IdxType::type, T_MdSpan::dim()> auto const& idx)
         {
             constexpr uint32_t valueAlignment = static_cast<uint32_t>(alignof(value_type));
             constexpr auto align = Alignment<valueAlignment>{};

--- a/include/alpaka/mem/concepts/IndexVec.hpp
+++ b/include/alpaka/mem/concepts/IndexVec.hpp
@@ -12,12 +12,15 @@ namespace alpaka::concepts
      * @details The type must fulfill alpaka::concepts::Vector, and its type must be convertible to an expected index
      * type without loss of precision.
      *
+     * If you observe that nvcc segfaults during compile, and you used this concept in the function signature, replace
+     * it with a static assert inside the function body. see SimdPtr::operator[]().
+     *
      * @tparam T_IndexType expected index type
-     * @tparam T_Dim expected dimension
+     * @tparam T_dim expected dimension
      */
-    template<typename T, typename T_IndexType, auto T_Dim>
+    template<typename T, typename T_IndexType, uint32_t T_dim>
     concept IndexVec = requires {
-        requires concepts::Vector<T, alpaka::NotRequired, T_Dim>;
+        requires concepts::Vector<T, alpaka::NotRequired, T_dim>;
         requires isLosslesslyConvertible_v<typename T::type, T_IndexType>;
     };
 } // namespace alpaka::concepts

--- a/test/unit/algorithm/transform.cpp
+++ b/test/unit/algorithm/transform.cpp
@@ -293,3 +293,136 @@ TEMPLATE_LIST_TEST_CASE("transform generator", "", TestBackends)
 
     std::apply([&](auto... extents) { (prepareTest<DataType>(cfg, extents, functorList), ...); }, extentMdList);
 }
+
+/** Cross stencil
+ *
+ * N-dimensional asymmetric cross stencil. The positive direction is weighted with 5 and the negative with 3.
+ * The middle value is not weighted.
+ */
+struct CrossStencil
+{
+    constexpr auto operator()(concepts::SimdPtr auto const& in) const
+    {
+        using SimdPtrType = ALPAKA_TYPEOF(in);
+        using VecIdxType = typename SimdPtrType::IdxType;
+
+        // Load the value the simd pointer is pointing to.
+        auto result = in.load();
+
+        for(uint32_t d = 0u; d < VecIdxType::dim(); ++d)
+        {
+            /* Shift relative to the current element pointed to into the negative or positive direction within a
+             * dimension.
+             */
+            concepts::Vector auto negative = VecIdxType::fill(0);
+            concepts::Vector auto positive = VecIdxType::fill(0);
+            negative[d] = -1;
+            positive[d] = 1;
+
+            result += in[negative].load() * 3;
+            result += in[positive].load() * 5;
+        }
+
+        return result;
+    }
+};
+
+template<typename T_DataType, typename T_StencilFn>
+void testStencilTransform(auto cfg, concepts::Vector auto extentMd)
+{
+    using DataType = T_DataType;
+    using Extent = std::decay_t<decltype(extentMd)>;
+
+    auto deviceSpec = cfg[object::deviceSpec];
+    alpaka::concepts::Executor auto exec = cfg[object::exec];
+
+    auto computeDevSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!computeDevSelector.isAvailable())
+    {
+        SUCCEED("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    onHost::Device computeDev = computeDevSelector.makeDevice(0);
+    onHost::Queue computeQueue = computeDev.makeQueue();
+
+    INFO("device spec: " << getName(deviceSpec));
+    INFO("device name: " << computeDev.getName());
+    INFO("executor   : " << exec.getName());
+    INFO("extents    : " << extentMd);
+
+    auto const halo = Extent::fill(1);
+    auto const innerExtent = extentMd - Extent::fill(2);
+
+    onHost::SharedBuffer computeIn = onHost::allocDeferred<DataType>(computeQueue, extentMd);
+    // The output does not need helo's
+    onHost::SharedBuffer computeOut = onHost::allocDeferred<DataType>(computeQueue, innerExtent);
+
+    onHost::SharedBuffer hostIn = onHost::allocLike(onHost::makeHostDevice(), computeIn);
+    onHost::SharedBuffer hostOut = onHost::allocLike(onHost::makeHostDevice(), computeOut);
+
+    meta::ndLoopIncIdx(
+        extentMd,
+        [&](auto idx)
+        {
+            /* Use a fake size of 1000 for each direction, this would make the index human.
+             * Accidentally switching the index order z,y,x in SImdPtr during the stencil access will be detracted
+             * and easy to debug. e.g. (y,x) -> (13,5) will become 13005
+             */
+            int32_t value = alpaka::linearize(ALPAKA_TYPEOF(extentMd)::fill(1000), idx);
+
+            hostIn[idx] = value;
+        });
+
+    onHost::memcpy(computeQueue, computeIn, hostIn);
+
+    /* For the stencil operation we work only on the inner volume, this allows performing the stencil operation
+     * without handling out of memory access at the boundaries.
+     */
+    auto shiftedComputeIn = computeIn.getView().getSubView(halo, innerExtent);
+
+    onHost::transform(computeQueue, exec, computeOut, StencilFunc{T_StencilFn{}}, shiftedComputeIn);
+    onHost::memcpy(computeQueue, hostOut, computeOut);
+    onHost::wait(computeQueue);
+
+    meta::ndLoopIncIdx(
+        innerExtent,
+        [&](concepts::Vector auto outIdx)
+        {
+            concepts::Vector auto const inIdx = outIdx + halo;
+
+            DataType expected = hostIn[inIdx];
+
+            for(uint32_t d = 0u; d < extentMd.dim(); ++d)
+            {
+                // absolut offset from the origin of hostIn including helo
+                auto negative = inIdx;
+                auto positive = inIdx;
+
+                --negative[d];
+                ++positive[d];
+
+                expected += hostIn[negative] * 3;
+                expected += hostIn[positive] * 5;
+            }
+
+            REQUIRE(hostOut[outIdx] == expected);
+        });
+}
+
+/** Validate the transform stencil feature.
+ *
+ * Additionally, this checks take care that SimdPtr::operator[]() works as expected.
+ */
+TEMPLATE_LIST_TEST_CASE("transform SimdPtr cross stencil", "", TestBackends)
+{
+    auto cfg = TestType::makeDict();
+
+    using DataType = int32_t;
+
+    auto extentMdList = std::make_tuple(Vec{17}, Vec{17, 19}, Vec{13, 17, 19}, Vec{7, 11, 13, 17});
+
+    std::apply(
+        [&](auto... extents) { (testStencilTransform<DataType, CrossStencil>(cfg, extents), ...); },
+        extentMdList);
+}

--- a/test/unit/algorithm/transform.cpp
+++ b/test/unit/algorithm/transform.cpp
@@ -307,7 +307,12 @@ struct CrossStencil
         using VecIdxType = typename SimdPtrType::IdxType;
 
         // Load the value the simd pointer is pointing to.
-        auto result = in.load();
+        concepts::Simd auto result = in.load();
+
+        // Arbitrary constant added to the result.
+        using SimdType = ALPAKA_TYPEOF(result);
+        concepts::Simd auto const value = SimdType::fill(42);
+        result += value;
 
         for(uint32_t d = 0u; d < VecIdxType::dim(); ++d)
         {
@@ -391,7 +396,7 @@ void testStencilTransform(auto cfg, concepts::Vector auto extentMd)
         {
             concepts::Vector auto const inIdx = outIdx + halo;
 
-            DataType expected = hostIn[inIdx];
+            DataType expected = hostIn[inIdx] + 42;
 
             for(uint32_t d = 0u; d < extentMd.dim(); ++d)
             {


### PR DESCRIPTION
In #543 the reviewer would like to have a test for the stencil feature usable within transform. To avoid breaking the feature see #550.

The test is using a simple asymetric cross stencil and test it for up to 4 dimensions.

The second commit is adding a workaround for nvcc. Nvcc segfaults during compile wenn calling `SimdPtr::operator[]()` due to the concept in the function signature.