### PR TITLE
test Catch2 skip

### DIFF
--- a/test/unit/atomic/atomic.cpp
+++ b/test/unit/atomic/atomic.cpp
@@ -207,7 +207,7 @@ struct TestAtomicOperations
         {
             if(device.getNativeHandle().first.template get_info<sycl::info::device::double_fp_config>().size() == 0)
             {
-                SUCCEED(
+                SKIP(
                     onHost::getName(device)
                     << " does not support double precision.\n Skip benchmark.\n"
                        "For Intel Arc GPUs, use the environment variables `IGC_EnableDPEmulation=1 "

--- a/test/unit/event/event.cpp
+++ b/test/unit/event/event.cpp
@@ -95,7 +95,7 @@ TEMPLATE_LIST_TEST_CASE("test trigger event", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -132,7 +132,7 @@ TEMPLATE_LIST_TEST_CASE("eventTestShouldBeFalseWhileInQueueAndTrueAfterBeingProc
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -171,7 +171,7 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfNobodyWaitsFor", "", Te
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -185,14 +185,14 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfNobodyWaitsFor", "", Te
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        SUCCEED(
+        SKIP(
             "Event tests can not be executed with " << deviceSpec.getName()
                                                     << " because the device does not support concurrent queues.");
         return;
     }
     if(deviceSpec.getApi() == api::oneApi && deviceSpec.getDeviceKind() == deviceKind::intelGpu)
     {
-        SUCCEED("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
+        SKIP("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
         return;
     }
 
@@ -247,7 +247,7 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "", T
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -261,14 +261,14 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "", T
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        SUCCEED(
+        SKIP(
             "Event tests can not be executed with " << deviceSpec.getName()
                                                     << " because the device does not support concurrent queues.");
         return;
     }
     if(deviceSpec.getApi() == api::oneApi && deviceSpec.getDeviceKind() == deviceKind::intelGpu)
     {
-        SUCCEED("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
+        SKIP("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
         return;
     }
 
@@ -337,7 +337,7 @@ TEMPLATE_LIST_TEST_CASE("waitForEventThatAlreadyFinishedShouldBeSkipped", "", Te
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -351,14 +351,14 @@ TEMPLATE_LIST_TEST_CASE("waitForEventThatAlreadyFinishedShouldBeSkipped", "", Te
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        SUCCEED(
+        SKIP(
             "Event tests can not be executed with " << deviceSpec.getName()
                                                     << " because the device does not support concurrent queues.");
         return;
     }
     if(deviceSpec.getApi() == api::oneApi && deviceSpec.getDeviceKind() == deviceKind::intelGpu)
     {
-        SUCCEED("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
+        SKIP("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
         return;
     }
 
@@ -424,7 +424,7 @@ TEMPLATE_LIST_TEST_CASE("evReEnqueueWithSomeoneWaitsForEventInOrderLifetimeRelea
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -438,14 +438,14 @@ TEMPLATE_LIST_TEST_CASE("evReEnqueueWithSomeoneWaitsForEventInOrderLifetimeRelea
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        SUCCEED(
+        SKIP(
             "Event tests can not be executed with " << deviceSpec.getName()
                                                     << " because the device does not support concurrent queues.");
         return;
     }
     if(deviceSpec.getApi() == api::oneApi && deviceSpec.getDeviceKind() == deviceKind::intelGpu)
     {
-        SUCCEED("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
+        SKIP("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
         return;
     }
 
@@ -551,7 +551,7 @@ TEMPLATE_LIST_TEST_CASE("EventOutOfOrderLifetimeRelease", "", TestApis)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -565,14 +565,14 @@ TEMPLATE_LIST_TEST_CASE("EventOutOfOrderLifetimeRelease", "", TestApis)
          * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
          * will not run out of order which is assumed for some of the tests.
          */
-        SUCCEED(
+        SKIP(
             "Event tests can not be executed with " << deviceSpec.getName()
                                                     << " because the device does not support concurrent queues.");
         return;
     }
     if(deviceSpec.getApi() == api::oneApi && deviceSpec.getDeviceKind() == deviceKind::intelGpu)
     {
-        SUCCEED("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
+        SKIP("Skip test for " << deviceSpec.getName() << " because the test is typically deadlocking.");
         return;
     }
 

--- a/test/unit/math/TestTemplate.hpp
+++ b/test/unit/math/TestTemplate.hpp
@@ -132,7 +132,7 @@ namespace mathtest
                 if(device.getNativeHandle().first.template get_info<sycl::info::device::double_fp_config>().size()
                    == 0)
                 {
-                    SUCCEED(
+                    SKIP(
                         onHost::getName(device)
                         << " does not support double precision.\n Skip benchmark.\n"
                            "For Intel Arc GPUs, use the environment variables `IGC_EnableDPEmulation=1 "

--- a/test/unit/math/executeOnComputeDevice.hpp
+++ b/test/unit/math/executeOnComputeDevice.hpp
@@ -42,7 +42,7 @@ namespace alpaka::test
         {
             if(device.getNativeHandle().first.template get_info<sycl::info::device::double_fp_config>().size() == 0)
             {
-                SUCCEED(
+                SKIP(
                     onHost::getName(device)
                     << " does not support double precision.\n Skip benchmark.\n"
                        "For Intel Arc GPUs, use the environment variables `IGC_EnableDPEmulation=1 "

--- a/test/unit/mem/alloc.cpp
+++ b/test/unit/mem/alloc.cpp
@@ -120,7 +120,7 @@ TEMPLATE_LIST_TEST_CASE("alloc zero bytes", "", TestDeviceSpecs)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -189,7 +189,7 @@ TEMPLATE_LIST_TEST_CASE("alloc alignment", "", TestDeviceSpecs)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 
@@ -223,7 +223,7 @@ TEMPLATE_LIST_TEST_CASE("alloc volatile memory", "", TestDeviceSpecs)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/mem/memcpy.cpp
+++ b/test/unit/mem/memcpy.cpp
@@ -142,7 +142,7 @@ TEMPLATE_LIST_TEST_CASE("memcopy test", "", DeviceSpecs)
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 

--- a/test/unit/wait/device.cpp
+++ b/test/unit/wait/device.cpp
@@ -118,7 +118,7 @@ void prepareAndExecuteWaitTest(auto cfg)
     auto deviceSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!deviceSelector.isAvailable())
     {
-        SUCCEED("No device available for " << deviceSpec.getName());
+        SKIP("No device available for " << deviceSpec.getName());
         return;
     }
 


### PR DESCRIPTION
DO not merge this PR is this only a check if skip is still failing the test case.
This is most likely faling where `onHost::getDeviceSpecsFor(onHost::enabledApis)` is used. 
The reason is that all available API's are combined with any device that is supported by the APi even it is not selected by CMake. This is the expected behaviour.