### PR TITLE
CI: install ROCm via script.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,29 +204,8 @@ jobs:
       # ROCm
       - name: Install ROCm
         if: matrix.config.hip != 'no'
-        run: |
-          apt-get update
-          apt-get install -y hiprand-dev rocrand-dev
-
-          export ROCM_PATH=/opt/rocm
-          export CMAKE_PREFIX_PATH=$ROCM_PATH:$CMAKE_PREFIX_PATH
-          export HIP_PLATFORM="amd"
-          export HIP_DEVICE_LIB_PATH=${ROCM_PATH}/amdgcn/bitcode
-          export HSA_PATH=$ROCM_PATH
-          export PATH=${ROCM_PATH}/bin:$PATH
-          export PATH=${ROCM_PATH}/llvm/bin:$PATH
-
-          # Export variables to make them globally visible
-          echo "ROCM_PATH=${ROCM_PATH}" >> $GITHUB_ENV
-          echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}" >> $GITHUB_ENV
-          echo "HIP_PLATFORM=${HIP_PLATFORM}" >> $GITHUB_ENV
-          echo "HSA_PATH=${HSA_PATH}" >> $GITHUB_ENV
-          echo "PATH=${PATH}" >> $GITHUB_ENV
-
-          which clang++
-          clang++ --version
-          hipconfig --platform
-          hipconfig -v
+        shell: bash
+        run: $APCI_ALPAKA_ROOT/script/ci/install/rocm.sh
 
       # intel oneAPI ipcx
       - name: Install oneAPI
@@ -271,6 +250,14 @@ jobs:
               export CC=/usr/bin/clang-${{ matrix.config.version }}
               export CXX=/usr/bin/clang++-${{ matrix.config.version }}
             else
+              export ROCM_PATH=/opt/rocm
+              export CMAKE_PREFIX_PATH=$ROCM_PATH:$CMAKE_PREFIX_PATH
+              export HIP_PLATFORM="amd"
+              export HIP_DEVICE_LIB_PATH=${ROCM_PATH}/amdgcn/bitcode
+              export HSA_PATH=$ROCM_PATH
+              export PATH=${ROCM_PATH}/bin:$PATH
+              export PATH=${ROCM_PATH}/llvm/bin:$PATH
+
               echo "set clang as hip compiler"
               export CC=clang
               export CXX=clang++

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,3 +54,27 @@ clang-20-agc:
   variables:
     APCI_DEVICE_COMPILER : clang@20
     APCI_CMAKE: 3.31.4
+
+hipcc-7.0:
+  image: ubuntu:24.04
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : clang@20
+    APCI_CMAKE: 3.31.4
+    APCI_HIP : 7.0
+
+hipcc-7.2-agc:
+  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu24.04-gcc:4.0
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : clang@22
+    APCI_CMAKE: 3.28.3
+    APCI_HIP : 7.2
+
+hipcc-6.3-agc:
+  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu24.04-rocm6.3:addubuntu2204cudacontainer-4.0
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : clang@21
+    APCI_CMAKE: 3.28.3
+    APCI_HIP : 6.3

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -12,8 +12,10 @@ script_msg "Run CMake configure (configure.sh)"
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 
+CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-""}
+
 # TODO: remove me, if all install scripts are ported
-if [[ "$compiler_name" == "gcc" || ("$compiler_name" == "clang" && "$APCI_HIP" == 0) ]]; then
+if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
     load_variable_if_not_exist APCI_CMAKE_BIN_PATH
     load_variable_if_not_exist APCI_C_COMPILER
     load_variable_if_not_exist APCI_CXX_COMPILER
@@ -34,6 +36,26 @@ if [[ "$compiler_name" == "gcc" || ("$compiler_name" == "clang" && "$APCI_HIP" =
         "-DCMAKE_C_COMPILER=$APCI_C_COMPILER"
         "-DCMAKE_CXX_COMPILER=$APCI_CXX_COMPILER"
     )
+
+    if [[ "$APCI_HIP" != 0 ]]; then
+        load_variable_if_not_exist ROCM_PATH
+        load_variable_if_not_exist HIP_PLATFORM
+        load_variable_if_not_exist HIP_DEVICE_LIB_PATH
+        load_variable_if_not_exist HSA_PATH
+
+        export ROCM_PATH
+        export HIP_PLATFORM
+        export HIP_DEVICE_LIB_PATH
+        export HSA_PATH
+        export PATH=${ROCM_PATH}/bin:$PATH
+        export PATH=${ROCM_PATH}/llvm/bin:$PATH
+        export CMAKE_PREFIX_PATH=$ROCM_PATH:$CMAKE_PREFIX_PATH
+
+        CMAKE_ARGS+=(-Dalpaka_DEP_HIP=ON
+            -Dalpaka_DEP_OMP=OFF
+            -DCMAKE_HIP_ARCHITECTURES=gfx906
+            -DAMDGPU_TARGETS=gfx906)
+    fi
 
     echo_green "${APCI_CMAKE_BIN_PATH}/cmake ${CMAKE_ARGS[*]}"
     if [[ -z ${GITHUB_ACTIONS+x} ]]; then

--- a/script/ci/install/clang.sh
+++ b/script/ci/install/clang.sh
@@ -24,7 +24,8 @@ if [[ -f "/etc/apt/sources.list.d/llvm.list" ]]; then
     sudo rm /etc/apt/sources.list.d/llvm.list
 fi
 
-if [[ "$compiler_name" == "clang" ]]; then
+# If HIP is enabled, the clang compiler is handled by the rocm.sh script
+if [[ "$compiler_name" == "clang" && "$APCI_HIP" == 0 ]]; then
     if agc-manager -e "clang@${compiler_version}"; then
         echo_green "use preinstalled clang@${compiler_version}"
 
@@ -35,8 +36,6 @@ if [[ "$compiler_name" == "clang" ]]; then
     else
         install_msg "Clang $compiler_version"
 
-        lazy_apt_update
-        DEBIAN_FRONTEND=noninteractive apt install -y software-properties-common wget gnupg2
         retry_cmd wget https://apt.llvm.org/llvm-snapshot.gpg.key
         mv ./llvm-snapshot.gpg.key /etc/apt/trusted.gpg.d/apt.llvm.org.asc
         case "${compiler_version}" in

--- a/script/ci/install/rocm.sh
+++ b/script/ci/install/rocm.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+# shellcheck source=script/ci/utils/default.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
+
+if [[ "$APCI_OS_NAME" != "Linux" ]]; then
+    exit_error "Install GCC script does not support Windows or MacOS"
+fi
+
+: "${APCI_HIP?'The rocm version must be specified'}"
+
+script_msg "Install ROCm"
+
+if [[ "$APCI_HIP" != 0 ]]; then
+    if agc-manager -e "rocm@${APCI_HIP}"; then
+        echo_green "rocm@${APCI_HIP}"
+        ROCM_PATH=$(agc-manager -b "rocm@${APCI_HIP}")
+    else
+        if [[ "${APCI_IMAGE_NAME}" =~ "rocm/dev-ubuntu-" ]]; then
+            install_msg "ROCm ${APCI_HIP} in official ROCm container."
+
+            lazy_apt_update
+            # TODO: CHECK if rand library is still required
+            DEBIAN_FRONTEND=noninteractive apt install -y hiprand-dev rocrand-dev
+        else
+            install_msg "ROCm ${APCI_HIP} in default Ubuntu container."
+
+            wget https://repo.radeon.com/rocm/rocm.gpg.key -O - |
+                gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg >/dev/null
+
+            # Prevents apt warnings when the script is run a second time.
+            # Delete and recreate the source list to ensure that the correct apt sources are set.
+            if [[ -f /etc/apt/sources.list.d/rocm.list ]]; then
+                rm /etc/apt/sources.list.d/rocm.list
+            fi
+
+            # require to set environment variable VERSION_CODENAME
+            source /etc/os-release
+            echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${APCI_HIP} ${VERSION_CODENAME} main" |
+                sudo tee -a /etc/apt/sources.list.d/rocm.list
+            echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/${APCI_HIP}/ubuntu ${VERSION_CODENAME} main" |
+                sudo tee -a /etc/apt/sources.list.d/rocm.list
+
+            DEBIAN_FRONTEND=noninteractive retry_cmd apt update
+
+            APCI_ROCM="${APCI_HIP}"
+            # append .0 if no patch level is defined
+            if ! echo "${APCI_ROCM}" | grep -Eq '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+'; then
+                APCI_ROCM="${APCI_ROCM}.0"
+            fi
+
+            DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \
+                "rocm-llvm${APCI_ROCM}" \
+                "hip-runtime-amd${APCI_ROCM}" \
+                "rocm-dev${APCI_ROCM}" \
+                "rocm-utils${APCI_ROCM}" \
+                "rocrand-dev${APCI_ROCM}" \
+                "rocminfo${APCI_ROCM}" \
+                "rocm-cmake${APCI_ROCM}" \
+                "rocm-device-libs${APCI_ROCM}" \
+                "rocm-core${APCI_ROCM}" \
+                "rocm-smi-lib${APCI_ROCM}"
+
+            function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
+            if [ "$(version "${APCI_ROCM}")" -ge "$(version "6.0.0")" ]; then
+                DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \
+                    "hiprand-dev${APCI_ROCM}"
+            fi
+        fi
+        export ROCM_PATH=/opt/rocm
+    fi
+
+    export ROCM_PATH
+    # TODO: CHECK if HIP_PLATFORM, HIP_DEVICE_LIB_PATH and HSA_PATH are still required
+    export HIP_PLATFORM="amd"
+    export HIP_DEVICE_LIB_PATH=${ROCM_PATH}/amdgcn/bitcode
+    export HSA_PATH=$ROCM_PATH
+    export APCI_C_COMPILER="${ROCM_PATH}/llvm/bin/clang"
+    export APCI_CXX_COMPILER="${ROCM_PATH}/llvm/bin/clang++"
+
+    export PATH=${ROCM_PATH}/bin:$PATH
+    export PATH=${ROCM_PATH}/llvm/bin:$PATH
+
+    echo_green "${APCI_C_COMPILER} --version"
+    $APCI_C_COMPILER --version
+    echo_green "${APCI_CXX_COMPILER} --version"
+    $APCI_CXX_COMPILER --version
+
+    echo_green "hipconfig --platform"
+    hipconfig --platform
+    echo_green "\nhipconfig --v"
+    hipconfig -v
+    echo
+
+    store_variable ROCM_PATH
+    store_variable HIP_PLATFORM
+    store_variable HIP_DEVICE_LIB_PATH
+    store_variable HSA_PATH
+    store_variable APCI_C_COMPILER
+    store_variable APCI_CXX_COMPILER
+fi

--- a/script/ci/install_dependencies.sh
+++ b/script/ci/install_dependencies.sh
@@ -23,3 +23,5 @@ source "${APCI_ALPAKA_ROOT}/script/ci/install/cmake.sh"
 source "${APCI_ALPAKA_ROOT}/script/ci/install/gcc.sh"
 # shellcheck source=script/ci/install/clang.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/install/clang.sh"
+# shellcheck source=script/ci/install/rocm.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/install/rocm.sh"

--- a/script/ci/job_info/linux.sh
+++ b/script/ci/job_info/linux.sh
@@ -31,10 +31,10 @@ done
 echo_yellow "\n3. Run the following scripts.\n"
 
 echo_yellow "# install all required software, e.g. compiler, GPU SDKs and more
-\$APCI_ALPAKA_ROOT/script/ci/install_dependencies.sh
+\"\$APCI_ALPAKA_ROOT/script/ci/install_dependencies.sh\"
 # run CMake configure
-\$APCI_ALPAKA_ROOT/script/ci/configure.sh
+\"\$APCI_ALPAKA_ROOT/script/ci/configure.sh\"
 # compile alpaka
-\$APCI_ALPAKA_ROOT/script/ci/build.sh
+\"\$APCI_ALPAKA_ROOT/script/ci/build.sh\"
 # run tests
-\$APCI_ALPAKA_ROOT/script/ci/test.sh"
+\"\$APCI_ALPAKA_ROOT/script/ci/test.sh\""


### PR DESCRIPTION
- [x] merge #603 before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded CI coverage for HIP/ROCm builds with new ROCm/HIP versioned jobs.
* **Bug Fixes**
  * Improved HIP/ROCm CI setup by centralizing ROCm installation and ensuring required ROCm/HIP environment variables and paths are set consistently.
  * Adjusted CI build configuration so HIP builds don’t rely on Clang installation paths meant for non-HIP builds.
* **Refactor**
  * Reworked CI ROCm install logic to use a dedicated installer script.
* **Chores**
  * Updated CI command output formatting for clearer local-run instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->