### PR TITLE
test SKIP() in test::getAvailableDevice()

### DIFF
--- a/test/include/alpakaTest/deviceHelper.hpp
+++ b/test/include/alpakaTest/deviceHelper.hpp
@@ -32,7 +32,7 @@ namespace alpaka::test
 
         if(!devSelector.isAvailable())
         {
-            WARN("No device available for " << deviceSpec.getName());
+            SKIP("No device available for " << deviceSpec.getName());
             return {};
         }
 

--- a/test/include/alpakaTest/deviceHelper.hpp
+++ b/test/include/alpakaTest/deviceHelper.hpp
@@ -19,10 +19,24 @@ namespace alpaka::test
      *
      * Prints information about the device Spec, API and device.
      *
+     * @attention This function should only be used with the Catch2 macro `TEMPLATE_LIST_TEST_CASE`.
+     * See following code snippet:
+     *
+     * @code
+     * using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs,
+     * exec::enabledExecutors))>;
+     *
+     * TEMPLATE_LIST_TEST_CASE("device analysis", "", TestApis)
+     * {
+     *    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
+     *    // ...
+     * }
+     * @endcode
+     *
      * @param cfg Test configuration. An entry of the list returned from alpaka::onHost::allBackends().
      * @return The device 0 if available. Otherwise, SKIP() the test.
      */
-    [[nodiscard]] auto getAvailableDevice(auto const& cfg)
+    [[nodiscard]] auto getDeviceOrSkipTest(auto const& cfg)
         -> decltype(onHost::makeDeviceSelector(cfg[object::deviceSpec]).makeDevice(0))
     {
         auto deviceSpec = cfg[object::deviceSpec];
@@ -44,13 +58,29 @@ namespace alpaka::test
      *
      * Prints information about the device Spec, API, device and executor.
      *
+     * @attention This function should only be used with the Catch2 macro `TEMPLATE_LIST_TEST_CASE`.
+     * See following code snippet:
+     *
+     * @code
+     * using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs,
+     * exec::enabledExecutors))>;
+     *
+     * TEMPLATE_LIST_TEST_CASE("device analysis", "", TestApis)
+     * {
+     *    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
+     *    onHost::Device device = test::getDevice(deviceExec);
+     *    concepts::Executor auto exec = test::getExecutor(deviceExec);
+     *    // ...
+     * }
+     * @endcode
+     *
      * @param cfg Test configuration. An entry of the list returned from alpaka::onHost::allBackends().
      * @return A std::tuple with the device 0 and an executor. If no device is available, SKIP() the test.
      */
-    [[nodiscard]] auto getAvailableDeviceExecutor(auto const& cfg) -> std::
+    [[nodiscard]] auto getDeviceExecutorOrSkipTest(auto const& cfg) -> std::
         tuple<decltype(onHost::makeDeviceSelector(cfg[object::deviceSpec]).makeDevice(0)), decltype(cfg[object::exec])>
     {
-        auto device = alpaka::test::getAvailableDevice(cfg);
+        auto device = alpaka::test::getDeviceOrSkipTest(cfg);
         concepts::Executor auto executor = cfg[object::exec];
         UNSCOPED_INFO("Executor: " << executor.getName());
 

--- a/test/include/alpakaTest/deviceHelper.hpp
+++ b/test/include/alpakaTest/deviceHelper.hpp
@@ -20,10 +20,10 @@ namespace alpaka::test
      * Prints information about the device Spec, API and device.
      *
      * @param cfg Test configuration. An entry of the list returned from alpaka::onHost::allBackends().
-     * @return The device 0 if available. Otherwise, the std::optional is invalid.
+     * @return The device 0 if available. Otherwise, SKIP() the test.
      */
     [[nodiscard]] auto getAvailableDevice(auto const& cfg)
-        -> std::optional<decltype(onHost::makeDeviceSelector(cfg[object::deviceSpec]).makeDevice(0))>
+        -> decltype(onHost::makeDeviceSelector(cfg[object::deviceSpec]).makeDevice(0))
     {
         auto deviceSpec = cfg[object::deviceSpec];
         auto devSelector = onHost::makeDeviceSelector(deviceSpec);
@@ -33,7 +33,6 @@ namespace alpaka::test
         if(!devSelector.isAvailable())
         {
             SKIP("No device available for " << deviceSpec.getName());
-            return {};
         }
 
         onHost::Device device = devSelector.makeDevice(0);
@@ -46,53 +45,30 @@ namespace alpaka::test
      * Prints information about the device Spec, API, device and executor.
      *
      * @param cfg Test configuration. An entry of the list returned from alpaka::onHost::allBackends().
-     * @return A std::optional containing a std::tuple with the device 0 and an executor.
+     * @return A std::tuple with the device 0 and an executor. If no device is available, SKIP() the test.
      */
-    [[nodiscard]] auto getAvailableDeviceExecutor(auto const& cfg) -> std::optional<std::tuple<
-        decltype(onHost::makeDeviceSelector(cfg[object::deviceSpec]).makeDevice(0)),
-        decltype(cfg[object::exec])>>
+    [[nodiscard]] auto getAvailableDeviceExecutor(auto const& cfg) -> std::
+        tuple<decltype(onHost::makeDeviceSelector(cfg[object::deviceSpec]).makeDevice(0)), decltype(cfg[object::exec])>
     {
         auto device = alpaka::test::getAvailableDevice(cfg);
-        if(!device)
-        {
-            return {};
-        }
         concepts::Executor auto executor = cfg[object::exec];
         UNSCOPED_INFO("Executor: " << executor.getName());
 
-        return std::make_tuple(*device, executor);
+        return std::make_tuple(device, executor);
     }
 
-    /** Takes std::optional with an alpaka::onHost::Device and returns the device.
-     *
-     * @attention Does not check, if the optional is valid.
-     */
-    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
-    [[nodiscard]] alpaka::onHost::Device<T_Api, T_DeviceKind> getDevice(
-        std::optional<alpaka::onHost::Device<T_Api, T_DeviceKind>> const& optionalDevice)
-    {
-        return *optionalDevice;
-    }
-
-    /** Takes std::optional with an alpaka::onHost::Device and an executor and returns the device.
-     *
-     * @attention Does not check, if the optional is valid.
-     */
+    /** Takes a tuple with an alpaka::onHost::Device and an executor and returns the device. */
     template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind, alpaka::concepts::Executor T_Exec>
     [[nodiscard]] alpaka::onHost::Device<T_Api, T_DeviceKind> getDevice(
-        std::optional<std::tuple<alpaka::onHost::Device<T_Api, T_DeviceKind>, T_Exec>> const& optionalDeviceExec)
+        std::tuple<alpaka::onHost::Device<T_Api, T_DeviceKind>, T_Exec> const& deviceExec)
     {
-        return std::get<0>(*optionalDeviceExec);
+        return std::get<0>(deviceExec);
     }
 
-    /** Takes std::optional with an alpaka::onHost::Device and an executor and returns the executor.
-     *
-     * @attention Does not check, if the optional is valid.
-     */
+    /** Takes a tuple with an alpaka::onHost::Device and an executor and returns the executor. */
     template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind, alpaka::concepts::Executor T_Exec>
-    [[nodiscard]] T_Exec getExecutor(
-        std::optional<std::tuple<alpaka::onHost::Device<T_Api, T_DeviceKind>, T_Exec>> const& optionalDeviceExec)
+    [[nodiscard]] T_Exec getExecutor(std::tuple<alpaka::onHost::Device<T_Api, T_DeviceKind>, T_Exec> const& deviceExec)
     {
-        return std::get<1>(*optionalDeviceExec);
+        return std::get<1>(deviceExec);
     }
 } // namespace alpaka::test

--- a/test/unit/algorithm/concurrent.cpp
+++ b/test/unit/algorithm/concurrent.cpp
@@ -120,7 +120,7 @@ template<typename T_DataType>
 void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
-    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
     onHost::Device computeDev = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/algorithm/concurrent.cpp
+++ b/test/unit/algorithm/concurrent.cpp
@@ -120,11 +120,9 @@ template<typename T_DataType>
 void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device computeDev = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    onHost::Device computeDev = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     onHost::Queue computeQueue = computeDev.makeQueue();
 

--- a/test/unit/algorithm/iota.cpp
+++ b/test/unit/algorithm/iota.cpp
@@ -93,7 +93,7 @@ template<typename T_DataType>
 void prepareTest(auto cfg, concepts::Vector auto extentMd)
 {
     using DataType = T_DataType;
-    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
     onHost::Device computeDev = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/algorithm/iota.cpp
+++ b/test/unit/algorithm/iota.cpp
@@ -93,11 +93,9 @@ template<typename T_DataType>
 void prepareTest(auto cfg, concepts::Vector auto extentMd)
 {
     using DataType = T_DataType;
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device computeDev = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    onHost::Device computeDev = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     onHost::Queue computeQueue = computeDev.makeQueue();
     executeTest<DataType>(exec, computeQueue, extentMd);

--- a/test/unit/algorithm/reduce.cpp
+++ b/test/unit/algorithm/reduce.cpp
@@ -119,7 +119,7 @@ template<typename T_DataType>
 void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
-    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
     onHost::Device computeDev = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/algorithm/reduce.cpp
+++ b/test/unit/algorithm/reduce.cpp
@@ -119,11 +119,9 @@ template<typename T_DataType>
 void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device computeDev = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    onHost::Device computeDev = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     onHost::Queue computeQueue = computeDev.makeQueue();
 

--- a/test/unit/algorithm/scan.cpp
+++ b/test/unit/algorithm/scan.cpp
@@ -159,7 +159,7 @@ template<typename T_Data>
 void prepareTest(auto cfg, concepts::Vector auto extents)
 {
     using DataType = T_Data;
-    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
     onHost::Device computeDev = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/algorithm/scan.cpp
+++ b/test/unit/algorithm/scan.cpp
@@ -159,11 +159,9 @@ template<typename T_Data>
 void prepareTest(auto cfg, concepts::Vector auto extents)
 {
     using DataType = T_Data;
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device computeDev = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    onHost::Device computeDev = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     onHost::Queue computeQueue = computeDev.makeQueue();
 

--- a/test/unit/algorithm/transform.cpp
+++ b/test/unit/algorithm/transform.cpp
@@ -131,7 +131,7 @@ template<typename T_DataType>
 void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
-    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
     onHost::Device computeDev = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 
@@ -326,7 +326,7 @@ void testStencilTransform(auto cfg, concepts::Vector auto extentMd)
     using DataType = T_DataType;
     using Extent = std::decay_t<decltype(extentMd)>;
 
-    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
     onHost::Device computeDev = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue computeQueue = computeDev.makeQueue();

--- a/test/unit/algorithm/transform.cpp
+++ b/test/unit/algorithm/transform.cpp
@@ -131,11 +131,9 @@ template<typename T_DataType>
 void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device computeDev = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    onHost::Device computeDev = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     onHost::Queue computeQueue = computeDev.makeQueue();
 
@@ -328,11 +326,9 @@ void testStencilTransform(auto cfg, concepts::Vector auto extentMd)
     using DataType = T_DataType;
     using Extent = std::decay_t<decltype(extentMd)>;
 
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device computeDev = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    onHost::Device computeDev = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue computeQueue = computeDev.makeQueue();
 
     INFO("extents    : " << extentMd);

--- a/test/unit/algorithm/transformReduce.cpp
+++ b/test/unit/algorithm/transformReduce.cpp
@@ -157,11 +157,9 @@ template<typename T_DataType>
 void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device computeDev = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    onHost::Device computeDev = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     onHost::Queue computeQueue = computeDev.makeQueue();
 
@@ -451,11 +449,9 @@ void prepareOnAccTest(auto cfg, concepts::Vector auto extentMd, auto const& setu
 {
     using DataType = T_DataType;
 
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device computeDev = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    onHost::Device computeDev = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     onHost::Queue computeQueue = computeDev.makeQueue();
 

--- a/test/unit/algorithm/transformReduce.cpp
+++ b/test/unit/algorithm/transformReduce.cpp
@@ -157,7 +157,7 @@ template<typename T_DataType>
 void prepareTest(auto cfg, concepts::Vector auto extentMd, auto const& setupTuple)
 {
     using DataType = T_DataType;
-    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
     onHost::Device computeDev = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 
@@ -449,7 +449,7 @@ void prepareOnAccTest(auto cfg, concepts::Vector auto extentMd, auto const& setu
 {
     using DataType = T_DataType;
 
-    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
     onHost::Device computeDev = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/atomic/atomic.cpp
+++ b/test/unit/atomic/atomic.cpp
@@ -240,11 +240,9 @@ struct TestAtomicOperations
 
 TEMPLATE_LIST_TEST_CASE("atomicOperationsWorking", "[atomic]", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     // According to the CUDA 12.1 Programming Guide, Section 7.14. Atomic Functions, an atomic function performs a
     // read-modify-write atomic operation on one 32-bit or 64-bit word residing in global or shared memory.

--- a/test/unit/atomic/atomic.cpp
+++ b/test/unit/atomic/atomic.cpp
@@ -240,7 +240,7 @@ struct TestAtomicOperations
 
 TEMPLATE_LIST_TEST_CASE("atomicOperationsWorking", "[atomic]", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/atomic/atomicAdd.cpp
+++ b/test/unit/atomic/atomicAdd.cpp
@@ -39,11 +39,9 @@ TEMPLATE_LIST_TEST_CASE("cpu atomic add increments", "[executor][atomic]", TestA
      */
     using namespace alpaka;
 
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     auto queue = device.makeQueue(queueKind::blocking);
 
     auto counterDev = onHost::alloc<std::uint32_t>(device, Vec{1u});

--- a/test/unit/atomic/atomicAdd.cpp
+++ b/test/unit/atomic/atomicAdd.cpp
@@ -39,7 +39,7 @@ TEMPLATE_LIST_TEST_CASE("cpu atomic add increments", "[executor][atomic]", TestA
      */
     using namespace alpaka;
 
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     auto queue = device.makeQueue(queueKind::blocking);

--- a/test/unit/block/block.cpp
+++ b/test/unit/block/block.cpp
@@ -40,11 +40,9 @@ struct BlockIotaKernel
 
 TEMPLATE_LIST_TEST_CASE("block iota", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    alpaka::concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     Queue queue = device.makeQueue();
     constexpr Vec numChunks = Vec{9u};

--- a/test/unit/block/block.cpp
+++ b/test/unit/block/block.cpp
@@ -40,7 +40,7 @@ struct BlockIotaKernel
 
 TEMPLATE_LIST_TEST_CASE("block iota", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/cvecKernelCall/cvecKernelCall.cpp
+++ b/test/unit/cvecKernelCall/cvecKernelCall.cpp
@@ -44,11 +44,9 @@ struct KernelCVecFrameExtents
 
 TEMPLATE_LIST_TEST_CASE("CVec frame extent kernel call", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    alpaka::concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
     Queue queue = device.makeQueue();
 
     auto dBuff = onHost::alloc<bool>(device, Vec{1u});
@@ -86,11 +84,9 @@ struct KernelCVecThreadExtents
 
 TEMPLATE_LIST_TEST_CASE("CVec thread extent kernel call", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    alpaka::concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
     Queue queue = device.makeQueue();
 
     auto dBuff = onHost::alloc<bool>(device, Vec{1u});

--- a/test/unit/cvecKernelCall/cvecKernelCall.cpp
+++ b/test/unit/cvecKernelCall/cvecKernelCall.cpp
@@ -44,7 +44,7 @@ struct KernelCVecFrameExtents
 
 TEMPLATE_LIST_TEST_CASE("CVec frame extent kernel call", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
     Queue queue = device.makeQueue();
@@ -84,7 +84,7 @@ struct KernelCVecThreadExtents
 
 TEMPLATE_LIST_TEST_CASE("CVec thread extent kernel call", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
     Queue queue = device.makeQueue();

--- a/test/unit/device/deviceProperties.cpp
+++ b/test/unit/device/deviceProperties.cpp
@@ -17,10 +17,7 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDevice
  */
 TEMPLATE_LIST_TEST_CASE("deviceProperties", "[device][property]", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
 
     onHost::DeviceProperties deviceProperties = device.getDeviceProperties();
     INFO(deviceProperties);

--- a/test/unit/device/deviceProperties.cpp
+++ b/test/unit/device/deviceProperties.cpp
@@ -17,7 +17,7 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDevice
  */
 TEMPLATE_LIST_TEST_CASE("deviceProperties", "[device][property]", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
 
     onHost::DeviceProperties deviceProperties = device.getDeviceProperties();
     INFO(deviceProperties);

--- a/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -74,7 +74,7 @@ struct DeviceGlobalMemKernelCArray2D
 
 TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
 
@@ -177,7 +177,7 @@ struct DeviceGlobalMemCpyCArray2DKernel
 
 TEMPLATE_LIST_TEST_CASE("device global mem copy", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
+++ b/test/unit/deviceGlobalMem/deviceGlobalMem.cpp
@@ -74,11 +74,9 @@ struct DeviceGlobalMemKernelCArray2D
 
 TEMPLATE_LIST_TEST_CASE("device global mem", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    alpaka::concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     Queue queue = device.makeQueue();
     constexpr Vec numBlocks = Vec{1u};
@@ -179,11 +177,9 @@ struct DeviceGlobalMemCpyCArray2DKernel
 
 TEMPLATE_LIST_TEST_CASE("device global mem copy", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    alpaka::concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     Queue queue = device.makeQueue();
     constexpr Vec numBlocks = Vec{1u};

--- a/test/unit/event/event.cpp
+++ b/test/unit/event/event.cpp
@@ -40,7 +40,7 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDevice
  */
 TEMPLATE_LIST_TEST_CASE("device analysis", "", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
 
     bool hasCQueue = detectConcurrentQueue(device);
     INFO("Concurrent kernel queue detected: " << (hasCQueue ? "yes" : "no"));
@@ -51,7 +51,7 @@ TEMPLATE_LIST_TEST_CASE("device analysis", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("event creation and enqueue", "", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
 
     onHost::Queue queue = device.makeQueue();
     onHost::Event ev = device.makeEvent();
@@ -62,7 +62,7 @@ TEMPLATE_LIST_TEST_CASE("event creation and enqueue", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("basic queue wait for event", "", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
 
     onHost::Queue queue0 = device.makeQueue();
     onHost::Queue queue1 = device.makeQueue();

--- a/test/unit/event/event.cpp
+++ b/test/unit/event/event.cpp
@@ -40,10 +40,7 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDevice
  */
 TEMPLATE_LIST_TEST_CASE("device analysis", "", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
 
     bool hasCQueue = detectConcurrentQueue(device);
     INFO("Concurrent kernel queue detected: " << (hasCQueue ? "yes" : "no"));
@@ -54,10 +51,7 @@ TEMPLATE_LIST_TEST_CASE("device analysis", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("event creation and enqueue", "", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
 
     onHost::Queue queue = device.makeQueue();
     onHost::Event ev = device.makeEvent();
@@ -68,10 +62,7 @@ TEMPLATE_LIST_TEST_CASE("event creation and enqueue", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("basic queue wait for event", "", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
 
     onHost::Queue queue0 = device.makeQueue();
     onHost::Queue queue1 = device.makeQueue();

--- a/test/unit/fn/fn.cpp
+++ b/test/unit/fn/fn.cpp
@@ -41,10 +41,7 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, 
 
 TEMPLATE_LIST_TEST_CASE("fn with alpaka fallback", "", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
 
     if constexpr(device.getApi() == api::host && device.getDeviceKind() == deviceKind::cpu)
     {
@@ -97,10 +94,7 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, 
 
 TEMPLATE_LIST_TEST_CASE("fn with generic fallback", "", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
 
     if constexpr(device.getApi() == api::host && device.getDeviceKind() == deviceKind::cpu)
     {
@@ -165,10 +159,7 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, 
 
 TEMPLATE_LIST_TEST_CASE("fn without fallback", "", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
 
     if constexpr(device.getApi() == api::host && device.getDeviceKind() == deviceKind::cpu)
     {

--- a/test/unit/fn/fn.cpp
+++ b/test/unit/fn/fn.cpp
@@ -41,7 +41,7 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, 
 
 TEMPLATE_LIST_TEST_CASE("fn with alpaka fallback", "", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
 
     if constexpr(device.getApi() == api::host && device.getDeviceKind() == deviceKind::cpu)
     {
@@ -94,7 +94,7 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, 
 
 TEMPLATE_LIST_TEST_CASE("fn with generic fallback", "", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
 
     if constexpr(device.getApi() == api::host && device.getDeviceKind() == deviceKind::cpu)
     {
@@ -159,7 +159,7 @@ using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledApis, 
 
 TEMPLATE_LIST_TEST_CASE("fn without fallback", "", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
 
     if constexpr(device.getApi() == api::host && device.getDeviceKind() == deviceKind::cpu)
     {

--- a/test/unit/frame/getFrameSpec.cpp
+++ b/test/unit/frame/getFrameSpec.cpp
@@ -81,7 +81,7 @@ void testVector(auto const& computeDev, alpaka::concepts::Executor auto exec)
 
 TEMPLATE_LIST_TEST_CASE("getFrameSpec scalar", "", TestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device computeDev = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 
@@ -90,7 +90,7 @@ TEMPLATE_LIST_TEST_CASE("getFrameSpec scalar", "", TestBackends)
 
 TEMPLATE_LIST_TEST_CASE("getFrameSpec vector", "", TestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device computeDev = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/frame/getFrameSpec.cpp
+++ b/test/unit/frame/getFrameSpec.cpp
@@ -81,22 +81,18 @@ void testVector(auto const& computeDev, alpaka::concepts::Executor auto exec)
 
 TEMPLATE_LIST_TEST_CASE("getFrameSpec scalar", "", TestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device computeDev = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device computeDev = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     std::apply([&]<typename... T>(T...) { (testScalar<T>(computeDev, exec), ...); }, TestBufferElemTypes{});
 }
 
 TEMPLATE_LIST_TEST_CASE("getFrameSpec vector", "", TestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device computeDev = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device computeDev = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     std::apply([&]<typename... T>(T...) { (testVector<T>(computeDev, exec), ...); }, TestBufferElemTypes{});
 }

--- a/test/unit/intrinsic/clz.cpp
+++ b/test/unit/intrinsic/clz.cpp
@@ -28,7 +28,7 @@ struct PopcountKernel
 
 TEMPLATE_LIST_TEST_CASE("clz", "[intrinsic][clz]", TestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device devAcc = test::getDevice(deviceExec);
     concepts::Executor auto computeExec = test::getExecutor(deviceExec);
 

--- a/test/unit/intrinsic/clz.cpp
+++ b/test/unit/intrinsic/clz.cpp
@@ -28,11 +28,9 @@ struct PopcountKernel
 
 TEMPLATE_LIST_TEST_CASE("clz", "[intrinsic][clz]", TestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device devAcc = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto computeExec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device devAcc = test::getDevice(deviceExec);
+    concepts::Executor auto computeExec = test::getExecutor(deviceExec);
 
     // Create a queue on the device
     alpaka::onHost::Queue queue = devAcc.makeQueue();

--- a/test/unit/intrinsic/ffs.cpp
+++ b/test/unit/intrinsic/ffs.cpp
@@ -42,11 +42,9 @@ static int32_t naiveFfs(TValue value)
 
 TEMPLATE_LIST_TEST_CASE("ffs", "[intrinsic][ffs]", TestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device devAcc = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto computeExec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device devAcc = test::getDevice(deviceExec);
+    concepts::Executor auto computeExec = test::getExecutor(deviceExec);
 
     // Create a queue on the device
     alpaka::onHost::Queue queue = devAcc.makeQueue();

--- a/test/unit/intrinsic/ffs.cpp
+++ b/test/unit/intrinsic/ffs.cpp
@@ -42,7 +42,7 @@ static int32_t naiveFfs(TValue value)
 
 TEMPLATE_LIST_TEST_CASE("ffs", "[intrinsic][ffs]", TestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device devAcc = test::getDevice(deviceExec);
     concepts::Executor auto computeExec = test::getExecutor(deviceExec);
 

--- a/test/unit/intrinsic/popc.cpp
+++ b/test/unit/intrinsic/popc.cpp
@@ -28,7 +28,7 @@ struct TestKernel
 
 TEMPLATE_LIST_TEST_CASE("popcount", "[intrinsic][popc]", TestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device devAcc = test::getDevice(deviceExec);
     concepts::Executor auto computeExec = test::getExecutor(deviceExec);
 

--- a/test/unit/intrinsic/popc.cpp
+++ b/test/unit/intrinsic/popc.cpp
@@ -28,11 +28,9 @@ struct TestKernel
 
 TEMPLATE_LIST_TEST_CASE("popcount", "[intrinsic][popc]", TestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device devAcc = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto computeExec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device devAcc = test::getDevice(deviceExec);
+    concepts::Executor auto computeExec = test::getExecutor(deviceExec);
 
     // Create a queue on the device
     alpaka::onHost::Queue queue = devAcc.makeQueue();

--- a/test/unit/kernel/makeIdxMap.cpp
+++ b/test/unit/kernel/makeIdxMap.cpp
@@ -84,11 +84,9 @@ void runTest(Queue& queue, Exec exec, Extent const& extentsAndFrameSize, Policy 
  */
 TEMPLATE_LIST_TEST_CASE("makeIdxMap", "[kernel][makeIdxMap]", TestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     onHost::Queue queue = device.makeQueue();
 

--- a/test/unit/kernel/makeIdxMap.cpp
+++ b/test/unit/kernel/makeIdxMap.cpp
@@ -84,7 +84,7 @@ void runTest(Queue& queue, Exec exec, Extent const& extentsAndFrameSize, Policy 
  */
 TEMPLATE_LIST_TEST_CASE("makeIdxMap", "[kernel][makeIdxMap]", TestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/math/TestTemplate.hpp
+++ b/test/unit/math/TestTemplate.hpp
@@ -115,13 +115,9 @@ namespace mathtest
             std::random_device rd{};
             auto const seed = rd();
 
-            auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-            if(!optionalDeviceExec)
-            {
-                return;
-            }
-            onHost::Device device = test::getDevice(optionalDeviceExec);
-            concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+            auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+            onHost::Device device = test::getDevice(deviceExec);
+            concepts::Executor auto exec = test::getExecutor(deviceExec);
 
 #if ALPAKA_LANG_ONEAPI
             // support for double precision is not guaranteed for sycl devices such as Intel GPUs

--- a/test/unit/math/TestTemplate.hpp
+++ b/test/unit/math/TestTemplate.hpp
@@ -115,7 +115,7 @@ namespace mathtest
             std::random_device rd{};
             auto const seed = rd();
 
-            auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+            auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
             onHost::Device device = test::getDevice(deviceExec);
             concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/math/executeOnComputeDevice.hpp
+++ b/test/unit/math/executeOnComputeDevice.hpp
@@ -28,7 +28,7 @@ namespace alpaka::test
     template<typename T_DataType = alpaka::NotRequired>
     bool executeOnComputeDevice(auto cfg, auto kernelFnObj, auto&&... args)
     {
-        auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+        auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
         onHost::Device device = test::getDevice(deviceExec);
         concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/math/executeOnComputeDevice.hpp
+++ b/test/unit/math/executeOnComputeDevice.hpp
@@ -28,13 +28,9 @@ namespace alpaka::test
     template<typename T_DataType = alpaka::NotRequired>
     bool executeOnComputeDevice(auto cfg, auto kernelFnObj, auto&&... args)
     {
-        auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-        if(!optionalDeviceExec)
-        {
-            return false;
-        }
-        onHost::Device device = test::getDevice(optionalDeviceExec);
-        concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+        auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+        onHost::Device device = test::getDevice(deviceExec);
+        concepts::Executor auto exec = test::getExecutor(deviceExec);
 
 #if ALPAKA_LANG_ONEAPI
         // support for double precision is not guaranteed for sycl devices such as Intel GPUs

--- a/test/unit/mem/alloc.cpp
+++ b/test/unit/mem/alloc.cpp
@@ -102,11 +102,9 @@ void allocDeferredImplicitWait(auto device, alpaka::concepts::Executor auto exec
 
 TEMPLATE_LIST_TEST_CASE("alloc", "", TestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     allocDeferredImplicitWait(device, exec);
 }

--- a/test/unit/mem/alloc.cpp
+++ b/test/unit/mem/alloc.cpp
@@ -102,7 +102,7 @@ void allocDeferredImplicitWait(auto device, alpaka::concepts::Executor auto exec
 
 TEMPLATE_LIST_TEST_CASE("alloc", "", TestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/mem/allocDeferred.cpp
+++ b/test/unit/mem/allocDeferred.cpp
@@ -93,11 +93,9 @@ void allocDeferredExplicitWait(auto device, auto exec)
 
 TEMPLATE_LIST_TEST_CASE("allocDeferred", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     // repeat the test multiple times to increase the change to trigger data races
     constexpr int testRounds = 10;

--- a/test/unit/mem/allocDeferred.cpp
+++ b/test/unit/mem/allocDeferred.cpp
@@ -93,7 +93,7 @@ void allocDeferredExplicitWait(auto device, auto exec)
 
 TEMPLATE_LIST_TEST_CASE("allocDeferred", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/mem/keepAlive.cpp
+++ b/test/unit/mem/keepAlive.cpp
@@ -32,11 +32,9 @@ struct IotaKernel
 
 TEMPLATE_LIST_TEST_CASE("keep alive", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
 
     constexpr std::size_t N = 256;

--- a/test/unit/mem/keepAlive.cpp
+++ b/test/unit/mem/keepAlive.cpp
@@ -32,7 +32,7 @@ struct IotaKernel
 
 TEMPLATE_LIST_TEST_CASE("keep alive", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();

--- a/test/unit/mem/memFenceBasic.cpp
+++ b/test/unit/mem/memFenceBasic.cpp
@@ -44,7 +44,7 @@ struct MemoryFenceTestKernel
 // Run over all enabled backend+executor combinations exposed via TestApis.
 TEMPLATE_LIST_TEST_CASE("thread fence operations", "[memFence][basic]", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/mem/memFenceBasic.cpp
+++ b/test/unit/mem/memFenceBasic.cpp
@@ -44,11 +44,9 @@ struct MemoryFenceTestKernel
 // Run over all enabled backend+executor combinations exposed via TestApis.
 TEMPLATE_LIST_TEST_CASE("thread fence operations", "[memFence][basic]", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto queue = device.makeQueue();
 

--- a/test/unit/mem/memFenceProducerConsumer.cpp
+++ b/test/unit/mem/memFenceProducerConsumer.cpp
@@ -91,11 +91,9 @@ struct ProducerConsumerKernel
 
 TEMPLATE_LIST_TEST_CASE("memFence producer-consumer publication", "[memFence][producer-consumer]", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     auto queue = device.makeQueue();
 
     // modest to keep test fast.
@@ -265,11 +263,9 @@ struct BlockSharedMemOrderKernel
 
 TEMPLATE_LIST_TEST_CASE("memFence block shared-memory ordering", "[memFence][block-shared]", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     auto queue = device.makeQueue();
 
     // success flag: 1 = pass, 0 = failure detected

--- a/test/unit/mem/memFenceProducerConsumer.cpp
+++ b/test/unit/mem/memFenceProducerConsumer.cpp
@@ -91,7 +91,7 @@ struct ProducerConsumerKernel
 
 TEMPLATE_LIST_TEST_CASE("memFence producer-consumer publication", "[memFence][producer-consumer]", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     auto queue = device.makeQueue();
@@ -263,7 +263,7 @@ struct BlockSharedMemOrderKernel
 
 TEMPLATE_LIST_TEST_CASE("memFence block shared-memory ordering", "[memFence][block-shared]", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     auto queue = device.makeQueue();

--- a/test/unit/precision/precision.cpp
+++ b/test/unit/precision/precision.cpp
@@ -67,7 +67,7 @@ enum Sign : bool
 template<Sign T_signedMemIdx, Sign T_signedKernelIdx>
 void callTests(auto cfg)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
     onHost::Device device = test::getDevice(deviceExec);
     alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
     Queue queue = device.makeQueue();
@@ -212,7 +212,7 @@ struct IotaKernelNDForceCast
 template<typename T_MemIdx, typename T_LoopIdx>
 void callForceCastTests(auto cfg)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
     onHost::Device device = test::getDevice(deviceExec);
     alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
     Queue queue = device.makeQueue();

--- a/test/unit/precision/precision.cpp
+++ b/test/unit/precision/precision.cpp
@@ -67,11 +67,9 @@ enum Sign : bool
 template<Sign T_signedMemIdx, Sign T_signedKernelIdx>
 void callTests(auto cfg)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    alpaka::concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    onHost::Device device = test::getDevice(deviceExec);
+    alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
     Queue queue = device.makeQueue();
 
     IotaKernelND iotaKernelND;
@@ -214,11 +212,9 @@ struct IotaKernelNDForceCast
 template<typename T_MemIdx, typename T_LoopIdx>
 void callForceCastTests(auto cfg)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(cfg);
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    alpaka::concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(cfg);
+    onHost::Device device = test::getDevice(deviceExec);
+    alpaka::concepts::Executor auto exec = test::getExecutor(deviceExec);
     Queue queue = device.makeQueue();
 
     IotaKernelNDForceCast<T_LoopIdx> iotaKernelNDForceCast;

--- a/test/unit/queue/blockingQueue.cpp
+++ b/test/unit/queue/blockingQueue.cpp
@@ -41,11 +41,9 @@ struct BlockingTestKernel
 
 TEMPLATE_LIST_TEST_CASE("blocking queue memory operations", "[bq][memory]", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto blockingQueue0 = device.makeQueue(queueKind::blocking);
     auto blockingQueue1 = device.makeQueue(queueKind::blocking);
@@ -114,11 +112,9 @@ struct FillKernel
 // enqueue different steps of a compute chain in independent blocking queues
 TEMPLATE_LIST_TEST_CASE("blocking queue chained operations", "[bq][chain]", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto qBlocking0 = device.makeQueue(queueKind::blocking);
     auto qBlocking1 = device.makeQueue(queueKind::blocking);
@@ -154,11 +150,9 @@ TEMPLATE_LIST_TEST_CASE("blocking queue chained operations", "[bq][chain]", Test
 // Test blocking and non-blocking queue should be usable together
 TEMPLATE_LIST_TEST_CASE("mixed queues independence", "[bq][mixed]", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     constexpr Vec extent = Vec{8u};
     constexpr auto frameSize = CVec<uint32_t, 4u>{};
@@ -181,11 +175,9 @@ TEMPLATE_LIST_TEST_CASE("mixed queues independence", "[bq][mixed]", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("blocking queue event semantics", "[bq][event]", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     // Blocking producer queue, non-blocking consumer queue
     auto qBlocking = device.makeQueue(queueKind::blocking);
@@ -266,10 +258,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue event semantics", "[bq][event]", TestApi
 // blocking queue event-cache behavior tests
 TEMPLATE_LIST_TEST_CASE("blocking queue event cache functionality", "[event][blocking-queue]", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
 
     SECTION("Rapid event enqueueing")
     {
@@ -335,10 +324,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue event cache functionality", "[event][blo
 // Test for race condition in blocking queue event enqueue
 TEMPLATE_LIST_TEST_CASE("blocking queue event race condition", "[bq][event][race]", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
     auto blockingQueue = device.makeQueue(queueKind::blocking);
 
     // Test concurrent event operations to detect race conditions

--- a/test/unit/queue/blockingQueue.cpp
+++ b/test/unit/queue/blockingQueue.cpp
@@ -41,7 +41,7 @@ struct BlockingTestKernel
 
 TEMPLATE_LIST_TEST_CASE("blocking queue memory operations", "[bq][memory]", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 
@@ -112,7 +112,7 @@ struct FillKernel
 // enqueue different steps of a compute chain in independent blocking queues
 TEMPLATE_LIST_TEST_CASE("blocking queue chained operations", "[bq][chain]", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 
@@ -150,7 +150,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue chained operations", "[bq][chain]", Test
 // Test blocking and non-blocking queue should be usable together
 TEMPLATE_LIST_TEST_CASE("mixed queues independence", "[bq][mixed]", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 
@@ -175,7 +175,7 @@ TEMPLATE_LIST_TEST_CASE("mixed queues independence", "[bq][mixed]", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("blocking queue event semantics", "[bq][event]", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 
@@ -258,7 +258,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue event semantics", "[bq][event]", TestApi
 // blocking queue event-cache behavior tests
 TEMPLATE_LIST_TEST_CASE("blocking queue event cache functionality", "[event][blocking-queue]", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
 
     SECTION("Rapid event enqueueing")
     {
@@ -324,7 +324,7 @@ TEMPLATE_LIST_TEST_CASE("blocking queue event cache functionality", "[event][blo
 // Test for race condition in blocking queue event enqueue
 TEMPLATE_LIST_TEST_CASE("blocking queue event race condition", "[bq][event][race]", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
     auto blockingQueue = device.makeQueue(queueKind::blocking);
 
     // Test concurrent event operations to detect race conditions

--- a/test/unit/queue/isEmpty.cpp
+++ b/test/unit/queue/isEmpty.cpp
@@ -23,7 +23,7 @@ TEMPLATE_LIST_TEST_CASE("queue isEmpty", "[queue][isEmpty]", TestSetup)
 {
     using Backend = std::tuple_element_t<0u, TestType>;
     using QueueKind = std::tuple_element_t<1u, TestType>;
-    onHost::Device device = test::getAvailableDevice(Backend::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(Backend::makeDict());
 
     INFO("queue kind : " << QueueKind::getName());
 

--- a/test/unit/queue/isEmpty.cpp
+++ b/test/unit/queue/isEmpty.cpp
@@ -23,10 +23,7 @@ TEMPLATE_LIST_TEST_CASE("queue isEmpty", "[queue][isEmpty]", TestSetup)
 {
     using Backend = std::tuple_element_t<0u, TestType>;
     using QueueKind = std::tuple_element_t<1u, TestType>;
-    auto optionalDevice = test::getAvailableDevice(Backend::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(Backend::makeDict());
 
     INFO("queue kind : " << QueueKind::getName());
 

--- a/test/unit/queue/kernelMD.cpp
+++ b/test/unit/queue/kernelMD.cpp
@@ -76,11 +76,9 @@ void validate(auto& queue, auto& device, auto exec, auto testCase)
 
 TEMPLATE_LIST_TEST_CASE("kernelCallMD", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
 
     auto testCfg = std::make_tuple(

--- a/test/unit/queue/kernelMD.cpp
+++ b/test/unit/queue/kernelMD.cpp
@@ -76,7 +76,7 @@ void validate(auto& queue, auto& device, auto exec, auto testCase)
 
 TEMPLATE_LIST_TEST_CASE("kernelCallMD", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();

--- a/test/unit/queue/queue.cpp
+++ b/test/unit/queue/queue.cpp
@@ -25,7 +25,7 @@ struct NoArgumentsKernel
  */
 TEMPLATE_LIST_TEST_CASE("kernel no arguments", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 
@@ -52,7 +52,7 @@ struct IotaKernel
 
 TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 
@@ -82,7 +82,7 @@ struct IotaKernelND
 
 TEMPLATE_LIST_TEST_CASE("iota2D", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
@@ -102,7 +102,7 @@ TEMPLATE_LIST_TEST_CASE("iota2D", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("iota3D", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
@@ -122,7 +122,7 @@ TEMPLATE_LIST_TEST_CASE("iota3D", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("iota4D", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
@@ -176,7 +176,7 @@ struct IotaKernelNDSelection
 
 TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
@@ -260,7 +260,7 @@ private:
 /** Test that memcpy and memset can be called with non copy-able and move-able data as lvalue and rvalue. */
 TEMPLATE_LIST_TEST_CASE("memcpy", "", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
     onHost::Queue queue = device.makeQueue();
     constexpr Vec problemSize = Vec{16u};
 
@@ -317,7 +317,7 @@ TEMPLATE_LIST_TEST_CASE("memcpy", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("host task callback", "", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
     onHost::Queue queue = device.makeQueue();
 
     std::promise<bool> promise;
@@ -330,7 +330,7 @@ TEMPLATE_LIST_TEST_CASE("host task callback", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("host task", "", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
     onHost::Queue queue = device.makeQueue();
 
     bool flag = false;
@@ -352,7 +352,7 @@ TEMPLATE_LIST_TEST_CASE("host task", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("queue wait should work", "", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
     onHost::Queue queue = device.makeQueue();
 
     std::atomic<bool> callbackFinished{false};
@@ -369,7 +369,7 @@ TEMPLATE_LIST_TEST_CASE("queue wait should work", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("task is destroyed after execution", "", TestApis)
 {
-    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
     onHost::Queue queue = device.makeQueue();
 
     struct Task

--- a/test/unit/queue/queue.cpp
+++ b/test/unit/queue/queue.cpp
@@ -25,11 +25,9 @@ struct NoArgumentsKernel
  */
 TEMPLATE_LIST_TEST_CASE("kernel no arguments", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     INFO("mem=" << device.getDeviceProperties().globalMemCapacityBytes);
     INFO("free mem=" << device.getFreeGlobalMemBytes());
@@ -54,11 +52,9 @@ struct IotaKernel
 
 TEMPLATE_LIST_TEST_CASE("iota", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec extent = Vec{12u};
@@ -86,11 +82,9 @@ struct IotaKernelND
 
 TEMPLATE_LIST_TEST_CASE("iota2D", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
 
     constexpr Vec extent = Vec{8u, 16u};
@@ -108,11 +102,9 @@ TEMPLATE_LIST_TEST_CASE("iota2D", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("iota3D", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
 
     constexpr Vec extent = Vec{4u, 8u, 16u};
@@ -130,11 +122,9 @@ TEMPLATE_LIST_TEST_CASE("iota3D", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("iota4D", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
 
     constexpr Vec extent = Vec{4u, 8u, 16, 32};
@@ -186,11 +176,9 @@ struct IotaKernelNDSelection
 
 TEMPLATE_LIST_TEST_CASE("iota3D 2D iterate", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
 
     constexpr Vec numBlocks = Vec{4u, 8u, 16u};
@@ -272,10 +260,7 @@ private:
 /** Test that memcpy and memset can be called with non copy-able and move-able data as lvalue and rvalue. */
 TEMPLATE_LIST_TEST_CASE("memcpy", "", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
     onHost::Queue queue = device.makeQueue();
     constexpr Vec problemSize = Vec{16u};
 
@@ -332,10 +317,7 @@ TEMPLATE_LIST_TEST_CASE("memcpy", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("host task callback", "", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
     onHost::Queue queue = device.makeQueue();
 
     std::promise<bool> promise;
@@ -348,10 +330,7 @@ TEMPLATE_LIST_TEST_CASE("host task callback", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("host task", "", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
     onHost::Queue queue = device.makeQueue();
 
     bool flag = false;
@@ -373,10 +352,7 @@ TEMPLATE_LIST_TEST_CASE("host task", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("queue wait should work", "", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
     onHost::Queue queue = device.makeQueue();
 
     std::atomic<bool> callbackFinished{false};
@@ -393,10 +369,7 @@ TEMPLATE_LIST_TEST_CASE("queue wait should work", "", TestApis)
 
 TEMPLATE_LIST_TEST_CASE("task is destroyed after execution", "", TestApis)
 {
-    auto optionalDevice = test::getAvailableDevice(TestType::makeDict());
-    if(!optionalDevice)
-        return;
-    onHost::Device device = test::getDevice(optionalDevice);
+    onHost::Device device = test::getAvailableDevice(TestType::makeDict());
     onHost::Queue queue = device.makeQueue();
 
     struct Task

--- a/test/unit/rand/uniformReal.cpp
+++ b/test/unit/rand/uniformReal.cpp
@@ -131,7 +131,7 @@ void testCase(HelperPack<T_Engine, T_FP, T_Interval>, uint64_t seed, T_FP minF, 
     using namespace alpaka;
 
     // ---- device selection ---------------------------------------------------
-    auto deviceExec = test::getAvailableDeviceExecutor(T_TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(T_TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     auto queue = device.makeQueue(queueKind::blocking);

--- a/test/unit/rand/uniformReal.cpp
+++ b/test/unit/rand/uniformReal.cpp
@@ -131,11 +131,9 @@ void testCase(HelperPack<T_Engine, T_FP, T_Interval>, uint64_t seed, T_FP minF, 
     using namespace alpaka;
 
     // ---- device selection ---------------------------------------------------
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(T_TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(T_TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     auto queue = device.makeQueue(queueKind::blocking);
 
     // ---- allocate output buffer (1D of N values) ----------------------------

--- a/test/unit/sharedMem/sharedMem.cpp
+++ b/test/unit/sharedMem/sharedMem.cpp
@@ -43,11 +43,9 @@ struct SharedBlockIotaKernel
 
 TEMPLATE_LIST_TEST_CASE("block shared iota", "[sharedMem]", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
 
     constexpr Vec numBlocks = Vec{2u};
@@ -170,11 +168,9 @@ namespace alpaka::onHost::trait
 
 TEMPLATE_LIST_TEST_CASE("block shared alias", "[SharedMem]", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     onHost::Queue queue = device.makeQueue();
     constexpr Vec numBlocks = Vec{1u};
@@ -236,11 +232,9 @@ void test_index_type(auto& queue, auto const& exec, auto name)
 
 TEMPLATE_LIST_TEST_CASE("test shared memory index type", "[sharedMem]", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     alpaka::onHost::Queue queue = device.makeQueue();
 
     test_index_type<uint32_t>(queue, exec, "uint32_t");

--- a/test/unit/sharedMem/sharedMem.cpp
+++ b/test/unit/sharedMem/sharedMem.cpp
@@ -43,7 +43,7 @@ struct SharedBlockIotaKernel
 
 TEMPLATE_LIST_TEST_CASE("block shared iota", "[sharedMem]", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     onHost::Queue queue = device.makeQueue();
@@ -168,7 +168,7 @@ namespace alpaka::onHost::trait
 
 TEMPLATE_LIST_TEST_CASE("block shared alias", "[SharedMem]", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 
@@ -232,7 +232,7 @@ void test_index_type(auto& queue, auto const& exec, auto name)
 
 TEMPLATE_LIST_TEST_CASE("test shared memory index type", "[sharedMem]", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
     alpaka::onHost::Queue queue = device.makeQueue();

--- a/test/unit/warp/activemask.cpp
+++ b/test/unit/warp/activemask.cpp
@@ -64,7 +64,7 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp activemask reflects participating lanes", "[warp][activemask]", WarpTestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/warp/activemask.cpp
+++ b/test/unit/warp/activemask.cpp
@@ -64,11 +64,9 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp activemask reflects participating lanes", "[warp][activemask]", WarpTestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto deviceProperties = device.getDeviceProperties();
     auto const warpExtent = deviceProperties.warpSize;

--- a/test/unit/warp/all.cpp
+++ b/test/unit/warp/all.cpp
@@ -70,11 +70,9 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp all vote honours only active lanes", "[warp][all]", WarpTestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto deviceProperties = device.getDeviceProperties();
     auto const warpExtent = deviceProperties.warpSize;

--- a/test/unit/warp/all.cpp
+++ b/test/unit/warp/all.cpp
@@ -70,7 +70,7 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp all vote honours only active lanes", "[warp][all]", WarpTestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/warp/any.cpp
+++ b/test/unit/warp/any.cpp
@@ -70,7 +70,7 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp any vote observes active lanes", "[warp][any]", WarpTestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/warp/any.cpp
+++ b/test/unit/warp/any.cpp
@@ -70,11 +70,9 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp any vote observes active lanes", "[warp][any]", WarpTestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto deviceProperties = device.getDeviceProperties();
     auto const warpExtent = deviceProperties.warpSize;

--- a/test/unit/warp/ballot.cpp
+++ b/test/unit/warp/ballot.cpp
@@ -80,7 +80,7 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp ballot captures predicate lanes", "[warp][ballot]", WarpTestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/warp/ballot.cpp
+++ b/test/unit/warp/ballot.cpp
@@ -80,11 +80,9 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp ballot captures predicate lanes", "[warp][ballot]", WarpTestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto deviceProperties = device.getDeviceProperties();
     auto const warpExtent = deviceProperties.warpSize;

--- a/test/unit/warp/getSize.cpp
+++ b/test/unit/warp/getSize.cpp
@@ -75,7 +75,7 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp size trait matches runtime size", "[warp][getSize]", WarpTestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/warp/getSize.cpp
+++ b/test/unit/warp/getSize.cpp
@@ -75,11 +75,9 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp size trait matches runtime size", "[warp][getSize]", WarpTestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto deviceProperties = device.getDeviceProperties();
     auto const warpExtent = deviceProperties.warpSize;

--- a/test/unit/warp/iota.cpp
+++ b/test/unit/warp/iota.cpp
@@ -39,7 +39,7 @@ struct IotaKernelND
 
 TEMPLATE_LIST_TEST_CASE("warp iota1D", "", TestApis)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/warp/iota.cpp
+++ b/test/unit/warp/iota.cpp
@@ -39,11 +39,9 @@ struct IotaKernelND
 
 TEMPLATE_LIST_TEST_CASE("warp iota1D", "", TestApis)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto deviceProperties = device.getDeviceProperties();
     uint32_t warpSize = deviceProperties.warpSize;

--- a/test/unit/warp/shfl.cpp
+++ b/test/unit/warp/shfl.cpp
@@ -100,7 +100,7 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp shfl moves values between lanes", "[warp][shfl]", WarpTestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/warp/shfl.cpp
+++ b/test/unit/warp/shfl.cpp
@@ -100,11 +100,9 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp shfl moves values between lanes", "[warp][shfl]", WarpTestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto deviceProperties = device.getDeviceProperties();
     auto const warpExtent = deviceProperties.warpSize;

--- a/test/unit/warp/shfl_down.cpp
+++ b/test/unit/warp/shfl_down.cpp
@@ -110,7 +110,7 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp shflDown shifts toward higher lanes", "[warp][shfl_down]", WarpTestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/warp/shfl_down.cpp
+++ b/test/unit/warp/shfl_down.cpp
@@ -110,11 +110,9 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp shflDown shifts toward higher lanes", "[warp][shfl_down]", WarpTestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto deviceProperties = device.getDeviceProperties();
     auto const warpExtent = deviceProperties.warpSize;

--- a/test/unit/warp/shfl_up.cpp
+++ b/test/unit/warp/shfl_up.cpp
@@ -100,7 +100,7 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp shflUp shifts toward lower lanes", "[warp][shfl_up]", WarpTestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 

--- a/test/unit/warp/shfl_up.cpp
+++ b/test/unit/warp/shfl_up.cpp
@@ -100,11 +100,9 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp shflUp shifts toward lower lanes", "[warp][shfl_up]", WarpTestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto deviceProperties = device.getDeviceProperties();
     auto const warpExtent = deviceProperties.warpSize;

--- a/test/unit/warp/shfl_xor.cpp
+++ b/test/unit/warp/shfl_xor.cpp
@@ -98,11 +98,9 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp shflXor exchanges partner lanes", "[warp][shfl_xor]", WarpTestBackends)
 {
-    auto optionalDeviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
-    if(!optionalDeviceExec)
-        return;
-    onHost::Device device = test::getDevice(optionalDeviceExec);
-    concepts::Executor auto exec = test::getExecutor(optionalDeviceExec);
+    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
 
     auto deviceProperties = device.getDeviceProperties();
     auto const warpExtent = deviceProperties.warpSize;

--- a/test/unit/warp/shfl_xor.cpp
+++ b/test/unit/warp/shfl_xor.cpp
@@ -98,7 +98,7 @@ namespace
 
 TEMPLATE_LIST_TEST_CASE("warp shflXor exchanges partner lanes", "[warp][shfl_xor]", WarpTestBackends)
 {
-    auto deviceExec = test::getAvailableDeviceExecutor(TestType::makeDict());
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
 


### PR DESCRIPTION
Refactor testing. The basic idea is, that tests should fail if they does not check anything but tests should not fail if all tests are skipped because of a missing runtime device.

Split up both steps in two PR's to make it easier to review.
- This PR introduces Catch2 `SKIP()` to get easier an alpaka device if available
- PR #581 enables the check, that each test does a assertation 