### PR TITLE
CI: calculate APCI_BUILD_THREADS only if variable is not set

### DIFF
--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -10,6 +10,32 @@ source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
 
 script_msg "Run CMake build (build.sh)"
 
+# Return the number of build threads depending on the
+# - maximum number of available threads (first parameter)
+# - available memory (second parameter)
+# - required memory per thread (configure via variable ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES)
+function get_build_threads() {
+    if [[ $# -lt 2 ]]; then
+        echo -e "\e[1;31m[ERROR]: " \
+            "get_build_threads() set as first argument maximum number of available build threads " \
+            "and as second argument max number of available memory in bytes" \
+            "\e[0m"
+        exit 1
+    fi
+
+    local max_possible_build_threads=$(($2 / ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES))
+
+    if [[ $max_possible_build_threads -lt 1 ]]; then
+        max_possible_build_threads=1
+    fi
+
+    if [[ $1 -le $max_possible_build_threads ]]; then
+        echo "$1"
+    else
+        echo "$max_possible_build_threads"
+    fi
+}
+
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-""}
 
 if [[ "$APCI_ONEAPI" != 0 ]]; then
@@ -21,11 +47,16 @@ if [[ "$APCI_ONEAPI" != 0 ]]; then
     fi
 fi
 
+if [[ -z ${APCI_BUILD_THREADS+x} ]]; then
+    APCI_BUILD_THREADS=$(get_build_threads "${APCI_MAX_NUM_BUILD_THREADS}" "${APCI_TOTAL_MEMORY_BYTES}")
+fi
+
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 # TODO: remove me, if all install scripts are ported
 if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "icpx" ]]; then
     load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 
+    echo_green "Set APCI_BUILD_THREADS to overwrite automatically calculated number of build threads."
     echo_green "$(echo_if_not_empty LD_LIBRARY_PATH)" \
         "${APCI_CMAKE_BIN_PATH}/cmake" \
         --build /build \

--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -13,7 +13,7 @@ script_msg "Run CMake build (build.sh)"
 # Return the number of build threads depending on the
 # - maximum number of available threads (first parameter)
 # - available memory (second parameter)
-# - required memory per thread (configure via variable ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES)
+# - required memory per thread (configure via variable APCI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES)
 function get_build_threads() {
     if [[ $# -lt 2 ]]; then
         echo -e "\e[1;31m[ERROR]: " \
@@ -23,7 +23,7 @@ function get_build_threads() {
         exit 1
     fi
 
-    local max_possible_build_threads=$(($2 / ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES))
+    local max_possible_build_threads=$(($2 / APCI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES))
 
     if [[ $max_possible_build_threads -lt 1 ]]; then
         max_possible_build_threads=1
@@ -48,7 +48,24 @@ if [[ "$APCI_ONEAPI" != 0 ]]; then
 fi
 
 if [[ -z ${APCI_BUILD_THREADS+x} ]]; then
-    APCI_BUILD_THREADS=$(get_build_threads "${APCI_MAX_NUM_BUILD_THREADS}" "${APCI_TOTAL_MEMORY_BYTES}")
+    # local container
+    if [[ -z ${GITHUB_ACTIONS+x} ]] && [[ -z ${GITLAB_CI+x} ]]; then
+        max_num_build_threads=$(nproc)
+        total_memory_bytes=$(free -b | awk '/Mem:/ { print $2 }')
+    fi
+
+    if [[ -n ${GITHUB_ACTIONS+x} ]]; then
+        max_num_build_threads=$(nproc)
+        total_memory_bytes=$(free -b | awk '/Mem:/ { print $2 }')
+    fi
+
+    if [[ -n ${GITLAB_CI+x} ]]; then
+        # CI_CPU and CI_RAM_BYTES_TOTAL are predefined on the HZDR runner
+        max_num_build_threads="${CI_CPUS}"
+        total_memory_bytes="${CI_RAM_BYTES_TOTAL}"
+    fi
+
+    APCI_BUILD_THREADS=$(get_build_threads "${max_num_build_threads}" "${total_memory_bytes}")
 fi
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -8,39 +8,7 @@
 # setup environment variables depending on os environment (on local system, GitLab CI, GitHub Action ...)
 
 # set the required memory per build thread in GB
-ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES=$((2 * 1024 ** 3))
-
-# Return the number of build threads depending on the
-# - maximum number of available threads (first parameter)
-# - available memory (second parameter)
-# - required memory per thread (configure via variable ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES)
-function get_build_threads() {
-    if [[ $# -lt 2 ]]; then
-        echo -e "\e[1;31m[ERROR]: " \
-            "get_build_threads() set as first argument maximum number of available build threads " \
-            "and as second argument max number of available memory in bytes" \
-            "\e[0m"
-        exit 1
-    fi
-
-    local max_possible_build_threads=$(($2 / ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES))
-
-    if [[ $max_possible_build_threads -lt 1 ]]; then
-        max_possible_build_threads=1
-    fi
-
-    if [[ $1 -le $max_possible_build_threads ]]; then
-        echo "$1"
-    else
-        echo "$max_possible_build_threads"
-    fi
-}
-
-# local container
-if [[ -z ${GITHUB_ACTIONS+x} ]] && [[ -z ${GITLAB_CI+x} ]]; then
-    max_num_build_threads=$(nproc)
-    total_memory_bytes=$(free -b | awk '/Mem:/ { print $2 }')
-fi
+export ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES=$((2 * 1024 ** 3))
 
 if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     # force color output
@@ -71,9 +39,6 @@ if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     if [[ "${APCI_ONEAPI}" == 0 ]] && [[ -z ${APCI_ONEAPI_TARGET+x} ]]; then
         export APCI_ONEAPI_TARGET=none
     fi
-
-    max_num_build_threads=$(nproc)
-    total_memory_bytes=$(free -b | awk '/Mem:/ { print $2 }')
 fi
 
 if [[ -n ${GITLAB_CI+x} ]]; then
@@ -115,10 +80,4 @@ if [[ -n ${GITLAB_CI+x} ]]; then
     fi
     export APCI_AMD_GPU_ARCH
 
-    # CI_CPU and CI_RAM_BYTES_TOTAL are predefined on the HZDR runner
-    max_num_build_threads="${CI_CPUS}"
-    total_memory_bytes="${CI_RAM_BYTES_TOTAL}"
 fi
-
-APCI_BUILD_THREADS=$(get_build_threads "${max_num_build_threads}" "${total_memory_bytes}")
-export APCI_BUILD_THREADS

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -8,7 +8,7 @@
 # setup environment variables depending on os environment (on local system, GitLab CI, GitHub Action ...)
 
 # set the required memory per build thread in GB
-export ACPI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES=$((2 * 1024 ** 3))
+export APCI_REQUIRED_RAM_PER_BUILD_THREAD_BYTES=$((2 * 1024 ** 3))
 
 if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     # force color output
@@ -79,5 +79,4 @@ if [[ -n ${GITLAB_CI+x} ]]; then
         fi
     fi
     export APCI_AMD_GPU_ARCH
-
 fi


### PR DESCRIPTION
- Because of a bug, the number was automatically calculated each time independent of if the variable was set.
- Move calculation to build.sh script because the number of build threads is dependent of the runner and should be calculated dynamically instead be part of the CI job configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI build setup to automatically compute a safer default parallel build thread count from available memory (minimum of one), while still allowing manual override.
  * Centralized build resource initialization so thread count is determined during the build pipeline initialization, rather than across multiple setup steps.
  * Updated shared CI variables by exporting the “RAM per build thread” requirement; adjusted the GitLab CI initialization path to stop after exporting the GPU architecture setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->