### PR TITLE
CI: add hip runtime jobs in GitLab CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
                 echo "APCI_BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
             fi
       - name: job configuration environment variables
-        run: $APCI_ALPAKA_ROOT/script/ci/job_info.sh
+        run: "${APCI_ALPAKA_ROOT}/script/ci/job_info.sh"
       # Install base dependencies
       - name: Install base dependencies
         run: |
@@ -183,10 +183,10 @@ jobs:
           echo "TSAN_OPTIONS=suppressions=${SANITIZERS_DIR}/tsan_suppressions.txt,ignore_noninstrumented_modules=1" >> $GITHUB_ENV
           echo "LSAN_OPTIONS=suppressions=${SANITIZERS_DIR}/lsan_suppressions.txt" >> $GITHUB_ENV
           echo "UBSAN_OPTIONS=suppressions=${SANITIZERS_DIR}/ubsan_suppressions.txt" >> $GITHUB_ENV
-          $APCI_ALPAKA_ROOT/script/ci/utils/install_helper_apps.sh
+          "${APCI_ALPAKA_ROOT}/script/ci/utils/install_helper_apps.sh"
 
       - name: Install CMake
-        run: $APCI_ALPAKA_ROOT/script/ci/install/cmake.sh
+        run: "${APCI_ALPAKA_ROOT}/script/ci/install/cmake.sh"
       - name: Install oneTBB
         if: matrix.config.tbb == 'on' && matrix.config.compiler != 'icpx'
         run: |
@@ -194,18 +194,18 @@ jobs:
           apt-get update
           apt-get install -y libtbb-dev
       - name: Install GCC
-        run: $APCI_ALPAKA_ROOT/script/ci/install/gcc.sh
+        run: "${APCI_ALPAKA_ROOT}/script/ci/install/gcc.sh"
       # Install Clang if specified
       - name: Install Clang
         shell: bash
         if: matrix.config.compiler == 'clang' && matrix.config.hip == 'no'
-        run: $APCI_ALPAKA_ROOT/script/ci/install/clang.sh
+        run: "${APCI_ALPAKA_ROOT}/script/ci/install/clang.sh"
 
       # ROCm
       - name: Install ROCm
         if: matrix.config.hip != 'no'
         shell: bash
-        run: $APCI_ALPAKA_ROOT/script/ci/install/rocm.sh
+        run: "${APCI_ALPAKA_ROOT}/script/ci/install/rocm.sh"
 
       # intel oneAPI ipcx
       - name: Install oneAPI
@@ -226,12 +226,12 @@ jobs:
 
       # Configure CMake with the selected compiler and options
       - name: Configure CMake
-        run: $APCI_ALPAKA_ROOT/script/ci/configure.sh
+        run: "${APCI_ALPAKA_ROOT}/script/ci/configure.sh"
       - name: Compile Code
-        run: $APCI_ALPAKA_ROOT/script/ci/build.sh
+        run: "${APCI_ALPAKA_ROOT}/script/ci/build.sh"
       - name: Run tests
         if: matrix.config.cuda == 'no' && matrix.config.hip == 'no'
-        run: $APCI_ALPAKA_ROOT/script/ci/test.sh
+        run: "${APCI_ALPAKA_ROOT}/script/ci/test.sh"
       - name: Configure CMake (old solution)
         run: |
           mkdir build && cd build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 .base:
   variables:
     APCI_ALPAKA_ROOT: "$CI_PROJECT_DIR"
-    APCI_RUN_CTEST: ON
+    APCI_RUN_CTEST: "ON"
     APCI_HIP : 0
   script:
     - $APCI_ALPAKA_ROOT/script/ci/job_info.sh
@@ -12,6 +12,12 @@
   tags:
   - x86_64
   - cpuonly
+
+.hip:
+  extends: .base
+  tags:
+    - x86_64
+    - rocm
 
 gcc-13:
   image: docker.io/ubuntu:24.04
@@ -55,26 +61,50 @@ clang-20-agc:
     APCI_DEVICE_COMPILER : clang@20
     APCI_CMAKE: 3.31.4
 
+hipcc-6.2-agc:
+  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu22.04-rocm6.2:4.0
+  extends: .hip
+  variables:
+    APCI_DEVICE_COMPILER : clang@18
+    APCI_CMAKE: 3.31.4
+    APCI_HIP : 6.2
+
+hipcc-6.3-rocm-container:
+  image: rocm/dev-ubuntu-24.04:6.3.4
+  extends: .hip
+  variables:
+    APCI_DEVICE_COMPILER : clang@18
+    APCI_CMAKE: 3.28.3
+    APCI_HIP : 6.3
+
+hipcc-6.4:
+  image: docker.io/ubuntu:24.04
+  extends: .hip
+  variables:
+    APCI_DEVICE_COMPILER : clang@21
+    APCI_CMAKE: 3.28.3
+    APCI_HIP : 6.4.2
+
 hipcc-7.0:
   image: ubuntu:24.04
-  extends: .base
+  extends: .hip
   variables:
     APCI_DEVICE_COMPILER : clang@20
     APCI_CMAKE: 3.31.4
     APCI_HIP : 7.0
 
-hipcc-7.2-agc:
-  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu24.04-gcc:4.0
-  extends: .base
+hipcc-7.1:
+  image: docker.io/ubuntu:24.04
+  extends: .hip
+  variables:
+    APCI_DEVICE_COMPILER : clang@20
+    APCI_CMAKE: 3.28.3
+    APCI_HIP : 7.1
+
+hipcc-7.2-rocm-container:
+  image: rocm/dev-ubuntu-24.04:7.2
+  extends: .hip
   variables:
     APCI_DEVICE_COMPILER : clang@22
     APCI_CMAKE: 3.28.3
     APCI_HIP : 7.2
-
-hipcc-6.3-agc:
-  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu24.04-rocm6.3:addubuntu2204cudacontainer-4.0
-  extends: .base
-  variables:
-    APCI_DEVICE_COMPILER : clang@21
-    APCI_CMAKE: 3.28.3
-    APCI_HIP : 6.3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@
     - $APCI_ALPAKA_ROOT/script/ci/configure.sh
     - $APCI_ALPAKA_ROOT/script/ci/build.sh
     - $APCI_ALPAKA_ROOT/script/ci/test.sh
+  interruptible: true
   tags:
   - x86_64
   - cpuonly

--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -12,7 +12,7 @@ script_msg "Run CMake build (build.sh)"
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 # TODO: remove me, if all install scripts are ported
-if [[ "$compiler_name" == "gcc" || ("$compiler_name" == "clang" && "$APCI_HIP" == 0) ]]; then
+if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
     load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 
     echo_green "${APCI_CMAKE_BIN_PATH}/cmake --build /build -j"

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -52,14 +52,7 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
 
     if [[ "$APCI_HIP" != 0 ]]; then
         load_variable_if_not_exist ROCM_PATH
-        load_variable_if_not_exist HIP_PLATFORM
-        load_variable_if_not_exist HIP_DEVICE_LIB_PATH
-        load_variable_if_not_exist HSA_PATH
 
-        export ROCM_PATH
-        export HIP_PLATFORM
-        export HIP_DEVICE_LIB_PATH
-        export HSA_PATH
         export PATH=${ROCM_PATH}/bin:$PATH
         export PATH=${ROCM_PATH}/llvm/bin:$PATH
         export CMAKE_PREFIX_PATH=$ROCM_PATH:$CMAKE_PREFIX_PATH

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -67,8 +67,8 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
         ap_deps['alpaka_DEP_HIP']=ON
 
         CMAKE_ARGS+=(
-            -DCMAKE_HIP_ARCHITECTURES=gfx906
-            -DAMDGPU_TARGETS=gfx906)
+            -DCMAKE_HIP_ARCHITECTURES="${APCI_AMD_GPU_ARCH}"
+            -DGPU_TARGETS="${APCI_AMD_GPU_ARCH}")
     fi
 
     for dep in "${!ap_deps[@]}"; do

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -59,9 +59,11 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
 
         ap_deps['alpaka_DEP_HIP']=ON
 
-        CMAKE_ARGS+=(
-            -DCMAKE_HIP_ARCHITECTURES="${APCI_AMD_GPU_ARCH}"
-            -DGPU_TARGETS="${APCI_AMD_GPU_ARCH}")
+        if [[ -n ${APCI_AMD_GPU_ARCH+x} ]]; then
+            CMAKE_ARGS+=(
+                -DCMAKE_HIP_ARCHITECTURES="${APCI_AMD_GPU_ARCH}"
+                -DGPU_TARGETS="${APCI_AMD_GPU_ARCH}")
+        fi
     fi
 
     for dep in "${!ap_deps[@]}"; do

--- a/script/ci/install/rocm.sh
+++ b/script/ci/install/rocm.sh
@@ -10,7 +10,7 @@
 source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
 
 if [[ "$APCI_OS_NAME" != "Linux" ]]; then
-    exit_error "Install GCC script does not support Windows or MacOS"
+    exit_error "Install ROCm script does not support Windows or MacOS"
 fi
 
 : "${APCI_HIP?'The rocm version must be specified'}"
@@ -44,8 +44,10 @@ if [[ "$APCI_HIP" != 0 ]]; then
             source /etc/os-release
             echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${APCI_HIP} ${VERSION_CODENAME} main" |
                 sudo tee -a /etc/apt/sources.list.d/rocm.list
-            echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/${APCI_HIP}/ubuntu ${VERSION_CODENAME} main" |
-                sudo tee -a /etc/apt/sources.list.d/rocm.list
+            if [ "$(version "${APCI_HIP}")" -ge "$(version "7")" ]; then
+                echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/${APCI_HIP}/ubuntu ${VERSION_CODENAME} main" |
+                    sudo tee -a /etc/apt/sources.list.d/rocm.list
+            fi
 
             retry_cmd sudo DEBIAN_FRONTEND=noninteractive apt update
 
@@ -66,8 +68,6 @@ if [[ "$APCI_HIP" != 0 ]]; then
                 "rocm-device-libs${APCI_ROCM}" \
                 "rocm-core${APCI_ROCM}" \
                 "rocm-smi-lib${APCI_ROCM}"
-
-            function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
             if [ "$(version "${APCI_ROCM}")" -ge "$(version "6.0.0")" ]; then
                 quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \

--- a/script/ci/install/rocm.sh
+++ b/script/ci/install/rocm.sh
@@ -78,15 +78,8 @@ if [[ "$APCI_HIP" != 0 ]]; then
     fi
 
     export ROCM_PATH
-    # TODO: CHECK if HIP_PLATFORM, HIP_DEVICE_LIB_PATH and HSA_PATH are still required
-    export HIP_PLATFORM="amd"
-    export HIP_DEVICE_LIB_PATH=${ROCM_PATH}/amdgcn/bitcode
-    export HSA_PATH=$ROCM_PATH
     export APCI_C_COMPILER="${ROCM_PATH}/llvm/bin/clang"
     export APCI_CXX_COMPILER="${ROCM_PATH}/llvm/bin/clang++"
-
-    export PATH=${ROCM_PATH}/bin:$PATH
-    export PATH=${ROCM_PATH}/llvm/bin:$PATH
 
     echo_green "${APCI_C_COMPILER} --version"
     $APCI_C_COMPILER --version
@@ -94,15 +87,12 @@ if [[ "$APCI_HIP" != 0 ]]; then
     $APCI_CXX_COMPILER --version
 
     echo_green "hipconfig --platform"
-    hipconfig --platform
+    "${ROCM_PATH}"/bin/hipconfig --platform
     echo_green "\nhipconfig --v"
-    hipconfig -v
+    "${ROCM_PATH}"/bin/hipconfig -v
     echo
 
     store_variable ROCM_PATH
-    store_variable HIP_PLATFORM
-    store_variable HIP_DEVICE_LIB_PATH
-    store_variable HSA_PATH
     store_variable APCI_C_COMPILER
     store_variable APCI_CXX_COMPILER
 fi

--- a/script/ci/test.sh
+++ b/script/ci/test.sh
@@ -12,7 +12,8 @@ script_msg "Run CTest (test.sh)"
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 # TODO: remove me, if all install scripts are ported
-if [[ "$compiler_name" == "gcc" || ("$compiler_name" == "clang" && "$APCI_HIP" == 0) ]]; then
+# HIP jobs will be tested
+if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
     if [[ "${APCI_RUN_CTEST}" == "ON" ]]; then
         load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -53,6 +53,17 @@ parse_compiler_version() {
     export compiler_version
 }
 
+# parse a string containing a version number to a format, which can be compare in a if statement
+#
+# e.g.  if [ "$(version "${APCI_ROCM}")" -ge "$(version "6.0.0")" ]; then
+#
+# allowed version numbers:
+# - major: 7
+# - major.minor: 7.1
+# - major-minor.patch: 7.1.2
+# - major-minor.patch.subpatch: 7.1.2.8
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
 # If an error occurs (command does not return 0), try running the command again.
 # Usage: retry_cmd command arg1 arg2 ...
 #

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -22,7 +22,7 @@ if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     fi
 
     # there are no GPU runner on GitHub, therefore simply choose one architecture
-    APCI_AMD_GPU_ARCH=gfx1030
+    APCI_AMD_GPU_ARCH=gfx90a
     export APCI_AMD_GPU_ARCH
 fi
 
@@ -60,7 +60,7 @@ if [[ -n ${GITLAB_CI+x} ]]; then
             APCI_AMD_GPU_ARCH=$CI_GPU_ARCH
         else
             # in compile only jobs, use simply this architecture
-            APCI_AMD_GPU_ARCH=gfx1030
+            APCI_AMD_GPU_ARCH=gfx90a
         fi
     fi
     export APCI_AMD_GPU_ARCH

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -20,6 +20,10 @@ if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     if [[ -z ${APCI_HIP+x} ]]; then
         export APCI_HIP=0
     fi
+
+    # there are no GPU runner on GitHub, therefore simply choose one architecture
+    APCI_AMD_GPU_ARCH=gfx1030
+    export APCI_AMD_GPU_ARCH
 fi
 
 if [[ -n ${GITLAB_CI+x} ]]; then
@@ -49,4 +53,15 @@ if [[ -n ${GITLAB_CI+x} ]]; then
         export APCI_GIT_URL="https://github.com/alpaka-group/alpaka3.git"
         export APCI_BRANCH_NAME="${CI_COMMIT_REF_NAME}"
     fi
+
+    if [[ "$APCI_HIP" != 0 ]]; then
+        # on the GPU runner, the variable CI_GPU_ARCH is predefined
+        if [[ -n ${CI_GPU_ARCH} ]]; then
+            APCI_AMD_GPU_ARCH=$CI_GPU_ARCH
+        else
+            # in compile only jobs, use simply this architecture
+            APCI_AMD_GPU_ARCH=gfx1030
+        fi
+    fi
+    export APCI_AMD_GPU_ARCH
 fi


### PR DESCRIPTION
No full test coverage of ROCm. Only a functional test of the CI scripts.

- requires PR #537 because Ubuntu 22.04 only provides Python 3.10 which is not compatible with the current implementation of `var_storage`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded GPU CI coverage with refreshed HIP/ROCm job variants and runner targeting.
  * Added dynamic selection of the AMD GPU architecture for GPU build setups.
* **Bug Fixes**
  * Improved CI command robustness by consistently quoting repository path variables.
  * Updated build and test gating so Clang/HIP job flows execute the intended steps.
  * Refreshed ROCm installation and environment setup, including updated hipconfig usage and version-aware ROCm repo handling.
* **Chores**
  * Centralized version comparison logic for shell scripting utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->