### PR TITLE
claim ownerchip of alpaka3 for context7

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/alpaka-group/alpaka3",
+  "public_key": "pk_GDG64v1uvatikaoCpK6tM"
+}


### PR DESCRIPTION
Configuration to claim the ownership of alpaka3 to be able to configure alpaka3 in [context7](https://context7.com/).

Context7 is providing AI-optimized summaries of projects.
To be able to set it up, I need to claim the ownership. 
Currently, *alpaka3* is registered there but is not under our control.