### PR TITLE
`pCast` and CUDA atomics cleanup

### DIFF
--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -652,7 +652,7 @@ namespace alpaka
         template<typename T_To, typename T_Type, uint32_t T_width, typename T_Storage>
         struct PCast::Op<T_To, alpaka::Simd<T_Type, T_width, T_Storage>>
         {
-            constexpr decltype(auto) operator()(auto&& input) const
+            constexpr auto operator()(auto&& input) const
                 requires std::convertible_to<T_Type, T_To> && (!std::same_as<T_To, T_Type>)
             {
                 return typename alpaka::Simd<T_To, T_width, T_Storage>::UniSimd(
@@ -661,7 +661,7 @@ namespace alpaka
 
             constexpr decltype(auto) operator()(auto&& input) const requires std::same_as<T_To, T_Type>
             {
-                return input;
+                return std::forward<decltype(input)>(input);
             }
         };
     } // namespace internal

--- a/include/alpaka/SimdMask.hpp
+++ b/include/alpaka/SimdMask.hpp
@@ -507,7 +507,7 @@ namespace alpaka
         template<typename T_To, typename T_Type, uint32_t T_width, typename T_Storage>
         struct PCast::Op<T_To, alpaka::SimdMask<T_Type, T_width, T_Storage>>
         {
-            constexpr decltype(auto) operator()(auto&& input) const
+            constexpr auto operator()(auto&& input) const
                 requires std::convertible_to<T_Type, T_To> && (!std::same_as<T_To, T_Type>)
             {
                 return typename alpaka::SimdMask<T_To, T_width, T_Storage>::UniSimdMask(
@@ -516,7 +516,7 @@ namespace alpaka
 
             constexpr decltype(auto) operator()(auto&& input) const requires std::same_as<T_To, T_Type>
             {
-                return input;
+                return std::forward<decltype(input)>(input);
             }
         };
     } // namespace internal

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -18,6 +18,7 @@
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 namespace alpaka
 {
@@ -968,7 +969,7 @@ namespace alpaka
         template<typename T_To, typename T_Type, uint32_t T_dim, typename T_Storage>
         struct PCast::Op<T_To, alpaka::Vec<T_Type, T_dim, T_Storage>>
         {
-            constexpr decltype(auto) operator()(auto&& input) const
+            constexpr auto operator()(auto&& input) const
                 requires std::convertible_to<T_Type, T_To> && (!std::same_as<T_To, T_Type>)
             {
                 return typename alpaka::Vec<T_To, T_dim, T_Storage>::UniVec([&](uint32_t idx) constexpr
@@ -977,7 +978,7 @@ namespace alpaka
 
             constexpr decltype(auto) operator()(auto&& input) const requires std::same_as<T_To, T_Type>
             {
-                return input;
+                return std::forward<decltype(input)>(input);
             }
         };
     } // namespace internal

--- a/include/alpaka/api/unifiedCudaHip/atomic.hpp
+++ b/include/alpaka/api/unifiedCudaHip/atomic.hpp
@@ -12,6 +12,7 @@
 #include "alpaka/onAcc/scope.hpp"
 #include "alpaka/operation.hpp"
 
+#include <bit>
 #include <limits>
 #include <type_traits>
 
@@ -23,27 +24,23 @@ namespace alpaka::onAcc::internalCompute
     {
         struct EmulationBase
         {
-            //! reinterprets an address as an 32bit value for atomicCas emulation usage
-            template<typename TAddressType>
-            static __device__ auto reinterpretAddress(TAddressType* address)
-                -> std::enable_if_t<sizeof(TAddressType) == 4u, unsigned int*>
-            {
-                return reinterpret_cast<unsigned int*>(address);
-            }
+            template<typename T_Type>
+            using AtomicCasType = std::conditional_t<
+                sizeof(T_Type) == 4u,
+                unsigned int,
+                std::conditional_t<sizeof(T_Type) == 8u, unsigned long long int, void>>;
 
-            //! reinterprets a address as an 64bit value for atomicCas emulation usage
-            template<typename TAddressType>
-            static __device__ auto reinterpretAddress(TAddressType* address)
-                -> std::enable_if_t<sizeof(TAddressType) == 8u, unsigned long long int*>
-            {
-                return reinterpret_cast<unsigned long long int*>(address);
-            }
+            template<typename T_Type>
+            static __device__ auto reinterpretAddress(T_Type* address)
+                -> AtomicCasType<T_Type>* requires(sizeof(T_Type) == 4u || sizeof(T_Type) == 8u) {
+                    return reinterpret_cast<AtomicCasType<T_Type>*>(address);
+                }
 
-            //! reinterprets a value to be usable for the atomicCAS emulation
             template<typename T_Type>
             static __device__ auto reinterpretValue(T_Type value)
+                -> AtomicCasType<T_Type> requires(sizeof(T_Type) == 4u || sizeof(T_Type) == 8u)
             {
-                return *reinterpretAddress(&value);
+                return std::bit_cast<AtomicCasType<T_Type>>(value);
             }
         };
 
@@ -80,13 +77,13 @@ namespace alpaka::onAcc::internalCompute
                 do
                 {
                     assumed = old;
-                    T v = *(reinterpret_cast<T*>(&assumed));
+                    T v = std::bit_cast<T>(assumed);
                     TOp{}(&v, value);
                     using Cas = Atomic::Op<alpaka::operation::Cas, internal::CudaHipAtomic, EmulatedType, T_Scope>;
                     old = Cas::atomicOp(ctx, addressAsIntegralType, assumed, reinterpretValue(v));
                     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
                 } while(assumed != old);
-                return *(reinterpret_cast<T*>(&old));
+                return std::bit_cast<T>(old);
             }
         };
 
@@ -112,7 +109,7 @@ namespace alpaka::onAcc::internalCompute
                         reinterpretedCompare,
                         reinterpretedValue);
 
-                return *(reinterpret_cast<T*>(&old));
+                return std::bit_cast<T>(old);
             }
         };
 

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -173,7 +173,7 @@ namespace alpaka
             alpaka::concepts::Vector T_Stride>
         struct PCast::Op<T_To, IdxRange<T_End, T_Begin, T_Stride>>
         {
-            constexpr decltype(auto) operator()(auto&& input) const
+            constexpr auto operator()(auto&& input) const
                 requires std::convertible_to<typename T_End::type, T_To> && (!std::same_as<T_To, typename T_End::type>)
             {
                 return IdxRange{pCast<T_To>(input.m_begin), pCast<T_To>(input.m_end), pCast<T_To>(input.m_stride)};
@@ -181,7 +181,7 @@ namespace alpaka
 
             constexpr decltype(auto) operator()(auto&& input) const requires std::same_as<T_To, typename T_End::type>
             {
-                return input;
+                return std::forward<decltype(input)>(input);
             }
         };
 

--- a/include/alpaka/mem/ThreadSpace.hpp
+++ b/include/alpaka/mem/ThreadSpace.hpp
@@ -105,7 +105,7 @@ namespace alpaka
         template<typename T_To, typename T_ThreadIdx, typename T_ThreadCount>
         struct PCast::Op<T_To, ThreadSpace<T_ThreadIdx, T_ThreadCount>>
         {
-            constexpr decltype(auto) operator()(auto&& input) const
+            constexpr auto operator()(auto&& input) const
                 requires std::convertible_to<typename T_ThreadIdx::type, T_To>
                          && (!std::same_as<T_To, typename T_ThreadIdx::type>)
             {
@@ -115,7 +115,7 @@ namespace alpaka
             constexpr decltype(auto) operator()(auto&& input) const
                 requires std::same_as<T_To, typename T_ThreadIdx::type>
             {
-                return input;
+                return std::forward<decltype(input)>(input);
             }
         };
     } // namespace internal


### PR DESCRIPTION
- cleanup `pCast` implementation to handle rvalues correctly
- use `std::bit_cast` instead of `reinterpret_cast` to reinterpret types