### PR TITLE
CI: add OneAPI 2026.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,13 @@ jobs:
               env : {APCI_DEVICE_COMPILER : icpx@2025.2, APCI_CMAKE : 3.28.3} }
           - { compiler: icpx, version: "2025.3", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.3.0-0-devel-ubuntu24.04",
               env : {APCI_DEVICE_COMPILER : icpx@2025.3, APCI_CMAKE : 3.28.3} }
-          - { compiler: icpx, version: "2025.3", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.3.0-0-devel-ubuntu24.04", simd: "EMULATION", hwloc: "no",
-              env : {APCI_DEVICE_COMPILER : icpx@2025.3, APCI_CMAKE : 3.28.3} }
+          - { compiler: icpx, version: "2026.0", cuda: "no", hip: "no", container: "intel/oneapi:2026.0.0-devel-ubuntu24.04",
+              env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3} }
+          - { compiler: icpx, version: "2026.0", cuda: "no", hip: "no", container: "intel/oneapi:2026.0.0-devel-ubuntu24.04", simd: "EMULATION", hwloc: "no",
+              env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3} }
           # Use/validate oneAPI-provided oneTBB package with the latest icpx toolchain
-          - { compiler: icpx, version: "2025.3", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.3.0-0-devel-ubuntu24.04", tbb: "on",
-              env : {APCI_DEVICE_COMPILER : icpx@2025.3, APCI_CMAKE : 3.28.3} }
+          - { compiler: icpx, version: "2026.0", cuda: "no", hip: "no", container: "intel/oneapi:2026.0.0-devel-ubuntu24.04", tbb: "on",
+              env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3} }
           - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "asan",
               env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3} }
           - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "asan" , simd: "EMULATION", hwloc: "no",
@@ -227,7 +229,7 @@ jobs:
       - name: Install oneAPI
         if: matrix.config.compiler == 'icpx'
         run: |
-          echo "test is adding -DCMAKE_CXX_FLAGS='-fsycl -fsycl-targets=spir64_x86_64' to speedup execution"
+          echo "test is adding '-Dalpaka_ONEAPI_IntelGpu=OFF -Dalpaka_EXEC_CpuSerial=OFF -Dalpaka_DEP_OMP=OFF' to speedup execution"
           # for TBB there is nothing to do because TBB is configured in the container correctly
 
       # hwloc (opt out)
@@ -276,7 +278,7 @@ jobs:
                 -DCMAKE_BUILD_TYPE=Release \
                 ${alpaka_cmake_flags} -Dalpaka_DEP_OMP=ON \
                 ${{ matrix.config.hwloc == 'no' && '-Dalpaka_DEP_HWLOC=OFF' || '-Dalpaka_DEP_HWLOC=ON -Dalpaka_HOST_MemPinningCanFail=ON'}} \
-                ${{ matrix.config.compiler == 'icpx' && '-DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_FLAGS="-fsycl -fsycl-targets=spir64_x86_64" -Dalpaka_DEP_ONEAPI=ON -Dalpaka_ONEAPI_IntelGpu=OFF -Dalpaka_EXEC_CpuSerial=OFF -Dalpaka_DEP_OMP=OFF' || '' }} \
+                ${{ matrix.config.compiler == 'icpx' && '-DCMAKE_CXX_COMPILER=icpx -Dalpaka_DEP_ONEAPI=ON -Dalpaka_ONEAPI_IntelGpu=OFF -Dalpaka_EXEC_CpuSerial=OFF -Dalpaka_DEP_OMP=OFF' || '' }} \
                 ${{ matrix.config.cuda != 'no' && '-Dalpaka_DEP_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=80' || '' }} \
                 ${{ matrix.config.cuda != 'no' && matrix.config.compiler == 'clang' && '-Dalpaka_DEP_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=80 -DCMAKE_CUDA_COMPILER=$CXX -DCMAKE_CUDA_HOST_COMPILER=$CXX -Dalpaka_SUPPRESS_TARGET_WARNING=ON -Dalpaka_DEP_OMP=OFF' || '' }} \
                 ${{ matrix.config.hip != 'no' && '-DCMAKE_CXX_COMPILER=clang++ -Dalpaka_DEP_HIP=ON -Dalpaka_DEP_OMP=OFF \

--- a/cmake/alpakaCompilePedantic.cmake
+++ b/cmake/alpakaCompilePedantic.cmake
@@ -15,11 +15,11 @@ if(TARGET alpaka_target_cuda)
         alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Werror all-warnings>")
         alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Werror default-stream-launch>")
         alpaka_set_compiler_options(
-            DEVICE
-            target
-            alpaka_target_cuda
-            "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-pedantic>"
-            "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wno-pedantic>"
+                DEVICE
+                target
+                alpaka_target_cuda
+                "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-pedantic>"
+                "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wno-pedantic>"
         )
         alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Wall>")
         alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Wextra>")
@@ -48,5 +48,10 @@ if(TARGET alpaka_target_host)
         # error: '*(std::function<bool(char)>*)((char*)&__tmp + offsetof(std::__detail::_StateT, std::__detail::_State<char>::<unnamed>.std::__detail::_State_base::<unnamed>)).std::function<bool(char)>::_M_invoker' may be used uninitialized [-Werror=maybe-uninitialized]
         # see also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105616
         alpaka_set_compiler_options(HOST target alpaka_target_host "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-Wno-error=maybe-uninitialized>")
+    endif()
+
+    # disable the warning/error: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "2026.0")
+        alpaka_set_compiler_options(HOST target alpaka_target_host "$<$<COMPILE_LANG_AND_ID:CXX,IntelLLVM,Clang>:-Wno-c2y-extensions>")
     endif()
 endif()

--- a/test/unit/algorithm/transformReduce.cpp
+++ b/test/unit/algorithm/transformReduce.cpp
@@ -215,7 +215,15 @@ TEMPLATE_LIST_TEST_CASE("transformReduce", "", TestBackends)
             std::make_pair(std::plus{}, std::plus{}),
             std::make_pair(
                 ScalarFunc{[] ALPAKA_FN_ACC(DataType const& a, DataType const& b)
-                           { return math::min(a + DataType{1}, b); }},
+                           {
+                               /* Temporary variable is required to avoid icpx 2026.0 linker issue.
+                                * Running pass
+                                * "function(vpo-cfg-restructuring,replace-with-math-library-functions,inject-tli-mappings,auto-vec-dir-insert,vplan-vec,replace-with-math-library-functions)"
+                                * on module "main" llvm-foreach: Segmentation fault (core dumped)
+                                */
+                               auto lhs = a + DataType{1};
+                               return alpaka::math::min(lhs, b);
+                           }},
                 [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); }),
             TestWithMdSpan{}),
         std::make_tuple(
@@ -343,7 +351,15 @@ TEMPLATE_LIST_TEST_CASE("transformReduce generator", "", TestBackends)
             std::make_pair(std::plus{}, std::plus{}),
             std::make_pair(
                 ScalarFunc{[] ALPAKA_FN_ACC(DataType const& a, DataType const& b)
-                           { return math::min(a + DataType{1}, b); }},
+                           {
+                               /* Temporary variable is required to avoid icpx 2026.0 linker issue.
+                                * Running pass
+                                * "function(vpo-cfg-restructuring,replace-with-math-library-functions,inject-tli-mappings,auto-vec-dir-insert,vplan-vec,replace-with-math-library-functions)"
+                                * on module "main" llvm-foreach: Segmentation fault (core dumped)
+                                */
+                               auto lhs = a + DataType{1};
+                               return math::min(lhs, b);
+                           }},
                 [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); }),
             TestWithGenerator{}),
         std::make_tuple(
@@ -499,7 +515,14 @@ TEMPLATE_LIST_TEST_CASE("onAcc transformReduce", "", TestBackends)
             std::make_pair(std::plus{}, std::plus{}),
             std::make_pair(
                 ScalarFunc{[] ALPAKA_FN_ACC(DataType const& a, DataType const& b)
-                           { return math::min(a + DataType{1}, b); }},
+                           {
+                               /* std::min() instead of alpaka::min() is used to avoid icpx 2026.0 linker issue.
+                                * Running pass
+                                * "function(vpo-cfg-restructuring,replace-with-math-library-functions,inject-tli-mappings,auto-vec-dir-insert,vplan-vec,replace-with-math-library-functions)"
+                                * on module "main" llvm-foreach: Segmentation fault (core dumped)
+                                */
+                               return std::min(a + DataType{1}, b);
+                           }},
                 [](DataType const& a, DataType const& b) { return math::min(a + DataType{1}, b); }),
             TestOnAccWithMdSpan{}),
         std::make_tuple(


### PR DESCRIPTION
 * Updated CI validation: add Intel oneAPI 2026.0
 * Refined pedantic warning for IntelLLVM (2026.0+) avoid warning about the usage of `__COUNTER__`.
 * Updated unit test `transformReduce` setup to avoid an icpx 2026.0 linker/segmentation-fault issue.