### PR TITLE
Critical: fix n-dimensional memcpy

### DIFF
--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -385,6 +385,11 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
                 constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
 
+                // use always 64bit precision to avoid overflows in the pitch calculations
+                auto extentMd = pCast<size_t>(extents);
+                if(extentMd.product() == size_t{0u})
+                    return;
+
                 /* Get all required properties outside the lambda function to not extend the life-time of the data.
                  * The life-time is not extended to have some life-time behaviours with all backends.
                  */
@@ -394,36 +399,38 @@ namespace alpaka::onHost
                 if constexpr(dim == 1u)
                 {
                     queue.submit(
-                        [extents, destPtr, srcPtr]()
+                        [numElementsInX = extentMd.x(), destPtr, srcPtr]()
                         {
-                            std::memcpy(destPtr, srcPtr, extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
+                            std::memcpy(
+                                destPtr,
+                                srcPtr,
+                                numElementsInX * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
                         });
                 }
                 else
                 {
                     // memcpy is implemented as row wise copy therefore the last dimension is not required
-                    auto destPitchBytesWithoutColumn = dest.getPitches().eraseBack();
-                    auto sourcePitchBytesWithoutColumn = source.getPitches().eraseBack();
+                    auto destPitchBytesWithoutColumn = pCast<size_t>(onHost::getPitches(dest).eraseBack());
+                    auto sourcePitchBytesWithoutColumn = pCast<size_t>(onHost::getPitches(source).eraseBack());
 
                     queue.submit(
-                        [extents, destPtr, srcPtr, destPitchBytesWithoutColumn, sourcePitchBytesWithoutColumn]()
+                        [extentMd, destPtr, srcPtr, destPitchBytesWithoutColumn, sourcePitchBytesWithoutColumn]()
                         {
-                            auto const dstExtentWithoutColumn = extents.eraseBack();
-                            if(static_cast<std::size_t>(extents.product()) != 0u)
-                            {
-                                meta::ndLoopIncIdx(
-                                    dstExtentWithoutColumn,
-                                    [&](auto const& idx)
-                                    {
-                                        std::memcpy(
-                                            reinterpret_cast<std::uint8_t*>(destPtr)
-                                                + (idx * destPitchBytesWithoutColumn).sum(),
-                                            reinterpret_cast<std::uint8_t const*>(srcPtr)
-                                                + (idx * sourcePitchBytesWithoutColumn).sum(),
-                                            static_cast<size_t>(extents.back())
-                                                * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
-                                    });
-                            }
+                            alpaka::concepts::Vector<size_t> auto const dstExtentWithoutColumn
+                                = pCast<size_t>(extentMd.eraseBack());
+
+                            meta::ndLoopIncIdx(
+                                dstExtentWithoutColumn,
+                                [&](auto const& idx)
+                                {
+                                    std::memcpy(
+                                        reinterpret_cast<std::uint8_t*>(destPtr)
+                                            + (idx * destPitchBytesWithoutColumn).sum(),
+                                        reinterpret_cast<std::uint8_t const*>(srcPtr)
+                                            + (idx * sourcePitchBytesWithoutColumn).sum(),
+                                        static_cast<size_t>(extentMd.back())
+                                            * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
+                                });
                         });
                 }
             }

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -379,6 +379,11 @@ namespace alpaka::onHost
         template<typename T_Device, typename T_Dest, typename T_Source, typename T_Extents>
         struct Memcpy::Op<cpu::Queue<T_Device>, T_Dest, T_Source, T_Extents>
         {
+            /** Perform data copy.
+             *
+             * To understand the usage of pitches to shift pointers within the implementation see
+             * https://alpaka3.readthedocs.io/en/latest/advanced/datastorage.html#pitches
+             */
             void operator()(cpu::Queue<T_Device>& queue, auto&& dest, T_Source const& source, T_Extents const& extents)
                 const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
             {

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -73,6 +73,11 @@ namespace alpaka::onHost::internal
     requires(alpaka::trait::getDim_v<T_Extents> > 1u)
     struct internal::Memcpy::Op<syclGeneric::Queue<T_Device>, T_Dest, T_Source, T_Extents>
     {
+        /** Perform data copy.
+         *
+         * To understand the usage of pitches to shift pointers within the implementation see
+         * https://alpaka3.readthedocs.io/en/latest/advanced/datastorage.html#pitches
+         */
         void operator()(
             syclGeneric::Queue<T_Device>& queue,
             auto&& dest,
@@ -133,7 +138,7 @@ namespace alpaka::onHost::internal
 
                     ev = memcopy2D<alpaka::trait::GetValueType_t<T_Dest>>(
                         sycl_queue,
-                        // 3D is nativ supported therefore we can handle the memcpy with a single call
+                        // 2D is nativ supported therefore we can handle the memcpy with a single call
                         VecIdxType::fill(1u),
                         VecIdxType::fill(0u),
                         VecIdxType::fill(0u),

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -76,16 +76,20 @@ namespace alpaka::onHost::internal
         void operator()(
             syclGeneric::Queue<T_Device>& queue,
             auto&& dest,
-            T_Source const& source,
+            T_Source const& src,
             T_Extents const& extents) const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
         {
             sycl::queue sycl_queue = queue.getNativeHandle();
 
+            // use always 64bit precision to avoid overflows in the pitch calculations
             auto extentMd = pCast<size_t>(extents);
-            auto const destPitchBytesWithoutColumn = dest.getPitches().eraseBack();
+            if(extentMd.product() == size_t{0u})
+                return;
+
             auto* destPtr = data(dest);
-            auto const sourcePitchBytesWithoutColumn = source.getPitches().eraseBack();
-            auto* sourcePtr = data(source);
+            auto destPitch = pCast<size_t>(onHost::getPitches(dest));
+            auto const* srcPtr = data(src);
+            auto srcPitch = pCast<size_t>(onHost::getPitches(src));
 
             constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
 
@@ -95,27 +99,141 @@ namespace alpaka::onHost::internal
             {
                 ev = sycl_queue.ext_oneapi_memcpy2d(
                     destPtr,
-                    destPitchBytesWithoutColumn.back(),
-                    sourcePtr,
-                    sourcePitchBytesWithoutColumn.back(),
+                    destPitch.y(),
+                    srcPtr,
+                    srcPitch.y(),
                     extentMd.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
                     extentMd.y());
             }
             else if constexpr(dim >= 3u)
             {
-                auto const dstExtentWithoutColumn = extentMd.eraseBack();
-                ev = sycl_queue.ext_oneapi_memcpy2d(
-                    destPtr,
-                    destPitchBytesWithoutColumn.back(),
-                    sourcePtr,
-                    sourcePitchBytesWithoutColumn.back(),
-                    extentMd.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
-                    dstExtentWithoutColumn.product());
+                // Both src and dest must be contiguous memory after the 2 dimension
+                bool isContiguous = true;
+
+                /* Skip the fastest dimension.
+                 * We need to check that we do not have padding between dimension 2->3 or higher.
+                 * Padding in column or between rows is no problem because this is supported by 2d memcpy
+                 */
+                for(uint32_t d = dim - 2u; d >= 1u; --d)
+                {
+                    isContiguous = isContiguous && (extentMd[d] * destPitch[d] == destPitch[d - 1u])
+                                   && (extentMd[d] * srcPitch[d] == srcPitch[d - 1u]);
+                }
+
+                if(isContiguous)
+                {
+                    /* If the memory is contiguous in the dimensions higher than 2 we can emulate the N-dimensional
+                     * copy with a 2D memcpy by mapping the higher dimensions into y.
+                     * This is more efficient than calling the sycl memcopy function multiple times.
+                     */
+                    alpaka::concepts::Vector<size_t, 2u> auto mappedExtentMd = extentMd.template rshrink<2u>();
+                    // remove x dimension, fuse all other dimensions into the y component
+                    mappedExtentMd.y() = extentMd.eraseBack().product();
+                    using VecIdxType = ALPAKA_TYPEOF(mappedExtentMd);
+
+                    ev = memcopy2D<alpaka::trait::GetValueType_t<T_Dest>>(
+                        sycl_queue,
+                        // 3D is nativ supported therefore we can handle the memcpy with a single call
+                        VecIdxType::fill(1u),
+                        VecIdxType::fill(0u),
+                        VecIdxType::fill(0u),
+                        mappedExtentMd,
+                        destPtr,
+                        destPitch.template rshrink<2u>(),
+                        srcPtr,
+                        srcPitch.template rshrink<2u>());
+                }
+                else
+                {
+                    // remove the 2 fast moving dimensions
+                    auto repetitions = extentMd.template rshrink<dim - 2u>(dim - 3u);
+                    auto srcPitchJump = srcPitch.template rshrink<dim - 2u>(dim - 3u);
+                    auto destPitchJump = destPitch.template rshrink<dim - 2u>(dim - 3u);
+
+                    ev = memcopy2D<alpaka::trait::GetValueType_t<T_Dest>>(
+                        sycl_queue,
+                        repetitions,
+                        destPitchJump,
+                        srcPitchJump,
+                        extentMd,
+                        destPtr,
+                        destPitch,
+                        srcPtr,
+                        srcPitch);
+                }
             }
 
             queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
+        }
+
+        /** Memcopy which calls multiple times the 2D memcpy.
+         *
+         * The copy method is repetitions times repeated and the srcPtr and destPtr is advanced each time by the
+         * corresponding pitches in bytes.
+         *
+         *  @param repetitions how often the 2D memcpy should be called
+         *  @param destPitchJump bytes vector with pitches required to jump to the next 2D block to copy for the
+         * destPtr. Dimension must be equal to repetitions.
+         *  @param srcPitchJump bytes vector with pitches required to jump to the next 2D block to copy for the srcPtr.
+         * Dimension must be equal to repetitions.
+         *  @param extentMd Extents to describe how many elements should be copied. Dimension should be equal to the
+         * original buffer/view dimension.
+         *  @param destPitchesOriginal Original pitches of destPtr. Dimension should be equal to the original
+         * buffer/view dimension.
+         *  @param srcPitchesOriginal Original pitches of srcPtr. Dimension should be equal to the original buffer/view
+         * dimension.
+         */
+        template<typename T_ValueType>
+        sycl::event memcopy2D(
+            sycl::queue& sycl_queue,
+            alpaka::concepts::Vector<size_t> auto const& repetitions,
+            alpaka::concepts::Vector<size_t> auto const& destPitchJump,
+            alpaka::concepts::Vector<size_t> auto const& srcPitchJump,
+            alpaka::concepts::Vector<size_t> auto const& extentMd,
+            void* destPtr,
+            alpaka::concepts::Vector<size_t> auto const& destPitchesOriginal,
+            void const* srcPtr,
+            alpaka::concepts::Vector<size_t> auto const& srcPitchesOriginal) const
+        {
+            static_assert(
+                ALPAKA_TYPEOF(repetitions)::dim() == ALPAKA_TYPEOF(destPitchJump)::dim()
+                && ALPAKA_TYPEOF(repetitions)::dim() == ALPAKA_TYPEOF(srcPitchJump)::dim());
+            static_assert(
+                ALPAKA_TYPEOF(extentMd)::dim() == ALPAKA_TYPEOF(destPitchesOriginal)::dim()
+                && ALPAKA_TYPEOF(extentMd)::dim() == ALPAKA_TYPEOF(srcPitchesOriginal)::dim());
+
+            sycl::event ev;
+            meta::ndLoopIncIdx(
+                repetitions,
+                [&](auto const& idx)
+                {
+                    if(idx != repetitions - ALPAKA_TYPEOF(repetitions)::fill(1u))
+                    {
+                        // Sycl is allowed to optimize and not create events for each call.
+                        sycl_queue.ext_oneapi_memcpy2d(
+                            reinterpret_cast<uint8_t*>(destPtr) + (idx * destPitchJump).sum(),
+                            destPitchesOriginal.y(),
+                            reinterpret_cast<uint8_t const*>(srcPtr) + (idx * srcPitchJump).sum(),
+                            srcPitchesOriginal.y(),
+                            extentMd.x() * sizeof(T_ValueType),
+                            extentMd.y());
+                    }
+                    else
+                    {
+                        // the last call must create an event
+                        ev = sycl_queue.ext_oneapi_memcpy2d(
+                            reinterpret_cast<uint8_t*>(destPtr) + (idx * destPitchJump).sum(),
+                            destPitchesOriginal.y(),
+                            reinterpret_cast<uint8_t const*>(srcPtr) + (idx * srcPitchJump).sum(),
+                            srcPitchesOriginal.y(),
+                            extentMd.x() * sizeof(T_ValueType),
+                            extentMd.y());
+                    }
+                });
+
+            return ev;
         }
     };
 

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -462,6 +462,11 @@ namespace alpaka::onHost
         template<typename T_Device, typename T_Dest, typename T_Source, typename T_Extents>
         struct Memcpy::Op<unifiedCudaHip::Queue<T_Device>, T_Dest, T_Source, T_Extents>
         {
+            /** Perform data copy.
+             *
+             * To understand the usage of pitches to shift pointers within the implementation see
+             * https://alpaka3.readthedocs.io/en/latest/advanced/datastorage.html#pitches
+             */
             void operator()(
                 unifiedCudaHip::Queue<T_Device>& queue,
                 auto&& dest,

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -3,6 +3,7 @@
  */
 #pragma once
 
+#include "alpaka/Vec.hpp"
 #include "alpaka/api/concepts/api.hpp"
 #include "alpaka/api/cuda/IdxLayer.hpp"
 #include "alpaka/api/cuda/computeApi.hpp"
@@ -464,25 +465,31 @@ namespace alpaka::onHost
             void operator()(
                 unifiedCudaHip::Queue<T_Device>& queue,
                 auto&& dest,
-                T_Source const& source,
+                T_Source const& src,
                 T_Extents const& extents) const requires std::same_as<ALPAKA_TYPEOF(dest), T_Dest>
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
                 using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
 
+                // use always 64bit precision to avoid overflows in the pitch calculations
                 auto extentMd = pCast<size_t>(extents);
+
+                if(extentMd.product() == size_t{0u})
+                    return;
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ApiInterface,
                     ApiInterface::setDevice(onHost::getNativeHandle(queue.m_device)));
 
                 void* destPtr = toVoidPtr(onHost::data(dest));
-                void const* srcPtr = toVoidPtr(onHost::data(source));
+                auto destPitch = pCast<size_t>(onHost::getPitches(dest));
+                void const* srcPtr = toVoidPtr(onHost::data(src));
+                auto srcPitch = pCast<size_t>(onHost::getPitches(src));
 
                 auto copyKind = unifiedCudaHip::MemcpyKind<
                     ApiInterface,
                     ALPAKA_TYPEOF(alpaka::internal::getApi(dest)),
-                    ALPAKA_TYPEOF(alpaka::internal::getApi(source))>::kind;
+                    ALPAKA_TYPEOF(alpaka::internal::getApi(src))>::kind;
 
                 constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
                 if constexpr(dim == 1u)
@@ -503,43 +510,163 @@ namespace alpaka::onHost
                         ApiInterface,
                         ApiInterface::memcpy2DAsync(
                             destPtr,
-                            dest.getPitches().y(),
+                            destPitch.y(),
                             srcPtr,
-                            source.getPitches().y(),
+                            srcPitch.y(),
                             extentMd.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
                             extentMd.y(),
                             copyKind,
                             internal::getNativeHandle(queue)));
                 }
-                else if constexpr(dim >= 3u)
+                else if constexpr(dim == 3u)
                 {
-                    auto const extentMdNoXY = extentMd.eraseBack().eraseBack();
-                    // zero-init required per CUDA documentation
-                    typename ApiInterface::Memcpy3DParms_t memCpy3DParms{};
+                    using VecIdxType = ALPAKA_TYPEOF(extentMd);
 
-                    memCpy3DParms.srcPtr = ApiInterface::makePitchedPtr(
-                        // CUDA/HIP does not support const for pitched pointer
-                        const_cast<void*>(srcPtr),
-                        source.getPitches().y(),
-                        source.getExtents().x(),
-                        source.getExtents().y());
-                    memCpy3DParms.dstPtr = ApiInterface::makePitchedPtr(
+                    memcopy3D<alpaka::trait::GetValueType_t<T_Dest>, ApiInterface>(
+                        queue,
+                        copyKind,
+                        // 3D is nativ supported therefore we can handle the memcpy with a single call
+                        VecIdxType::fill(1u),
+                        // we do not need to adjust the src and dest pointer
+                        VecIdxType::fill(0u),
+                        VecIdxType::fill(0u),
+                        extentMd,
                         destPtr,
-                        dest.getPitches().y(),
-                        dest.getExtents().x(),
-                        dest.getExtents().y());
-                    memCpy3DParms.extent = ApiInterface::makeExtent(
-                        extentMd.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
-                        extentMd.y(),
-                        extentMdNoXY.product());
-                    memCpy3DParms.kind = copyKind;
+                        destPitch,
+                        srcPtr,
+                        srcPitch);
+                }
+                else if constexpr(dim >= 4u)
+                {
+                    // Both src and dest must be contiguous memory after the 3 dimension.
+                    bool isContiguous = true;
+                    /* Skip the fastest two dimensions.
+                     * We need to check that we do not have padding between dimension 3->4 or higher.
+                     * Padding in between row and column is no problem because this is supported by CUDA/HIP.
+                     */
+                    for(uint32_t d = dim - 3u; d >= 1u; --d)
+                    {
+                        isContiguous = isContiguous && (extentMd[d] * destPitch[d] == destPitch[d - 1u])
+                                       && (extentMd[d] * srcPitch[d] == srcPitch[d - 1u]);
+                    }
 
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ApiInterface,
-                        ApiInterface::memcpy3DAsync(&memCpy3DParms, internal::getNativeHandle(queue)));
+                    if(isContiguous)
+                    {
+                        /* If the memory is contiguous in the dimensions higher than 3 we can emulate the N-dimensional
+                         * copy with a 3D memcpy by mapping the higher dimensions into z.
+                         * This is more efficient than calling the CUDA/HIP copy function multiple times.
+                         */
+                        alpaka::concepts::Vector<size_t, 3u> auto mappedExtentMd = extentMd.template rshrink<3u>();
+                        // remove x,y dimension, fuse all other dimensions into the z component
+                        mappedExtentMd.z() = extentMd.template rshrink<dim - 2u>(dim - 3u).product();
+                        using VecIdxType = ALPAKA_TYPEOF(mappedExtentMd);
+
+                        memcopy3D<alpaka::trait::GetValueType_t<T_Dest>, ApiInterface>(
+                            queue,
+                            copyKind,
+                            // 3D is nativ supported therefore we can handle the memcpy with a single call
+                            VecIdxType::fill(1u),
+                            VecIdxType::fill(0u),
+                            VecIdxType::fill(0u),
+                            mappedExtentMd,
+                            destPtr,
+                            destPitch.template rshrink<3u>(),
+                            srcPtr,
+                            srcPitch.template rshrink<3u>());
+                    }
+                    else
+                    {
+                        // remove the 3 fast moving dimensions
+                        auto repetitions = extentMd.template rshrink<dim - 3u>(dim - 4u);
+                        auto srcPitchJump = srcPitch.template rshrink<dim - 3u>(dim - 4u);
+                        auto destPitchJump = destPitch.template rshrink<dim - 3u>(dim - 4u);
+
+                        memcopy3D<alpaka::trait::GetValueType_t<T_Dest>, ApiInterface>(
+                            queue,
+                            copyKind,
+                            repetitions,
+                            destPitchJump,
+                            srcPitchJump,
+                            extentMd,
+                            destPtr,
+                            destPitch,
+                            srcPtr,
+                            srcPitch);
+                    }
                 }
 
                 queue.conditionalWait();
+            }
+
+            /** Memcopy which calls multiple times the 3D memcpy.
+             *
+             * The copy method is repetitions times repeated and the srcPtr and destPtr is advanced each time by the
+             * corresponding pitches in bytes.
+             *
+             *  @param copyKind cuda/hip memcopy kind
+             *  @param repetitions how often the 3D memcpy should be called
+             *  @param destPitchJump bytes vector with pitches required to jump to the next 3D block to copy for the
+             * destPtr. Dimension must be equal to repetitions.
+             *  @param srcPitchJump bytes vector with pitches required to jump to the next 3D block to copy for the
+             * srcPtr. Dimension must be equal to repetitions.
+             *  @param extentMd Extents to describe how many elements should be copied. Dimension should be equal to
+             * the original buffer/view dimension.
+             *  @param destPitchesOriginal Original pitches of destPtr. Dimension should be equal to the original
+             * buffer/view dimension.
+             *  @param srcPitchesOriginal Original pitches of srcPtr. Dimension should be equal to the original
+             * buffer/view dimension.
+             */
+            template<typename T_ValueType, typename T_ApiInterface>
+            void memcopy3D(
+                auto& queue,
+                auto copyKind,
+                alpaka::concepts::Vector<size_t> auto const& repetitions,
+                alpaka::concepts::Vector<size_t> auto const& destPitchJump,
+                alpaka::concepts::Vector<size_t> auto const& srcPitchJump,
+                alpaka::concepts::Vector<size_t> auto const& extentMd,
+                void* destPtr,
+                alpaka::concepts::Vector<size_t> auto const& destPitchesOriginal,
+                void const* srcPtr,
+                alpaka::concepts::Vector<size_t> auto const& srcPitchesOriginal) const
+            {
+                static_assert(
+                    ALPAKA_TYPEOF(repetitions)::dim() == ALPAKA_TYPEOF(destPitchJump)::dim()
+                    && ALPAKA_TYPEOF(repetitions)::dim() == ALPAKA_TYPEOF(srcPitchJump)::dim());
+                static_assert(
+                    ALPAKA_TYPEOF(extentMd)::dim() == ALPAKA_TYPEOF(destPitchesOriginal)::dim()
+                    && ALPAKA_TYPEOF(extentMd)::dim() == ALPAKA_TYPEOF(srcPitchesOriginal)::dim());
+
+                meta::ndLoopIncIdx(
+                    repetitions,
+                    [&](auto const& idx)
+                    {
+                        // zero-init required per CUDA documentation
+                        typename T_ApiInterface::Memcpy3DParms_t memCpy3DParms{};
+
+                        memCpy3DParms.srcPtr = T_ApiInterface::makePitchedPtr(
+                            // CUDA/HIP does not support const for pitched pointer
+                            const_cast<uint8_t*>(
+                                reinterpret_cast<uint8_t const*>(srcPtr) + (idx * srcPitchJump).sum()),
+                            srcPitchesOriginal.y(),
+                            extentMd.x(),
+                            // number of elements in y dimension in the original memory blob
+                            srcPitchesOriginal.z() / srcPitchesOriginal.y());
+                        memCpy3DParms.dstPtr = T_ApiInterface::makePitchedPtr(
+                            reinterpret_cast<uint8_t*>(destPtr) + (idx * destPitchJump).sum(),
+                            destPitchesOriginal.y(),
+                            extentMd.x(),
+                            // number of elements in y dimension in the original memory blob
+                            destPitchesOriginal.z() / destPitchesOriginal.y());
+                        memCpy3DParms.extent = T_ApiInterface::makeExtent(
+                            extentMd.x() * sizeof(T_ValueType),
+                            extentMd.y(),
+                            extentMd.z());
+                        memCpy3DParms.kind = copyKind;
+
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            T_ApiInterface,
+                            T_ApiInterface::memcpy3DAsync(&memCpy3DParms, internal::getNativeHandle(queue)));
+                    });
             }
         };
 

--- a/test/unit/mem/memcpy.cpp
+++ b/test/unit/mem/memcpy.cpp
@@ -205,11 +205,14 @@ void memcpySubViewTest(auto& copyQueue, auto& destDevice, auto& srcDevice, alpak
         alpaka::concepts::IView auto output = outputFull.getSubView(negGuard, extents - negGuard - posGuard);
 
         alpaka::concepts::IBuffer auto resultFull = onHost::allocHost<T_DataType>(extents);
-        onHost::fill(srcQueue, inputFull, T_DataType{0});
+
         onHost::iota(srcQueue, T_DataType{0}, input);
         onHost::fill(destQueue, outputFull, T_DataType{42});
-        // Overwrite the inner part
+        /* Overwrite the inner part, this is the operation we would like to validate in this test setup.
+         * It is operating on subviews.
+         */
         onHost::memcpy(copyQueue, output, input);
+        // Use copy of the full buffer, this is already validated in a separate test.
         onHost::memcpy(copyQueue, resultFull, outputFull);
 
         // validate without using the forward iterator

--- a/test/unit/mem/memcpy.cpp
+++ b/test/unit/mem/memcpy.cpp
@@ -40,7 +40,7 @@ void memcpyHostToHostTest(auto& device, alpaka::concepts::Vector auto extents)
         extents,
         [&](auto idx)
         {
-            CHECK(refIotaCounter == output[idx]);
+            REQUIRE(refIotaCounter == output[idx]);
             ++refIotaCounter;
         });
 }
@@ -68,7 +68,7 @@ void memcpyDeviceToHostTest(auto& device, alpaka::concepts::Vector auto extents)
         extents,
         [&](auto idx)
         {
-            CHECK(refIotaCounter == output[idx]);
+            REQUIRE(refIotaCounter == output[idx]);
             ++refIotaCounter;
         });
 }
@@ -99,7 +99,7 @@ void memcpyHostToDeviceTest(auto& device, alpaka::concepts::Vector auto extents)
         extents,
         [&](auto idx)
         {
-            CHECK(refIotaCounter == hostOutput[idx]);
+            REQUIRE(refIotaCounter == hostOutput[idx]);
             ++refIotaCounter;
         });
 }
@@ -130,7 +130,7 @@ void memcpyHostToDeviceDevice(auto& device, alpaka::concepts::Vector auto extent
         extents,
         [&](auto idx)
         {
-            CHECK(refIotaCounter == hostOutput[idx]);
+            REQUIRE(refIotaCounter == hostOutput[idx]);
             ++refIotaCounter;
         });
 }
@@ -151,8 +151,14 @@ TEMPLATE_LIST_TEST_CASE("memcopy test", "", DeviceSpecs)
 
     using DataType = int;
 
-    auto extentMdList
-        = std::make_tuple(Vec{5, 7, 3, 11}, Vec{93, 7, 123}, Vec{5, 7, 4111}, Vec{5, 7, 3}, Vec{7, 3}, Vec{3});
+    auto extentMdList = std::make_tuple(
+        Vec{17, 19, 23, 29, 31},
+        Vec{5, 7, 3, 11},
+        Vec{93, 7, 123},
+        Vec{5, 7, 4111},
+        Vec{5, 7, 3},
+        Vec{7, 3},
+        Vec{3});
 
     SECTION("host->host")
     {
@@ -169,5 +175,116 @@ TEMPLATE_LIST_TEST_CASE("memcopy test", "", DeviceSpecs)
     SECTION("device->device")
     {
         std::apply([&](auto... extents) { (memcpyHostToDeviceDevice<DataType>(device, extents), ...); }, extentMdList);
+    }
+}
+
+template<typename T_DataType>
+void memcpySubViewTest(auto& copyQueue, auto& destDevice, auto& srcDevice, alpaka::concepts::Vector auto extents)
+{
+    DYNAMIC_SECTION(
+        "extents=" << extents << " copy: " << srcDevice.getApi().getName() << " -> " << destDevice.getApi().getName())
+    {
+        auto destQueue = destDevice.makeQueue(queueKind::blocking);
+        auto srcQueue = srcDevice.makeQueue(queueKind::blocking);
+
+        using IndexType = ALPAKA_TYPEOF(extents)::type;
+        constexpr uint32_t dim = ALPAKA_TYPEOF(extents)::dim();
+
+        auto negGuard = iotaCVec<IndexType, dim>() + IndexType{1u};
+        // times 2 avoid that the negative and positive guard is equal
+        auto posGuard = (iotaCVec<IndexType, dim>() + IndexType{1u}) * IndexType{2u};
+
+        /* Increase the size of the input in x dimension to create the buffer with a different pitch in y dimension.
+         * This should guard against mixing source and destination pitch in the copy implementation.
+         */
+        auto inputExtents = extents.rAssign(extents.x() * 9u);
+        alpaka::concepts::IBuffer auto inputFull = onHost::alloc<T_DataType>(srcDevice, inputExtents);
+        // we use posGuard on the negative side to have different offsets for input and output sub-views
+        alpaka::concepts::IView auto input = inputFull.getSubView(posGuard, extents - posGuard - negGuard);
+        alpaka::concepts::IBuffer auto outputFull = onHost::alloc<T_DataType>(destDevice, extents);
+        alpaka::concepts::IView auto output = outputFull.getSubView(negGuard, extents - negGuard - posGuard);
+
+        alpaka::concepts::IBuffer auto resultFull = onHost::allocHost<T_DataType>(extents);
+        onHost::fill(srcQueue, inputFull, T_DataType{0});
+        onHost::iota(srcQueue, T_DataType{0}, input);
+        onHost::fill(destQueue, outputFull, T_DataType{42});
+        // Overwrite the inner part
+        onHost::memcpy(copyQueue, output, input);
+        onHost::memcpy(copyQueue, resultFull, outputFull);
+
+        // validate without using the forward iterator
+        T_DataType refIotaCounter = 0;
+        meta::ndLoopIncIdx(
+            extents,
+            [&](auto idx)
+            {
+                // value in the guard region is always 42
+                if((idx < negGuard).reduce(std::logical_or{})
+                   || (idx >= (extents - posGuard)).reduce(std::logical_or{}))
+                    REQUIRE(T_DataType{42} == resultFull[idx]);
+                else
+                {
+                    REQUIRE(refIotaCounter == resultFull[idx]);
+                    ++refIotaCounter;
+                }
+            });
+        // check that we touched at least once an inner value
+        REQUIRE(refIotaCounter != 0);
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("memcopy subview test", "", DeviceSpecs)
+{
+    auto deviceSpec = TestType{};
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        SUCCEED("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
+
+    using DataType = int;
+
+    auto extentMdList
+        = std::make_tuple(Vec{17}, Vec{17, 19}, Vec{17, 19, 23}, Vec{17, 19, 23, 29}, Vec{17, 19, 23, 29, 31});
+
+
+    SECTION("host->host")
+    {
+        auto copyQueue = device.makeQueue(queueKind::blocking);
+        auto host = onHost::makeHostDevice();
+        std::apply(
+            [&](auto... extents) { (memcpySubViewTest<DataType>(copyQueue, host, host, extents), ...); },
+            extentMdList);
+    }
+
+    SECTION("device->host")
+    {
+        auto copyQueue = device.makeQueue(queueKind::blocking);
+        auto host = onHost::makeHostDevice();
+        std::apply(
+            [&](auto... extents) { (memcpySubViewTest<DataType>(copyQueue, host, device, extents), ...); },
+            extentMdList);
+    }
+
+    SECTION("host->device")
+    {
+        auto copyQueue = device.makeQueue(queueKind::blocking);
+        auto host = onHost::makeHostDevice();
+        std::apply(
+            [&](auto... extents) { (memcpySubViewTest<DataType>(copyQueue, device, host, extents), ...); },
+            extentMdList);
+    }
+
+    SECTION("device->device")
+    {
+        auto copyQueue = device.makeQueue(queueKind::blocking);
+        std::apply(
+            [&](auto... extents) { (memcpySubViewTest<DataType>(copyQueue, device, device, extents), ...); },
+            extentMdList);
     }
 }


### PR DESCRIPTION
The memcopy operation with n-dimensional data was broken if a sub-view was used.

Cuda: copies with more than 3 dimensions are broken
OneApi: copies with more than 2 dimensions are broken
Host: all works as expected

- add test to check the sub-view copy method
- fix backends
- use `size_t` for all calculations to avoid index range overflows

**important**:  If you **not** use sub-views but full views or buffers directly, all works as expected. This has already been tested.

`alpaka::onHost::memset()` has the same problem. A fix for `memset` will be provided in a separate PR on top of this fix.