### PR TITLE
fix nvcc compile with keep files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,10 @@ repos:
     - id: shellcheck
       # required that shellcheck can follow sourced scripts
       args: [-x]
+- repo: local
+  hooks:
+    - id: ascii-check
+      name: ASCII check
+      entry: python3 script/gitPreCommit/checkForNonASCII.py
+      language: system
+      files: \.(c|cc|cpp|cxx|cu|h|hh|hpp|hxx|cuh)$

--- a/docs/alpaka_docs.yml
+++ b/docs/alpaka_docs.yml
@@ -20,7 +20,7 @@ channels:
   - conda-forge
 
 dependencies:
-  # Core Python – choose the version you need
+  # Core Python - choose the version you need
   - python >=3.9,<3.13        # adjust as required
 
   # ---------------------------------------------------------

--- a/docs/snippets/example/050_kernel.cpp
+++ b/docs/snippets/example/050_kernel.cpp
@@ -69,7 +69,7 @@ TEMPLATE_LIST_TEST_CASE("tutorial kernel intro vector add", "[docs]", docs::test
      */
     onHost::concepts::FrameSpec auto frameSpec = onHost::getFrameSpec(device, exec::anyExecutor, Vec{numElements});
 
-    /* Create a kernel object and enqueue it along with the `frameSpec´ and kernel arguments.
+    /* Create a kernel object and enqueue it along with the `frameSpec` and kernel arguments.
      * Depending on how many tasks are still in the queue, the kernel may be executed immediately or after a delay.
      */
     queue.enqueue(frameSpec, KernelBundle{VectorAddKernel{}, resultBuffer, lhsBuffer, rhsBuffer});

--- a/docs/snippets/example/090_kernelParallelism.cpp
+++ b/docs/snippets/example/090_kernelParallelism.cpp
@@ -9,6 +9,8 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
+
 using namespace alpaka;
 
 // BEGIN-TUTORIAL-hierarchyKernel
@@ -140,21 +142,6 @@ TEMPLATE_LIST_TEST_CASE("tutorial hierarchy blocks threads warps", "[docs]", doc
     CHECK(hostRowCounts[2u] == warpSize);
     CHECK(hostRowCounts[3u] == 0u);
 }
-
-/* Copyright 2026 René Widera
- * SPDX-License-Identifier: MPL-2.0
- */
-
-#include "docsTest.hpp"
-
-#include <alpaka/alpaka.hpp>
-
-#include <catch2/catch_template_test_macros.hpp>
-#include <catch2/catch_test_macros.hpp>
-
-#include <array>
-
-using namespace alpaka;
 
 // BEGIN-TUTORIAL-chunkedKernel
 struct ChunkedVectorAddKernel

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -6,7 +6,7 @@
     width: auto;
 }
 
-/* Phones <1600px – use the whole width */
+/* Phones <1600px - use the whole width */
 @media (max-width: 1600px) {
     .wy-nav-content {
         max-width: none;

--- a/example/randomInit/src/randomInitNormal.hpp
+++ b/example/randomInit/src/randomInitNormal.hpp
@@ -83,8 +83,8 @@ bool validateNormal(auto const& data, auto expectedMean, auto expectedStdDev)
     std::cout << "Normal distribution stats:\n";
     std::cout << "   Mean:      " << mean << " (expected " << expectedMean << ")\n";
     std::cout << "   Stddev:    " << stddev << " (expected " << expectedStdDev << ")\n";
-    std::cout << "   Skewness:  " << skewness << " (ideal ≈ 0)\n";
-    std::cout << "   Kurtosis:  " << kurtosis << " (ideal ≈ 3)\n";
+    std::cout << "   Skewness:  " << skewness << " (ideal ~= 0)\n";
+    std::cout << "   Kurtosis:  " << kurtosis << " (ideal ~= 3)\n";
 
     // Acceptable tolerance for mean and stddev (adjust as needed for your sample size)
     double meanTol = 0.01;

--- a/include/alpaka/onAcc/interface.hpp
+++ b/include/alpaka/onAcc/interface.hpp
@@ -34,7 +34,7 @@ namespace alpaka::onAcc
     } // namespace concepts
 
     /**@{
-     * @name range‑based loop indexable index container
+     * @name range-based loop indexable index container
      */
 
     /** Creates an index container
@@ -51,7 +51,7 @@ namespace alpaka::onAcc
      * @param range     Index range description.
      * @param traverse  Policy describing how the next value can be found.
      * @param idxLayout Policy describing how real worker threads will be mapped to the range.
-     * @return A index container that can be used in a range‑based for loop.
+     * @return A index container that can be used in a range-based for loop.
      */
     template<concepts::IdxTraversing T_Traverse = traverse::Flat, concepts::IdxMapping T_IdxLayout = layout::Optimized>
     ALPAKA_FN_HOST_ACC constexpr auto makeIdxMap(
@@ -104,7 +104,7 @@ namespace alpaka::onAcc
      * @param range     Index range description.
      * @param traverse  Policy describing how the next value can be found.
      * @param idxLayout Policy describing how real worker threads will be mapped to the range.
-     * @return A index container that can be used in a range‑based for loop.
+     * @return A index container that can be used in a range-based for loop.
      */
     template<
         typename T_ScalarIdxType,
@@ -126,7 +126,7 @@ namespace alpaka::onAcc
     }
 
     ///@cond NO_HTML
-    /** Specialisation for one‑dimensional ranges. */
+    /** Specialisation for one-dimensional ranges. */
     template<
         concepts::IdxTraversing T_Traverse = traverse::Tiled,
         concepts::IdxMapping T_IdxLayout = layout::Optimized>
@@ -145,7 +145,7 @@ namespace alpaka::onAcc
                 idxLayout);
     }
 
-    /** Specialisation for one‑dimensional ranges. */
+    /** Specialisation for one-dimensional ranges. */
     template<
         typename T_ScalarIdxType,
         concepts::IdxTraversing T_Traverse = traverse::Tiled,

--- a/include/alpaka/onAcc/warp.hpp
+++ b/include/alpaka/onAcc/warp.hpp
@@ -165,7 +165,7 @@ namespace alpaka::onAcc::warp
     /** Read data from threads with higher lane index within a warp.
      *
      * It copies from a lane with higher ID relative to caller.
-     * The lane ID is calculated by adding delta to the caller’s lane ID.
+     * The lane ID is calculated by adding delta to the caller's lane ID.
      *
      * Effectively executes:
      *
@@ -201,7 +201,7 @@ namespace alpaka::onAcc::warp
     /** Read data from threads with lower lane index within a warp.
      *
      * It copies from a lane with lower ID relative to caller.
-     * The lane ID is calculated by subtracting delta from the caller’s lane ID.
+     * The lane ID is calculated by subtracting delta from the caller's lane ID.
      *
      * Effectively executes:
      *
@@ -236,7 +236,7 @@ namespace alpaka::onAcc::warp
     /** Exchange data between threads within a warp.
      *
      * It copies from a lane based on bitwise XOR of own lane ID.
-     * The lane ID is calculated by performing a bitwise XOR of the caller’s lane ID with laneMask
+     * The lane ID is calculated by performing a bitwise XOR of the caller's lane ID with laneMask
      *
      * Effectively executes:
      *

--- a/include/alpaka/onHost/interface.hpp
+++ b/include/alpaka/onHost/interface.hpp
@@ -78,20 +78,20 @@ namespace alpaka::onHost
      * @name Query the name
      */
 
-    /** Compile‑time available name for a given object.
+    /** Compile-time available name for a given object.
      *
      * @param any object whose name shall be queried
-     * @return a `std::string`‑compatible value holding the static name
+     * @return a `std::string`-compatible value holding the static name
      */
     inline std::convertible_to<std::string> auto getStaticName(auto const& any)
     {
         return alpaka::internal::GetStaticName::Op<ALPAKA_TYPEOF(any)>{}(any);
     }
 
-    /** Compile‑time available name of an handle
+    /** Compile-time available name of an handle
      *
      * @param handle object whose name shall be queried
-     * @return a `std::string`‑compatible value holding the static name
+     * @return a `std::string`-compatible value holding the static name
      */
     inline std::convertible_to<std::string> auto getStaticName(concepts::StaticNameHandle auto const& handle)
     {
@@ -101,7 +101,7 @@ namespace alpaka::onHost
     /** Runtime name for a given object.
      *
      * @param any object whose name shall be queried
-     * @return a `std::string`‑compatible value holding the name
+     * @return a `std::string`-compatible value holding the name
      */
     inline std::convertible_to<std::string> auto getName(auto&& any)
     {
@@ -111,7 +111,7 @@ namespace alpaka::onHost
     /** Runtime name for a given handle.
      *
      * @param handle object whose name shall be queried
-     * @return a `std::string`‑compatible value holding the name
+     * @return a `std::string`-compatible value holding the name
      */
     inline std::convertible_to<std::string> auto getName(concepts::NameHandle auto const& handle)
     {
@@ -123,10 +123,10 @@ namespace alpaka::onHost
     /** Get the native handle of an handle.
      *
      * The native handle can be passed to the underlying backend API
-     * (e.g. CUDA, HIP, OpenMP) for low‑level operations.
+     * (e.g. CUDA, HIP, OpenMP) for low-level operations.
      *
      * @param handle object exposing a native handle
-     * @return the native handle returned by the backend‑specific implementation
+     * @return the native handle returned by the backend-specific implementation
      */
     inline auto getNativeHandle(auto const& handle)
     {
@@ -149,7 +149,7 @@ namespace alpaka::onHost
      */
     /** pointer to data of an object
      *
-     * For multi‑dimensional data the data is not required to be continuous.
+     * For multi-dimensional data the data is not required to be continuous.
      *
      * @param any object providing data access (e.g. std::vector)
      * @return raw pointer to the underlying data (equivalent to `std::data`)
@@ -161,7 +161,7 @@ namespace alpaka::onHost
 
     /** pointer to data of an handle
      *
-     * For multi‑dimensional data the data is not required to be continuous.
+     * For multi-dimensional data the data is not required to be continuous.
      *
      * @param handle handle providing data access (e.g. view)
      * @return raw pointer to the underlying data

--- a/include/alpaka/rand/distribution/NormalReal.hpp
+++ b/include/alpaka/rand/distribution/NormalReal.hpp
@@ -14,7 +14,7 @@ namespace alpaka::rand::distribution
     namespace internal
     {
         /**
-         * @brief Scalar Box–Muller transform for floating-point types.
+         * @brief Scalar Box-Muller transform for floating-point types.
          *
          * Generates independent standard normal samples from a uniform
          * scalar engine. The implementation caches the second sample so

--- a/script/gitPreCommit/checkForNonASCII.py
+++ b/script/gitPreCommit/checkForNonASCII.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 René Widera
+# SPDX-License-Identifier: MPL-2.0
+
+from pathlib import Path
+import re
+import sys
+
+
+NON_ASCII = re.compile(r"[^\x00-\x7F]")
+
+def find_header_end(text: str) -> int:
+    """Return the character offset after the initial license/author block."""
+
+    if text.startswith("/*"):
+        end = text.find("*/")
+        if end != -1:
+            return end + 2
+
+    elif text.startswith("//"):
+        offset = 0
+        for line in text.splitlines(keepends=True):
+            if line.startswith("//"):
+                offset += len(line)
+            else:
+                break
+        return offset
+
+    return 0
+
+
+def check_file(filename: str) -> bool:
+    try:
+        text = Path(filename).read_text(encoding="utf-8")
+    except UnicodeDecodeError as e:
+        print(f"{filename}: invalid UTF-8: {e}")
+        return False
+
+    allowed_end = find_header_end(text)
+
+    header = text[:allowed_end]
+    remainder = text[allowed_end:]
+
+    start_line = header.count("\n") + 1
+    found_non_ascii = False
+
+    for line_offset, line in enumerate(remainder.splitlines(), start_line):
+        for match in NON_ASCII.finditer(line):
+            ch = match.group(0)
+            col_no = match.start() + 1
+
+            print(
+                f"{filename}:{line_offset}:{col_no}: "
+                f"unsupported non-ASCII character U+{ord(ch):04X} ({ch!r})"
+            )
+            found_non_ascii = True
+
+    return not found_non_ascii
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(f"usage: {sys.argv[0]} <files...>", file=sys.stderr)
+        return 1
+
+    all_ok = True
+
+    for filename in sys.argv[1:]:
+        if not check_file(filename):
+            all_ok = False
+
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/mem/memFenceBasic.cpp
+++ b/test/unit/mem/memFenceBasic.cpp
@@ -35,7 +35,7 @@ struct MemoryFenceTestKernel
             // Convenience helper forms (should map to identical implementations).
             onAcc::memFence(acc, onAcc::scope::Block{}, order::AcqRel{});
             onAcc::memFence(acc, onAcc::scope::Device{}, order::SeqCst{});
-            // Post‑fence update. If fences caused unintended reordering, test value would mismatch.
+            // Post-fence update. If fences caused unintended reordering, test value would mismatch.
             out[idx.x()] += 1u;
         }
     }

--- a/test/unit/mem/memFenceProducerConsumer.cpp
+++ b/test/unit/mem/memFenceProducerConsumer.cpp
@@ -71,7 +71,7 @@ struct ProducerConsumerKernel
                 }
                 // Acquire fence: prevents compiler/hardware from speculatively reading
                 // payload before observing the flag. This is the "Acquire" part; which is completing the
-                // release-acquire pair The busy‑wait loop guarantees thread 1 doesn’t leave the loop until it
+                // release-acquire pair The busy-wait loop guarantees thread 1 doesn't leave the loop until it
                 // has observed flag==1, but it does not by itself force any refresh/invalidation of the cache
                 // line holding payload array values, nor prevent the compiler from reordering a payload-read
                 // above the while-loop unless the flag read is treated as a dependency (atomic/volatile) and


### PR DESCRIPTION
`nvcc` does not like non-ASCII characters in the code. If keep files and source code embedding are enabled, the compiler complains about non-ASCII characters.
Code comments should therefore only contain ASCII characters.

- remove non-ASCII characters in C++ code
- add git pre-commit to avoid non-ASCII in the future