### PR TITLE
validate pCast and lpCast

### DIFF
--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -58,7 +58,7 @@ namespace alpaka
             /** do not use ALPAKA_TYPEOF(thisApi()) here else nvcc + gcc can trigger a compile error
              * error: use of built-in trait '__remove_cv(alpaka::api::Host)' in function signature;
              */
-        typename trait::GetSimdStorageType<decltype(thisApi()), T_Type, T_width>::type>
+        typename alpaka::trait::GetSimdStorageType<decltype(thisApi()), T_Type, T_width>::type>
     struct Simd;
 
     namespace trait

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -174,7 +174,7 @@ namespace alpaka
         constexpr bool TemplateSignatureStorage_v = TemplateSignatureStorage<T>::value;
     } // namespace detail
 
-    template<typename T_Type, uint32_t T_dim, typename T_Storage = ArrayStorage<T_Type, T_dim>>
+    template<typename T_Type, uint32_t T_dim, typename T_Storage = alpaka::ArrayStorage<T_Type, T_dim>>
     struct Vec : private T_Storage
     {
         using Storage = T_Storage;

--- a/include/alpaka/vecConcepts.hpp
+++ b/include/alpaka/vecConcepts.hpp
@@ -56,6 +56,6 @@ namespace alpaka
                   || detail::integralFloatLossless<T_From, T_To>);
 
         template<typename T_From, typename T_To>
-        concept Convertible = requires { std::is_convertible_v<T_From, T_To>; };
+        concept Convertible = std::is_convertible_v<T_From, T_To>;
     }; // namespace concepts
 } // namespace alpaka

--- a/test/unit/utility/cast.cpp
+++ b/test/unit/utility/cast.cpp
@@ -18,53 +18,59 @@ using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDe
 template<typename T_To, typename T_AnyInput>
 concept IsLpCastCallable = requires(T_AnyInput in) { lpCast<T_To>(in); };
 
+// Test type for user type conversion.
+struct Foo
+{
+};
+
 struct TestKernelLpCast
 {
-    ALPAKA_FN_ACC void operator()(auto const& acc) const
+    /* Vec and Simd have the same required template signature, therefore we can combine the tests.
+     *
+     * Do not move this test implementation into a lambda with templates, nvcc will show unused variable warnings
+     * pointing to the template parameters.
+     */
+    template<uint32_t T_dim, template<typename, uint32_t, typename...> class T_ClassToTest>
+    static constexpr void check()
     {
-        // Test type for user type conversion.
-        struct Foo
-        {
-        };
+        alpaka::unused(T_dim);
+        // integral type identity
+        static_assert(IsLpCastCallable<uint32_t, ALPAKA_TYPEOF(T_ClassToTest<uint32_t, T_dim>{})>);
+        static_assert(IsLpCastCallable<uint64_t, T_ClassToTest<uint64_t, T_dim>>);
+        // down cast is forbidden
+        static_assert(!IsLpCastCallable<uint32_t, T_ClassToTest<uint64_t, T_dim>>);
+        // sign flip is forbidden if the original data is not fully representable
+        static_assert(!IsLpCastCallable<int32_t, T_ClassToTest<uint32_t, T_dim>>);
+        // sign flip is allowed if the original data is fully representable
+        static_assert(IsLpCastCallable<int32_t, T_ClassToTest<uint16_t, T_dim>>);
+        // integral to floating point
+        static_assert(IsLpCastCallable<float, T_ClassToTest<int16_t, T_dim>>);
+        static_assert(!IsLpCastCallable<float, T_ClassToTest<int32_t, T_dim>>);
+        // floating point to integral
+        static_assert(!IsLpCastCallable<int32_t, T_ClassToTest<float, T_dim>>);
+        // floating point type identity
+        static_assert(IsLpCastCallable<float, T_ClassToTest<float, T_dim>>);
+        static_assert(IsLpCastCallable<double, T_ClassToTest<double, T_dim>>);
+        // floating point precision loss is forbidden
+        static_assert(!IsLpCastCallable<float, T_ClassToTest<double, T_dim>>);
+        // floating point up cast kept precision
+        static_assert(IsLpCastCallable<double, T_ClassToTest<float, T_dim>>);
 
-        // Vec and Simd have the same required template signature, therefore we can combine the tests
-        auto testCases = []<uint32_t T_dim, template<typename, uint32_t> class T_ClassToTest>
-        {
-            // integral type identity
-            static_assert(IsLpCastCallable<uint32_t, T_ClassToTest<uint32_t, T_dim>>);
-            static_assert(IsLpCastCallable<uint64_t, T_ClassToTest<uint64_t, T_dim>>);
-            // down cast is forbidden
-            static_assert(!IsLpCastCallable<uint32_t, T_ClassToTest<uint64_t, T_dim>>);
-            // sign flip is forbidden if the original data is not fully representable
-            static_assert(!IsLpCastCallable<int32_t, T_ClassToTest<uint32_t, T_dim>>);
-            // sign flip is allowed if the original data is fully representable
-            static_assert(IsLpCastCallable<int32_t, T_ClassToTest<uint16_t, T_dim>>);
-            // integral to floating point
-            static_assert(IsLpCastCallable<float, T_ClassToTest<int16_t, T_dim>>);
-            static_assert(!IsLpCastCallable<float, T_ClassToTest<int32_t, T_dim>>);
-            // floating point to integral
-            static_assert(!IsLpCastCallable<int32_t, T_ClassToTest<float, T_dim>>);
-            // floating point type identity
-            static_assert(IsLpCastCallable<float, T_ClassToTest<float, T_dim>>);
-            static_assert(IsLpCastCallable<double, T_ClassToTest<double, T_dim>>);
-            // floating point precision loss is forbidden
-            static_assert(!IsLpCastCallable<float, T_ClassToTest<double, T_dim>>);
-            // floating point up cast kept precision
-            static_assert(IsLpCastCallable<double, T_ClassToTest<float, T_dim>>);
+        // custom value type is not castable
+        static_assert(!IsLpCastCallable<uint32_t, T_ClassToTest<Foo, T_dim>>);
+    }
 
-            // custom value type is not castable
-            static_assert(!IsLpCastCallable<uint32_t, T_ClassToTest<Foo, T_dim>>);
-        };
+    ALPAKA_FN_ACC void operator()(auto const&) const
+    {
+        check<1u, Vec>();
+        check<2u, Vec>();
+        check<3u, Vec>();
+        check<4u, Vec>();
 
-        testCases.template operator()<1u, Vec>();
-        testCases.template operator()<2u, Vec>();
-        testCases.template operator()<3u, Vec>();
-        testCases.template operator()<4u, Vec>();
-
-        testCases.template operator()<1u, Simd>();
-        testCases.template operator()<2u, Simd>();
-        testCases.template operator()<3u, Simd>();
-        testCases.template operator()<4u, Simd>();
+        check<1u, Simd>();
+        check<2u, Simd>();
+        check<3u, Simd>();
+        check<4u, Simd>();
     }
 };
 
@@ -86,48 +92,48 @@ concept IsPCastCallable = requires(T_AnyInput in) { pCast<T_To>(in); };
 
 struct TestKernelPCast
 {
-    ALPAKA_FN_ACC void operator()(auto const& acc) const
+    /* Vec and Simd have the same required template signature, therefore we can combine the tests.
+     *
+     * Do not move this test implementation into a lambda with templates, nvcc will show unused variable warnings
+     * pointing to the template parameters.
+     */
+    template<uint32_t T_dim, template<typename, uint32_t, typename...> class T_ClassToTest>
+    static constexpr void check()
     {
-        // Test type for user type conversion.
-        struct Foo
-        {
-        };
+        // integral type identity
+        static_assert(IsPCastCallable<uint32_t, T_ClassToTest<uint32_t, T_dim>>);
+        static_assert(IsPCastCallable<uint64_t, T_ClassToTest<uint64_t, T_dim>>);
+        // down cast
+        static_assert(IsPCastCallable<uint32_t, T_ClassToTest<uint64_t, T_dim>>);
+        // sign flip
+        static_assert(IsPCastCallable<int32_t, T_ClassToTest<uint32_t, T_dim>>);
+        static_assert(IsPCastCallable<int32_t, T_ClassToTest<uint16_t, T_dim>>);
+        // integral and floating point cross casts
+        static_assert(IsPCastCallable<float, T_ClassToTest<int32_t, T_dim>>);
+        static_assert(IsPCastCallable<int32_t, T_ClassToTest<float, T_dim>>);
+        // floating point type identity
+        static_assert(IsPCastCallable<float, T_ClassToTest<float, T_dim>>);
+        static_assert(IsPCastCallable<double, T_ClassToTest<double, T_dim>>);
+        // floating point precision loss
+        static_assert(IsPCastCallable<float, T_ClassToTest<double, T_dim>>);
+        // floating point up cast kept precision
+        static_assert(IsPCastCallable<double, T_ClassToTest<float, T_dim>>);
 
-        // Vec and Simd have the same required template signature, therefore we can combine the tests
-        auto testCases = []<uint32_t T_dim, template<typename, uint32_t> class T_ClassToTest>
-        {
-            // integral type identity
-            static_assert(IsPCastCallable<uint32_t, T_ClassToTest<uint32_t, T_dim>>);
-            static_assert(IsPCastCallable<uint64_t, T_ClassToTest<uint64_t, T_dim>>);
-            // down cast
-            static_assert(IsPCastCallable<uint32_t, T_ClassToTest<uint64_t, T_dim>>);
-            // sign flip
-            static_assert(IsPCastCallable<int32_t, T_ClassToTest<uint32_t, T_dim>>);
-            static_assert(IsPCastCallable<int32_t, T_ClassToTest<uint16_t, T_dim>>);
-            // integral and floating point cross casts
-            static_assert(IsPCastCallable<float, T_ClassToTest<int32_t, T_dim>>);
-            static_assert(IsPCastCallable<int32_t, T_ClassToTest<float, T_dim>>);
-            // floating point type identity
-            static_assert(IsPCastCallable<float, T_ClassToTest<float, T_dim>>);
-            static_assert(IsPCastCallable<double, T_ClassToTest<double, T_dim>>);
-            // floating point precision loss
-            static_assert(IsPCastCallable<float, T_ClassToTest<double, T_dim>>);
-            // floating point up cast kept precision
-            static_assert(IsPCastCallable<double, T_ClassToTest<float, T_dim>>);
+        // custom value type is not castable
+        static_assert(!IsPCastCallable<uint32_t, T_ClassToTest<Foo, T_dim>>);
+    }
 
-            // custom value type is not castable
-            static_assert(!IsPCastCallable<uint32_t, T_ClassToTest<Foo, T_dim>>);
-        };
+    ALPAKA_FN_ACC void operator()(auto const&) const
+    {
+        check<1u, Vec>();
+        check<2u, Vec>();
+        check<3u, Vec>();
+        check<4u, Vec>();
 
-        testCases.template operator()<1u, Vec>();
-        testCases.template operator()<2u, Vec>();
-        testCases.template operator()<3u, Vec>();
-        testCases.template operator()<4u, Vec>();
-
-        testCases.template operator()<1u, Simd>();
-        testCases.template operator()<2u, Simd>();
-        testCases.template operator()<3u, Simd>();
-        testCases.template operator()<4u, Simd>();
+        check<1u, Simd>();
+        check<2u, Simd>();
+        check<3u, Simd>();
+        check<4u, Simd>();
     }
 };
 

--- a/test/unit/utility/cast.cpp
+++ b/test/unit/utility/cast.cpp
@@ -1,0 +1,145 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <alpakaTest/deviceHelper.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+/** @file Test different casting methods. The cast test is a static compile time test within the kernel.
+ * This ensures that the device compiler is handling the tests, to avoid testing with the CPU host compiler only.
+ */
+using namespace alpaka;
+
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
+
+template<typename T_To, typename T_AnyInput>
+concept IsLpCastCallable = requires(T_AnyInput in) { lpCast<T_To>(in); };
+
+struct TestKernelLpCast
+{
+    ALPAKA_FN_ACC void operator()(auto const& acc) const
+    {
+        // Test type for user type conversion.
+        struct Foo
+        {
+        };
+
+        // Vec and Simd have the same required template signature, therefore we can combine the tests
+        auto testCases = []<uint32_t T_dim, template<typename, uint32_t> class T_ClassToTest>
+        {
+            // integral type identity
+            static_assert(IsLpCastCallable<uint32_t, T_ClassToTest<uint32_t, T_dim>>);
+            static_assert(IsLpCastCallable<uint64_t, T_ClassToTest<uint64_t, T_dim>>);
+            // down cast is forbidden
+            static_assert(!IsLpCastCallable<uint32_t, T_ClassToTest<uint64_t, T_dim>>);
+            // sign flip is forbidden if the original data is not fully representable
+            static_assert(!IsLpCastCallable<int32_t, T_ClassToTest<uint32_t, T_dim>>);
+            // sign flip is allowed if the original data is fully representable
+            static_assert(IsLpCastCallable<int32_t, T_ClassToTest<uint16_t, T_dim>>);
+            // integral to floating point
+            static_assert(IsLpCastCallable<float, T_ClassToTest<int16_t, T_dim>>);
+            static_assert(!IsLpCastCallable<float, T_ClassToTest<int32_t, T_dim>>);
+            // floating point to integral
+            static_assert(!IsLpCastCallable<int32_t, T_ClassToTest<float, T_dim>>);
+            // floating point type identity
+            static_assert(IsLpCastCallable<float, T_ClassToTest<float, T_dim>>);
+            static_assert(IsLpCastCallable<double, T_ClassToTest<double, T_dim>>);
+            // floating point precision loss is forbidden
+            static_assert(!IsLpCastCallable<float, T_ClassToTest<double, T_dim>>);
+            // floating point up cast kept precision
+            static_assert(IsLpCastCallable<double, T_ClassToTest<float, T_dim>>);
+
+            // custom value type is not castable
+            static_assert(!IsLpCastCallable<uint32_t, T_ClassToTest<Foo, T_dim>>);
+        };
+
+        testCases.template operator()<1u, Vec>();
+        testCases.template operator()<2u, Vec>();
+        testCases.template operator()<3u, Vec>();
+        testCases.template operator()<4u, Vec>();
+
+        testCases.template operator()<1u, Simd>();
+        testCases.template operator()<2u, Simd>();
+        testCases.template operator()<3u, Simd>();
+        testCases.template operator()<4u, Simd>();
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("lpCast", "[utility][lpCast]", TestBackends)
+{
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
+
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
+
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    queue.enqueue(onHost::FrameSpec{1u, 1u, exec}, TestKernelLpCast{});
+
+    SUCCEED("Static test passed");
+}
+
+template<typename T_To, typename T_AnyInput>
+concept IsPCastCallable = requires(T_AnyInput in) { pCast<T_To>(in); };
+
+struct TestKernelPCast
+{
+    ALPAKA_FN_ACC void operator()(auto const& acc) const
+    {
+        // Test type for user type conversion.
+        struct Foo
+        {
+        };
+
+        // Vec and Simd have the same required template signature, therefore we can combine the tests
+        auto testCases = []<uint32_t T_dim, template<typename, uint32_t> class T_ClassToTest>
+        {
+            // integral type identity
+            static_assert(IsPCastCallable<uint32_t, T_ClassToTest<uint32_t, T_dim>>);
+            static_assert(IsPCastCallable<uint64_t, T_ClassToTest<uint64_t, T_dim>>);
+            // down cast
+            static_assert(IsPCastCallable<uint32_t, T_ClassToTest<uint64_t, T_dim>>);
+            // sign flip
+            static_assert(IsPCastCallable<int32_t, T_ClassToTest<uint32_t, T_dim>>);
+            static_assert(IsPCastCallable<int32_t, T_ClassToTest<uint16_t, T_dim>>);
+            // integral and floating point cross casts
+            static_assert(IsPCastCallable<float, T_ClassToTest<int32_t, T_dim>>);
+            static_assert(IsPCastCallable<int32_t, T_ClassToTest<float, T_dim>>);
+            // floating point type identity
+            static_assert(IsPCastCallable<float, T_ClassToTest<float, T_dim>>);
+            static_assert(IsPCastCallable<double, T_ClassToTest<double, T_dim>>);
+            // floating point precision loss
+            static_assert(IsPCastCallable<float, T_ClassToTest<double, T_dim>>);
+            // floating point up cast kept precision
+            static_assert(IsPCastCallable<double, T_ClassToTest<float, T_dim>>);
+
+            // custom value type is not castable
+            static_assert(!IsPCastCallable<uint32_t, T_ClassToTest<Foo, T_dim>>);
+        };
+
+        testCases.template operator()<1u, Vec>();
+        testCases.template operator()<2u, Vec>();
+        testCases.template operator()<3u, Vec>();
+        testCases.template operator()<4u, Vec>();
+
+        testCases.template operator()<1u, Simd>();
+        testCases.template operator()<2u, Simd>();
+        testCases.template operator()<3u, Simd>();
+        testCases.template operator()<4u, Simd>();
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("pCast", "[utility][pCast]", TestBackends)
+{
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
+
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
+
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    queue.enqueue(onHost::FrameSpec{1u, 1u, exec}, TestKernelPCast{});
+
+    SUCCEED("Static test passed");
+}


### PR DESCRIPTION
Add a static compile test to check that `pCast` and `lpCast` is callable. 
It is not validating the results, this should be added to the tests for the corresponding types because both cast methods change the type signature.
The casting methods are also allowed to return an absolutely different type; that's not the case at the moment, but it's not forbidden.

Fix their broken `isConvertible_v` implementation found by the test.

note: `SimdMask` is currently not tested because the value type of `SimdMask` is always `bool` even if a mask is stored as a value bit mask. How to test this is out of scope for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the compile-time type-conversion rules used by vector operations by refining the “convertible” concept.
  * Corrected the default storage policy selection for `Vec` and `Simd` so the intended storage type is consistently used.

* **Tests**
  * Added device-side compile-time checks for `lpCast` and `pCast`, validating which casts are accepted or rejected across common `Vec`/`Simd` sizes and types (including negative/non-castable cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->