### PR TITLE
CI: set number of build threads

### DIFF
--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -15,8 +15,8 @@ parse_compiler_version "$APCI_DEVICE_COMPILER"
 if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
     load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 
-    echo_green "${APCI_CMAKE_BIN_PATH}/cmake --build /build -j"
+    echo_green "${APCI_CMAKE_BIN_PATH}/cmake --build /build -j${APCI_BUILD_THREADS}"
     if [[ -z ${GITHUB_ACTIONS+x} ]]; then
-        "${APCI_CMAKE_BIN_PATH}/cmake" --build /build -j
+        "${APCI_CMAKE_BIN_PATH}/cmake" --build /build "-j${APCI_BUILD_THREADS}"
     fi
 fi

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -7,6 +7,41 @@
 
 # setup environment variables depending on os environment (on local system, GitLab CI, GitHub Action ...)
 
+# set the required memory per build thread in GB
+ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES=$((2 * 1024 ** 3))
+
+# Return the number of build threads depending on the
+# - maximum number of available threads (first parameter)
+# - available memory (second parameter)
+# - required memory per thread (configure via variable ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES)
+function get_build_threads() {
+    if [[ $# -lt 2 ]]; then
+        echo -e "\e[1;31m[ERROR]: " \
+            "get_build_threads() set as first argument maximum number of available build threads " \
+            "and as second argument max number of available memory in bytes" \
+            "\e[0m"
+        exit 1
+    fi
+
+    local max_possible_build_threads=$(($2 / ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES))
+
+    if [[ $max_possible_build_threads -lt 1 ]]; then
+        max_possible_build_threads=1
+    fi
+
+    if [[ $1 -le $max_possible_build_threads ]]; then
+        echo "$1"
+    else
+        echo "$max_possible_build_threads"
+    fi
+}
+
+# local container
+if [[ -z ${GITHUB_ACTIONS+x} ]] && [[ -z ${GITLAB_CI+x} ]]; then
+    max_num_build_threads=$(nproc)
+    total_memory_bytes=$(free -b | awk '/Mem:/ { print $2 }')
+fi
+
 if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     # force color output
     export TERM=xterm-256color
@@ -24,6 +59,9 @@ if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     # there are no GPU runner on GitHub, therefore simply choose one architecture
     APCI_AMD_GPU_ARCH=gfx90a
     export APCI_AMD_GPU_ARCH
+
+    max_num_build_threads=$(nproc)
+    total_memory_bytes=$(free -b | awk '/Mem:/ { print $2 }')
 fi
 
 if [[ -n ${GITLAB_CI+x} ]]; then
@@ -64,4 +102,11 @@ if [[ -n ${GITLAB_CI+x} ]]; then
         fi
     fi
     export APCI_AMD_GPU_ARCH
+
+    # CI_CPU and CI_RAM_BYTES_TOTAL are predefined on the HZDR runner
+    max_num_build_threads="${CI_CPUS}"
+    total_memory_bytes="${CI_RAM_BYTES_TOTAL}"
 fi
+
+APCI_BUILD_THREADS=$(get_build_threads "${max_num_build_threads}" "${total_memory_bytes}")
+export APCI_BUILD_THREADS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI builds now automatically calculate a safe parallel thread count based on available CPU and memory, and use it during the build.
  * Build status output now reflects the selected thread count.

* **Bug Fixes**
  * Improved CI build stability by preventing overly aggressive parallelism on resource-constrained runners.
  * Ensures the configured thread count is applied consistently to the build command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->