### PR TITLE
Fix test destination path for alpaka3 installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Copyright 2023 Benjamin Worpitz, Erik Zenker, Axel Hübl, Jan Stephan, René Widera, Jeffrey Kelling, Andrea Bocci,
-#                Bernhard Manfred Gruber, Aurora Perego
+#                Bernhard Manfred Gruber, Aurora Perego, Tim Hanel
 # SPDX-License-Identifier: MPL-2.0
 #
 
@@ -126,8 +126,8 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/alpakaConfig.cmake DESTINATION ${CMAKE
 install(DIRECTORY ${_alpaka_TESTS_DIR} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR} USE_SOURCE_PERMISSIONS)
 
 # Files required to validate optional features std::atomic_ref and std::simd
-install(FILES "${_alpaka_FEATURE_TESTS_DIR}/StdAtomicRef.cpp" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/alpaka/tests)
-install(FILES "${_alpaka_FEATURE_TESTS_DIR}/StdSimd.cpp" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/alpaka/tests)
+install(FILES "${_alpaka_FEATURE_TESTS_DIR}/StdAtomicRef.cpp" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/alpaka/test)
+install(FILES "${_alpaka_FEATURE_TESTS_DIR}/StdSimd.cpp" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/alpaka/test)
 
 # Load alpaka's languages after FetchContent_MakeAvailable()
 #

--- a/docs/source/basic/terms.rst
+++ b/docs/source/basic/terms.rst
@@ -226,7 +226,7 @@ Executor
 Backend
 -------
 
-A ``Backend`` the combination of a ``DeviceSpec`` and an ``Executor``. It is typically returned by ``onHost::allBackends(...)``.
+A ``Backend`` is the combination of a ``DeviceSpec`` and an ``Executor``. It is typically returned by ``onHost::allBackends(...)``.
 
 .. _thread_spec:
 

--- a/include/alpaka/api/unifiedCudaHip/Event.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Event.hpp
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#pragma once
-
 #include "alpaka/api/cuda/IdxLayer.hpp"
 #include "alpaka/api/generic.hpp"
 #include "alpaka/api/hip/IdxLayer.hpp"


### PR DESCRIPTION
This PR changes the install destination to `lib/cmake/alpaka/test`, matching the
  test paths referenced in `alpakaConfig.cmake` and `alpakaCommon.cmake` instead of using the wrong `lib/cmake/alpaka/tests` installation target directory. 
  
During installation, the feature-test sources are copied to
`lib/cmake/alpaka/tests`, but an installed alpaka enabled through `find_package(alpaka CONFIG
REQUIRED)` sets `_alpaka_FEATURE_TESTS_DIR` from the directory containing
`alpakaConfig.cmake` and looks for them under `lib/cmake/alpaka/test`, which results in an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the installation location for optional feature validation sources, so they are placed in the expected test directory.
* **Documentation**
  * Fixed a terminology sentence in the backend documentation for clearer wording.
* **Chores**
  * Updated copyright header information.
  * Cleaned up a redundant header directive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->