### PR TITLE
rename ADL alpaka function names

### DIFF
--- a/benchmark/HACCmk/src/main_alpaka.cpp
+++ b/benchmark/HACCmk/src/main_alpaka.cpp
@@ -26,11 +26,11 @@ namespace haccmkAlpaka
         }
     };
 
-    constexpr void simdizedInvoke(auto&& f, alpaka::concepts::SpecializationOf<DeltaMove> auto&&... args)
+    constexpr void alpakaSimdizedInvoke(auto&& f, alpaka::concepts::SpecializationOf<DeltaMove> auto&&... args)
     {
-        simdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).x...);
-        simdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).y...);
-        simdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).z...);
+        alpakaSimdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).x...);
+        alpakaSimdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).y...);
+        alpakaSimdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).z...);
     }
 
     template<uint32_t T_width, typename T>
@@ -38,7 +38,7 @@ namespace haccmkAlpaka
     {
         using SimdMemberType = ALPAKA_TYPEOF(alpaka::makeSimdized<T_width>(std::declval<T>()));
         DeltaMove<SimdMemberType> result;
-        simdizedInvoke([](alpaka::concepts::Simd auto& lhs, auto const& rhs) { lhs = rhs; }, result, value);
+        alpakaSimdizedInvoke([](alpaka::concepts::Simd auto& lhs, auto const& rhs) { lhs = rhs; }, result, value);
         return result;
     }
 

--- a/docs/snippets/example/230_kernelFn.cpp
+++ b/docs/snippets/example/230_kernelFn.cpp
@@ -23,7 +23,7 @@ namespace tutorial
     ALPAKA_FN_SYMBOL(VectorAdd);
 
     // Genic function dispatch signature which is used if no more specific specification for the symbol is provided.
-    ALPAKA_FN_ACC void fnDispatch(
+    ALPAKA_FN_ACC void alpakaFnDispatch(
         VectorAdd,
         onAcc::concepts::Acc auto const& acc,
         concepts::IMdSpan auto out,
@@ -55,7 +55,7 @@ namespace tutorial
      * to the usage of CUDA build in variables.
      */
     template<typename T_DeviceKind>
-    ALPAKA_FN_ACC void fnDispatch(
+    ALPAKA_FN_ACC void alpakaFnDispatch(
         VectorAdd::Spec<api::Cuda, T_DeviceKind>,
         onAcc::concepts::Acc auto const& acc,
         concepts::IMdSpan auto out,

--- a/docs/source/tutorial/kernelFn.rst
+++ b/docs/source/tutorial/kernelFn.rst
@@ -12,9 +12,9 @@ Writing a Kernel as a Function
 
 This example uses the simple one-dimensional vector-add kernel from the :ref:`kernel tutorial <tutorial-kernel>`.
 
-Instead of defining a functor with ``operator()``, you implement a function named ``fnDispatch``.
+Instead of defining a functor with ``operator()``, you implement a function named ``alpakaFnDispatch``.
 The first argument must be an *alpaka* function symbol or a function-symbol specialization, which allows *alpaka* to select the correct implementation at compile time.
-Function symbols and all corresponding ``fnDispatch`` overloads must be placed inside a namespace.
+Function symbols and all corresponding ``alpakaFnDispatch`` overloads must be placed inside a namespace.
 *alpaka* relies on `Argument-Dependent Lookup (ADL) <https://de.wikipedia.org/wiki/Argument_dependent_name_lookup>`_ to find matching overloads, and functions located in the global namespace cannot be found reliably.
 
 The following example defines a generic vector-add kernel implementation that can run on any supported backend.
@@ -44,7 +44,7 @@ Typical reasons include:
 * achieving maximum performance for a specific platform
 * gradually porting existing CUDA code to *alpaka*
 
-This can be achieved by overloading ``fnDispatch`` for a specific API and device kind.
+This can be achieved by overloading ``alpakaFnDispatch`` for a specific API and device kind.
 When a kernel is launched on a matching backend, *alpaka* automatically selects the specialized overload.
 
 The example below provides a CUDA-specific implementation using native CUDA thread and grid indices.
@@ -61,13 +61,13 @@ Without this guard, compilation would fail on systems where CUDA support is not 
 Overload Resolution
 -------------------
 
-When a kernel is launched, *alpaka* selects the most specialized matching ``fnDispatch`` overload.
+When a kernel is launched, *alpaka* selects the most specialized matching ``alpakaFnDispatch`` overload.
 
 For example:
 
-* ``fnDispatch(VectorAdd, ...)`` provides a generic implementation.
-* ``fnDispatch(VectorAdd::Spec<api::Cuda, T_DeviceKind>, ...)`` provides a CUDA-specific implementation.
-* ``fnDispatch(VectorAdd::Spec<api::OneApi, deviceKind::IntelGpu>, ...)`` provides a implementation for the Intel GPU accessed via OneApi. (not used in this example)
+* ``alpakaFnDispatch(VectorAdd, ...)`` provides a generic implementation.
+* ``alpakaFnDispatch(VectorAdd::Spec<api::Cuda, T_DeviceKind>, ...)`` provides a CUDA-specific implementation.
+* ``alpakaFnDispatch(VectorAdd::Spec<api::OneApi, deviceKind::IntelGpu>, ...)`` provides a implementation for the Intel GPU accessed via OneApi. (not used in this example)
 
 If the kernel is executed on a queue for an CUDA device, the CUDA specialization is selected.
 For all other backends, the generic implementation is used automatically.

--- a/example/vendorApi/src/alpakaFn.hpp
+++ b/example/vendorApi/src/alpakaFn.hpp
@@ -18,12 +18,12 @@ namespace vendorExample
      * @{
      */
     template<alpaka::concepts::DeviceKind T_DeviceKind>
-    constexpr void fnRegister(Transform::Spec<alpaka::fn::api::Alpaka, T_DeviceKind>)
+    constexpr void alpakaFnRegister(Transform::Spec<alpaka::fn::api::Alpaka, T_DeviceKind>)
     {
     }
 
     template<alpaka::concepts::DeviceKind T_DeviceKind>
-    constexpr void fnDispatch(
+    constexpr void alpakaFnDispatch(
         Transform::Spec<alpaka::fn::api::Alpaka, T_DeviceKind>,
         auto&& queue,
         alpaka::concepts::IMdSpan auto&& output,

--- a/example/vendorApi/src/cudaFn.hpp
+++ b/example/vendorApi/src/cudaFn.hpp
@@ -18,11 +18,11 @@ namespace vendorExample
      *
      * @{
      */
-    constexpr void fnRegister(Transform::Spec<alpaka::api::Cuda, alpaka::deviceKind::NvidiaGpu>)
+    constexpr void alpakaFnRegister(Transform::Spec<alpaka::api::Cuda, alpaka::deviceKind::NvidiaGpu>)
     {
     }
 
-    constexpr void fnDispatch(
+    constexpr void alpakaFnDispatch(
         Transform::Spec<alpaka::api::Cuda, alpaka::deviceKind::NvidiaGpu>,
         auto&& queue,
         alpaka::concepts::IMdSpan auto&& output,

--- a/example/vendorApi/src/fn.hpp
+++ b/example/vendorApi/src/fn.hpp
@@ -32,7 +32,7 @@ namespace vendorExample
      * }
      * @endcode
      */
-    constexpr void fnRegister(Transform::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
+    constexpr void alpakaFnRegister(Transform::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
     {
     }
 
@@ -41,7 +41,7 @@ namespace vendorExample
      * This function will be called if Transform::call() is called with a queue or device specification of api Host and
      * device kind Cpu.
      */
-    constexpr void fnDispatch(
+    constexpr void alpakaFnDispatch(
         Transform::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>,
         auto&& queue,
         alpaka::concepts::IMdSpan auto&& output,

--- a/include/alpaka/fn.hpp
+++ b/include/alpaka/fn.hpp
@@ -26,11 +26,11 @@
  * The main components of the interface are:
  * - `alpaka::fn::Fn`: The function symbol baseclass that can be used to register, dispatch and call third party
  * functions.
- * - `fnRegister`: A function template that can be specialized to register a function overload for a
+ * - `alpakaFnRegister`: A function template that can be specialized to register a function overload for a
  * device specification. This is optional and only required if Registration::enforced is set to the function
  * symbol. It allows the usage of isRegistered() function to check if a third party function overload is defined.
- * - `fnDispatch`: A function template that can be specialized to dispatch a function symbol to a third party function
- * depending on the device specification.
+ * - `alpakaFnDispatch`: A function template that can be specialized to dispatch a function symbol to a third party
+ * function depending on the device specification.
  *
  * For an example of how to use the interface see example/vendorApi.
  */
@@ -96,16 +96,16 @@ namespace alpaka::fn
     enum class Registration : int
     {
         /** The isRegistered() function will always return true. This can be used to skip the registration of the
-         * function symbol via fnRegister().
+         * function symbol via alpakaFnRegister().
          */
         alwaysTrue = 1,
-        /** It is required to define fnRegister() for a function symbol. isRegistered() can be called to check if
+        /** It is required to define alpakaFnRegister() for a function symbol. isRegistered() can be called to check if
          * a vendor function overload is registered for the given device specification.
          */
         enforced = 2,
         /** The isRegistered() function is not available and no registration of the vendor function overloads is
          * required. This can be used if you do not want to use the isRegistered() function and do not want to require
-         * the definition of fnRegister() for a function symbol.
+         * the definition of alpakaFnRegister() for a function symbol.
          */
         none = 3
     };
@@ -114,23 +114,23 @@ namespace alpaka::fn
     {
         /** @brief Concept to check if a function symbol can be called.
          *
-         * This concept checks if the fnDispatch() can be called with the given function symbol (if
+         * This concept checks if the alpakaFnDispatch() can be called with the given function symbol (if
          * Fallback::toGeneric) or function symbol device specification. It is used to check if a function dispatch is
          * defined for the given device specification or function symbol and if it can be called with the given
          * arguments.
          */
         template<typename T_FnSpec, typename... Args>
         concept DispatchedFnInvocable
-            = requires(T_FnSpec fnSpec, Args&&... args) { fnDispatch(fnSpec, std::forward<Args>(args)...); };
+            = requires(T_FnSpec fnSpec, Args&&... args) { alpakaFnDispatch(fnSpec, std::forward<Args>(args)...); };
 
         /** @brief Concept to check if a function symbol is registered.
          *
-         * This concept checks if the fnRegister() can be called with the given function symbol or
+         * This concept checks if the alpakaFnRegister() can be called with the given function symbol or
          * function symbol device specification. It is used to check if a vendor function overload is defined for the
          * given device specification without taking any function arguments into account.
          */
         template<typename T_FnSpec>
-        concept FnRegistered = requires(T_FnSpec fnSpec) { fnRegister(fnSpec); };
+        concept FnRegistered = requires(T_FnSpec fnSpec) { alpakaFnRegister(fnSpec); };
     } // namespace concepts
 
     /** @brief Base class for function symbols.
@@ -142,7 +142,7 @@ namespace alpaka::fn
      * set to Fallback::none no fallback is performed and a static assert is triggered if no function overload is
      * defined for the given device specification.
      * @tparam T_registrationPolicy If set to Registration::enforced the isRegistered() can be called, and it is
-     * required to define fnRegister() for on T_FnClass. If set to Registration::none the isRegistered()
+     * required to define alpakaFnRegister() for on T_FnClass. If set to Registration::none the isRegistered()
      * function is not available and no registration of the vendor function overloads is required. If set to
      * Registration::alwaysTrue isRegistered() will always return true. This can be used to skip the registration
      * of the function symbol.
@@ -180,7 +180,7 @@ namespace alpaka::fn
          * @code
          * ALPAKA_FN_SYMBOL(Foo,alpaka::fn::Fallback::none, alpaka::fn::Registration::enforced);
          *
-         * void fnRegister(Foo::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
+         * void alpakaFnRegister(Foo::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
          * {
          * }
          *
@@ -233,7 +233,7 @@ namespace alpaka::fn
             static_assert(
                 T_registrationPolicy != Registration::enforced || concepts::FnRegistered<ALPAKA_TYPEOF(spec(any))>,
                 "Function dispatch for the given function symbol, API and device kind is not registered.");
-            return fnDispatch(spec(any), std::forward<T_Any>(any), std::forward<Args>(args)...);
+            return alpakaFnDispatch(spec(any), std::forward<T_Any>(any), std::forward<Args>(args)...);
         }
 
         /** Fallback operator() to alpaka implementation if the function is not dispatchable for the given device
@@ -252,7 +252,7 @@ namespace alpaka::fn
                 T_registrationPolicy != Registration::enforced
                     || concepts::FnRegistered<ALPAKA_TYPEOF(spec(api::Alpaka{}, getDeviceKind(any)))>,
                 "Function for the given function group, device kind the api fn::api::alpaka is not registered.");
-            return fnDispatch(
+            return alpakaFnDispatch(
                 spec(api::Alpaka{}, getDeviceKind(any)),
                 std::forward<T_Any>(any),
                 std::forward<Args>(args)...);
@@ -275,7 +275,7 @@ namespace alpaka::fn
             static_assert(
                 T_registrationPolicy != Registration::enforced || concepts::FnRegistered<T_FnClass>,
                 "Function dispatch for the given function symbol, is not registered.");
-            return fnDispatch(T_FnClass{}, std::forward<T_Any>(any), std::forward<Args>(args)...);
+            return alpakaFnDispatch(T_FnClass{}, std::forward<T_Any>(any), std::forward<Args>(args)...);
         }
 
         /** Call the function overload for the given device specification.
@@ -304,7 +304,7 @@ namespace alpaka::fn
  * triggered if no vendor function overload is defined for the given device specification. Default:
  * Fallback::toGeneric.
  * @param optional_registartion If set to Registration::enforced the isRegistered() can be called, and it is
- * required to define fnRegister() for on T_FnClass. If set to Registration::none the isRegistered()
+ * required to define alpakaFnRegister() for on T_FnClass. If set to Registration::none the isRegistered()
  * function is not available and no registration of the vendor function overloads is required. If set to
  * Registration::alwaysTrue isRegistered() will always return true. This can be used to skip the registration of
  * the function symbol. Default: Registration::none.

--- a/include/alpaka/onAcc/atomic.hpp
+++ b/include/alpaka/onAcc/atomic.hpp
@@ -196,17 +196,18 @@ namespace alpaka::onAcc
          * @param inOut pointer to the values which is updated
          * @param args arguments normally forwarded to the user functor
          */
-        ALPAKA_FN_ACC void atomicInvoke(auto&& fn, concepts::Acc auto const& acc, auto* inOut, auto&&... args)
+        ALPAKA_FN_ACC void alpakaAtomicInvoke(auto&& fn, concepts::Acc auto const& acc, auto* inOut, auto&&... args)
         {
             alpaka::unused(acc, inOut, args...);
             static_assert(
                 sizeof(ALPAKA_TYPEOF(fn)) && false,
-                "You must specialize atomicInvoke() for your functor. Best place the overload in the namespace of the "
+                "You must specialize alpakaAtomicInvoke() for your functor. Best place the overload in the namespace "
+                "of the "
                 "functor, it will be found by ADL.");
         }
 
         template<typename T>
-        ALPAKA_FN_ACC void atomicInvoke(std::plus<T>, concepts::Acc auto const& acc, auto* inOut, auto&&... args)
+        ALPAKA_FN_ACC void alpakaAtomicInvoke(std::plus<T>, concepts::Acc auto const& acc, auto* inOut, auto&&... args)
         {
             atomicAdd(acc, inOut, ALPAKA_FORWARD(args)...);
         }

--- a/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
+++ b/include/alpaka/onAcc/internal/SimdTransformReduce.hpp
@@ -88,7 +88,7 @@ namespace alpaka::onAcc::internal
             }
 
             auto result = neutralElement;
-            simdizedInvoke(
+            alpakaSimdizedInvoke(
                 [](auto& lhs, alpaka::concepts::Simd auto const& rhs) { lhs = rhs[0]; },
                 result,
                 simdizedReducedValue);
@@ -479,7 +479,7 @@ namespace alpaka::onAcc::internal
                     SimdPtr{data0, idx, T_MemAlignment{}, CVec<uint32_t, 1u>{}},
                     SimdPtr{dataN, idx, T_MemAlignment{}, CVec<uint32_t, 1u>{}}...);
 
-                simdizedInvoke(
+                alpakaSimdizedInvoke(
                     [reduceFunc](auto& lhs, alpaka::concepts::Simd auto const& rhs)
                     {
                         // std simd non-const operator[] is returning a smart reference, therefore we need
@@ -491,7 +491,7 @@ namespace alpaka::onAcc::internal
             }
 
             ALPAKA_TYPEOF(neutralElement) result;
-            simdizedInvoke(
+            alpakaSimdizedInvoke(
                 [reduceFunc](auto& lhs, alpaka::concepts::Simd auto const& rhs) { lhs = rhs.reduce(reduceFunc); },
                 result,
                 simdizedReducedValue);

--- a/include/alpaka/onHost/algo/internal/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/internal/transformReduce.hpp
@@ -110,21 +110,21 @@ namespace alpaka::onHost::internal
             // Atomic update of the global result
             if(laneIdInBlock == 0)
             {
-                using alpaka::onAcc::atomic::atomicInvoke;
+                using alpaka::onAcc::atomic::alpakaAtomicInvoke;
                 if constexpr(
                     alpaka::concepts::SpecializationOf<ALPAKA_TYPEOF(reduceFunc), ScalarFunc>
                     || alpaka::concepts::SpecializationOf<ALPAKA_TYPEOF(reduceFunc), StencilFunc>)
                 {
                     // Handle wrapped reduce functors e.g. ScalarFunc or StencilFunc
                     using ReduceFunctor = typename ALPAKA_TYPEOF(reduceFunc)::Functor;
-                    atomicInvoke(
+                    alpakaAtomicInvoke(
                         static_cast<ReduceFunctor const&>(reduceFunc),
                         acc,
                         output.data(),
                         dynS[laneIdInBlock]);
                 }
                 else
-                    atomicInvoke(reduceFunc, acc, output.data(), dynS[laneIdInBlock]);
+                    alpakaAtomicInvoke(reduceFunc, acc, output.data(), dynS[laneIdInBlock]);
             }
         }
     };

--- a/include/alpaka/onHost/algo/reduce.hpp
+++ b/include/alpaka/onHost/algo/reduce.hpp
@@ -18,9 +18,9 @@ namespace alpaka::onHost
      * @param out MdSpan for the result. The value_type must be equal to neutralElement and the result of the binary
      * reduce functor type. The result is written to the first element of the output data.
      * @param binaryReduceFn Reduce binary functor, the functor operation must be transitive and commutative.
-     *   The atomic operation atomic::atomicInvoke(ReduceFnType, onAcc::concepts::Acc, auto* destination,auto source)
-     * must be overloaded. The functor execution order is not specified. The functor should support Simd packages, if
-     * not you can enforce the element wise execution by wrapping into ScalarFunc.
+     *   The atomic operation atomic::alpakaAtomicInvoke(ReduceFnType, onAcc::concepts::Acc, auto* destination,auto
+     * source) must be overloaded. The functor execution order is not specified. The functor should support Simd
+     * packages, if not you can enforce the element wise execution by wrapping into ScalarFunc.
      * @param in The input data which should be reduced.
      *
      * @{

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -26,9 +26,9 @@ namespace alpaka::onHost
      * @param out MdSpan for the result. The value_type must be equal to neutralElement and the result of the binary
      * reduce functor type. The result is written to the first element of the output data.
      * @param binaryReduceFn Reduce binary functor, the functor operation must be transitive and commutative.
-     *   The atomic operation atomic::atomicInvoke(ReduceFnType, onAcc::concepts::Acc, auto* destination,auto source)
-     * must be overloaded. The functor execution order is not specified. The functor should support Simd packages, if
-     * not you can enforce the element wise execution by wrapping into
+     *   The atomic operation atomic::alpakaAtomicInvoke(ReduceFnType, onAcc::concepts::Acc, auto* destination,auto
+     * source) must be overloaded. The functor execution order is not specified. The functor should support Simd
+     * packages, if not you can enforce the element wise execution by wrapping into
      *   @see ScalarFunc.
      * @param transformFn The function to apply to each element of the input data.
      *   The functor should support Simd packages. If not you can enforce the element wise execution by wrapping into

--- a/include/alpaka/simd/simdized.hpp
+++ b/include/alpaka/simd/simdized.hpp
@@ -20,7 +20,7 @@ namespace alpaka
      * A simdized value is not necessarily a data type wrapped by alpaka::Simd, it can be a structured hierarchical
      * type where each component is a SIMD pack. This function can be specialized within the namespace of the input
      * type and will be found via ADL.
-     * @see simdizedInvoke should be specialized together with this function.
+     * @see alpakaSimdizedInvoke should be specialized together with this function.
      *
      * Simdizing of structured types as shown in the code example often improves the performance compared to wrapping
      * into a SIMD pack.
@@ -55,7 +55,7 @@ namespace alpaka
     /** Invokes the callable object fn with the parameters args.
      *
      * For structured data where each component is a SIMD pack, the functor should be forwarded to the members while
-     * recursively calling simdizedInvoke.
+     * recursively calling alpakaSimdizedInvoke.
      * As soon as there is no use specialization available, the recursion is terminated by the invocation of the
      * functor with the forwarded arguments. This function can be specialized within the namespace of the argument
      * types and will be found via ADL.
@@ -66,19 +66,19 @@ namespace alpaka
      * rule but are useful within the user code.
      * @code{.cpp}
      * // A typical case of how this specialization is called is
-     * // `simdizedInvoke(f, Pos<int>{}, Pos<alpaka::Simd<int,4>>{})`.
-     * constexpr void simdizedInvoke(auto&& f, alpaka::concepts::SpecializationOf<Pos> auto&&... args)
+     * // `alpakaSimdizedInvoke(f, Pos<int>{}, Pos<alpaka::Simd<int,4>>{})`.
+     * constexpr void alpakaSimdizedInvoke(auto&& f, alpaka::concepts::SpecializationOf<Pos> auto&&... args)
      * {
      *    // Accessing .x and .y must be supported by all arguments.
-     *    simdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).x...);
-     *    simdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).y...);
+     *    alpakaSimdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).x...);
+     *    alpakaSimdizedInvoke(ALPAKA_FORWARD(f), ALPAKA_FORWARD(args).y...);
      * }
      * @endcode
      *
      * @param fn Callable object to which the arguments will be forwarded.
      * @param args Arguments forwarded to fn.
      */
-    constexpr void simdizedInvoke(auto&& fn, auto&&... args)
+    constexpr void alpakaSimdizedInvoke(auto&& fn, auto&&... args)
     {
         ALPAKA_FORWARD(fn)(ALPAKA_FORWARD(args)...);
     }

--- a/test/unit/algorithm/reduce.cpp
+++ b/test/unit/algorithm/reduce.cpp
@@ -28,7 +28,7 @@ namespace myTest
         }
     };
 
-    ALPAKA_FN_ACC void atomicInvoke(
+    ALPAKA_FN_ACC void alpakaAtomicInvoke(
         MinValue const&,
         alpaka::onAcc::concepts::Acc auto const& acc,
         auto* dest,
@@ -46,7 +46,7 @@ namespace myTest
         }
     };
 
-    ALPAKA_FN_ACC void atomicInvoke(
+    ALPAKA_FN_ACC void alpakaAtomicInvoke(
         MaxValue const&,
         alpaka::onAcc::concepts::Acc auto const& acc,
         auto* dest,

--- a/test/unit/algorithm/transformReduce.cpp
+++ b/test/unit/algorithm/transformReduce.cpp
@@ -73,7 +73,7 @@ namespace myTest
         }
     };
 
-    ALPAKA_FN_ACC void atomicInvoke(
+    ALPAKA_FN_ACC void alpakaAtomicInvoke(
         MinValue const&,
         alpaka::onAcc::concepts::Acc auto const& acc,
         auto* dest,

--- a/test/unit/fn/fn.cpp
+++ b/test/unit/fn/fn.cpp
@@ -13,16 +13,16 @@ using namespace alpaka;
 
 ALPAKA_FN_SYMBOL(FnFallBackAlpakaRegisterEnforced, alpaka::fn::Fallback::toAlpaka, alpaka::fn::Registration::enforced);
 
-constexpr void fnRegister(FnFallBackAlpakaRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
+constexpr void alpakaFnRegister(FnFallBackAlpakaRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
 {
 }
 
 template<concepts::DeviceKind T_DeviceKind>
-constexpr void fnRegister(FnFallBackAlpakaRegisterEnforced::Spec<alpaka::fn::api::Alpaka, T_DeviceKind>)
+constexpr void alpakaFnRegister(FnFallBackAlpakaRegisterEnforced::Spec<alpaka::fn::api::Alpaka, T_DeviceKind>)
 {
 }
 
-constexpr int fnDispatch(
+constexpr int alpakaFnDispatch(
     FnFallBackAlpakaRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>,
     auto const&)
 {
@@ -30,7 +30,9 @@ constexpr int fnDispatch(
 }
 
 template<concepts::DeviceKind T_DeviceKind>
-constexpr int fnDispatch(FnFallBackAlpakaRegisterEnforced::Spec<alpaka::fn::api::Alpaka, T_DeviceKind>, auto const&)
+constexpr int alpakaFnDispatch(
+    FnFallBackAlpakaRegisterEnforced::Spec<alpaka::fn::api::Alpaka, T_DeviceKind>,
+    auto const&)
 {
     return 43;
 }
@@ -71,22 +73,22 @@ ALPAKA_FN_SYMBOL(
     alpaka::fn::Fallback::toGeneric,
     alpaka::fn::Registration::enforced);
 
-constexpr void fnRegister(FnFallBackGenericRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
+constexpr void alpakaFnRegister(FnFallBackGenericRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
 {
 }
 
-constexpr void fnRegister(FnFallBackGenericRegisterEnforced)
+constexpr void alpakaFnRegister(FnFallBackGenericRegisterEnforced)
 {
 }
 
-constexpr int fnDispatch(
+constexpr int alpakaFnDispatch(
     FnFallBackGenericRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>,
     auto const&)
 {
     return 52;
 }
 
-constexpr int fnDispatch(FnFallBackGenericRegisterEnforced, auto const&)
+constexpr int alpakaFnDispatch(FnFallBackGenericRegisterEnforced, auto const&)
 {
     return 53;
 }
@@ -139,20 +141,22 @@ TEMPLATE_LIST_TEST_CASE("fn with generic fallback", "", TestApis)
  */
 ALPAKA_FN_SYMBOL(FnFallBackNoRegisterEnforced, alpaka::fn::Fallback::none, alpaka::fn::Registration::enforced);
 
-constexpr void fnRegister(FnFallBackNoRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
+constexpr void alpakaFnRegister(FnFallBackNoRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>)
 {
 }
 
-constexpr void fnRegister(FnFallBackNoRegisterEnforced)
+constexpr void alpakaFnRegister(FnFallBackNoRegisterEnforced)
 {
 }
 
-constexpr int fnDispatch(FnFallBackNoRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>, auto const&)
+constexpr int alpakaFnDispatch(
+    FnFallBackNoRegisterEnforced::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>,
+    auto const&)
 {
     return 62;
 }
 
-constexpr int fnDispatch(FnFallBackNoRegisterEnforced, auto const&)
+constexpr int alpakaFnDispatch(FnFallBackNoRegisterEnforced, auto const&)
 {
     return 63;
 }


### PR DESCRIPTION
Rename function names for interfaces those used by the user to connect user types with alpaka.

This change affects:
- function interface:
  - `fnDispatch` -> `alpakaFnDispatch`
  - `isRegistered` -> `alpakaIsRegistered`
- SIMD interface
  - `simdizedInvode` -> `alpakaSimdizedInvoke`
- atomic interface
  - `atomicInvoke` -> `alpakaAtomicInvoke`

Motivation: If you use the function within the user code it is not visible that these are functions you need to define to interact with alpaka. By adding the name alpaka as prefix it becomes visible. This also avoids symbol issues if other projects use the same name for their functions. Function dispatch via user-defined function is very common, and other libraries also prefix there function often with the project name. Currently, all of the changed functions are mostly not used by other projects, therefor it is better to clean up this now instead of after the release of alpaka3.