### PR TITLE
set CMake project langugage to NONE Pt. I

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ project(
     VERSION ${alpaka_VERSION_MAJOR}.${alpaka_VERSION_MINOR}.${alpaka_VERSION_PATCH}
     DESCRIPTION "The alpaka library is a header-only C++20 abstraction library for accelerator development."
     HOMEPAGE_URL "https://github.com/alpaka-group/alpaka3"
+    LANGUAGES NONE
 )
 
 # This file's directory.


### PR DESCRIPTION
If no project lanugage is specified, the langugage is set to C and C++. Therefore CMake requires a C compiler, which is not used.

This is the first PR, which sets the language. In a second PR, the C compiler is removed from the CI. I cannot do this in one PR, because the fetch content example pulls the alpaka dev branch version, which stills requires a C compiler. Therefore this PR needs to be merged first that the dev branch version does not require a C compiler anymore.

- fetch Content example: https://github.com/alpaka-group/alpaka3/blob/c72b12e1b30984a7632db5254c1a29f7c582e078/docs/snippets/fetchContent/CMakeLists.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project initialization so CMake won’t automatically enable any language toolchains during configuration.
  * Improved CI CMake configuration by adding a compiler-selection fallback and explicitly passing the C compiler to CMake during configure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->