### PR TITLE
Introduce `Backend` concept

### DIFF
--- a/docs/source/basic/terms.rst
+++ b/docs/source/basic/terms.rst
@@ -1,7 +1,7 @@
 Terms & Structure
 =================
 
-.. sectionauthor:: Simeon Ehrig, René Widera
+.. sectionauthor:: Simeon Ehrig, René Widera, Tim Hanel
 
 
 Host and Accelerator
@@ -220,6 +220,13 @@ Kernel
 
 Executor
 --------
+
+.. _backend:
+
+Backend
+-------
+
+A ``Backend`` is a configuration dictionary (``alpaka::Dict``), typically returned by ``onHost::allBackends(...)``, that provides a ``DeviceSpec`` and an ``Executor``.
 
 .. _thread_spec:
 

--- a/docs/source/basic/terms.rst
+++ b/docs/source/basic/terms.rst
@@ -226,7 +226,7 @@ Executor
 Backend
 -------
 
-A ``Backend`` is a configuration dictionary (``alpaka::Dict``), typically returned by ``onHost::allBackends(...)``, that provides a ``DeviceSpec`` and an ``Executor``.
+A ``Backend`` the combination of a ``DeviceSpec`` and an ``Executor``. It is typically returned by ``onHost::allBackends(...)``.
 
 .. _thread_spec:
 

--- a/example/boundaryIter/src/boundaryIter.cpp
+++ b/example/boundaryIter/src/boundaryIter.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Anton Reinhard
+/* Copyright 2025 Anton Reinhard, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -172,6 +172,7 @@ auto main() -> int
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
     return onHost::executeForEachIfHasDevice(
-        [=](auto const& backend) { return example(backend[object::deviceSpec], backend[object::exec]); },
+        [=](alpaka::concepts::Backend auto const& backend)
+        { return example(backend[object::deviceSpec], backend[object::exec]); },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/grayScale/src/grayScale.cpp
+++ b/example/grayScale/src/grayScale.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Mehmet Yusufoglu, René Widera
+/* Copyright 2025 Mehmet Yusufoglu, René Widera, Tim Hanel
  * SPDX-License-Identifier: ISC
  */
 
@@ -351,6 +351,7 @@ auto main(int argc, char* argv[]) -> int
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
     return onHost::executeForEachIfHasDevice(
-        [=](auto const& tag) { return example(tag, numElements, numberOfRuns, enableStdForEach); },
+        [=](alpaka::concepts::Backend auto const& backend)
+        { return example(backend, numElements, numberOfRuns, enableStdForEach); },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -1,5 +1,5 @@
 /* Copyright 2020 Benjamin Worpitz, Matthias Werner, Jakob Krude, Sergei Bastrakov, Bernhard Manfred Gruber,
- * Tapish Narwal, Anton Reinhard
+ * Tapish Narwal, Anton Reinhard, Tim Hanel
  * SPDX-License-Identifier: ISC
  */
 
@@ -343,7 +343,7 @@ auto main(int argc, char* argv[]) -> int
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
     return onHost::executeForEachIfHasDevice(
-        [=](auto const& backend)
+        [=](alpaka::concepts::Backend auto const& backend)
         {
             return alpaka::example::heatEquation::example(
                 backend[object::deviceSpec],

--- a/example/nBody/src/nBody.cpp
+++ b/example/nBody/src/nBody.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Anton Reinhard
+/* Copyright 2025 Anton Reinhard, Tim Hanel
  * SPDX-License-Identifier: ISC
  */
 
@@ -379,14 +379,14 @@ auto main(int argc, char* argv[]) -> int
     if(benchmarkMode)
     {
         return onHost::executeForEachIfHasDevice(
-            [=](auto const& backend)
+            [=](alpaka::concepts::Backend auto const& backend)
             { return alpaka::example::nBody::benchmark(backend[object::deviceSpec], backend[object::exec], dt); },
             onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
     }
     else
     {
         return onHost::executeForEachIfHasDevice(
-            [=](auto const& backend)
+            [=](alpaka::concepts::Backend auto const& backend)
             {
                 return alpaka::example::nBody::example(
                     backend[object::deviceSpec],

--- a/example/randomInit/src/randomInit.cpp
+++ b/example/randomInit/src/randomInit.cpp
@@ -394,7 +394,7 @@ auto main(int argc, char* argv[]) -> int
     return onHost::executeForEachIfHasDevice(
         [=](alpaka::concepts::Backend auto const& backend)
         {
-            bool retVal = exampleUniformDist(backend, numElements) || exampleNormalDist(tag, numElementsNormal);
+            bool retVal = exampleUniformDist(backend, numElements) || exampleNormalDist(backend, numElementsNormal);
             return retVal == false ? EXIT_SUCCESS : EXIT_FAILURE;
         },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));

--- a/example/randomInit/src/randomInit.cpp
+++ b/example/randomInit/src/randomInit.cpp
@@ -392,9 +392,9 @@ auto main(int argc, char* argv[]) -> int
     using namespace alpaka;
     // Execute the example once for each enabled API and executor.
     return onHost::executeForEachIfHasDevice(
-        [=](auto const& tag)
+        [=](alpaka::concepts::Backend auto const& backend)
         {
-            bool retVal = exampleUniformDist(tag, numElements) || exampleNormalDist(tag, numElementsNormal);
+            bool retVal = exampleUniformDist(backend, numElements) || exampleNormalDist(tag, numElementsNormal);
             return retVal == false ? EXIT_SUCCESS : EXIT_FAILURE;
         },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));

--- a/example/scan/src/scan_main.hpp
+++ b/example/scan/src/scan_main.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Anton Reinhard
+/* Copyright 2025 Anton Reinhard, Tim Hanel
  * SPDX-License-Identifier: ISC
  *
  * This file contains the main setup and surrounding functions for the scan example.
@@ -199,7 +199,7 @@ auto main(int argc, char* argv[]) -> int
 
     // Execute the example once for each enabled API and executor.
     auto result = onHost::executeForEachIfHasDevice(
-        [=](auto const& backend)
+        [=](alpaka::concepts::Backend auto const& backend)
         {
             return alpaka::example::scan::example(
                 backend[alpaka::object::deviceSpec],

--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Andrea Bocci, René Widera
+/* Copyright 2024 Andrea Bocci, René Widera, Tim Hanel
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -265,7 +265,7 @@ auto main() -> int
 
     // Execute the example once for each enabled API, device kind, and executor.
     return onHost::executeForEachIfHasDevice(
-        [=](auto const& backend)
+        [=](alpaka::concepts::Backend auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Andrea Bocci, René Widera
+/* Copyright 2024 Andrea Bocci, René Widera, Tim Hanel
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -286,7 +286,7 @@ auto main() -> int
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
     return onHost::executeForEachIfHasDevice(
-        [=](auto const& backend)
+        [=](alpaka::concepts::Backend auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -336,7 +336,7 @@ auto main() -> int
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
     return onHost::executeForEachIfHasDevice(
-        [=](concepts::Backend auto const& backend)
+        [=](alpaka::concepts::Backend auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Andrea Bocci, René Widera
+/* Copyright 2024 Andrea Bocci, René Widera, Tim Hanel
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -336,7 +336,7 @@ auto main() -> int
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
     return onHost::executeForEachIfHasDevice(
-        [=](auto const& backend)
+        [=](concepts::Backend auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024  Jan Stephan, Luca Ferragina, Aurora Perego, Andrea Bocci, René Widera, Mehmet Yusufoglu.
+/* Copyright 2024  Jan Stephan, Luca Ferragina, Aurora Perego, Andrea Bocci, René Widera, Mehmet Yusufoglu, Tim Hanel.
  * SPDX-License-Identifier: ISC
  */
 
@@ -269,7 +269,7 @@ auto main(int argc, char* argv[]) -> int
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
     return onHost::executeForEachIfHasDevice(
-        [=](auto const& backend)
+        [=](alpaka::concepts::Backend auto const& backend)
         {
             return example(
                 backend[alpaka::object::deviceSpec],

--- a/example/vendorApi/src/main.cpp
+++ b/example/vendorApi/src/main.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026  René Widera
+/* Copyright 2026  René Widera, Tim Hanel
  * SPDX-License-Identifier: ISC
  */
 
@@ -179,7 +179,7 @@ auto main(int argc, char* argv[]) -> int
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
     return onHost::executeForEachIfHasDevice(
-        [=](auto const& backend)
+        [=](alpaka::concepts::Backend auto const& backend)
         { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec], numElements); },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/include/alpaka/concepts.hpp
+++ b/include/alpaka/concepts.hpp
@@ -1,11 +1,13 @@
-/* Copyright 2024 René Widera
+/* Copyright 2024 René Widera, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
 #include "alpaka/api/concepts/api.hpp"
+#include "alpaka/api/trait.hpp"
 #include "alpaka/concepts/hasName.hpp"
+#include "alpaka/core/common.hpp"
 #include "alpaka/mem/concepts/AssignableFrom.hpp"
 #include "alpaka/mem/concepts/ExpectedValueType.hpp"
 #include "alpaka/mem/concepts/IBuffer.hpp"
@@ -57,6 +59,15 @@ namespace alpaka
         concept DeviceSpec = requires(T t) {
             { internal::getApi(t) } -> alpaka::concepts::Api;
             { internal::getDeviceKind(t) } -> alpaka::concepts::DeviceKind;
+        };
+
+        /** Concept to check for a backend object containing a device specification and executor.
+         */
+        template<typename T>
+        concept Backend = requires(T t) {
+            requires std::decay_t<T>::hasKey(object::deviceSpec);
+            requires alpaka::concepts::DeviceSpec<ALPAKA_TYPEOF(t[object::deviceSpec])>;
+            { internal::getExecutor(t) } -> alpaka::concepts::Executor;
         };
     } // namespace concepts
 

--- a/include/alpaka/core/Dict.hpp
+++ b/include/alpaka/core/Dict.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 René Widera
+/* Copyright 2024 René Widera, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -7,6 +7,7 @@
 #include "alpaka/Tuple.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/core/util.hpp"
+#include "alpaka/tag.hpp"
 #include "alpaka/unused.hpp"
 #include "alpaka/utility.hpp"
 
@@ -134,6 +135,12 @@ namespace alpaka
             return Dict{alpaka::makeTuple(DictEntry<T_Keys, T_Values>{}...)};
         }
 
+        static constexpr bool hasKey(auto key)
+        {
+            constexpr auto idx = alpaka::internal::KeyIdx<ALPAKA_TYPEOF(key), Dict>::value;
+            return idx != -1;
+        }
+
         ALPAKA_NO_HOST_ACC_WARNING
         constexpr decltype(auto) operator[](auto const tag) const
         {
@@ -165,6 +172,19 @@ namespace alpaka
 
     template<typename... T_Keys, typename... T_Values>
     ALPAKA_FN_HOST_ACC Dict(DictEntry<T_Keys, T_Values> const&...) -> Dict<DictEntry<T_Keys, T_Values>...>;
+
+    namespace internal
+    {
+        template<typename... T_Entries>
+        requires(Dict<T_Entries...>::hasKey(object::exec))
+        struct GetExecutor::Op<Dict<T_Entries...>>
+        {
+            inline constexpr auto operator()(auto&& any) const
+            {
+                return any[object::exec];
+            }
+        };
+    } // namespace internal
 
 } // namespace alpaka
 

--- a/include/alpaka/core/common.hpp
+++ b/include/alpaka/core/common.hpp
@@ -1,5 +1,5 @@
-/* Copyright 2024 Axel Hübl, Benjamin Worpitz, Matthias Werner, Jan Stephan, René Widera, Andrea Bocci, Aurora Perego, Tim Hanel
- * SPDX-License-Identifier: MPL-2.0
+/* Copyright 2024 Axel Hübl, Benjamin Worpitz, Matthias Werner, Jan Stephan, René Widera, Andrea Bocci, Aurora Perego,
+ * Tim Hanel SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once

--- a/include/alpaka/core/common.hpp
+++ b/include/alpaka/core/common.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Axel Hübl, Benjamin Worpitz, Matthias Werner, Jan Stephan, René Widera, Andrea Bocci, Aurora Perego
+/* Copyright 2024 Axel Hübl, Benjamin Worpitz, Matthias Werner, Jan Stephan, René Widera, Andrea Bocci, Aurora Perego, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -7,6 +7,19 @@
 #include "alpaka/core/config.hpp"
 
 #include <type_traits>
+
+namespace alpaka::internal
+{
+    // Forward declaration to avoid a circular include between Dict and the interface helpers.
+    struct GetExecutor
+    {
+        template<typename T_Any>
+        struct Op;
+    };
+
+    template<typename T_Any>
+    inline constexpr auto getExecutor(T_Any&& any) -> decltype(GetExecutor::Op<std::decay_t<T_Any>>{}(any));
+} // namespace alpaka::internal
 
 #if ALPAKA_LANG_HIP
 // HIP defines some keywords like __forceinline__ in header files.

--- a/include/alpaka/interface.hpp
+++ b/include/alpaka/interface.hpp
@@ -1,9 +1,10 @@
-/* Copyright 2024 René Widera
+/* Copyright 2024 René Widera, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
+#include "alpaka/api/trait.hpp"
 #include "alpaka/concepts.hpp"
 #include "alpaka/internal/interface.hpp"
 #include "alpaka/tag.hpp"
@@ -12,6 +13,24 @@
 
 namespace alpaka
 {
+    /** Get the executor associated with an object
+     *
+     * @param any object carrying an executor, e.g. an accelerator or backend dictionary
+     * @return executor tag
+     *
+     * @{
+     */
+    inline constexpr decltype(auto) getExecutor(auto&& any)
+    {
+        return alpaka::internal::getExecutor(ALPAKA_FORWARD(any));
+    }
+
+    inline constexpr decltype(auto) getExecutor(alpaka::concepts::HasGet auto&& any)
+    {
+        return alpaka::internal::getExecutor(*any.get());
+    }
+
+    /** @} */
 
     /** Get the API an object depends on
      *
@@ -32,6 +51,13 @@ namespace alpaka
 
     namespace concepts
     {
+        /** Concept to check if the given type implements the `getExecutor(T x)` function returning an
+         * alpaka::concepts::Executor
+         */
+        template<typename T_Any>
+        concept HasExecutor = requires(T_Any&& any) {
+            { getExecutor(any) } -> alpaka::concepts::Executor;
+        };
         /** Concept to check if the given type implements the `getApi(T x)` function returning an alpaka::concepts::Api
          */
         template<typename T_Any>

--- a/include/alpaka/interface.hpp
+++ b/include/alpaka/interface.hpp
@@ -49,6 +49,11 @@ namespace alpaka
         return alpaka::internal::getApi(*any.get());
     }
 
+    inline constexpr decltype(auto) getApi(alpaka::concepts::Backend auto&& backend)
+    {
+        return getApi(ALPAKA_FORWARD(backend)[object::deviceSpec]);
+    }
+
     namespace concepts
     {
         /** Concept to check if the given type implements the `getExecutor(T x)` function returning an
@@ -83,6 +88,11 @@ namespace alpaka
     inline constexpr decltype(auto) getDeviceKind(alpaka::concepts::HasGet auto&& any)
     {
         return alpaka::internal::getDeviceKind(*any.get());
+    }
+
+    inline constexpr decltype(auto) getDeviceKind(alpaka::concepts::Backend auto&& backend)
+    {
+        return getDeviceKind(ALPAKA_FORWARD(backend)[object::deviceSpec]);
     }
 
     /** @} */

--- a/include/alpaka/internal/interface.hpp
+++ b/include/alpaka/internal/interface.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 René Widera
+/* Copyright 2024 René Widera, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -68,6 +68,27 @@ namespace alpaka
         inline constexpr auto getApi(onHost::Handle<T_Any>&& anyHandle)
         {
             return GetApi::Op<ALPAKA_TYPEOF(*anyHandle.get())>{}(*anyHandle.get());
+        }
+
+        template<typename T_Any>
+        struct GetExecutor::Op
+        {
+            inline constexpr auto operator()(auto&& any) const -> decltype(any.getExecutor())
+            {
+                return any.getExecutor();
+            }
+        };
+
+        template<typename T_Any>
+        inline constexpr auto getExecutor(T_Any&& any) -> decltype(GetExecutor::Op<std::decay_t<T_Any>>{}(any))
+        {
+            return GetExecutor::Op<std::decay_t<T_Any>>{}(ALPAKA_FORWARD(any));
+        }
+
+        template<typename T_Any>
+        inline constexpr auto getExecutor(onHost::Handle<T_Any>&& anyHandle)
+        {
+            return GetExecutor::Op<ALPAKA_TYPEOF(*anyHandle.get())>{}(*anyHandle.get());
         }
 
         struct GetDeviceType

--- a/include/alpaka/onAcc/Acc.hpp
+++ b/include/alpaka/onAcc/Acc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 René Widera
+/* Copyright 2024 René Widera, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -70,6 +70,11 @@ namespace alpaka::onAcc
         constexpr auto getDeviceKind() const
         {
             return T_Storage::operator[](object::deviceKind);
+        }
+
+        constexpr auto getExecutor() const
+        {
+            return T_Storage::operator[](object::exec);
         }
 
         /** Check if a frame spec was used to enqueue the kernel

--- a/include/alpaka/onHost/DeviceSelector.hpp
+++ b/include/alpaka/onHost/DeviceSelector.hpp
@@ -1,9 +1,10 @@
-/* Copyright 2024 René Widera
+/* Copyright 2024 René Widera, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
+#include "alpaka/concepts.hpp"
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/onHost/DeviceSpec.hpp"
 #include "alpaka/utility.hpp"
@@ -18,6 +19,10 @@ namespace alpaka::onHost
             DeviceSpec<T_Api, T_DeviceKind>::isValid(),
             "Invalid combination of device kind and api. The api does not know how to talk to the device or the "
             "required dependencies to enable the api are not fulfilled.");
+
+        constexpr DeviceSelector(alpaka::concepts::Backend auto backend) : DeviceSelector(backend[object::deviceSpec])
+        {
+        }
 
         constexpr DeviceSelector(DeviceSpec<T_Api, T_DeviceKind> deviceSpec)
             : m_platform(internal::makePlatform(deviceSpec.getApi(), deviceSpec.getDeviceKind()))
@@ -72,6 +77,12 @@ namespace alpaka::onHost
     template<typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     inline auto makeDeviceSelector(DeviceSpec<T_Api, T_DeviceKind> deviceSpec)
     {
+        return DeviceSelector{deviceSpec};
+    }
+
+    inline auto makeDeviceSelector(alpaka::concepts::Backend auto backend)
+    {
+        auto deviceSpec = backend[object::deviceSpec];
         return DeviceSelector{deviceSpec};
     }
 

--- a/include/alpaka/onHost/executeForEach.hpp
+++ b/include/alpaka/onHost/executeForEach.hpp
@@ -1,8 +1,9 @@
-/* Copyright 2023 Jeffrey Kelling, Bernhard Manfred Gruber, Jan Stephan, Aurora Perego, Andrea Bocci
+/* Copyright 2023 Jeffrey Kelling, Bernhard Manfred Gruber, Jan Stephan, Aurora Perego, Andrea Bocci, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #include "alpaka/api/api.hpp"
+#include "alpaka/interface.hpp"
 #include "alpaka/onHost/DeviceSelector.hpp"
 
 #include <functional>
@@ -56,9 +57,10 @@ namespace alpaka::onHost
      * @return The disjunction of all returned error codes. If false, the result is `EXIT_SUCCESS`;
      *          otherwise, at least a failure occurred.
      */
-    inline int executeForEachIfHasDevice(auto&& callable, auto const& tupleOfBackends)
+    template<alpaka::concepts::Backend... T_Backends>
+    inline int executeForEachIfHasDevice(auto&& callable, std::tuple<T_Backends...> const& tupleOfBackends)
     {
-        auto exe = [=](auto const& backend)
+        auto exe = [=](alpaka::concepts::Backend auto const& backend)
         {
             auto devSelector = onHost::makeDeviceSelector(backend[object::deviceSpec]);
             if(devSelector.isAvailable())

--- a/test/unit/concepts/concepts.cpp
+++ b/test/unit/concepts/concepts.cpp
@@ -1,24 +1,27 @@
-/* Copyright 2025 Anton Reinhard
+/* Copyright 2025 Anton Reinhard, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #include <alpaka/alpaka.hpp>
 
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstddef>
+#include <type_traits>
 
 using namespace alpaka;
 
 using Data = std::size_t;
+using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
 template<typename TIdx>
 void testVector()
 {
-    STATIC_CHECK(concepts::Vector<alpaka::Vec<TIdx, TIdx{0}>>); // only disallowed at runtime
-    STATIC_CHECK(concepts::Vector<alpaka::Vec<Data, TIdx{1}>>);
-    STATIC_CHECK(concepts::Vector<alpaka::Vec<Data, TIdx{2}>>);
-    STATIC_CHECK(concepts::Vector<alpaka::Vec<Data, TIdx{3}>>);
+    STATIC_CHECK(concepts::Vector<Vec<TIdx, TIdx{0}>>); // only disallowed at runtime
+    STATIC_CHECK(concepts::Vector<Vec<Data, TIdx{1}>>);
+    STATIC_CHECK(concepts::Vector<Vec<Data, TIdx{2}>>);
+    STATIC_CHECK(concepts::Vector<Vec<Data, TIdx{3}>>);
     STATIC_CHECK_FALSE(concepts::CVector<alpaka::Vec<TIdx, TIdx{0}>>); // only disallowed at runtime
     STATIC_CHECK_FALSE(concepts::CVector<alpaka::Vec<Data, TIdx{1}>>);
     STATIC_CHECK_FALSE(concepts::CVector<alpaka::Vec<Data, TIdx{2}>>);
@@ -81,4 +84,14 @@ TEST_CASE("thread spec concepts", "[concepts][threadspec]")
 
     STATIC_CHECK_FALSE(onHost::concepts::ThreadSpec<ThreadSpec<TestVec2, TestVec2>, int>);
     STATIC_CHECK_FALSE(onHost::concepts::ThreadSpec<ThreadSpec<TestVec1, TestVec1>, size_t, 2>);
+}
+
+TEMPLATE_LIST_TEST_CASE("backend concept", "[concepts][backend]", TestBackends)
+{
+    auto backend = TestType::makeDict();
+
+    STATIC_CHECK(alpaka::concepts::Backend<TestType>);
+    STATIC_CHECK_FALSE(alpaka::concepts::Backend<decltype(backend[alpaka::object::deviceSpec])>);
+    CHECK(alpaka::getApi(backend) == alpaka::getApi(backend[alpaka::object::deviceSpec]));
+    CHECK(alpaka::getDeviceKind(backend) == alpaka::getDeviceKind(backend[alpaka::object::deviceSpec]));
 }

--- a/test/unit/concepts/concepts.cpp
+++ b/test/unit/concepts/concepts.cpp
@@ -14,6 +14,7 @@ using namespace alpaka;
 
 using Data = std::size_t;
 using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
+using DictWithoutDeviceSpecOrExec = Dict<DictEntry<object::Api, api::Host>>;
 
 template<typename TIdx>
 void testVector()
@@ -91,6 +92,7 @@ TEMPLATE_LIST_TEST_CASE("backend concept", "[concepts][backend]", TestBackends)
     auto backend = TestType::makeDict();
 
     STATIC_CHECK(alpaka::concepts::Backend<TestType>);
+    STATIC_CHECK_FALSE(alpaka::concepts::Backend<DictWithoutDeviceSpecOrExec>);
     STATIC_CHECK_FALSE(alpaka::concepts::Backend<decltype(backend[alpaka::object::deviceSpec])>);
     CHECK(alpaka::getApi(backend) == alpaka::getApi(backend[alpaka::object::deviceSpec]));
     CHECK(alpaka::getDeviceKind(backend) == alpaka::getDeviceKind(backend[alpaka::object::deviceSpec]));

--- a/test/unit/device/deviceProperties.cpp
+++ b/test/unit/device/deviceProperties.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2026 René Widera
+/* Copyright 2026 René Widera, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -7,6 +7,8 @@
 #include <alpakaTest/deviceHelper.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
+
+#include <type_traits>
 
 using namespace alpaka;
 
@@ -34,4 +36,17 @@ TEMPLATE_LIST_TEST_CASE("deviceProperties", "[device][property]", TestApis)
     INFO("dim = 5 blocksPerGrid = " << deviceProperties.getMaxBlocksPerGrid<5>());
     // This call is required else no information will be shown on the terminal.
     SUCCEED("-----------------------------");
+}
+
+TEMPLATE_LIST_TEST_CASE("device selector from backend", "[device][selector]", TestApis)
+{
+    auto backend = TestType::makeDict();
+    STATIC_CHECK(alpaka::concepts::Backend<decltype(backend)>);
+
+    auto selectorFromBackend = onHost::makeDeviceSelector(backend);
+    auto selectorFromDeviceSpec = onHost::makeDeviceSelector(backend[object::deviceSpec]);
+
+    STATIC_CHECK(std::is_same_v<decltype(selectorFromBackend), decltype(selectorFromDeviceSpec)>);
+    CHECK(selectorFromBackend.isAvailable() == selectorFromDeviceSpec.isAvailable());
+    CHECK(selectorFromBackend.getDeviceCount() == selectorFromDeviceSpec.getDeviceCount());
 }

--- a/test/unit/interface/executor.cpp
+++ b/test/unit/interface/executor.cpp
@@ -1,0 +1,74 @@
+/* Copyright 2026 Tim Hanel
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <alpakaTest/deviceHelper.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <type_traits>
+
+using namespace alpaka;
+
+using TestApis = ALPAKA_TYPEOF(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
+
+struct GetExecutorKernel
+{
+    template<onAcc::concepts::Acc T_Acc>
+    ALPAKA_FN_ACC void operator()(T_Acc const& acc, auto result) const
+    {
+        auto executor = alpaka::getExecutor(acc);
+
+        static_assert(concepts::Executor<ALPAKA_TYPEOF(executor)>);
+        static_assert(std::is_same_v<ALPAKA_TYPEOF(executor), ALPAKA_TYPEOF(acc.getExecutor())>);
+
+        result[0] = executor == acc.getExecutor();
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("get executor", "[interface][executor]", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto executor = alpaka::getExecutor(cfg);
+
+    static_assert(concepts::HasExecutor<ALPAKA_TYPEOF(cfg)>);
+    static_assert(concepts::Executor<ALPAKA_TYPEOF(executor)>);
+    CHECK((executor == cfg[object::exec]));
+
+    onHost::Device device = test::getDeviceOrSkipTest(cfg);
+    onHost::Queue queue = device.makeQueue();
+
+    auto dBuff = onHost::alloc<bool>(device, Vec{1u});
+    auto hBuff = onHost::allocHostLike(dBuff);
+
+    queue.enqueue(onHost::FrameSpec{Vec{1u}, Vec{1u}, executor}, KernelBundle{GetExecutorKernel{}, dBuff});
+    onHost::memcpy(queue, hBuff, dBuff);
+    onHost::wait(queue);
+
+    CHECK(hBuff[0]);
+}
+
+TEMPLATE_LIST_TEST_CASE("get device kind", "[interface][deviceKind]", TestApis)
+{
+    auto cfg = TestType::makeDict();
+    auto deviceKind = alpaka::getDeviceKind(cfg);
+
+    static_assert(concepts::DeviceKind<ALPAKA_TYPEOF(deviceKind)>);
+    CHECK((deviceKind == cfg[object::deviceSpec].getDeviceKind()));
+
+    onHost::Device device = test::getDeviceOrSkipTest(cfg);
+    onHost::Queue queue = device.makeQueue();
+
+    auto deviceDeviceKind = alpaka::getDeviceKind(device);
+    auto queueDeviceKind = alpaka::getDeviceKind(queue);
+
+    static_assert(concepts::DeviceKind<ALPAKA_TYPEOF(deviceDeviceKind)>);
+    static_assert(concepts::DeviceKind<ALPAKA_TYPEOF(queueDeviceKind)>);
+    static_assert(std::is_same_v<ALPAKA_TYPEOF(deviceDeviceKind), ALPAKA_TYPEOF(device.getDeviceKind())>);
+    static_assert(std::is_same_v<ALPAKA_TYPEOF(queueDeviceKind), ALPAKA_TYPEOF(device.getDeviceKind())>);
+
+    CHECK((deviceDeviceKind == device.getDeviceKind()));
+    CHECK((queueDeviceKind == device.getDeviceKind()));
+}


### PR DESCRIPTION
`Backend` is a term that has been used loosely throughout this repository without providing a clear interface or contract. This PR introduces a precise concept definition for the term and applies it where appropriate.

A `Backend` is an `alpaka::Dict` that allows a user to retrieve a `DeviceKind` and an `Executor` via corresponding keys using the [] operator. 
Based on this definition, this PR introduces a small additional interface, `getExecutor`, to describe the concept more clearly.

The introduced `getExecutor` is a free function defined similarly to `getApi`. Currently, it returns the requested `Executor` for an `alpaka::Dict` and for an accelerator, `onAcc::acc`.

Additionally it provides  a `getDeviceKind` overload, which is enabled for objects fullfiling the `backend` concept.

On top of that this PR introduces a small convenience function that allows directly retrieving a `deviceSelector` from an object that fulfills the described `Backend` concept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a first-class, type-safe **Backend** concept.
  * Introduced backend-derived helpers: **getExecutor**, **getApi**, and **getDeviceKind**.
  * Added backend-based device selector construction and an **executor** accessor on accelerator objects.
* **Bug Fixes**
  * Improved type-safety in examples by tightening backend callback typing (no behavior changes).
* **Tests**
  * Expanded unit coverage for the Backend concept, device selectors, executor access, and device kind queries.
* **Documentation**
  * Updated terms to document the new Backend concept and related definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->