### PR TITLE
restrict the number of parallel AMD GPU runtime tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,6 +71,7 @@ hipcc-6.2-agc:
     APCI_HIP : 6.2
 
 hipcc-6.3-rocm-container:
+  needs: ["hipcc-6.2-agc"]
   image: rocm/dev-ubuntu-24.04:6.3.4
   extends: .hip
   variables:
@@ -87,6 +88,7 @@ hipcc-6.4:
     APCI_HIP : 6.4.2
 
 hipcc-7.0:
+  needs: ["hipcc-6.4"]
   image: ubuntu:24.04
   extends: .hip
   variables:
@@ -103,6 +105,7 @@ hipcc-7.1:
     APCI_HIP : 7.1
 
 hipcc-7.2-rocm-container:
+  needs: ["hipcc-7.1"]
   image: rocm/dev-ubuntu-24.04:7.2
   extends: .hip
   variables:


### PR DESCRIPTION
- Looks like the GPU of the GPU runner gets problems, if to many CI jobs are executed in paralllel.
- Temporary solution until the job generator is implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI pipeline to enforce clearer job ordering for several ROCm-related builds.
  * This should improve build consistency and reduce issues caused by jobs running before their prerequisites are ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->