### PR TITLE
allow to rerun cmake.sh script if CMake is already installed

### DIFF
--- a/script/ci/install/cmake/linux.sh
+++ b/script/ci/install/cmake/linux.sh
@@ -15,7 +15,11 @@ else
 
     _cmake_install_path="/opt/cmake/${APCI_CMAKE}"
     if [[ -d "${_cmake_install_path}" ]]; then
-        echo_yellow "${_cmake_install_path} already exist. Skip install."
+        if "${_cmake_install_path}/bin/cmake" --version; then
+            echo_yellow "${_cmake_install_path} already exist. Skip install."
+        else
+            exit_error "${_cmake_install_path}/bin/cmake is not installed"
+        fi
     else
 
         IFS="." read -r -a _cmake_ver_semantic <<<"${APCI_CMAKE}"
@@ -24,20 +28,23 @@ else
         _cmake_pkg_file_name_base=cmake-${APCI_CMAKE}-linux-x86_64
         _cmake_pkg_file_name=${_cmake_pkg_file_name_base}.tar.gz
 
+        _cmake_tmp_dir=$(mktemp -d)
+
         retry_cmd wget --no-verbose \
             https://cmake.org/files/v"${_cmake_ver_major}"."${_cmake_ver_minor}"/"${_cmake_pkg_file_name}" \
-            -O "/tmp/${_cmake_pkg_file_name}"
-        tar -xzf "/tmp/${_cmake_pkg_file_name}" -C /tmp
+            -O "${_cmake_tmp_dir}/${_cmake_pkg_file_name}"
+        tar -xzf "${_cmake_tmp_dir}/${_cmake_pkg_file_name}" -C "${_cmake_tmp_dir}"
 
         mkdir -p "${_cmake_install_path}"
-        sudo mv "/tmp/${_cmake_pkg_file_name_base}"/* "${_cmake_install_path}"
-        sudo rm -rf "/tmp/${_cmake_pkg_file_name_base}" "/tmp/${_cmake_pkg_file_name}"
+        sudo mv "${_cmake_tmp_dir}/${_cmake_pkg_file_name_base}"/* "${_cmake_install_path}"
+        sudo rm -rf "${_cmake_tmp_dir}"
 
         unset _cmake_ver_semantic \
             _cmake_ver_major \
             _cmake_ver_minor \
             _cmake_pkg_file_name_base \
-            _cmake_pkg_file_name
+            _cmake_pkg_file_name \
+            _cmake_tmp_dir
     fi
 
     APCI_CMAKE_BIN_PATH="${_cmake_install_path}/bin"

--- a/script/ci/install/cmake/linux.sh
+++ b/script/ci/install/cmake/linux.sh
@@ -15,31 +15,32 @@ else
 
     _cmake_install_path="/opt/cmake/${APCI_CMAKE}"
     if [[ -d "${_cmake_install_path}" ]]; then
-        exit_error "${_cmake_install_path} already exist"
+        echo_yellow "${_cmake_install_path} already exist. Skip install."
+    else
+
+        IFS="." read -r -a _cmake_ver_semantic <<<"${APCI_CMAKE}"
+        _cmake_ver_major="${_cmake_ver_semantic[0]}"
+        _cmake_ver_minor="${_cmake_ver_semantic[1]}"
+        _cmake_pkg_file_name_base=cmake-${APCI_CMAKE}-linux-x86_64
+        _cmake_pkg_file_name=${_cmake_pkg_file_name_base}.tar.gz
+
+        retry_cmd wget --no-verbose \
+            https://cmake.org/files/v"${_cmake_ver_major}"."${_cmake_ver_minor}"/"${_cmake_pkg_file_name}" \
+            -O "/tmp/${_cmake_pkg_file_name}"
+        tar -xzf "/tmp/${_cmake_pkg_file_name}" -C /tmp
+
+        mkdir -p "${_cmake_install_path}"
+        sudo mv "/tmp/${_cmake_pkg_file_name_base}"/* "${_cmake_install_path}"
+        sudo rm -rf "/tmp/${_cmake_pkg_file_name_base}" "/tmp/${_cmake_pkg_file_name}"
+
+        unset _cmake_ver_semantic \
+            _cmake_ver_major \
+            _cmake_ver_minor \
+            _cmake_pkg_file_name_base \
+            _cmake_pkg_file_name
     fi
-
-    IFS="." read -r -a _cmake_ver_semantic <<<"${APCI_CMAKE}"
-    _cmake_ver_major="${_cmake_ver_semantic[0]}"
-    _cmake_ver_minor="${_cmake_ver_semantic[1]}"
-    _cmake_pkg_file_name_base=cmake-${APCI_CMAKE}-linux-x86_64
-    _cmake_pkg_file_name=${_cmake_pkg_file_name_base}.tar.gz
-
-    retry_cmd wget --no-verbose \
-        https://cmake.org/files/v"${_cmake_ver_major}"."${_cmake_ver_minor}"/"${_cmake_pkg_file_name}" \
-        -O "/tmp/${_cmake_pkg_file_name}"
-    tar -xzf "/tmp/${_cmake_pkg_file_name}" -C /tmp
-
-    mkdir -p "${_cmake_install_path}"
-    sudo mv "/tmp/${_cmake_pkg_file_name_base}"/* "${_cmake_install_path}"
-    sudo rm -rf "/tmp/${_cmake_pkg_file_name_base}" "/tmp/${_cmake_pkg_file_name}"
 
     APCI_CMAKE_BIN_PATH="${_cmake_install_path}/bin"
     export APCI_CMAKE_BIN_PATH
-
-    unset _cmake_install_path \
-        _cmake_ver_semantic \
-        _cmake_ver_major \
-        _cmake_ver_minor \
-        _cmake_pkg_file_name_base \
-        _cmake_pkg_file_name
+    unset _cmake_install_path
 fi


### PR DESCRIPTION
- before, script failed if CMake was already installed
- now it throws a warning and skip the rest of the install process
- use case: run install_dependencies.sh many times in a local container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reusing an existing CMake install directory no longer breaks setup; it now checks that the `cmake` binary is runnable before skipping installation.
  * Improved the CMake install process for fresh installs by validating the right version, extracting safely using a temporary workspace, and cleaning up afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->