### PR TITLE
add Codecov support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@ on:
   pull_request:
     branches: [ dev ]
 
+# Stop CI for the PR if the PR is updates.
+# Stop CI runs for dev branch if a new PR is merged into the dev branch.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('ref-{0}', github.ref) }}
   cancel-in-progress: true
 
 env:
@@ -318,3 +321,64 @@ jobs:
             echo "Matrix CI failed: ${{ needs.ci.result }}"
             exit 1
           fi
+
+  # We use only a single gcc version to check the coverage.
+  # Therefore, the results will be a ruf coverage overview.
+  coverage:
+    name: coverage
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-13 g++-13 ninja-build gcovr libhwloc-dev pkg-config
+
+      - name: Configure CMake
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER=gcc-13 \
+            -DCMAKE_CXX_COMPILER=g++-13 \
+            -Dalpaka_TESTS=ON \
+            -Dalpaka_EXAMPLES=OFF \
+            -Dalpaka_BENCHMARKS=OFF \
+            -Dalpaka_DOCS=OFF \
+            -Dalpaka_HEADERCHECKS=OFF \
+            -DBUILD_TESTING=ON \
+            -Dalpaka_DEP_HWLOC=ON \
+            -Dalpaka_DEP_OMP=ON \
+            -Dalpaka_COVERAGE=ON
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Generate coverage report
+        run: |
+          gcovr \
+            --root . \
+            --filter 'include/' \
+            --exclude 'test/' \
+            --exclude 'example/' \
+            --exclude 'benchmark/' \
+            --cobertura-pretty \
+            --output build/coverage.xml \
+            build
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          files: build/coverage.xml
+          disable_search: true
+          fail_ci_if_error: true
+          flags: cpu
+          name: cpu-coverage
+          use_oidc: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![License](https://img.shields.io/badge/license-MPL--2.0-6c757d.svg)](https://www.mozilla.org/en-US/MPL/2.0/)
 [![CI](https://github.com/alpaka-group/alpaka3/actions/workflows/ci.yml/badge.svg?branch=dev&event=push)](https://github.com/alpaka-group/alpaka3/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/github/alpaka-group/alpaka3/branch/dev/graph/badge.svg)](https://app.codecov.io/github/alpaka-group/alpaka3)
 [![Docs](https://img.shields.io/badge/docs-Read%20the%20Docs-0f766e.svg)](https://alpaka3.readthedocs.io)
 [![User API](https://img.shields.io/badge/User%20API-Doxygen-2563eb.svg)](https://alpaka3.readthedocs.io/en/latest/doxygen/namespaces.html)
 [![Dev API](https://img.shields.io/badge/Dev%20API-Doxygen-7c3aed.svg)](https://alpaka3.readthedocs.io/en/latest/doxygen_dev/namespaces.html)

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -312,6 +312,7 @@ option(alpaka_ASAN "Enable/Disable linking the address sanitizer for cpu targets
 option(alpaka_TSAN "Enable/Disable linking the thread sanitizer for cpu targets" OFF)
 option(alpaka_LSAN "Enable/Disable linking the memory leak sanitizer for cpu targets" OFF)
 option(alpaka_UBSAN "Enable/Disable linking the undefined behavior sanitizer for cpu targets" OFF)
+option(alpaka_COVERAGE "Enable/Disable coverage instrumentation for cpu targets" OFF)
 
 if(alpaka_TSAN)
     message(

--- a/cmake/finalize.cmake
+++ b/cmake/finalize.cmake
@@ -235,8 +235,20 @@ function(alpaka_internal_finalize target)
         target_compile_definitions(${target} PRIVATE ALPAKA_CMAKE_TARGET_ALPAKA_FINALIZE_CALLED)
     endif()
 
-    # conditionally add sanitizer if not compiling with cuda/hip/oneapi
+    # conditionally add coverage and sanitizer support if not compiling with cuda/hip/oneapi
     if(index_cuda EQUAL -1 AND index_hip EQUAL -1 AND index_oneapi EQUAL -1)
+        if(alpaka_COVERAGE)
+            if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+                message(STATUS "Enabling coverage instrumentation for ${target}")
+                target_compile_options(${target} PRIVATE --coverage)
+                target_link_options(${target} PRIVATE --coverage)
+            else()
+                message(
+                    WARNING
+                    "Coverage instrumentation requested for '${target}', but compiler '${CMAKE_CXX_COMPILER_ID}' is not supported."
+                )
+            endif()
+        endif()
         if(alpaka_ASAN)
             message(STATUS "Linking ASAN to ${target}")
             target_compile_options(${target} PRIVATE -fsanitize=address)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+codecov:
+  notify:
+    wait_for_ci: true
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+        paths:
+          - "include/"
+    patch:
+      default:
+        informational: true
+        paths:
+          - "include/"
+
+ignore:
+  - "benchmark/**"
+  - "docs/**"
+  - "example/**"
+  - "headerCheck/**"
+  - "test/**"


### PR DESCRIPTION
- add CMake option `alpaka_COVERAGE`
- add single CI job to compile with code coverage enabled
- update CI early stop rules if PRs get morged into the dev branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated code coverage reporting to CI, with results published to Codecov.
  * Added a coverage badge to the README for quick visibility into test coverage status.

* **Bug Fixes**
  * Improved CI job grouping so pull requests and branch updates are tracked more consistently.
  * Refined coverage checks to focus on relevant source code while excluding generated or auxiliary paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->