### PR TITLE
ci: install cuda via script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,28 +66,28 @@ jobs:
               env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: ON} }
           # nvcc CUDA (nvcc does not contain simd option because nvcc can not use std::simd and is always using simd emulation
           - { compiler: nvcc, version: "", cuda: "12.5", hip: "no", container: "nvidia/cuda:12.5.1-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : nvcc@12.5, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : nvcc@12.5, APCI_HOST_COMPILER : gcc@13 ,APCI_CMAKE : 3.28.3, APCI_CUDA: 12.5, APCI_RUN_CTEST: OFF} }
           - { compiler: nvcc, version: "", cuda: "12.6", hip: "no", container: "nvidia/cuda:12.6.3-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : nvcc@12.6, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : nvcc@12.6, APCI_HOST_COMPILER : gcc@13, APCI_CMAKE : 3.28.3, APCI_CUDA: 12.6, APCI_RUN_CTEST: OFF} }
           - { compiler: nvcc, version: "", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : nvcc@12.8, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : nvcc@12.8, APCI_HOST_COMPILER : gcc@13, APCI_CMAKE : 3.28.3, APCI_CUDA: 12.8, APCI_RUN_CTEST: OFF} }
           - { compiler: nvcc, version: "", cuda: "12.9", hip: "no", container: "nvidia/cuda:12.9.1-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : nvcc@12.9, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : nvcc@12.9, APCI_HOST_COMPILER : gcc@13, APCI_CMAKE : 3.28.3, APCI_CUDA: 12.9, APCI_RUN_CTEST: OFF} }
           - { compiler: nvcc, version: "", cuda: "13.0", hip: "no", container: "nvidia/cuda:13.0.0-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : nvcc@13.0, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : nvcc@13.0, APCI_HOST_COMPILER : gcc@13, APCI_CMAKE : 3.28.3, APCI_CUDA: 13.0, APCI_RUN_CTEST: OFF} }
           - { compiler: nvcc, version: "", cuda: "13.1", hip: "no", container: "nvidia/cuda:13.1.0-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : nvcc@13.1, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : nvcc@13.1, APCI_HOST_COMPILER : gcc@13, APCI_CMAKE : 3.28.3, APCI_CUDA: 13.1, APCI_RUN_CTEST: OFF} }
           - { compiler: nvcc, version: "", cuda: "13.2", hip: "no", container: "nvidia/cuda:13.2.0-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : nvcc@13.2, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : nvcc@13.2, APCI_HOST_COMPILER : gcc@13, APCI_CMAKE : 3.28.3, APCI_CUDA: 13.2, APCI_RUN_CTEST: OFF} }
           - { compiler: nvcc, version: "", cuda: "13.3", hip: "no", container: "nvidia/cuda:13.3.0-devel-ubuntu24.04",
-              env: { APCI_DEVICE_COMPILER: nvcc@13.3, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF } }
+              env: { APCI_DEVICE_COMPILER: nvcc@13.3, APCI_HOST_COMPILER : gcc@13, APCI_CMAKE : 3.28.3, APCI_CUDA: 13.3, APCI_RUN_CTEST: OFF } }
           # clang-cuda (device compile with clang)
           - { compiler: clang, version: "20", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : clang@20, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : clang@20, APCI_CMAKE : 3.28.3, APCI_CUDA: 12.8, APCI_RUN_CTEST: OFF} }
           - { compiler: clang, version: "21", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_CUDA: 12.8, APCI_RUN_CTEST: OFF} }
           - { compiler: clang, version: "21", cuda: "12.8", hip: "no", container: "nvidia/cuda:12.8.1-devel-ubuntu24.04", simd: "EMULATION", hwloc: "no",
-              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_CUDA: 12.8, APCI_RUN_CTEST: OFF} }
           # clang with ROCm HIP
           - { compiler: clang, version: "18", cuda: "no", hip: "6.2.4", container: "rocm/dev-ubuntu-24.04:6.2.4",
               env : {APCI_DEVICE_COMPILER : clang@18, APCI_CMAKE : 3.28.3, APCI_HIP: 6.2.4, APCI_RUN_CTEST: OFF} }
@@ -200,6 +200,12 @@ jobs:
         shell: bash
         if: matrix.config.compiler == 'clang' && matrix.config.hip == 'no'
         run: "${APCI_ALPAKA_ROOT}/script/ci/install/clang.sh"
+
+      # CUDA
+      - name: Install CUDA
+        if: matrix.config.cuda != 'no'
+        shell: bash
+        run: $APCI_ALPAKA_ROOT/script/ci/install/cuda.sh
 
       # ROCm
       - name: Install ROCm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@
     APCI_RUN_CTEST: "ON"
     APCI_EXEC_CPU_SERIAL: "OFF"
     APCI_HIP : 0
+    APCI_CUDA : 0
     APCI_ONEAPI : 0
     APCI_ONEAPI_TARGET: none
   script:
@@ -22,6 +23,15 @@
   tags:
     - x86_64
     - rocm
+
+.cuda:
+  extends: .base
+  image: ubuntu:24.04
+  variables:
+    APCI_CMAKE: 3.28.3
+  tags:
+  - x86_64
+  - cuda
 
 gcc-13:
   image: docker.io/ubuntu:24.04
@@ -213,3 +223,87 @@ icpx-2026.0-gpu-intel-container:
     APCI_ONEAPI: 2026.0
     APCI_ONEAPI_TARGET: intel_gpu
     APCI_RUN_CTEST: "OFF"
+
+cuda-12.5-gcc-agc:
+  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu24.04-cuda125:4.0
+  extends: .cuda
+  variables:
+    APCI_DEVICE_COMPILER: nvcc@12.5
+    APCI_HOST_COMPILER: gcc@13
+    APCI_CUDA: 12.5
+
+cuda-12.6-gcc:
+  extends: .cuda
+  variables:
+    APCI_DEVICE_COMPILER: nvcc@12.6
+    APCI_HOST_COMPILER: gcc@13
+    APCI_CUDA: 12.6
+
+cuda-12.8-gcc:
+  extends: .cuda
+  variables:
+    APCI_DEVICE_COMPILER: nvcc@12.8
+    APCI_HOST_COMPILER: gcc@13
+    APCI_CUDA: 12.8
+
+cuda-12.9-gcc-nvidia-container:
+  image: nvidia/cuda:12.9.1-devel-ubuntu24.04
+  extends: .cuda
+  variables:
+    APCI_DEVICE_COMPILER: nvcc@12.9
+    APCI_HOST_COMPILER: gcc@13
+    APCI_CUDA: 12.9
+
+cuda-13.0-gcc:
+  extends: .cuda
+  variables:
+    APCI_DEVICE_COMPILER: nvcc@13.0
+    APCI_HOST_COMPILER: gcc@13
+    APCI_CUDA: 13.0
+  tags:
+  - x86_64
+  - cuda
+  - a100
+
+cuda-13.1-gcc:
+  extends: .cuda
+  variables:
+    APCI_DEVICE_COMPILER: nvcc@13.1
+    APCI_HOST_COMPILER: gcc@13
+    APCI_CUDA: 13.1
+  tags:
+  - x86_64
+  - cuda
+  - a100
+
+cuda-13.2-gcc:
+  extends: .cuda
+  variables:
+    APCI_DEVICE_COMPILER: nvcc@13.2
+    APCI_HOST_COMPILER: gcc@13
+    APCI_CUDA: 13.2
+  tags:
+  - x86_64
+  - cuda
+  - a100
+
+cuda-13.3-gcc:
+  extends: .cuda
+  variables:
+    APCI_DEVICE_COMPILER: nvcc@13.3
+    APCI_HOST_COMPILER: gcc@13
+    APCI_CUDA: 13.3
+  tags:
+  - x86_64
+  - cuda
+  - a100
+
+clang-21-cuda-12.8:
+  extends: .cuda
+  variables:
+    APCI_DEVICE_COMPILER: clang@21
+    APCI_CUDA: 12.8
+  tags:
+  - x86_64
+  - cuda
+  - a100

--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -66,14 +66,16 @@ if [[ -z ${APCI_BUILD_THREADS+x} ]]; then
     fi
 
     APCI_BUILD_THREADS=$(get_build_threads "${max_num_build_threads}" "${total_memory_bytes}")
+    echo_green "Set APCI_BUILD_THREADS to overwrite automatically calculated number of build threads."
+else
+    echo_yellow "Use number of build threads set via APCI_BUILD_THREADS=${APCI_BUILD_THREADS}."
 fi
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 # TODO: remove me, if all install scripts are ported
-if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "icpx" ]]; then
+if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "nvcc" || "$compiler_name" == "icpx" ]]; then
     load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 
-    echo_green "Set APCI_BUILD_THREADS to overwrite automatically calculated number of build threads."
     echo_green "$(echo_if_not_empty LD_LIBRARY_PATH)" \
         "${APCI_CMAKE_BIN_PATH}/cmake" \
         --build /build \

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -13,10 +13,9 @@ script_msg "Run CMake configure (configure.sh)"
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 
 CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-""}
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-""}
 
 # TODO: remove me, if all install scripts are ported
-if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "icpx" ]]; then
+if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "nvcc" || "$compiler_name" == "icpx" ]]; then
     load_variable_if_not_exist APCI_CMAKE_BIN_PATH
     load_variable_if_not_exist APCI_C_COMPILER
     load_variable_if_not_exist APCI_CXX_COMPILER
@@ -66,6 +65,25 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
             CMAKE_ARGS+=(
                 -DCMAKE_HIP_ARCHITECTURES="${APCI_AMD_GPU_ARCH}"
                 -DGPU_TARGETS="${APCI_AMD_GPU_ARCH}")
+        fi
+    fi
+
+    if [[ "$APCI_CUDA" != 0 ]]; then
+        load_variable_if_not_exist CMAKE_CUDA_COMPILER
+
+        ap_deps['CUDA']=ON
+
+        CMAKE_ARGS+=(
+            -DCMAKE_CUDA_COMPILER="${CMAKE_CUDA_COMPILER}"
+            -Dalpaka_SUPPRESS_TARGET_WARNING=ON
+        )
+
+        if [[ -n ${APCI_CUDA_SM_LEVEL+x} ]]; then
+            CMAKE_ARGS+=(-DCMAKE_CUDA_ARCHITECTURES="${APCI_CUDA_SM_LEVEL}")
+        fi
+
+        if [[ "${CMAKE_CUDA_COMPILER}" =~ "nvcc" ]]; then
+            CMAKE_ARGS+=(-DCMAKE_CUDA_HOST_COMPILER="$APCI_CXX_COMPILER")
         fi
     fi
 

--- a/script/ci/install/clang.sh
+++ b/script/ci/install/clang.sh
@@ -17,6 +17,11 @@ fi
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 
+if [[ "$compiler_name" == "nvcc" ]]; then
+    : "${APCI_HOST_COMPILER?'The device compiler was detected. Therefore the host compiler needs to be set'}"
+    parse_compiler_version "$APCI_HOST_COMPILER"
+fi
+
 script_msg "Install Clang"
 
 #TODO(SimeonEhrig): remove this statement, if ppa's are fixed in alpaka-group-container

--- a/script/ci/install/cuda.sh
+++ b/script/ci/install/cuda.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+# shellcheck source=script/ci/utils/default.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
+
+if [[ "$APCI_OS_NAME" != "Linux" ]]; then
+    exit_error "Install CUDA script does not support Windows or MacOS"
+fi
+
+: "${APCI_CUDA?'The cuda version must be specified'}"
+
+script_msg "Install CUDA"
+
+if [[ "$APCI_CUDA" != 0 ]]; then
+    # To simplify the script, we assume that the host compiler is already installed
+    load_variable APCI_CXX_COMPILER
+    if agc-manager -e "cuda@${APCI_CUDA}"; then
+        echo_green "cuda@${APCI_CUDA}"
+        APCI_CUDA_PATH=$(agc-manager -b "cuda@${APCI_CUDA}")
+    else
+        if [[ "${APCI_IMAGE_NAME}" =~ "nvidia/cuda" ]]; then
+            echo_green "use preinstalled cuda from official cuda container"
+            APCI_CUDA_PATH=/usr/local/cuda
+        else
+            install_msg "CUDA ${APCI_CUDA} via apt"
+
+            if [[ "$(cat /etc/os-release)" == *"24.04"* ]]; then
+                cuda_ubuntu_distro=ubuntu2404
+            elif [[ "$(cat /etc/os-release)" == *"26.04"* ]]; then
+                cuda_ubuntu_distro=ubuntu2604
+            else
+                exit_error "Install CUDA: unknown os-release: $(cat /etc/os-release)"
+            fi
+
+            if [ "${APCI_CUDA}" == "12.0" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-12-0-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_12.0.1-525.85.12-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/12.0.1/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "12.1" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-12-1-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_12.1.1-530.30.02-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "12.2" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-12-2-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_12.2.2-535.104.05-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "12.3" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-12-3-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_12.3.2-545.23.08-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/12.3.2/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "12.4" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-12-4-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_12.4.1-550.54.15-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "12.5" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-12-5-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_12.5.1-555.42.06-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/12.5.1/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "12.6" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-12-6-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_12.6.3-560.35.05-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/12.6.3/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "12.8" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-12-8-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_12.8.1-570.124.06-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "12.9" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-12-9-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_12.9.1-575.57.08-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/12.9.1/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "13.0" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-13-0-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_13.0.2-580.95.05-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/13.0.2/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "13.1" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-13-1-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_13.1.2-590.48.01-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/13.1.2/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "13.2" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-13-2-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_13.2.1-595.58.03-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/13.2.1/local_installers/${cuda_pkg_file_name}
+            elif [ "${APCI_CUDA}" == "13.3" ]; then
+                cuda_pkg_deb_name=cuda-repo-"${cuda_ubuntu_distro}"-13-3-local
+                cuda_pkg_file_name="${cuda_pkg_deb_name}"_13.3.0-610.43.02-1_amd64.deb
+                cuda_pkg_file_file_path=https://developer.download.nvidia.com/compute/cuda/13.3.0/local_installers/${cuda_pkg_file_name}
+            else
+                exit_error "CUDA versions other than 12.0-13.3 are not currently supported on linux!"
+            fi
+
+            # use dash instead of dot as version delimiter
+            cuda_version_dash=${APCI_CUDA//./-}
+
+            cuda_apt_package_list=(cuda-compiler-"${cuda_version_dash}"
+                cuda-cudart-"${cuda_version_dash}"
+                cuda-cudart-dev-"${cuda_version_dash}"
+                libcurand-"${cuda_version_dash}"
+                libcurand-dev-"${cuda_version_dash}"
+                libcublas-"${cuda_version_dash}"
+                libcublas-dev-"${cuda_version_dash}"
+            )
+
+            if dpkg -s "${cuda_apt_package_list[@]}" >/dev/null 2>&1; then
+                echo_yellow "CUDA ${APCI_CUDA} is already installed via apt. Skip installation."
+            else
+                tmp_dir=$(mktemp -d)
+                echo_green "wget --no-verbose -O ${tmp_dir}/${cuda_pkg_file_name} ${cuda_pkg_file_file_path}"
+                retry_cmd wget --no-verbose -O "${tmp_dir}"/"${cuda_pkg_file_name}" "${cuda_pkg_file_file_path}"
+                sudo dpkg --install "${tmp_dir}"/"${cuda_pkg_file_name}"
+
+                sudo cp /var/"${cuda_pkg_deb_name}"/cuda-*-keyring.gpg /usr/share/keyrings
+                DEBIAN_FRONTEND=noninteractive retry_cmd apt update
+
+                # Install CUDA
+                # Currently we do not install CUDA fully: sudo apt-get --quiet -y install cuda
+                # We only install the minimal packages. Because of our manual partial installation we have to create a symlink at /usr/local/cuda
+                quiet_run sudo DEBIAN_FRONTEND=noninteractive apt -y --no-install-recommends install "${cuda_apt_package_list[@]}"
+
+                if [[ -n ${APCI_HOST_COMPILER+x} ]]; then
+                    parse_compiler_version "$APCI_HOST_COMPILER"
+                    if [[ "$compiler_name" == "clang" ]]; then
+                        quiet_run sudo DEBIAN_FRONTEND=noninteractive \
+                            apt -y --no-install-recommends install g++-multilib
+                    fi
+                fi
+
+                # clean up
+                sudo rm -rf "${tmp_dir}"/"${cuda_pkg_file_name}"
+                sudo dpkg --purge "${cuda_pkg_deb_name}"
+            fi
+
+            APCI_CUDA_PATH=/usr/local/cuda-"${APCI_CUDA}"
+        fi
+    fi
+
+    parse_compiler_version "$APCI_DEVICE_COMPILER"
+
+    if [[ "${compiler_name}" == "nvcc" ]]; then
+        CMAKE_CUDA_COMPILER="${APCI_CUDA_PATH}/bin/nvcc"
+        CMAKE_CUDA_HOST_COMPILER="${APCI_CXX_COMPILER}"
+
+        echo_green "${CMAKE_CUDA_COMPILER} --version"
+        ${CMAKE_CUDA_COMPILER} --version
+        echo_green "${CMAKE_CUDA_HOST_COMPILER} --version"
+        ${CMAKE_CUDA_HOST_COMPILER} --version
+
+        store_variable CMAKE_CUDA_HOST_COMPILER
+    elif [[ "${compiler_name}" == "clang" ]]; then
+        CMAKE_CUDA_COMPILER="${APCI_CXX_COMPILER}"
+
+        echo_green "${CMAKE_CUDA_COMPILER} --version"
+        ${CMAKE_CUDA_COMPILER} --version
+    else
+        exit_error "Device compiler is neither nvcc nor clang: ${compiler_name}"
+    fi
+
+    store_variable CMAKE_CUDA_COMPILER
+fi

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -17,6 +17,11 @@ fi
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 
+if [[ "$compiler_name" == "nvcc" ]]; then
+    : "${APCI_HOST_COMPILER?'The device compiler was detected. Therefore the host compiler needs to be set'}"
+    parse_compiler_version "$APCI_HOST_COMPILER"
+fi
+
 script_msg "Install GCC"
 
 if [[ "$compiler_name" == "gcc" ]]; then

--- a/script/ci/install_dependencies.sh
+++ b/script/ci/install_dependencies.sh
@@ -25,5 +25,7 @@ source "${APCI_ALPAKA_ROOT}/script/ci/install/gcc.sh"
 source "${APCI_ALPAKA_ROOT}/script/ci/install/clang.sh"
 # shellcheck source=script/ci/install/rocm.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/install/rocm.sh"
+# shellcheck source=script/ci/install/cuda.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/install/cuda.sh"
 # shellcheck source=script/ci/install/oneapi.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi.sh"

--- a/script/ci/job_info/linux.sh
+++ b/script/ci/job_info/linux.sh
@@ -9,11 +9,11 @@
 
 echo_yellow "1. Run the container. There are two options.\n
   1.1 Run the container and clone alpaka from the internet.
-    - docker run -it ${APCI_IMAGE_NAME} bash
+    - docker run -it --rm ${APCI_IMAGE_NAME} bash
     - apt update && apt install -y git
     - git clone ${APCI_GIT_URL} --depth 1 -b ${APCI_BRANCH_NAME} /alpaka
   1.2 Run the container and mount locally alpaka project.
-    - docker run -it -v /path/to/local/alpaka:/alpaka ${APCI_IMAGE_NAME} bash
+    - docker run -it --rm -v /path/to/local/alpaka:/alpaka ${APCI_IMAGE_NAME} bash
 "
 
 echo_yellow "2. Set the environment variables.\n"

--- a/script/ci/test.sh
+++ b/script/ci/test.sh
@@ -26,7 +26,7 @@ fi
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 # TODO: remove me, if all install scripts are ported
 # HIP jobs will be tested
-if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "icpx" ]]; then
+if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "nvcc" || "$compiler_name" == "icpx" ]]; then
     if [[ "${APCI_RUN_CTEST}" == "ON" ]]; then
         load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -32,6 +32,13 @@ if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     APCI_AMD_GPU_ARCH=gfx90a
     export APCI_AMD_GPU_ARCH
 
+    if [[ ! "${APCI_DEVICE_COMPILER}" =~ "nvcc" ]] && [[ -z ${APCI_CUDA+x} ]]; then
+        export APCI_CUDA=0
+    fi
+
+    # GitHub actions has no free GPU runner, therefore choose simply a single SM level
+    export APCI_CUDA_SM_LEVEL=80
+
     if [[ ! "${APCI_DEVICE_COMPILER}" =~ "icpx" ]] && [[ -z ${APCI_ONEAPI+x} ]]; then
         export APCI_ONEAPI=0
     fi
@@ -79,4 +86,15 @@ if [[ -n ${GITLAB_CI+x} ]]; then
         fi
     fi
     export APCI_AMD_GPU_ARCH
+
+    if [[ "$APCI_CUDA" != 0 ]]; then
+        # on the GPU runner, the variable CI_GPU_ARCH is predefined
+        if [[ -n ${CI_GPU_ARCH} ]]; then
+            APCI_CUDA_SM_LEVEL="${CI_GPU_ARCH}"
+        else
+            # in compile only jobs, use simply this architecture
+            APCI_CUDA_SM_LEVEL=80
+        fi
+    fi
+    export APCI_CUDA_SM_LEVEL
 fi


### PR DESCRIPTION
The CI supports scripts supports nvcc + clang as host compiler. We didn't test it yet and it fails to compile. I will not fix this in this PR because the PR is already complicated. Instead it will be done in an upcoming PR.

Failed job: https://gitlab.com/hzdr/crp/alpaka3/-/jobs/15132086331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added broader CUDA CI coverage across multiple compiler and CUDA version combinations.
  * Introduced automatic CUDA setup in CI jobs when GPU builds are enabled.

* **Bug Fixes**
  * Improved handling of CUDA builds so configuration, build, and test steps now run correctly for NVIDIA compiler setups.
  * Updated CI defaults and setup logic to better detect CUDA hardware and compiler settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->