### PR TITLE
add correct test condition to build `scan` and `vendorAPI` examples

### DIFF
--- a/example/scan/CMakeLists.txt
+++ b/example/scan/CMakeLists.txt
@@ -31,7 +31,9 @@ if(NOT TARGET alpaka::alpaka)
 endif()
 
 set(HAS_CUDA_CUB 0)
-if(alpaka_DEP_CUDA)
+# alpaka probes CUDA with check_language(CUDA),
+# which only sets CMAKE_CUDA_COMPILER if a valid CUDA compiler/toolchain is provided.
+if(CMAKE_CUDA_COMPILER)
     find_package(CUDAToolkit)
     if(NOT CUDAToolkit_FOUND)
         message(STATUS "Optional CUDAToolkit not found, cub scan implementation will be disabled.")
@@ -43,7 +45,9 @@ if(alpaka_DEP_CUDA)
 endif()
 
 set(HAS_HIP_CUB 0)
-if(alpaka_DEP_HIP)
+# alpaka probes HIP with check_language(HIP),
+# which only sets CMAKE_HIP_COMPILER if a valid HIP compiler/toolchain is provided.
+if(CMAKE_HIP_COMPILER)
     find_package(hip)
     find_package(hipCUB)
     if(NOT hip_FOUND)

--- a/example/vendorApi/CMakeLists.txt
+++ b/example/vendorApi/CMakeLists.txt
@@ -31,8 +31,9 @@ if(NOT TARGET alpaka::alpaka)
         find_package(alpaka REQUIRED)
     endif()
 endif()
-
-if(alpaka_DEP_CUDA)
+# alpaka probes CUDA with check_language(CUDA),
+# which only sets CMAKE_CUDA_COMPILER if a valid CUDA compiler/toolchain is provided.
+if(CMAKE_CUDA_COMPILER)
     find_package(CUDAToolkit)
     if(NOT CUDAToolkit_FOUND)
         message(STATUS "Optional CUDAToolkit not found, alpaka vendor api will not use thrust")


### PR DESCRIPTION
When the CUDA compiler is misconfigured, check_language(CUDA) may silently leave `CMAKE_CUDA_COMPILER` unset, as described in #585. In that case, relying on `alpaka_DEP_CUDA` alone is not sufficient: both examples use this flag to decide whether they can compile native CUDA code, but they may still produce compilation errors if no valid CUDA compiler/toolchain was detected.
Therefore, `CMAKE_CUDA_COMPILER` is the appropriate condition to check here, since it reflects whether CMake actually found a compatible CUDA - toolchain/Compiler.