### PR TITLE
fix CMake for `OneApi`

### DIFF
--- a/cmake/alpakaOneApi.cmake
+++ b/cmake/alpakaOneApi.cmake
@@ -12,7 +12,10 @@ if(NOT DEFINED alpaka_COUNT_API_DEPS)
     message(FATAL_ERROR "internal variable 'alpaka_COUNT_API_DEPS' must be defined.")
 endif()
 
-find_package(IntelSYCL REQUIRED)
+# only search for OneApi if the target is not already available
+if(NOT TARGET IntelSYCL::SYCL_CXX)
+    find_package(IntelSYCL REQUIRED)
+endif()
 
 if(NOT TARGET alpaka::oneapi)
     add_library(alpaka_target_oneapi INTERFACE)


### PR DESCRIPTION
Avoid searching for OneApi if we already did it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build setup to avoid reloading Intel SYCL when it is already available.
  * Builds now handle existing SYCL support more smoothly, reducing unnecessary configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->