### PR TITLE
warning for uncompatible nvcc host compiler

### DIFF
--- a/cmake/alpakaCuda.cmake
+++ b/cmake/alpakaCuda.cmake
@@ -26,6 +26,7 @@ check_language(CUDA)
 
 if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)
+    message(STATUS "CUDA language is available")
     checkcompilercxxsupport(CUDA ${alpaka_CXX_STANDARD})
 
     if(NOT TARGET alpaka::cuda)
@@ -135,5 +136,27 @@ if(CMAKE_CUDA_COMPILER)
     ## GCC compiler flag to show a longer stack for concept diagnostics
     if(${_alpaka_CUDA_HOST_COMPILER} STREQUAL "GNU")
         alpaka_set_compiler_options(HOST target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-fconcepts-diagnostics-depth=${alpaka_GCC_CONCEPT_DEPTH}>")
+    endif()
+else()
+    find_package(CUDAToolkit)
+    if(NOT CUDAToolkit_FOUND)
+        message(
+            WARNING
+            "CUDA support was requested, but no Cuda Compiler/Toolchain has been found. "
+            "CUDA backends will be disabled. "
+        )
+    else()
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.26)
+            set(_alpaka_CMAKE_CONFIGURE_LOG "${CMAKE_BINARY_DIR}/CMakeFiles/CMakeConfigureLog.yaml")
+        else()
+            set(_alpaka_CMAKE_CONFIGURE_LOG "${CMAKE_BINARY_DIR}/CMakeFiles/CMakeError.log")
+        endif()
+        message(
+            FATAL_ERROR
+            "CUDA support was requested, but CMake did not accept "
+            "CUDA as a language. This usually means that there is a compatibility problem, "
+            "for example an unsupported host compiler. Check "
+            "'${_alpaka_CMAKE_CONFIGURE_LOG}' for further information."
+        )
     endif()
 endif()

--- a/cmake/alpakaHip.cmake
+++ b/cmake/alpakaHip.cmake
@@ -16,6 +16,7 @@ check_language(HIP)
 
 if(CMAKE_HIP_COMPILER)
     enable_language(HIP)
+    message(STATUS "HIP language is available")
     find_package(hip REQUIRED)
 
     set(_alpaka_HIP_MIN_VER 6.0)
@@ -74,18 +75,37 @@ if(CMAKE_HIP_COMPILER)
     elseif(alpaka_RELOCATABLE_DEVICE_CODE STREQUAL OFF)
         alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fno-gpu-rdc>")
     endif()
+    target_compile_definitions(alpaka_target_hip INTERFACE ALPAKA_CMAKE_TARGET_HIP)
+    target_link_libraries(alpaka_target_hip INTERFACE alpaka::headers)
+
+    option(alpaka_HIP_AmdGpu "Enable support for api::hip and deviceKind::amdGpu in examples/benchmarks and tests" ON)
+    if(NOT alpaka_HIP_AmdGpu)
+        target_compile_definitions(alpaka_target_hip INTERFACE ALPAKA_DISABLE_Hip_AmdGpu)
+    endif()
+
+    if(alpaka_COUNT_API_DEPS EQUAL 1)
+        target_link_libraries(alpaka INTERFACE alpaka_target_hip)
+    endif()
 else()
-    message(FATAL_ERROR "Optional alpaka dependency HIP could not be found!")
-endif()
+    find_package(hip)
 
-target_compile_definitions(alpaka_target_hip INTERFACE ALPAKA_CMAKE_TARGET_HIP)
-target_link_libraries(alpaka_target_hip INTERFACE alpaka::headers)
-
-option(alpaka_HIP_AmdGpu "Enable support for api::hip and deviceKind::amdGpu in examples/benchmarks and tests" ON)
-if(NOT alpaka_HIP_AmdGpu)
-    target_compile_definitions(alpaka_target_hip INTERFACE ALPAKA_DISABLE_Hip_AmdGpu)
-endif()
-
-if(alpaka_COUNT_API_DEPS EQUAL 1)
-    target_link_libraries(alpaka INTERFACE alpaka_target_hip)
+    if(NOT hip_FOUND)
+        message(
+            WARNING
+            "HIP support was requested, but no HIP/ROCm "
+            "package was found. HIP backends will be disabled."
+        )
+    else()
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.26)
+            set(_alpaka_CMAKE_CONFIGURE_LOG "${CMAKE_BINARY_DIR}/CMakeFiles/CMakeConfigureLog.yaml")
+        else()
+            set(_alpaka_CMAKE_CONFIGURE_LOG "${CMAKE_BINARY_DIR}/CMakeFiles/CMakeError.log")
+        endif()
+        message(
+            FATAL_ERROR
+            "HIP support was requested, but CMake did not accept "
+            "HIP as a language. Check "
+            "'${_alpaka_CMAKE_CONFIGURE_LOG}' for further information."
+        )
+    endif()
 endif()


### PR DESCRIPTION
I ran into an issue where alpaka deactivated the CUDA backend without making the actual cause obvious. The problem only became clear after compiling a small CUDA “Hello World” device program: CUDA 12.8 was not compatible with the GCC 15.x host compiler.

From my understanding, the compatibility checks happen inside check_language(CUDA). If CUDA cannot be enabled, CMAKE_CUDA_COMPILER is set to NOTFOUND, even though a local CUDA installation and nvcc may still be present.

This PR adds an else() path that checks whether nvcc is available while CMAKE_CUDA_COMPILER is unset or NOTFOUND. If such a mismatch is detected, CMake now emits a warning. This should make CUDA host compiler incompatibilities and similar configuration problems much easier to identify.