### PR TITLE
Critical: fix n-dimensional memset

### DIFF
--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -754,7 +754,13 @@ namespace alpaka
     template<typename Type, uint32_t T_dim, typename T_Storage>
     std::ostream& operator<<(std::ostream& s, Vec<Type, T_dim, T_Storage> const& vec)
     {
-        return s << vec.toString();
+        /* Usage of a temporary universal vector variable is required as workaround to silent an error with gcc 15
+         * error: 'frameSpec' may be used uninitialized [-Werror=maybe-uninitialized] when compiling with 'ubsan'
+         * enabled. It is a false positive in some cases where a CVec is used. Since this method is not performance
+         * critical this workaround should be acceptable.
+         */
+        typename Vec<Type, T_dim, T_Storage>::UniVec v(vec);
+        return s << v.toString();
     }
 
 #define ALPAKA_VECTOR_BINARY_OP(typenameOrConcept, resultScalarType, op)                                              \

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -495,41 +495,42 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
                 constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
 
+                // use always 64bit precision to avoid overflows in the pitch calculations
+                auto extentMd = pCast<size_t>(extents);
+                if(extentMd.product() == size_t{0u})
+                    return;
+
                 void* destPtr = static_cast<void*>(alpaka::onHost::data(dest));
 
                 if constexpr(dim == 1u)
                 {
                     queue.submit(
-                        [extents, destPtr, byteValue]()
+                        [numElementsInX = extentMd.x(), destPtr, byteValue]()
                         {
                             std::memset(
                                 destPtr,
                                 byteValue,
-                                extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
+                                numElementsInX * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
                         });
                 }
                 else
                 {
                     // memset is implemented as row wise memset therefore the last dimension is not required
-                    auto destPitchBytesWithoutColumn = dest.getPitches().eraseBack();
+                    auto destPitchBytesWithoutColumn = pCast<size_t>(onHost::getPitches(dest).eraseBack());
                     queue.submit(
-                        [extents, destPtr, destPitchBytesWithoutColumn, byteValue]()
+                        [extentMd, destPtr, destPitchBytesWithoutColumn, byteValue]()
                         {
-                            auto const dstExtentWithoutColumn = extents.eraseBack();
-                            if(static_cast<std::size_t>(extents.product()) != 0u)
-                            {
-                                meta::ndLoopIncIdx(
-                                    dstExtentWithoutColumn,
-                                    [&](auto const& idx)
-                                    {
-                                        std::memset(
-                                            reinterpret_cast<std::uint8_t*>(destPtr)
-                                                + (idx * destPitchBytesWithoutColumn).sum(),
-                                            byteValue,
-                                            static_cast<size_t>(extents.back())
-                                                * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
-                                    });
-                            }
+                            auto const dstExtentWithoutColumn = extentMd.eraseBack();
+                            meta::ndLoopIncIdx(
+                                dstExtentWithoutColumn,
+                                [&](auto const& idx)
+                                {
+                                    std::memset(
+                                        reinterpret_cast<std::uint8_t*>(destPtr)
+                                            + (idx * destPitchBytesWithoutColumn).sum(),
+                                        byteValue,
+                                        extentMd.back() * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
+                                });
                         });
                 }
             }

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -35,8 +35,12 @@ namespace alpaka::onHost::internal
         {
             sycl::queue sycl_queue = queue.getNativeHandle();
 
+            // use always 64bit precision to avoid overflows in the pitch calculations
             auto extentMd = pCast<size_t>(extents);
-            auto const destPitchBytesWithoutColumn = dest.getPitches().eraseBack();
+            if(extentMd.product() == size_t{0u})
+                return;
+
+            auto destPitch = pCast<size_t>(onHost::getPitches(dest));
             auto* destPtr = data(dest);
 
             constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
@@ -47,25 +51,118 @@ namespace alpaka::onHost::internal
             {
                 ev = sycl_queue.ext_oneapi_memset2d(
                     destPtr,
-                    destPitchBytesWithoutColumn.back(),
+                    destPitch.y(),
                     byteValue,
                     extentMd.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
                     extentMd.y());
             }
             else if constexpr(dim >= 3u)
             {
-                auto const dstExtentWithoutColumn = extentMd.eraseBack();
-                ev = sycl_queue.ext_oneapi_memset2d(
-                    destPtr,
-                    destPitchBytesWithoutColumn.back(),
-                    byteValue,
-                    extentMd.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
-                    dstExtentWithoutColumn.product());
+                // dest must be contiguous memory after the 2 dimension
+                bool isContiguous = true;
+
+                /* Skip the fastest dimension.
+                 * We need to check that we do not have padding between dimension 2->3 or higher.
+                 * Padding in column or between rows is no problem because this is supported by 2d memcpy
+                 */
+                for(uint32_t d = dim - 2u; d >= 1u; --d)
+                    isContiguous = isContiguous && (extentMd[d] * destPitch[d] == destPitch[d - 1u]);
+
+                if(isContiguous)
+                {
+                    /* If the memory is contiguous in the dimensions higher than 2 we can emulate the N-dimensional
+                     * memset with a 2D memset by mapping the higher dimensions into y.
+                     * This is more efficient than calling the sycl memset function multiple times.
+                     */
+                    alpaka::concepts::Vector<size_t, 2u> auto mappedExtentMd = extentMd.template rshrink<2u>();
+                    // remove x dimension, fuse all other dimensions into the y component
+                    mappedExtentMd.y() = extentMd.eraseBack().product();
+
+                    ev = memset2D<alpaka::trait::GetValueType_t<T_Dest>>(
+                        sycl_queue,
+                        byteValue,
+                        // 2D is nativ supported therefore we can handle the memset with a single call
+                        ALPAKA_TYPEOF(mappedExtentMd)::fill(1u),
+                        ALPAKA_TYPEOF(mappedExtentMd)::fill(0u),
+                        mappedExtentMd,
+                        destPtr,
+                        destPitch.template rshrink<2u>());
+                }
+                else
+                {
+                    // remove the 2 fast moving dimensions
+                    auto repetitions = extentMd.template rshrink<dim - 2u>(dim - 3u);
+                    auto destPitchJump = destPitch.template rshrink<dim - 2u>(dim - 3u);
+
+                    ev = memset2D<alpaka::trait::GetValueType_t<T_Dest>>(
+                        sycl_queue,
+                        byteValue,
+                        repetitions,
+                        destPitchJump,
+                        extentMd,
+                        destPtr,
+                        destPitch);
+                }
             }
 
             queue.setLastEvent(ev);
             if(queue.isBlocking())
                 ev.wait_and_throw();
+        }
+
+        /** Memset which calls multiple times the memset2D.
+         *
+         * The memset method is repetitions times repeated and the destPtr is advanced each time by the corresponding
+         * pitches in bytes.
+         *
+         *  @param repetitions how often memset2D should be called
+         *  @param destPitchJump bytes vector with pitches required to jump to the next 2D block to memset for the
+         * destPtr. Dimension must be equal to repetitions.
+         *  @param extentMd Extents to describe how many elements should be copied. Dimension should be equal to the
+         * original buffer/view dimension.
+         *  @param destPitchesOriginal Original pitches of destPtr. Dimension should be equal to the original
+         * buffer/view dimension.
+         */
+        template<typename T_ValueType>
+        sycl::event memset2D(
+            sycl::queue& sycl_queue,
+            uint8_t byteValue,
+            alpaka::concepts::Vector<size_t> auto const& repetitions,
+            alpaka::concepts::Vector<size_t> auto const& destPitchJump,
+            alpaka::concepts::Vector<size_t> auto const& extentMd,
+            void* destPtr,
+            alpaka::concepts::Vector<size_t> auto const& destPitchesOriginal) const
+        {
+            static_assert(ALPAKA_TYPEOF(repetitions)::dim() == ALPAKA_TYPEOF(destPitchJump)::dim());
+            static_assert(ALPAKA_TYPEOF(extentMd)::dim() == ALPAKA_TYPEOF(destPitchesOriginal)::dim());
+
+            sycl::event ev;
+            meta::ndLoopIncIdx(
+                repetitions,
+                [&](auto const& idx)
+                {
+                    if(idx != repetitions - ALPAKA_TYPEOF(repetitions)::fill(1u))
+                    {
+                        // Sycl is allowed to optimize and not create events for each call.
+                        sycl_queue.ext_oneapi_memset2d(
+                            reinterpret_cast<uint8_t*>(destPtr) + (idx * destPitchJump).sum(),
+                            destPitchesOriginal.y(),
+                            byteValue,
+                            extentMd.x() * sizeof(T_ValueType),
+                            extentMd.y());
+                    }
+                    else
+                    {
+                        // the last call must create an event
+                        ev = sycl_queue.ext_oneapi_memset2d(
+                            reinterpret_cast<uint8_t*>(destPtr) + (idx * destPitchJump).sum(),
+                            destPitchesOriginal.y(),
+                            byteValue,
+                            extentMd.x() * sizeof(T_ValueType),
+                            extentMd.y());
+                    }
+                });
+            return ev;
         }
     };
 

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -762,13 +762,18 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
                 using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
+
+                // use always 64bit precision to avoid overflows in the pitch calculations
                 auto extentMd = pCast<size_t>(extents);
+                if(extentMd.product() == size_t{0u})
+                    return;
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ApiInterface,
                     ApiInterface::setDevice(onHost::getNativeHandle(queue.m_device)));
 
                 void* destPtr = toVoidPtr(onHost::data(dest));
+                auto destPitch = pCast<size_t>(onHost::getPitches(dest));
 
                 constexpr auto dim = alpaka::trait::getDim_v<T_Extents>;
                 if constexpr(dim == 1u)
@@ -787,36 +792,126 @@ namespace alpaka::onHost
                         ApiInterface,
                         ApiInterface::memset2DAsync(
                             destPtr,
-                            dest.getPitches().y(),
+                            destPitch.y(),
                             static_cast<int>(byteValue),
                             extentMd.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
                             extentMd.y(),
                             internal::getNativeHandle(queue)));
                 }
-                else if constexpr(dim >= 3u)
+                else if constexpr(dim == 3u)
                 {
-                    typename ApiInterface::PitchedPtr_t const pitchedPtrVal = ApiInterface::makePitchedPtr(
+                    using VecIdxType = ALPAKA_TYPEOF(extentMd);
+
+                    memset3D<alpaka::trait::GetValueType_t<T_Dest>, ApiInterface>(
+                        queue,
+                        byteValue,
+                        // 3D is nativ supported therefore we can handle the memset with a single call
+                        VecIdxType::fill(1u),
+                        VecIdxType::fill(0u),
+                        extentMd,
                         destPtr,
-                        dest.getPitches().y(),
-                        dest.getExtents().x(),
-                        dest.getExtents().y());
+                        destPitch);
+                }
+                else if constexpr(dim >= 4u)
+                {
+                    // dest must be contiguous memory after the 3 dimension
+                    bool isContiguous = true;
+                    /* Skip the fastest two dimensions.
+                     * We need to check that we do not have padding between dimension 3->4 or higher.
+                     * Padding in between row and column is no problem because this is supported by CUDA/HIP.
+                     */
+                    for(uint32_t d = dim - 3u; d >= 1u; --d)
+                        isContiguous = isContiguous && (extentMd[d] * destPitch[d] == destPitch[d - 1u]);
 
-                    auto const extentMdNoXY = extentMd.eraseBack().eraseBack();
-                    typename ApiInterface::Extent_t const extentVal = ApiInterface::makeExtent(
-                        extentMd.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>),
-                        extentMd.y(),
-                        extentMdNoXY.product());
+                    if(isContiguous)
+                    {
+                        /* If the memory is contiguous in the dimensions higher than 3 we can emulate the N-dimensional
+                         * memset with a 3D memset by mapping the higher dimensions into z.
+                         * This is more efficient than calling the CUDA/HIP memset function multiple times.
+                         */
+                        alpaka::concepts::Vector<size_t, 3u> auto mappedExtentMd = extentMd.template rshrink<3u>();
+                        // remove x,y dimension, fuse all other dimensions into the z component
+                        mappedExtentMd.z() = extentMd.template rshrink<dim - 2u>(dim - 3u).product();
+                        using VecIdxType = ALPAKA_TYPEOF(mappedExtentMd);
 
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ApiInterface,
-                        ApiInterface::memset3DAsync(
-                            pitchedPtrVal,
-                            static_cast<int>(byteValue),
-                            extentVal,
-                            internal::getNativeHandle(queue)));
+                        memset3D<alpaka::trait::GetValueType_t<T_Dest>, ApiInterface>(
+                            queue,
+                            byteValue,
+                            // 3D is nativ supported therefore we can handle the memset with a single call
+                            VecIdxType::fill(1u),
+                            VecIdxType::fill(0u),
+                            mappedExtentMd,
+                            destPtr,
+                            destPitch.template rshrink<3u>());
+                    }
+                    else
+                    {
+                        auto repetitions = extentMd.template rshrink<dim - 3u>(dim - 4u);
+                        auto destPitchJump = destPitch.template rshrink<dim - 3u>(dim - 4u);
+
+                        memset3D<alpaka::trait::GetValueType_t<T_Dest>, ApiInterface>(
+                            queue,
+                            byteValue,
+                            repetitions,
+                            destPitchJump,
+                            extentMd,
+                            destPtr,
+                            destPitch);
+                    }
                 }
 
                 queue.conditionalWait();
+            }
+
+            /** Memset which calls multiple times the 3D memset.
+             *
+             * The memset method is repetitions times repeated and the destPtr is advanced each time by the
+             * corresponding pitches in bytes.
+             *
+             *  @param repetitions how often the 3D memset should be called
+             *  @param destPitchJump bytes vector with pitches required to jump to the next 3D block to memset for the
+             * destPtr. Dimension must be equal to repetitions.
+             *  @param extentMd Extents to describe how many elements should be set. Dimension should be equal to the
+             * original buffer/view dimension.
+             *  @param destPitchesOriginal Original pitches of destPtr. Dimension should be equal to the original
+             * buffer/view dimension.
+             */
+            template<typename T_ValueType, typename T_ApiInterface>
+            void memset3D(
+                auto& queue,
+                uint8_t byteValue,
+                alpaka::concepts::Vector<size_t> auto const& repetitions,
+                alpaka::concepts::Vector<size_t> auto const& destPitchJump,
+                alpaka::concepts::Vector<size_t> auto const& extentMd,
+                void* destPtr,
+                alpaka::concepts::Vector<size_t> auto const& destPitchesOriginal) const
+            {
+                static_assert(ALPAKA_TYPEOF(repetitions)::dim() == ALPAKA_TYPEOF(destPitchJump)::dim());
+                static_assert(ALPAKA_TYPEOF(extentMd)::dim() == ALPAKA_TYPEOF(destPitchesOriginal)::dim());
+
+                meta::ndLoopIncIdx(
+                    repetitions,
+                    [&](auto const& idx)
+                    {
+                        auto const pitchedPtrVal = T_ApiInterface::makePitchedPtr(
+                            reinterpret_cast<uint8_t*>(destPtr) + (idx * destPitchJump).sum(),
+                            destPitchesOriginal.y(),
+                            extentMd.x(),
+                            destPitchesOriginal.z() / destPitchesOriginal.y());
+
+                        auto const extentVal = T_ApiInterface::makeExtent(
+                            extentMd.x() * sizeof(T_ValueType),
+                            extentMd.y(),
+                            extentMd.z());
+
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            T_ApiInterface,
+                            T_ApiInterface::memset3DAsync(
+                                pitchedPtrVal,
+                                static_cast<int>(byteValue),
+                                extentVal,
+                                internal::getNativeHandle(queue)));
+                    });
             }
         };
 

--- a/test/unit/mem/memset.cpp
+++ b/test/unit/mem/memset.cpp
@@ -1,0 +1,143 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/** @file Test memset with full extents of the buffer and with sub views.
+ * All test cases using a blocking queue that we can mix host and device queues without a need of events.
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+using namespace alpaka;
+
+using DeviceSpecs = std::decay_t<decltype(onHost::getDeviceSpecsFor(onHost::enabledApis))>;
+
+template<typename T_DataType>
+void memsetTest(auto& device, alpaka::concepts::Vector auto extents)
+{
+    DYNAMIC_SECTION("extents=" << extents << " memset on " << device.getApi().getName())
+    {
+        auto queue = device.makeQueue(queueKind::blocking);
+        auto host = onHost::makeHostDevice();
+        auto hostQueue = host.makeQueue(queueKind::blocking);
+        auto buffer = onHost::alloc<T_DataType>(device, extents);
+        auto result = onHost::alloc<T_DataType>(host, extents);
+
+        constexpr uint8_t byteValue = 0x11u;
+
+        onHost::fill(queue, buffer, T_DataType{42u});
+        onHost::fill(hostQueue, result, T_DataType{0u});
+        // main operation tested in this test
+        onHost::memset(queue, buffer, byteValue);
+        onHost::memcpy(queue, result, buffer);
+
+        T_DataType refValue{0};
+        std::memset(&refValue, byteValue, sizeof(T_DataType));
+
+        meta::ndLoopIncIdx(extents, [&](auto idx) { REQUIRE(refValue == result[idx]); });
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("memset test", "", DeviceSpecs)
+{
+    auto deviceSpec = TestType{};
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        SKIP("No device available for " << deviceSpec.getName());
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
+
+    using DataType = uint32_t;
+
+    auto extentMdList = std::make_tuple(
+        Vec{17, 19, 23, 29, 31},
+        Vec{5, 7, 3, 11},
+        Vec{93, 7, 123},
+        Vec{5, 7, 4111},
+        Vec{5, 7, 3},
+        Vec{7, 3},
+        Vec{3});
+
+    std::apply([&](auto... extents) { (memsetTest<DataType>(device, extents), ...); }, extentMdList);
+}
+
+template<typename T_DataType>
+void memsetSubViewTest(auto& device, alpaka::concepts::Vector auto extents)
+{
+    DYNAMIC_SECTION("extents=" << extents << " subview memset on " << device.getApi().getName())
+    {
+        auto queue = device.makeQueue(queueKind::blocking);
+        auto host = onHost::makeHostDevice();
+        auto hostQueue = host.makeQueue(queueKind::blocking);
+
+        using IndexType = ALPAKA_TYPEOF(extents)::type;
+        constexpr uint32_t dim = ALPAKA_TYPEOF(extents)::dim();
+
+        auto negGuard = iotaCVec<IndexType, dim>() + IndexType{1u};
+        // times 2 avoid that the negative and positive guard is equal
+        auto posGuard = (iotaCVec<IndexType, dim>() + IndexType{1u}) * IndexType{2u};
+
+        alpaka::concepts::IBuffer auto bufferFull = onHost::alloc<T_DataType>(device, extents);
+        alpaka::concepts::IView auto buffer = bufferFull.getSubView(posGuard, extents - posGuard - negGuard);
+        alpaka::concepts::IBuffer auto resultFull = onHost::alloc<T_DataType>(host, extents);
+
+        constexpr T_DataType guardValue = 0xA3F7'C9E2u;
+        constexpr uint8_t byteValue = 0x11u;
+
+        onHost::fill(queue, bufferFull, guardValue);
+        onHost::fill(hostQueue, resultFull, T_DataType{0u});
+        // main operation tested here, it works on a sub-view
+        onHost::memset(queue, buffer, byteValue);
+        // Use copy of the full buffer, this is already validated in a separate test.
+        onHost::memcpy(queue, resultFull, bufferFull);
+
+        T_DataType innerRefValue{0};
+        std::memset(&innerRefValue, byteValue, sizeof(T_DataType));
+
+        size_t numInnerValues = 0u;
+        meta::ndLoopIncIdx(
+            extents,
+            [&](auto idx)
+            {
+                // value in the guard region is always 'guardValue'
+                if((idx < posGuard).reduce(std::logical_or{})
+                   || (idx >= (extents - negGuard)).reduce(std::logical_or{}))
+                {
+                    REQUIRE(guardValue == resultFull[idx]);
+                }
+                else
+                {
+                    REQUIRE(innerRefValue == resultFull[idx]);
+                    ++numInnerValues;
+                }
+            });
+        // check that we touched at least once an inner value
+        REQUIRE(numInnerValues != 0u);
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("memset subview test", "", DeviceSpecs)
+{
+    auto deviceSpec = TestType{};
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        SKIP("No device available for " << deviceSpec.getName());
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
+
+    using DataType = uint32_t;
+
+    auto extentMdList
+        = std::make_tuple(Vec{17}, Vec{17, 19}, Vec{17, 19, 23}, Vec{17, 19, 23, 29}, Vec{17, 19, 23, 29, 31});
+
+    std::apply([&](auto... extents) { (memsetSubViewTest<DataType>(device, extents), ...); }, extentMdList);
+}


### PR DESCRIPTION
The memset operation with n-dimensional data was broken if a sub-view was used.

Cuda: memset with more than 3 dimensions is broken
OneApi: memset with more than 2 dimensions is broken
Host: all works as expected

- add test to check the full and sub-view memset method
- fix backends
- use size_t for all calculations to avoid index range overflows
- second commit contains a workaround for a GCC15 false positive

The fix uses the same structure for the fix and tests we use in https://github.com/alpaka-group/alpaka3/pull/580.

- [x] rebase against #580  (first commit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a GCC 15 compiler false-positive warning in vector stream insertion.
  * Improved memset precision for multi-dimensional memory operations with consistent 64-bit calculations.
  * Enhanced memset robustness for complex memory layouts and non-contiguous buffers.

* **Tests**
  * Added comprehensive unit tests for memset operations on full and partial buffer regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->