### PR TITLE
CI: install OneAPI via script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,18 +105,18 @@ jobs:
               env : {APCI_DEVICE_COMPILER : clang@22, APCI_CMAKE : 3.28.3, APCI_HIP: 7.2, APCI_RUN_CTEST: OFF} }
           # SYCL
           - { compiler: icpx, version: "2025.1", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.1.3-0-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : icpx@2025.1, APCI_CMAKE : 3.28.3, APCI_ONEAPI: 2025.1, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
+              env : { APCI_DEVICE_COMPILER : icpx@2025.1, APCI_CMAKE : 3.28.3, APCI_ONEAPI: 2025.1, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
           - { compiler: icpx, version: "2025.2", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : icpx@2025.2, APCI_CMAKE : 3.28.3, APCI_ONEAPI: 2025.2, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
+              env : { APCI_DEVICE_COMPILER : icpx@2025.2, APCI_CMAKE : 3.28.3, APCI_ONEAPI: 2025.2, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
           - { compiler: icpx, version: "2025.3", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.3.0-0-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : icpx@2025.3, APCI_CMAKE : 3.28.3, APCI_ONEAPI: 2025.3, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
+              env : { APCI_DEVICE_COMPILER : icpx@2025.3, APCI_CMAKE : 3.28.3, APCI_ONEAPI: 2025.3, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
           - { compiler: icpx, version: "2026.0", cuda: "no", hip: "no", container: "intel/oneapi:2026.0.0-devel-ubuntu24.04",
               env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3, APCI_ONEAPI: 2026.0, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
           - { compiler: icpx, version: "2026.0", cuda: "no", hip: "no", container: "intel/oneapi:2026.0.0-devel-ubuntu24.04", simd: "EMULATION", hwloc: "no",
               env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3, APCI_ONEAPI: 2026.0, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
           # Use/validate oneAPI-provided oneTBB package with the latest icpx toolchain
           - { compiler: icpx, version: "2026.0", cuda: "no", hip: "no", container: "intel/oneapi:2026.0.0-devel-ubuntu24.04", tbb: "on",
-              env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3, APCI_RUN_CTEST: ON} }
+              env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3, APCI_ONEAPI: 2026.0, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: ON} }
           - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "asan",
               env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: ON} }
           - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "asan" , simd: "EMULATION", hwloc: "no",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,15 +105,15 @@ jobs:
               env : {APCI_DEVICE_COMPILER : clang@22, APCI_CMAKE : 3.28.3, APCI_HIP: 7.2, APCI_RUN_CTEST: OFF} }
           # SYCL
           - { compiler: icpx, version: "2025.1", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.1.3-0-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : icpx@2025.1, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : icpx@2025.1, APCI_CMAKE : 3.28.3, APCI_ONEAPI: 2025.1, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
           - { compiler: icpx, version: "2025.2", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : icpx@2025.2, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : icpx@2025.2, APCI_CMAKE : 3.28.3, APCI_ONEAPI: 2025.2, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
           - { compiler: icpx, version: "2025.3", cuda: "no", hip: "no", container: "intel/oneapi-hpckit:2025.3.0-0-devel-ubuntu24.04",
-              env : {APCI_DEVICE_COMPILER : icpx@2025.3, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: OFF} }
+              env : {APCI_DEVICE_COMPILER : icpx@2025.3, APCI_CMAKE : 3.28.3, APCI_ONEAPI: 2025.3, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
           - { compiler: icpx, version: "2026.0", cuda: "no", hip: "no", container: "intel/oneapi:2026.0.0-devel-ubuntu24.04",
-              env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3, APCI_RUN_CTEST: OFF} }
+              env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3, APCI_ONEAPI: 2026.0, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
           - { compiler: icpx, version: "2026.0", cuda: "no", hip: "no", container: "intel/oneapi:2026.0.0-devel-ubuntu24.04", simd: "EMULATION", hwloc: "no",
-              env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3, APCI_RUN_CTEST: OFF} }
+              env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3, APCI_ONEAPI: 2026.0, APCI_ONEAPI_TARGET: cpu, APCI_RUN_CTEST: OFF} }
           # Use/validate oneAPI-provided oneTBB package with the latest icpx toolchain
           - { compiler: icpx, version: "2026.0", cuda: "no", hip: "no", container: "intel/oneapi:2026.0.0-devel-ubuntu24.04", tbb: "on",
               env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3, APCI_RUN_CTEST: ON} }
@@ -210,9 +210,8 @@ jobs:
       # intel oneAPI ipcx
       - name: Install oneAPI
         if: matrix.config.compiler == 'icpx'
-        run: |
-          echo "test is adding '-Dalpaka_ONEAPI_IntelGpu=OFF -Dalpaka_EXEC_CpuSerial=OFF -Dalpaka_DEP_OMP=OFF' to speedup execution"
-          # for TBB there is nothing to do because TBB is configured in the container correctly
+        shell: bash
+        run: "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi.sh"
 
       # hwloc (opt out)
       - name: Install hwloc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,8 @@
     APCI_ALPAKA_ROOT: "$CI_PROJECT_DIR"
     APCI_RUN_CTEST: "ON"
     APCI_HIP : 0
+    APCI_ONEAPI : 0
+    APCI_ONEAPI_TARGET: none
   script:
     - $APCI_ALPAKA_ROOT/script/ci/job_info.sh
     - $APCI_ALPAKA_ROOT/script/ci/install_dependencies.sh
@@ -109,3 +111,98 @@ hipcc-7.2-rocm-container:
     APCI_DEVICE_COMPILER : clang@22
     APCI_CMAKE: 3.28.3
     APCI_HIP : 7.2
+
+icpx-2025.1-cpu:
+   image: docker.io/ubuntu:24.04
+   extends: .base
+   variables:
+    APCI_DEVICE_COMPILER : icpx@2025.1
+    APCI_CMAKE: 3.28.3
+    APCI_ONEAPI: 2025.1
+    APCI_ONEAPI_TARGET: cpu
+
+icpx-2025.1-gpu:
+   image: docker.io/ubuntu:24.04
+   extends: .base
+   variables:
+    APCI_DEVICE_COMPILER : icpx@2025.1
+    APCI_CMAKE: 3.28.3
+    APCI_ONEAPI: 2025.1
+    APCI_ONEAPI_TARGET: intel_gpu
+    APCI_RUN_CTEST: "OFF"
+
+icpx-2025.2-cpu:
+   image: docker.io/ubuntu:24.04
+   extends: .base
+   variables:
+    APCI_DEVICE_COMPILER : icpx@2025.2
+    APCI_CMAKE: 3.28.3
+    APCI_ONEAPI: 2025.2
+    APCI_ONEAPI_TARGET: cpu
+
+icpx-2025.2-gpu:
+   image: docker.io/ubuntu:24.04
+   extends: .base
+   variables:
+    APCI_DEVICE_COMPILER : icpx@2025.2
+    APCI_CMAKE: 3.28.3
+    APCI_ONEAPI: 2025.2
+    APCI_ONEAPI_TARGET: intel_gpu
+    APCI_RUN_CTEST: "OFF"
+
+icpx-2025.3-cpu:
+   image: docker.io/ubuntu:24.04
+   extends: .base
+   variables:
+    APCI_DEVICE_COMPILER : icpx@2025.3
+    APCI_CMAKE: 3.28.3
+    APCI_ONEAPI: 2025.3
+    APCI_ONEAPI_TARGET: cpu
+
+icpx-2025.3-gpu:
+   image: docker.io/ubuntu:24.04
+   extends: .base
+   variables:
+    APCI_DEVICE_COMPILER : icpx@2025.3
+    APCI_CMAKE: 3.28.3
+    APCI_ONEAPI: 2025.3
+    APCI_ONEAPI_TARGET: intel_gpu
+    APCI_RUN_CTEST: "OFF"
+
+icpx-2026.0-cpu:
+   image: docker.io/ubuntu:24.04
+   extends: .base
+   variables:
+    APCI_DEVICE_COMPILER : icpx@2026.0
+    APCI_CMAKE: 3.28.3
+    APCI_ONEAPI: 2026.0
+    APCI_ONEAPI_TARGET: cpu
+
+icpx-2026.0-gpu:
+   image: docker.io/ubuntu:24.04
+   extends: .base
+   variables:
+    APCI_DEVICE_COMPILER : icpx@2026.0
+    APCI_CMAKE: 3.28.3
+    APCI_ONEAPI: 2026.0
+    APCI_ONEAPI_TARGET: intel_gpu
+    APCI_RUN_CTEST: "OFF"
+
+icpx-2026.0-cpu-intel-container:
+   image: docker.io/intel/oneapi:2026.0.0-devel-ubuntu24.04
+   extends: .base
+   variables:
+    APCI_DEVICE_COMPILER : icpx@2026.0
+    APCI_CMAKE: 3.28.3
+    APCI_ONEAPI: 2026.0
+    APCI_ONEAPI_TARGET: cpu
+
+icpx-2026.0-gpu-intel-container:
+   image: docker.io/intel/oneapi:2026.0.0-devel-ubuntu24.04
+   extends: .base
+   variables:
+    APCI_DEVICE_COMPILER : icpx@2026.0
+    APCI_CMAKE: 3.28.3
+    APCI_ONEAPI: 2026.0
+    APCI_ONEAPI_TARGET: intel_gpu
+    APCI_RUN_CTEST: "OFF"

--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -14,7 +14,7 @@ LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-""}
 
 if [[ "$APCI_ONEAPI" != 0 ]]; then
     if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
-        export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/2025.1/lib/:${LD_LIBRARY_PATH}"
+        export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${APCI_ONEAPI}/lib/:${LD_LIBRARY_PATH}"
     fi
 fi
 

--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -12,7 +12,7 @@ script_msg "Run CMake build (build.sh)"
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 # TODO: remove me, if all install scripts are ported
-if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
+if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "icpx" ]]; then
     load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 
     echo_green "${APCI_CMAKE_BIN_PATH}/cmake --build /build -j${APCI_BUILD_THREADS}"

--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -10,12 +10,23 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
 
 script_msg "Run CMake build (build.sh)"
 
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-""}
+
+if [[ "$APCI_ONEAPI" != 0 ]]; then
+    if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
+        export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/2025.1/lib/:${LD_LIBRARY_PATH}"
+    fi
+fi
+
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 # TODO: remove me, if all install scripts are ported
 if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "icpx" ]]; then
     load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 
-    echo_green "${APCI_CMAKE_BIN_PATH}/cmake --build /build -j${APCI_BUILD_THREADS}"
+    echo_green "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+        "${APCI_CMAKE_BIN_PATH}/cmake" \
+        --build /build \
+        "-j${APCI_BUILD_THREADS}"
     if [[ -z ${GITHUB_ACTIONS+x} ]]; then
         "${APCI_CMAKE_BIN_PATH}/cmake" --build /build "-j${APCI_BUILD_THREADS}"
     fi

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -13,6 +13,7 @@ script_msg "Run CMake configure (configure.sh)"
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 
 CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-""}
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-""}
 
 # TODO: remove me, if all install scripts are ported
 if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "icpx" ]]; then
@@ -93,6 +94,10 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
                 "Only supported values are: cpu, intel_gpu"
         fi
 
+        if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
+            export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/2025.1/lib/:${APCI_ONEAPI}"
+        fi
+
         for target in "${!ap_sycl_targets[@]}"; do
             CMAKE_ARGS+=("-D${target}=${ap_sycl_targets[$target]}")
         done
@@ -102,7 +107,9 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
         CMAKE_ARGS+=("-D${dep}=${ap_deps[$dep]}")
     done
 
-    echo_green "${APCI_CMAKE_BIN_PATH}/cmake ${CMAKE_ARGS[*]}"
+    echo_green "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+        "${APCI_CMAKE_BIN_PATH}/cmake" \
+        "${CMAKE_ARGS[*]}"
     if [[ -z ${GITHUB_ACTIONS+x} ]]; then
         "${APCI_CMAKE_BIN_PATH}/cmake" "${CMAKE_ARGS[@]}"
     fi

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -95,7 +95,7 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
         fi
 
         if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
-            export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/2025.1/lib/:${APCI_ONEAPI}"
+            export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${APCI_ONEAPI}/lib/:${APCI_ONEAPI}"
         fi
 
         for target in "${!ap_sycl_targets[@]}"; do

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -15,7 +15,7 @@ parse_compiler_version "$APCI_DEVICE_COMPILER"
 CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-""}
 
 # TODO: remove me, if all install scripts are ported
-if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
+if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "icpx" ]]; then
     load_variable_if_not_exist APCI_CMAKE_BIN_PATH
     load_variable_if_not_exist APCI_C_COMPILER
     load_variable_if_not_exist APCI_CXX_COMPILER
@@ -24,6 +24,7 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
         -S "${APCI_ALPAKA_ROOT}"
         -B "/build"
         -G Ninja
+        -DCMAKE_BUILD_TYPE=Release
         -Dalpaka_COMPILE_PEDANTIC=ON
         -Dalpaka_DOCS=ON
         -Dalpaka_TESTS=ON
@@ -64,6 +65,37 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
                 -DCMAKE_HIP_ARCHITECTURES="${APCI_AMD_GPU_ARCH}"
                 -DGPU_TARGETS="${APCI_AMD_GPU_ARCH}")
         fi
+    fi
+
+    if [[ "$APCI_ONEAPI" != 0 ]]; then
+        load_variable_if_not_exist ONEAPI_PATH
+
+        # shellcheck source=script/ci/install/oneapi/setvars.sh
+        source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi/setvars.sh"
+
+        ap_deps['alpaka_DEP_ONEAPI']=ON
+
+        CMAKE_ARGS+=(-Dalpaka_EXEC_CpuSerial=OFF)
+
+        declare -A ap_sycl_targets=(
+            ["alpaka_ONEAPI_Cpu"]=OFF
+            ["alpaka_ONEAPI_IntelGpu"]=OFF
+            ["alpaka_ONEAPI_NvidiaGpu"]=OFF
+            ["alpaka_ONEAPI_AmdGpu"]=OFF
+        )
+
+        if [[ "${APCI_ONEAPI_TARGET}" == "cpu" ]]; then
+            ap_sycl_targets['alpaka_ONEAPI_Cpu']=ON
+        elif [[ "${APCI_ONEAPI_TARGET}" == "intel_gpu" ]]; then
+            ap_sycl_targets['alpaka_ONEAPI_IntelGpu']=ON
+        else
+            exit_error "APCI_ONEAPI_TARGET unknown value: ${APCI_ONEAPI_TARGET}.\n" \
+                "Only supported values are: cpu, intel_gpu"
+        fi
+
+        for target in "${!ap_sycl_targets[@]}"; do
+            CMAKE_ARGS+=("-D${target}=${ap_sycl_targets[$target]}")
+        done
     fi
 
     for dep in "${!ap_deps[@]}"; do

--- a/script/ci/install/oneapi.sh
+++ b/script/ci/install/oneapi.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+# shellcheck source=script/ci/utils/default.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
+
+if [[ "$APCI_OS_NAME" != "Linux" ]]; then
+    exit_error "Install OneAPI script does not support Windows or MacOS"
+fi
+
+: "${APCI_ONEAPI?'The OneAPI version must be specified'}"
+: "${APCI_ONEAPI_TARGET?'The OneAPI target must be specified (cpu, intel_gpu, none)'}"
+
+script_msg "Install OneAPI"
+
+if [[ "$APCI_ONEAPI" != 0 ]]; then
+
+    if agc-manager -e "oneapi@${APCI_ONEAPI}"; then
+        echo_green "oneapi@${APCI_ONEAPI}"
+        ONEAPI_PATH=$(agc-manager -b "oneapi@${APCI_ONEAPI}")
+    else
+        if [[ "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
+            install_msg "OneAPI ${APCI_ONEAPI} in official APCI_ONEAPI container."
+            ONEAPI_PATH=/opt/intel/oneapi
+        else
+            wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB |
+                gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg >/dev/null
+            echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" |
+                sudo tee /etc/apt/sources.list.d/oneAPI.list
+            retry_cmd sudo DEBIAN_FRONTEND=noninteractive apt update
+
+            quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \
+                intel-oneapi-common-vars \
+                intel-oneapi-runtime-libs \
+                intel-oneapi-compiler-dpcpp-cpp-"${APCI_ONEAPI}"
+
+            ONEAPI_PATH=/opt/intel/oneapi
+        fi
+    fi
+
+    # shellcheck source=script/ci/install/oneapi/setvars.sh
+    source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi/setvars.sh"
+
+    APCI_C_COMPILER=$(which icx)
+    APCI_CXX_COMPILER=$(which icpx)
+
+    echo_green "${APCI_C_COMPILER} --version"
+    $APCI_C_COMPILER --version
+    echo_green "${APCI_CXX_COMPILER} --version"
+    $APCI_CXX_COMPILER --version
+
+    export ONEAPI_PATH
+    export APCI_C_COMPILER
+    export APCI_CXX_COMPILER
+    store_variable ONEAPI_PATH
+    store_variable APCI_C_COMPILER
+    store_variable APCI_CXX_COMPILER
+fi

--- a/script/ci/install/oneapi.sh
+++ b/script/ci/install/oneapi.sh
@@ -35,8 +35,7 @@ if [[ "$APCI_ONEAPI" != 0 ]]; then
             retry_cmd sudo DEBIAN_FRONTEND=noninteractive apt update
 
             quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \
-                intel-oneapi-common-vars \
-                intel-oneapi-runtime-libs \
+                "$(apt_package_version intel-oneapi-runtime-opencl "${APCI_ONEAPI}")" \
                 intel-oneapi-compiler-dpcpp-cpp-"${APCI_ONEAPI}"
 
             ONEAPI_PATH=/opt/intel/oneapi
@@ -46,8 +45,12 @@ if [[ "$APCI_ONEAPI" != 0 ]]; then
     # shellcheck source=script/ci/install/oneapi/setvars.sh
     source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi/setvars.sh"
 
-    APCI_C_COMPILER="${ONEAPI_PATH}/compiler/${APCI_ONEAPI}/bin/icx"
-    APCI_CXX_COMPILER="${ONEAPI_PATH}/compiler/${APCI_ONEAPI}/bin/icpx"
+    echo "Search for icx and icpx with 'which'"
+    # Use which to search for the compiler. If the /opt/intel/oneapi/setvars.sh script
+    # does not work, which will not find anything and the script exit because of return
+    # code non 0.
+    APCI_C_COMPILER="$(which icx)"
+    APCI_CXX_COMPILER="$(which icpx)"
 
     echo_green "${APCI_C_COMPILER} --version"
     $APCI_C_COMPILER --version

--- a/script/ci/install/oneapi.sh
+++ b/script/ci/install/oneapi.sh
@@ -46,8 +46,8 @@ if [[ "$APCI_ONEAPI" != 0 ]]; then
     # shellcheck source=script/ci/install/oneapi/setvars.sh
     source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi/setvars.sh"
 
-    APCI_C_COMPILER=$(which icx)
-    APCI_CXX_COMPILER=$(which icpx)
+    APCI_C_COMPILER="${ONEAPI_PATH}/compiler/${APCI_ONEAPI}/bin/icx"
+    APCI_CXX_COMPILER="${ONEAPI_PATH}/compiler/${APCI_ONEAPI}/bin/icpx"
 
     echo_green "${APCI_C_COMPILER} --version"
     $APCI_C_COMPILER --version

--- a/script/ci/install/oneapi/setvars.sh
+++ b/script/ci/install/oneapi/setvars.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${ONEAPI_PATH?'ONEAPI_PATH path is not set'}"
+
+# the OneAPI setvars.sh script has unbound variable and does not catch every non zero return value
+unset_set_e=false
+if echo "$-" | grep -q 'e'; then
+    set +e
+    unset_set_e=true
+fi
+
+unset_set_u=false
+if echo "$-" | grep -q 'u'; then
+    set +u
+    unset_set_u=true
+fi
+
+# shellcheck source=/dev/null
+source "${ONEAPI_PATH}/setvars.sh"
+
+if [[ $unset_set_e == true ]]; then
+    set -e
+    unset_set_e=false
+fi
+
+if [[ $unset_set_u == true ]]; then
+    set -u
+    unset_set_u=false
+fi

--- a/script/ci/install_dependencies.sh
+++ b/script/ci/install_dependencies.sh
@@ -25,3 +25,5 @@ source "${APCI_ALPAKA_ROOT}/script/ci/install/gcc.sh"
 source "${APCI_ALPAKA_ROOT}/script/ci/install/clang.sh"
 # shellcheck source=script/ci/install/rocm.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/install/rocm.sh"
+# shellcheck source=script/ci/install/oneapi.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi.sh"

--- a/script/ci/test.sh
+++ b/script/ci/test.sh
@@ -13,7 +13,7 @@ script_msg "Run CTest (test.sh)"
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 # TODO: remove me, if all install scripts are ported
 # HIP jobs will be tested
-if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" ]]; then
+if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "icpx" ]]; then
     if [[ "${APCI_RUN_CTEST}" == "ON" ]]; then
         load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 

--- a/script/ci/test.sh
+++ b/script/ci/test.sh
@@ -14,7 +14,7 @@ LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-""}
 
 if [[ "$APCI_ONEAPI" != 0 ]]; then
     if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
-        export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/2025.1/lib/:${LD_LIBRARY_PATH}"
+        export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${APCI_ONEAPI}/lib/:${LD_LIBRARY_PATH}"
     fi
 fi
 

--- a/script/ci/test.sh
+++ b/script/ci/test.sh
@@ -10,6 +10,14 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
 
 script_msg "Run CTest (test.sh)"
 
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-""}
+
+if [[ "$APCI_ONEAPI" != 0 ]]; then
+    if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
+        export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/2025.1/lib/:${LD_LIBRARY_PATH}"
+    fi
+fi
+
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 # TODO: remove me, if all install scripts are ported
 # HIP jobs will be tested
@@ -17,7 +25,9 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
     if [[ "${APCI_RUN_CTEST}" == "ON" ]]; then
         load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 
-        echo_green "${APCI_CMAKE_BIN_PATH}/ctest --test-dir /build --output-on-failure"
+        echo_green "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+            "${APCI_CMAKE_BIN_PATH}/ctest" \
+            "--test-dir /build --output-on-failure"
         if [[ -z ${GITHUB_ACTIONS+x} ]]; then
             "${APCI_CMAKE_BIN_PATH}/ctest" --test-dir /build --output-on-failure
         fi

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -145,3 +145,52 @@ lazy_apt_update() {
         DEBIAN_FRONTEND=noninteractive retry_cmd apt update
     fi
 }
+
+# Print a string to install a specific version of an apt package.
+#
+# Args:
+#   1. Name of the package
+#   2. Version searching for
+#
+# If you want to install a specific version an apt package you have to
+# set the exact version which can contain a patch level, distribution
+# depending patch level and more. The function is searching for a
+# apt version, which matches best the given version string.
+#
+# The printed value can be directly used in a `apt install` command.
+apt_package_version() {
+    if [[ $# -lt 1 ]]; then
+        exit_error "apt_package_version(): no package name set."
+    fi
+
+    if [[ $# -lt 2 ]]; then
+        exit_error "apt_package_version(): no package version set."
+    fi
+
+    local apt_ver
+    # search for a specific version
+    # if more than one apt version matches the given version, take the latest version
+    apt_ver=$(apt list --all-versions "$1" |
+        cut -d " " -f 2 |
+        grep "$2" |
+        sort | tail -n 1)
+
+    if [[ "${apt_ver}" == "" ]]; then
+        exit_error "apt_package_version(): Didn't find any apt version for package $1 with version $2 ."
+    fi
+
+    echo "$1=$apt_ver"
+}
+
+# print a variable in the format `name=value`, if the value is not empty
+# usage: echo_if_not_empty <variable_name>
+echo_if_not_empty() {
+    if [[ $# -lt 1 ]]; then
+        exit_error "echo_if_not_empty(): no variable name set."
+    fi
+
+    local var_name="$1"
+    if [[ "${!var_name}" != "" ]]; then
+        echo "${var_name}=${!var_name}"
+    fi
+}

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -60,6 +60,14 @@ if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     APCI_AMD_GPU_ARCH=gfx90a
     export APCI_AMD_GPU_ARCH
 
+    if [[ ! "${APCI_DEVICE_COMPILER}" =~ "icpx" ]] && [[ -z ${APCI_ONEAPI+x} ]]; then
+        export APCI_ONEAPI=0
+    fi
+
+    if [[ "${APCI_ONEAPI}" == 0 ]] && [[ -z ${APCI_ONEAPI_TARGET+x} ]]; then
+        export APCI_ONEAPI_TARGET=none
+    fi
+
     max_num_build_threads=$(nproc)
     total_memory_bytes=$(free -b | awk '/Mem:/ { print $2 }')
 fi

--- a/test/unit/math/ADL.cpp
+++ b/test/unit/math/ADL.cpp
@@ -412,7 +412,10 @@ struct AdlKernel
 
 TEMPLATE_LIST_TEST_CASE("mathOps", "[math] [operator] [adl]", TestBackends)
 {
-    auto cfg = TestType::makeDict();
-    auto testResult = alpaka::test::executeOnComputeDevice(cfg, AdlKernel{});
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
+
+    auto testResult = alpaka::test::executeOnComputeDevice(device, exec, AdlKernel{});
     REQUIRE(testResult);
 }

--- a/test/unit/math/executeOnComputeDevice.hpp
+++ b/test/unit/math/executeOnComputeDevice.hpp
@@ -26,12 +26,8 @@
 namespace alpaka::test
 {
     template<typename T_DataType = alpaka::NotRequired>
-    bool executeOnComputeDevice(auto cfg, auto kernelFnObj, auto&&... args)
+    bool executeOnComputeDevice(auto device, auto exec, auto kernelFnObj, auto&&... args)
     {
-        auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
-        onHost::Device device = test::getDevice(deviceExec);
-        concepts::Executor auto exec = test::getExecutor(deviceExec);
-
 #if ALPAKA_LANG_ONEAPI
         // support for double precision is not guaranteed for sycl devices such as Intel GPUs
         if constexpr(std::is_same_v<T_DataType, double> && std::is_same_v<decltype(device.getApi()), api::OneApi>)

--- a/test/unit/math/powMixedTypes.cpp
+++ b/test/unit/math/powMixedTypes.cpp
@@ -82,28 +82,55 @@ TEMPLATE_LIST_TEST_CASE("powMixedTypes", "[powMixedTypes]", TestBackends)
     alpaka::math::Complex<float> floatComplexArg{0.35f, -0.24f};
     alpaka::math::Complex<double> doubleComplexArg{0.35, -0.24};
 
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(cfg);
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
+
     // all combinations of pow(real, real)
-    REQUIRE(alpaka::test::executeOnComputeDevice(cfg, kernelFloat, floatArg, floatArg));
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernelDouble, floatArg, doubleArg));
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernelDouble, doubleArg, floatArg));
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernelDouble, doubleArg, doubleArg));
+    REQUIRE(alpaka::test::executeOnComputeDevice(device, exec, kernelFloat, floatArg, floatArg));
+    REQUIRE(alpaka::test::executeOnComputeDevice<double>(device, exec, kernelDouble, floatArg, doubleArg));
+    REQUIRE(alpaka::test::executeOnComputeDevice<double>(device, exec, kernelDouble, doubleArg, floatArg));
+    REQUIRE(alpaka::test::executeOnComputeDevice<double>(device, exec, kernelDouble, doubleArg, doubleArg));
 
     // all combinations of pow(real, complex)
-    REQUIRE(alpaka::test::executeOnComputeDevice(cfg, kernelComplexFloat, floatArg, floatComplexArg));
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernelComplexDouble, floatArg, doubleComplexArg));
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernelComplexDouble, doubleArg, floatComplexArg));
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernelComplexDouble, doubleArg, doubleComplexArg));
+    REQUIRE(alpaka::test::executeOnComputeDevice(device, exec, kernelComplexFloat, floatArg, floatComplexArg));
+    REQUIRE(
+        alpaka::test::executeOnComputeDevice<double>(device, exec, kernelComplexDouble, floatArg, doubleComplexArg));
+    REQUIRE(
+        alpaka::test::executeOnComputeDevice<double>(device, exec, kernelComplexDouble, doubleArg, floatComplexArg));
+    REQUIRE(
+        alpaka::test::executeOnComputeDevice<double>(device, exec, kernelComplexDouble, doubleArg, doubleComplexArg));
 
     // all combinations of pow(complex, real)
-    REQUIRE(alpaka::test::executeOnComputeDevice(cfg, kernelComplexFloat, floatComplexArg, floatArg));
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernelComplexDouble, floatComplexArg, doubleArg));
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernelComplexDouble, doubleComplexArg, floatArg));
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernelComplexDouble, doubleComplexArg, doubleArg));
+    REQUIRE(alpaka::test::executeOnComputeDevice(device, exec, kernelComplexFloat, floatComplexArg, floatArg));
+    REQUIRE(
+        alpaka::test::executeOnComputeDevice<double>(device, exec, kernelComplexDouble, floatComplexArg, doubleArg));
+    REQUIRE(
+        alpaka::test::executeOnComputeDevice<double>(device, exec, kernelComplexDouble, doubleComplexArg, floatArg));
+    REQUIRE(
+        alpaka::test::executeOnComputeDevice<double>(device, exec, kernelComplexDouble, doubleComplexArg, doubleArg));
 
     // all combinations of pow(complex, complex)
-    REQUIRE(alpaka::test::executeOnComputeDevice(cfg, kernelComplexFloat, floatComplexArg, floatComplexArg));
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernelComplexDouble, floatComplexArg, doubleComplexArg));
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernelComplexDouble, doubleComplexArg, floatComplexArg));
+    REQUIRE(alpaka::test::executeOnComputeDevice(device, exec, kernelComplexFloat, floatComplexArg, floatComplexArg));
     REQUIRE(
-        alpaka::test::executeOnComputeDevice<double>(cfg, kernelComplexDouble, doubleComplexArg, doubleComplexArg));
+        alpaka::test::executeOnComputeDevice<double>(
+            device,
+            exec,
+            kernelComplexDouble,
+            floatComplexArg,
+            doubleComplexArg));
+    REQUIRE(
+        alpaka::test::executeOnComputeDevice<double>(
+            device,
+            exec,
+            kernelComplexDouble,
+            doubleComplexArg,
+            floatComplexArg));
+    REQUIRE(
+        alpaka::test::executeOnComputeDevice<double>(
+            device,
+            exec,
+            kernelComplexDouble,
+            doubleComplexArg,
+            doubleComplexArg));
 }

--- a/test/unit/math/sincos.cpp
+++ b/test/unit/math/sincos.cpp
@@ -39,16 +39,24 @@ struct SinCosTestKernel
 
 TEMPLATE_LIST_TEST_CASE("sincos", "[sincos]", TestBackends)
 {
-    auto cfg = TestType::makeDict();
+    auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
+    onHost::Device device = test::getDevice(deviceExec);
+    concepts::Executor auto exec = test::getExecutor(deviceExec);
     SinCosTestKernel kernel;
 
-    REQUIRE(alpaka::test::executeOnComputeDevice(cfg, kernel, 0.42f)); // float
-    REQUIRE(alpaka::test::executeOnComputeDevice<double>(cfg, kernel, 0.42)); // double
-    REQUIRE(alpaka::test::executeOnComputeDevice(cfg, kernel, alpaka::math::Complex<float>{0.35f, -0.24f})); // complex
-                                                                                                             // float
+    REQUIRE(alpaka::test::executeOnComputeDevice(device, exec, kernel, 0.42f)); // float
+    REQUIRE(alpaka::test::executeOnComputeDevice<double>(device, exec, kernel, 0.42)); // double
+    REQUIRE(
+        alpaka::test::executeOnComputeDevice(
+            device,
+            exec,
+            kernel,
+            alpaka::math::Complex<float>{0.35f, -0.24f})); // complex
+                                                           // float
     REQUIRE(
         alpaka::test::executeOnComputeDevice<double>(
-            cfg,
+            device,
+            exec,
             kernel,
             alpaka::math::Complex<double>{0.35, -0.24})); // complex double
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI support for Intel OneAPI `icpx`, with new CPU/GPU job variants and corresponding target configuration.

* **Bug Fixes**
  * Improved OneAPI environment setup and handling in CI (including safer sourcing behavior).
  * Enhanced library path setup and expanded `icpx` to use the same CTest execution path as other compilers.

* **Tests**
  * Refactored unit math tests to use an explicit device/executor execution context.

* **Chores**
  * Updated CI defaults and job matrix variables to standardize OneAPI settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->