### PR TITLE
add vendor interop tutorial

### DIFF
--- a/docs/snippets/example/200_vendorInterop.cpp
+++ b/docs/snippets/example/200_vendorInterop.cpp
@@ -39,7 +39,10 @@ namespace vendorTutorial
     // END-TUTORIAL-vendorSymbol
 
     // BEGIN-TUTORIAL-vendorFallback
-    // Genic function dispatch signature which is used if no more specific specification for the symbol is provided.
+    /* Genic function dispatch signature which is used if no more specific specification for the symbol is provided.
+     * `input` and `output` should be one-dimensional, enforced by the required clause, to build a unified interface
+     * because std::transform used in the host CPU overload only supports one dimensional memory.
+     */
     template<typename T_Queue, alpaka::concepts::IMdSpan T_Output, alpaka::concepts::IMdSpan T_Input>
     constexpr void alpakaFnDispatch(
         AffineTransform,
@@ -47,7 +50,7 @@ namespace vendorTutorial
         T_Output&& output,
         float scale,
         float shift,
-        T_Input&& input) requires(ALPAKA_TYPEOF(output)::dim() == 1u && ALPAKA_TYPEOF(input)::dim() == 1u)
+        T_Input&& input) requires(concepts::Dim<ALPAKA_TYPEOF(input), 1u> && concepts::Dim<ALPAKA_TYPEOF(output), 1u>)
     {
         // Forward all arguments because the function signature chosen here matches the alpaka transform interface.
         alpaka::onHost::transform(
@@ -60,7 +63,10 @@ namespace vendorTutorial
     // END-TUTORIAL-vendorFallback
 
     // BEGIN-TUTORIAL-vendorHost
-    // This overload is used if the queue API is `api::Host` and the device kind is `deviceKind::Cpu`.
+    /* This overload is used if the queue API is `api::Host` and the device kind is `deviceKind::Cpu`.
+     * `input` and `output` should be one-dimensional, enforced by the requirement clause, due to the limitations of
+     * std::transform used for the implementation.
+     */
     template<typename T_Queue, alpaka::concepts::IMdSpan T_Output, alpaka::concepts::IMdSpan T_Input>
     constexpr void alpakaFnDispatch(
         AffineTransform::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>,
@@ -68,7 +74,7 @@ namespace vendorTutorial
         T_Output&& output,
         float scale,
         float shift,
-        T_Input&& input) requires(ALPAKA_TYPEOF(output)::dim() == 1u && ALPAKA_TYPEOF(input)::dim() == 1u)
+        T_Input&& input) requires(concepts::Dim<ALPAKA_TYPEOF(input), 1u> && concepts::Dim<ALPAKA_TYPEOF(output), 1u>)
     {
         /* Enqueue support only const lambdas/functors but the pointer must be writable, therefore create a copy of the
          * pointer before the multidimensional span becomes const due to the lambda. For IMdSpan the constness will be

--- a/docs/snippets/example/200_vendorInterop.cpp
+++ b/docs/snippets/example/200_vendorInterop.cpp
@@ -1,0 +1,128 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: ISC
+ */
+
+#include "docsTest.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <array>
+
+using namespace alpaka;
+
+namespace vendorTutorial
+{
+    // BEGIN-TUTORIAL-vendorFunctor
+    struct AffineTransformOp
+    {
+        float scale;
+        float shift;
+
+        ALPAKA_FN_ACC auto operator()(float const& value) const -> float
+        {
+            return scale * value + shift;
+        }
+    };
+
+    // END-TUTORIAL-vendorFunctor
+
+    // BEGIN-TUTORIAL-vendorSymbol
+    /* The function symbol is only defined without specifying the argument signature.
+     * You need to provide at least a generic function dispatch signature for the symbol.
+     */
+    ALPAKA_FN_SYMBOL(AffineTransform);
+
+    // END-TUTORIAL-vendorSymbol
+
+    // BEGIN-TUTORIAL-vendorFallback
+    // Genic function dispatch signature which is used if no more specific specification for the symbol is provided.
+    template<typename T_Queue, alpaka::concepts::IMdSpan T_Output, alpaka::concepts::IMdSpan T_Input>
+    constexpr void alpakaFnDispatch(
+        AffineTransform,
+        T_Queue&& queue,
+        T_Output&& output,
+        float scale,
+        float shift,
+        T_Input&& input) requires(ALPAKA_TYPEOF(output)::dim() == 1u && ALPAKA_TYPEOF(input)::dim() == 1u)
+    {
+        // Forward all arguments because the function signature chosen here matches the alpaka transform interface.
+        alpaka::onHost::transform(
+            ALPAKA_FORWARD(queue),
+            ALPAKA_FORWARD(output),
+            ScalarFunc{AffineTransformOp{scale, shift}},
+            ALPAKA_FORWARD(input));
+    }
+
+    // END-TUTORIAL-vendorFallback
+
+    // BEGIN-TUTORIAL-vendorHost
+    // This overload is used if the queue API is `api::Host` and the device kind is `deviceKind::Cpu`.
+    template<typename T_Queue, alpaka::concepts::IMdSpan T_Output, alpaka::concepts::IMdSpan T_Input>
+    constexpr void alpakaFnDispatch(
+        AffineTransform::Spec<alpaka::api::Host, alpaka::deviceKind::Cpu>,
+        T_Queue&& queue,
+        T_Output&& output,
+        float scale,
+        float shift,
+        T_Input&& input) requires(ALPAKA_TYPEOF(output)::dim() == 1u && ALPAKA_TYPEOF(input)::dim() == 1u)
+    {
+        /* Enqueue support only const lambdas/functors but the pointer must be writable, therefore create a copy of the
+         * pointer before the multidimensional span becomes const due to the lambda. For IMdSpan the constness will be
+         * propagated to the data.
+         */
+        auto outPtr = output.data();
+        // Enqueue the operation via a host function to ensure the order of executions within a non-blocking queue.
+        queue.enqueueHostFn(
+            [=]()
+            {
+                std::transform(
+                    input.data(),
+                    input.data() + input.getExtents().x(),
+                    outPtr,
+                    AffineTransformOp{scale, shift});
+            });
+    }
+
+    // END-TUTORIAL-vendorHost
+} // namespace vendorTutorial
+
+TEMPLATE_LIST_TEST_CASE("tutorial vendor interop dispatch", "[docs]", docs::test::TestBackends)
+{
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+
+    // BEGIN-TUTORIAL-vendorCall
+    std::array<float, 5u> hostInput{1.f, 2.f, 3.f, 4.f, 5.f};
+    std::array<float, 5u> hostOutput{};
+
+    auto inputBuffer = onHost::allocLike(device, hostInput);
+    auto outputBuffer = onHost::allocLike(device, hostOutput);
+
+    onHost::memcpy(queue, inputBuffer, hostInput);
+
+    /* Call the function, the overload will be dispatched based on the properties of the queue.
+     *
+     * You can also create an instance of the alpaka function symbol instead of using ::call().
+     * This allows using a function symbol as an argument of a method.
+     *
+     * example: `vendorTutorial::AffineTransform{}(....)`
+     */
+    vendorTutorial::AffineTransform::call(queue, outputBuffer, 2.0f, 0.5f, inputBuffer);
+
+    onHost::memcpy(queue, hostOutput, outputBuffer);
+    onHost::wait(queue);
+    // END-TUTORIAL-vendorCall
+
+    CHECK(hostOutput[0] == 2.5f);
+    CHECK(hostOutput[1] == 4.5f);
+    CHECK(hostOutput[2] == 6.5f);
+    CHECK(hostOutput[3] == 8.5f);
+    CHECK(hostOutput[4] == 10.5f);
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -79,6 +79,7 @@ Individual chapters are based on the information of the chapters before.
    tutorial/intrinsics.rst
    tutorial/warp.rst
    tutorial/kernelFn.rst
+   tutorial/vendorInterop.rst
 
 .. toctree::
    :caption: Advanced

--- a/docs/source/tutorial/kernelFn.rst
+++ b/docs/source/tutorial/kernelFn.rst
@@ -1,3 +1,5 @@
+.. _tutorial-fnkernel:
+
 Kernel Function
 ===============
 

--- a/docs/source/tutorial/vendorInterop.rst
+++ b/docs/source/tutorial/vendorInterop.rst
@@ -1,0 +1,104 @@
+Vendor and Third-Party Interop
+==============================
+
+At some point you would ask yourself how you can use native vendor implementations e.g. for BLAS, FFT or other functions together with *alpaka*.
+You might want to call ``thrust::transform`` on CUDA, ``rocPRIM`` on HIP, a oneAPI library on SYCL, or even a CPU-side library function on the host backend.
+*alpaka* provides a function-symbol interface for this request, which keeps the code to call vendor functions clean and readable without introducing precompiler macros around the functions calls.
+
+The following steps are required:
+
+- Define a *alpaka* function symbol with ``ALPAKA_FN_SYMBOL(symbolName)``
+- Optional implement a generic *alpaka* fallback, for any device.
+- Specialize implementations for the backends that have a special vendor path.
+
+Call the symbol via ``symbolName::call(queue, ...)`` or ``symbolName{}(queue, ...)`` and the correct implementation will be dispatched based on the API and device kind derived from the first argument, in this case the queue.
+
+The example a tiny image-processing operation is used.
+Each input value is read as a pixel intensity, and the operation computes ``scale * value + shift``.
+The affine operation itself is a tiny functor.
+
+  .. literalinclude:: ../../snippets/example/200_vendorInterop.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-vendorFunctor
+    :end-before: END-TUTORIAL-vendorFunctor
+    :dedent:
+
+  For the API ``host`` and the device kind ``cpu`` we will fallback to the C++ standard implementation via ``std::transform``.
+
+Defining a Dispatchable Function
+--------------------------------
+
+  .. literalinclude:: ../../snippets/example/200_vendorInterop.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-vendorSymbol
+    :end-before: END-TUTORIAL-vendorSymbol
+    :dedent:
+
+  It is allowed later to declare different dispatch function signatures for the same function symbol.
+  The function dispatch order follows the `C++ rules for function overloading <https://en.cppreference.com/cpp/language/overload_resolution>`__.
+
+Registering a Generic Fallback
+------------------------------
+
+  .. literalinclude:: ../../snippets/example/200_vendorInterop.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-vendorFallback
+    :end-before: END-TUTORIAL-vendorFallback
+    :dedent:
+
+  This overload is the portable baseline.
+  It works on every backend that can run the normal alpaka algorithm path, so it is a good default even when you later add CUDA-, HIP-, or SYCL-specific overloads.
+
+Registering a API-Device-Specific Overload
+------------------------------------------
+
+  .. literalinclude:: ../../snippets/example/200_vendorInterop.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-vendorHost
+    :end-before: END-TUTORIAL-vendorHost
+    :dedent:
+
+  This example uses ``std::transform`` as a small stand-in for a third-party backend function.
+  The pattern is the same when the backend-specific code comes from a GPU vendor library.
+  On CUDA, for example, this is where you would pass ``queue.getNativeHandle()`` to a library that expects a CUDA stream and then call the vendor routine there.
+  This host-specific overload is intentionally constrained to 1D spans because the example forwards to ``std::transform`` over a single contiguous range.
+
+  The important part is the ``Spec<api, deviceKind>`` type:
+
+  - it states which backend the overload belongs to,
+  - it keeps the backend choice out of the call site,
+  - and it lets the same public function symbol dispatch differently for different queues and devices.
+
+Calling the Function
+--------------------
+
+  The call itself stays simple.
+  You pass the queue and the ordinary data arguments.
+  *alpaka* looks at the queue's specification and forwards the call to the best matching overload.
+
+  .. literalinclude:: ../../snippets/example/200_vendorInterop.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-vendorCall
+    :end-before: END-TUTORIAL-vendorCall
+    :dedent:
+
+*alpaka*'s function interface is not limited to the usage on the host side only.
+As shown in the :ref:`function kernel tutorial <tutorial-fnkernel>` you can write kernels which are specializable for a device kind and/or API.
+You can also use it to call vendor/third-party functions from within a kernel (``onAcc``), in this case do not forgot to use the function attribute ``ALPAKA_FN_ACC`` or ``constexpr`` else some device compiler can not handle these functions.
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>200_vendorInterop.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/200_vendorInterop.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>
+   <br/>

--- a/docs/source/tutorial/vendorInterop.rst
+++ b/docs/source/tutorial/vendorInterop.rst
@@ -3,12 +3,12 @@ Vendor and Third-Party Interop
 
 At some point you would ask yourself how you can use native vendor implementations e.g. for BLAS, FFT or other functions together with *alpaka*.
 You might want to call ``thrust::transform`` on CUDA, ``rocPRIM`` on HIP, a oneAPI library on SYCL, or even a CPU-side library function on the host backend.
-*alpaka* provides a function-symbol interface for this request, which keeps the code to call vendor functions clean and readable without introducing precompiler macros around the functions calls.
+*alpaka* provides a function-symbol interface for this request, which keeps the code to call vendor functions clean and readable without introducing preprocessor macros around the function calls.
 
 The following steps are required:
 
-- Define a *alpaka* function symbol with ``ALPAKA_FN_SYMBOL(symbolName)``
-- Optional implement a generic *alpaka* fallback, for any device.
+- Define an *alpaka* function symbol with ``ALPAKA_FN_SYMBOL(symbolName)``
+- Optionally implement a generic *alpaka* fallback for any device.
 - Specialize implementations for the backends that have a special vendor path.
 
 Call the symbol via ``symbolName::call(queue, ...)`` or ``symbolName{}(queue, ...)`` and the correct implementation will be dispatched based on the API and device kind derived from the first argument, in this case the queue.
@@ -49,8 +49,8 @@ Registering a Generic Fallback
   This overload is the portable baseline.
   It works on every backend that can run the normal alpaka algorithm path, so it is a good default even when you later add CUDA-, HIP-, or SYCL-specific overloads.
 
-Registering a API-Device-Specific Overload
-------------------------------------------
+Registering an API-Device-Specific Overload
+-------------------------------------------
 
   .. literalinclude:: ../../snippets/example/200_vendorInterop.cpp
     :language: cpp
@@ -84,7 +84,7 @@ Calling the Function
 
 *alpaka*'s function interface is not limited to the usage on the host side only.
 As shown in the :ref:`function kernel tutorial <tutorial-fnkernel>` you can write kernels which are specializable for a device kind and/or API.
-You can also use it to call vendor/third-party functions from within a kernel (``onAcc``), in this case do not forgot to use the function attribute ``ALPAKA_FN_ACC`` or ``constexpr`` else some device compiler can not handle these functions.
+You can also use it to call vendor/third-party functions from within a kernel (``onAcc``); in this case do not forget to mark the function with the attribute ``ALPAKA_FN_ACC`` or ``constexpr``, otherwise some device compilers may fail to compile these functions.
 
 Complete Source File
 --------------------


### PR DESCRIPTION
Provide a tutorial on how to use alpakas function interface to write generic code dispatchable to fendor functions.

- [x] merge after #575 (avoid merge conflicts) 
- [x] merge after #576  (avoid merge conflicts) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Vendor and Third-Party Interop” tutorial explaining dispatchable function symbols and how to invoke them across backends.
  * Added a worked C++ example (including a validating test) demonstrating vendor-function interoperation.
* **Documentation**
  * Included the new tutorial in the documentation navigation.
  * Added a stable cross-reference target for the kernel function tutorial.
  * Embedded the full example source in the tutorial for easy reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->