### PR TITLE
fix missing return

### DIFF
--- a/example/randomInit/src/randomInit.cpp
+++ b/example/randomInit/src/randomInit.cpp
@@ -394,8 +394,8 @@ auto main(int argc, char* argv[]) -> int
     return onHost::executeForEachIfHasDevice(
         [=](auto const& tag)
         {
-            auto retVal = exampleUniformDist(tag, numElements) || exampleNormalDist(tag, numElementsNormal);
-            return retVal;
+            bool retVal = exampleUniformDist(tag, numElements) || exampleNormalDist(tag, numElementsNormal);
+            return retVal == false ? EXIT_SUCCESS : EXIT_FAILURE;
         },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/include/alpaka/onHost/executeForEach.hpp
+++ b/include/alpaka/onHost/executeForEach.hpp
@@ -13,56 +13,89 @@
 
 namespace alpaka::onHost
 {
-    //! execute a callable for each active accelerator tag
-    //
-    // @param callable callable which can be invoked with an accelerator tag
-    // @return disjunction of all invocation results
-    //
-    inline auto executeForEach(auto&& callable, auto const& backends)
+    /**! Execute a callable for each tuple entry.
+     *
+     * @attention: Execution is short-circuited and stops after the first error.
+     *
+     * @param callable Callable that can be invoked with each tuple entry and returns an execution status.
+     *        A return value of zero (`EXIT_SUCCESS`) indicates success; any non-zero value indicates a failure.
+     * @param tuple Tuple like list of entries used to invoke the callable.
+     * @return The disjunction of all returned error codes. If false, the result is `EXIT_SUCCESS`;
+     *          otherwise, at least a failure occurred.
+     */
+    template<template<typename...> class T_TupleLike, typename... T_Entries>
+    inline int executeForEach(auto&& callable, T_TupleLike<T_Entries...> const& tuple)
     {
         // Execute the callable once for each enabled accelerator.
         // Pass the tag as first argument to the callable.
-        return std::apply([=](auto const&... backend) { return (callable(backend) || ...); }, backends);
+        return std::apply(
+                   [=](auto const&... tupleEntry)
+                   {
+                       static_assert(
+                           (std::same_as<ALPAKA_TYPEOF(callable(tupleEntry)), int> && ...),
+                           "The callable must return 'int'.");
+                       return (static_cast<bool>(callable(tupleEntry)) || ...);
+                   },
+                   tuple)
+                       == false
+                   ? EXIT_SUCCESS
+                   : EXIT_FAILURE;
     }
 
-    //! execute a callable for each active backend if there is a device available
-    //
-    // The function contains a runtime check if at least one device is available, if there is no device the callable
-    // will not be executed. Not executed combinations will return EXIT_SUCCESS.
-    //
-    // @param callable callable which can be invoked with the backend
-    // @return disjunction of all invocation results
-    //
-    inline auto executeForEachIfHasDevice(auto&& callable, auto const& tupleOfBackends)
+    /**! execute a callable for each backend if there is a device available
+     *
+     * The function contains a runtime check if at least one device is available, if there is no device the callable
+     * will not be executed. Not executed combinations will return EXIT_SUCCESS.
+     *
+     * @attention: Execution is short-circuited and stops after the first error.
+     *
+     * @param callable Callable that can be invoked with each backend and returns an execution status.
+     *        A return value of zero (`EXIT_SUCCESS`) indicates success; any non-zero value indicates a failure.
+     * @param tuple Tuple like list of backends used to invoke the callable.
+     *         otherwise, at least one failure occurred.
+     * @return The disjunction of all returned error codes. If false, the result is `EXIT_SUCCESS`;
+     *          otherwise, at least a failure occurred.
+     */
+    inline int executeForEachIfHasDevice(auto&& callable, auto const& tupleOfBackends)
     {
         auto exe = [=](auto const& backend)
         {
             auto devSelector = onHost::makeDeviceSelector(backend[object::deviceSpec]);
             if(devSelector.isAvailable())
             {
-                callable(backend);
+                return callable(backend);
             }
             return EXIT_SUCCESS;
         };
-        // Execute the callable once for each enabled accelerator.
-        // Pass the tag as first argument to the callable.
-        return std::apply([=](auto const&... backends) { return (exe(backends) || ...); }, tupleOfBackends);
+        return executeForEach(exe, tupleOfBackends);
     }
 
+    /**! execute a callable for each device specification if there is a device available
+     *
+     * The function contains a runtime check if at least one device is available, if there is no device the callable
+     * will not be executed. Not executed combinations will return EXIT_SUCCESS.
+     *
+     * @attention: Execution is short-circuited and stops after the first error.
+     *
+     * @param callable Callable that can be invoked with device specification and returns an execution status.
+     *        A return value of zero (`EXIT_SUCCESS`) indicates success; any non-zero value indicates a failure.
+     * @param tuple Tuple like list of device specifications used to invoke the callable.
+     *         otherwise, at least one failure occurred.
+     * @return The disjunction of all returned error codes. If false, the result is `EXIT_SUCCESS`;
+     *          otherwise, at least a failure occurred.
+     */
     template<onHost::concepts::DeviceSpec... T_DeviceSpecs>
-    inline auto executeForEachIfHasDevice(auto&& callable, std::tuple<T_DeviceSpecs...> const& tupleOfDeviceSpecs)
+    inline int executeForEachIfHasDevice(auto&& callable, std::tuple<T_DeviceSpecs...> const& tupleOfDeviceSpecs)
     {
         auto exe = [=](auto const& devSpec)
         {
             auto devSelector = onHost::makeDeviceSelector(devSpec);
             if(devSelector.isAvailable())
             {
-                callable(devSpec);
+                return callable(devSpec);
             }
             return EXIT_SUCCESS;
         };
-        // Execute the callable once for each enabled accelerator.
-        // Pass the tag as first argument to the callable.
-        return std::apply([=](auto const&... devSpecs) { return (exe(devSpecs) || ...); }, tupleOfDeviceSpecs);
+        return executeForEach(exe, tupleOfDeviceSpecs);
     }
 } // namespace alpaka::onHost


### PR DESCRIPTION
In `executeForEachIfHasDevice()` we missed to return the error code of the executed functor.
The result is that each test provided true even if an error happened during the execution.

This PR: 
- fixed the comments copied over from alpaka mainline
- validates the return code of the callable
- stabilizes the interface by accepting any kind of tuple-like lists

This function is often used in examples; let's hope that we do not find new bugs with this fix.

note: The original code was copied from alpaka mainline. I write the peace of code in alpaka mainline by myself and we have the same issues there.

Thanks @TimHanel00 for pointing me to the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the host execution helper to propagate and aggregate the callback’s result instead of always reporting success when the device is available.
  * Fixed cases where non-executed combinations could mask failures; the final status now accurately reflects whether invoked callbacks reported success or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->