### PR TITLE
CI: add helper function quiet_run()

### DIFF
--- a/script/ci/install/clang.sh
+++ b/script/ci/install/clang.sh
@@ -47,7 +47,7 @@ if [[ "$compiler_name" == "clang" && "$APCI_HIP" == 0 ]]; then
             ;;
         esac
         DEBIAN_FRONTEND=noninteractive retry_cmd apt update
-        DEBIAN_FRONTEND=noninteractive apt install -y "clang-${compiler_version}" "libomp-${compiler_version}-dev"
+        quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y "clang-${compiler_version}" "libomp-${compiler_version}-dev"
 
         export APCI_C_COMPILER="/usr/bin/clang-${compiler_version}"
         export APCI_CXX_COMPILER="/usr/bin/clang++-${compiler_version}"

--- a/script/ci/install/clang.sh
+++ b/script/ci/install/clang.sh
@@ -47,7 +47,11 @@ if [[ "$compiler_name" == "clang" && "$APCI_HIP" == 0 ]]; then
             ;;
         esac
         DEBIAN_FRONTEND=noninteractive retry_cmd apt update
-        quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y "clang-${compiler_version}" "libomp-${compiler_version}-dev"
+        # TODO: set --no-install-recommends
+        # If clang is used as nvcc host compiler, the cmake configure fails because something is missing,
+        # which is automatically installed as recommend package. At the moment this is hard to debug, because
+        # local nvcc builds does not work yet. Fix, if local nvcc builds are possible.
+        quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install -y "clang-${compiler_version}" "libomp-${compiler_version}-dev"
 
         export APCI_C_COMPILER="/usr/bin/clang-${compiler_version}"
         export APCI_CXX_COMPILER="/usr/bin/clang++-${compiler_version}"

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -36,8 +36,8 @@ if [[ "$compiler_name" == "gcc" ]]; then
             # install requested GCC if it is not already available
             if ! command -v "gcc-${compiler_version}" >/dev/null 2>&1; then
                 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-                DEBIAN_FRONTEND=noninteractive sudo apt update
-                DEBIAN_FRONTEND=noninteractive sudo apt install -y "gcc-${compiler_version}" "g++-${compiler_version}"
+                sudo DEBIAN_FRONTEND=noninteractive apt update
+                quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y "gcc-${compiler_version}" "g++-${compiler_version}"
                 # select requested GCC as default
                 # TODO: Remove me, if APCI_CXX_COMPILER is used in production.
                 # Changing the system host compiler is pretty dangerous and error prone.

--- a/script/ci/install/rocm.sh
+++ b/script/ci/install/rocm.sh
@@ -27,7 +27,7 @@ if [[ "$APCI_HIP" != 0 ]]; then
 
             lazy_apt_update
             # TODO: CHECK if rand library is still required
-            DEBIAN_FRONTEND=noninteractive apt install -y hiprand-dev rocrand-dev
+            quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y hiprand-dev rocrand-dev
         else
             install_msg "ROCm ${APCI_HIP} in default Ubuntu container."
 
@@ -47,7 +47,7 @@ if [[ "$APCI_HIP" != 0 ]]; then
             echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/${APCI_HIP}/ubuntu ${VERSION_CODENAME} main" |
                 sudo tee -a /etc/apt/sources.list.d/rocm.list
 
-            DEBIAN_FRONTEND=noninteractive retry_cmd apt update
+            retry_cmd sudo DEBIAN_FRONTEND=noninteractive apt update
 
             APCI_ROCM="${APCI_HIP}"
             # append .0 if no patch level is defined
@@ -55,7 +55,7 @@ if [[ "$APCI_HIP" != 0 ]]; then
                 APCI_ROCM="${APCI_ROCM}.0"
             fi
 
-            DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \
+            quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \
                 "rocm-llvm${APCI_ROCM}" \
                 "hip-runtime-amd${APCI_ROCM}" \
                 "rocm-dev${APCI_ROCM}" \
@@ -70,7 +70,7 @@ if [[ "$APCI_HIP" != 0 ]]; then
             function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
             if [ "$(version "${APCI_ROCM}")" -ge "$(version "6.0.0")" ]; then
-                DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \
+                quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \
                     "hiprand-dev${APCI_ROCM}"
             fi
         fi

--- a/script/ci/utils/color_echo.sh
+++ b/script/ci/utils/color_echo.sh
@@ -11,9 +11,9 @@ echo_green() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
     if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
-        echo -e "\e[1;32m$1\e[0m"
+        echo -e "\e[1;32m$*\e[0m"
     else
-        echo -e "$1"
+        echo -e "$*"
     fi
 }
 
@@ -21,9 +21,9 @@ echo_blue() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
     if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
-        echo -e "\e[1;34m$1\e[0m"
+        echo -e "\e[1;34m$*\e[0m"
     else
-        echo -e "$1"
+        echo -e "$*"
     fi
 }
 
@@ -31,9 +31,9 @@ echo_yellow() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
     if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
-        echo -e "\e[1;33m$1\e[0m"
+        echo -e "\e[1;33m$*\e[0m"
     else
-        echo -e "$1"
+        echo -e "$*"
     fi
 }
 
@@ -41,8 +41,8 @@ echo_red() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
     if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
-        echo -e "\e[1;31m$1\e[0m"
+        echo -e "\e[1;31m$*\e[0m"
     else
-        echo -e "$1"
+        echo -e "$*"
     fi
 }

--- a/script/ci/utils/color_echo.sh
+++ b/script/ci/utils/color_echo.sh
@@ -11,9 +11,9 @@ echo_green() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
     if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
-        echo -e "\e[1;32m$*\e[0m"
+        echo -e "\e[1;32m" "$@" "\e[0m"
     else
-        echo -e "$*"
+        echo -e "$@"
     fi
 }
 
@@ -21,9 +21,9 @@ echo_blue() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
     if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
-        echo -e "\e[1;34m$*\e[0m"
+        echo -e "\e[1;34m" "$@" "\e[0m"
     else
-        echo -e "$*"
+        echo -e "$@"
     fi
 }
 
@@ -31,9 +31,9 @@ echo_yellow() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
     if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
-        echo -e "\e[1;33m$*\e[0m"
+        echo -e "\e[1;33m" "$@" "\e[0m"
     else
-        echo -e "$*"
+        echo -e "$@"
     fi
 }
 
@@ -41,8 +41,8 @@ echo_red() {
     # `-t 1`: if executed in terminal
     # `tput colors`: if no colors available, the value is negative
     if [[ -n "${_APCI_FORCE_COLOR_OUTPUT+x}" ]] || [[ -t 1 ]] && command -v tput >/dev/null && [[ "$(tput colors)" -gt 0 ]]; then
-        echo -e "\e[1;31m$*\e[0m"
+        echo -e "\e[1;31m" "$@" "\e[0m"
     else
-        echo -e "$*"
+        echo -e "$@"
     fi
 }

--- a/script/ci/utils/helper_apps/sudo.sh
+++ b/script/ci/utils/helper_apps/sudo.sh
@@ -23,6 +23,6 @@ if ! command -v sudo &>/dev/null; then
         install_msg "sudo"
 
         lazy_apt_update
-        DEBIAN_FRONTEND=noninteractive apt install -y sudo
+        DEBIAN_FRONTEND=noninteractive quiet_run apt install --no-install-recommends -y sudo
     fi
 fi

--- a/script/ci/utils/install_helper_apps.sh
+++ b/script/ci/utils/install_helper_apps.sh
@@ -41,6 +41,5 @@ lazy_apt_update
 # calls cmake configure as subprocess and does not respect the generator of the parent cmake
 # ninja for cmake build
 _helper_apps=(software-properties-common wget gnupg2 git ninja-build)
-install_msg "${_helper_apps[*]}"
-DEBIAN_FRONTEND=noninteractive apt install -y "${_helper_apps[@]}"
+quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y "${_helper_apps[@]}"
 unset _helper_apps

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -12,17 +12,17 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/color_echo.sh"
 
 # display a install message in green
 install_msg() {
-    echo_green "[INSTALL]: $1"
+    echo_green "[INSTALL]: $*"
 }
 
 # display a install message in green
 script_msg() {
-    echo_green "[SCRIPT]: $1"
+    echo_green "[SCRIPT]: $*"
 }
 
 # display a error message in red
 error_msg() {
-    echo_red "[ERROR]: $1"
+    echo_red "[ERROR]: $*"
 }
 
 exit_error() {
@@ -83,6 +83,47 @@ retry_cmd() {
         done
         exit_error "run '$*' failed" "$result"
     )
+}
+
+# Run a command suppress the output if the error code is 0.
+# If the error code is non 0, display output and run exit_error.
+quiet_run() {
+    if [[ $# -lt 1 ]]; then
+        exit_error "quiet_run requires at least one argument."
+    fi
+
+    echo_green "$*"
+
+    local set_options=$-
+    exit_no_non_zero=$(
+        echo "${set_options}" | grep -q -v 'e'
+        echo "$?"
+    )
+
+    local log_file
+    log_file=$(mktemp)
+
+    # disable temporary exit on non zero, that log can be displayed
+    if [[ ${exit_no_non_zero} -eq 1 ]]; then
+        set +e
+    fi
+
+    "$@" >"${log_file}" 2>&1
+    local exit_code=$?
+
+    if [[ ${exit_no_non_zero} -eq 1 ]]; then
+        set -e
+    fi
+
+    if [[ "${exit_code}" != 0 ]]; then
+        cat "${log_file}"
+    fi
+
+    rm "${log_file}"
+
+    if [[ ${exit_code} -ne 0 ]]; then
+        exit_error "failed cmd: $*"
+    fi
 }
 
 # does an 'apt update' only if no 'apt update' was done before

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -12,17 +12,17 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/color_echo.sh"
 
 # display a install message in green
 install_msg() {
-    echo_green "[INSTALL]: $*"
+    echo_green "[INSTALL]: " "$@"
 }
 
 # display a install message in green
 script_msg() {
-    echo_green "[SCRIPT]: $*"
+    echo_green "[SCRIPT]: " "$@"
 }
 
 # display a error message in red
 error_msg() {
-    echo_red "[ERROR]: $*"
+    echo_red "[ERROR]: " "$@"
 }
 
 exit_error() {
@@ -122,7 +122,7 @@ quiet_run() {
     rm "${log_file}"
 
     if [[ ${exit_code} -ne 0 ]]; then
-        exit_error "failed cmd: $*"
+        exit_error "failed cmd: " "$@"
     fi
 }
 


### PR DESCRIPTION
Run a command suppress the output if the error code is 0. If the error code is non 0, display output and run exit_error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quieter, consistent command execution for installation steps, reducing noisy logs while preserving clear error output.
* **Bug Fixes**
  * Improved colored/status console messages to display all provided text (not just the first word).
  * Standardized Linux package installation to be non-interactive and avoid recommended extras across toolchain, ROCm, and sudo fallback flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->