### PR TITLE
CI: configure enabled executors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@
   variables:
     APCI_ALPAKA_ROOT: "$CI_PROJECT_DIR"
     APCI_RUN_CTEST: "ON"
+    APCI_EXEC_CPU_SERIAL: "OFF"
     APCI_HIP : 0
     APCI_ONEAPI : 0
     APCI_ONEAPI_TARGET: none
@@ -28,6 +29,7 @@ gcc-13:
   variables:
     APCI_DEVICE_COMPILER : gcc@13
     APCI_CMAKE: 3.28.3
+    APCI_EXEC_CPU_SERIAL: "ON"
 
 gcc-15:
   image: docker.io/ubuntu:24.04
@@ -35,6 +37,7 @@ gcc-15:
   variables:
     APCI_DEVICE_COMPILER : gcc@15
     APCI_CMAKE: 3.28.3
+    APCI_EXEC_CPU_SERIAL: "ON"
 
 gcc-12-agc:
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu24.04-gcc:4.0
@@ -42,6 +45,7 @@ gcc-12-agc:
   variables:
     APCI_DEVICE_COMPILER : gcc@12
     APCI_CMAKE: 3.31.4
+    APCI_EXEC_CPU_SERIAL: "ON"
 
 clang-19:
   image: docker.io/ubuntu:24.04
@@ -49,6 +53,7 @@ clang-19:
   variables:
     APCI_DEVICE_COMPILER : clang@19
     APCI_CMAKE: 3.28.3
+    APCI_EXEC_CPU_SERIAL: "ON"
 
 clang-21:
   image: docker.io/ubuntu:24.04
@@ -56,6 +61,7 @@ clang-21:
   variables:
     APCI_DEVICE_COMPILER : clang@21
     APCI_CMAKE: 3.28.3
+    APCI_EXEC_CPU_SERIAL: "ON"
 
 clang-20-agc:
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu24.04-gcc:4.0
@@ -63,6 +69,7 @@ clang-20-agc:
   variables:
     APCI_DEVICE_COMPILER : clang@20
     APCI_CMAKE: 3.31.4
+    APCI_EXEC_CPU_SERIAL: "ON"
 
 hipcc-6.2-agc:
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu22.04-rocm6.2:4.0

--- a/docs/source/advanced/cmake.rst
+++ b/docs/source/advanced/cmake.rst
@@ -368,7 +368,7 @@ Executors
 
      Enable the OpenMP CPU blocks executor `exec::cpuOmpBlocks`.
 
-``alpaka_EXEC_CPU_TbbBlocks``
+``alpaka_EXEC_TbbBlocks``
   .. code-block:: markdown
 
      Enable the TBB CPU blocks executor `exec::cpuTbbBlocks`.

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -77,8 +77,6 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
 
         ap_deps['ONEAPI']=ON
 
-        CMAKE_ARGS+=(-Dalpaka_EXEC_CpuSerial=OFF)
-
         declare -A ap_sycl_targets=(
             ["alpaka_ONEAPI_Cpu"]=OFF
             ["alpaka_ONEAPI_IntelGpu"]=OFF
@@ -110,22 +108,13 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
     done
 
     # enable executor
-    if [[ ${ap_deps['OMP']} == "ON" || ${ap_deps['HWLOC']} == "ON" ]]; then
-        CMAKE_ARGS+=(
-            "-Dalpaka_EXEC_CpuSerial=ON"
-            "-Dalpaka_EXEC_CpuOmpBlocks=ON"
-        )
-    else
-        CMAKE_ARGS+=(
-            "-Dalpaka_EXEC_CpuSerial=OFF"
-            "-Dalpaka_EXEC_CpuOmpBlocks=OFF"
-        )
-    fi
     CMAKE_ARGS+=(
-        "-Dalpaka_EXEC_TbbBlocks=${ap_deps['TBB']}"
-        "-Dalpaka_EXEC_GpuCuda=${ap_deps['CUDA']}"
-        "-Dalpaka_EXEC_GpuHip=${ap_deps['HIP']}"
-        "-Dalpaka_EXEC_OneApi=${ap_deps['ONEAPI']}"
+        -Dalpaka_EXEC_CpuSerial="${APCI_EXEC_CPU_SERIAL}"
+        -Dalpaka_EXEC_CpuOmpBlocks=ON
+        -Dalpaka_EXEC_TbbBlocks=ON
+        -Dalpaka_EXEC_GpuCuda=ON
+        -Dalpaka_EXEC_GpuHip=ON
+        -Dalpaka_EXEC_OneApi=ON
     )
 
     echo_green "$(echo_if_not_empty LD_LIBRARY_PATH)" \

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -40,16 +40,17 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
     )
 
     declare -A ap_deps=(
-        ["alpaka_DEP_OMP"]=OFF
-        ["alpaka_DEP_HWLOC"]=OFF
-        ["alpaka_DEP_CUDA"]=OFF
-        ["alpaka_DEP_HIP"]=OFF
-        ["alpaka_DEP_ONEAPI"]=OFF
+        ["OMP"]=OFF
+        ["HWLOC"]=OFF
+        ["TBB"]=OFF
+        ["CUDA"]=OFF
+        ["HIP"]=OFF
+        ["ONEAPI"]=OFF
     )
 
     # if no GPU SDK is used
     if [[ ("$APCI_HIP" == 0) && ("$compiler_name" == "gcc" || "$compiler_name" == "clang") ]]; then
-        ap_deps['alpaka_DEP_OMP']=ON
+        ap_deps['OMP']=ON
     fi
 
     if [[ "$APCI_HIP" != 0 ]]; then
@@ -59,7 +60,7 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
         export PATH=${ROCM_PATH}/llvm/bin:$PATH
         export CMAKE_PREFIX_PATH=$ROCM_PATH:$CMAKE_PREFIX_PATH
 
-        ap_deps['alpaka_DEP_HIP']=ON
+        ap_deps['HIP']=ON
 
         if [[ -n ${APCI_AMD_GPU_ARCH+x} ]]; then
             CMAKE_ARGS+=(
@@ -74,7 +75,7 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
         # shellcheck source=script/ci/install/oneapi/setvars.sh
         source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi/setvars.sh"
 
-        ap_deps['alpaka_DEP_ONEAPI']=ON
+        ap_deps['ONEAPI']=ON
 
         CMAKE_ARGS+=(-Dalpaka_EXEC_CpuSerial=OFF)
 
@@ -103,9 +104,29 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
         done
     fi
 
+    # enable dependencies
     for dep in "${!ap_deps[@]}"; do
-        CMAKE_ARGS+=("-D${dep}=${ap_deps[$dep]}")
+        CMAKE_ARGS+=("-Dalpaka_DEP_${dep}=${ap_deps[$dep]}")
     done
+
+    # enable executor
+    if [[ ${ap_deps['OMP']} == "ON" || ${ap_deps['HWLOC']} == "ON" ]]; then
+        CMAKE_ARGS+=(
+            "-Dalpaka_EXEC_CpuSerial=ON"
+            "-Dalpaka_EXEC_CpuOmpBlocks=ON"
+        )
+    else
+        CMAKE_ARGS+=(
+            "-Dalpaka_EXEC_CpuSerial=OFF"
+            "-Dalpaka_EXEC_CpuOmpBlocks=OFF"
+        )
+    fi
+    CMAKE_ARGS+=(
+        "-Dalpaka_EXEC_TbbBlocks=${ap_deps['TBB']}"
+        "-Dalpaka_EXEC_GpuCuda=${ap_deps['CUDA']}"
+        "-Dalpaka_EXEC_GpuHip=${ap_deps['HIP']}"
+        "-Dalpaka_EXEC_OneApi=${ap_deps['ONEAPI']}"
+    )
 
     echo_green "$(echo_if_not_empty LD_LIBRARY_PATH)" \
         "${APCI_CMAKE_BIN_PATH}/cmake" \

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -173,7 +173,7 @@ apt_package_version() {
     apt_ver=$(apt list --all-versions "$1" |
         cut -d " " -f 2 |
         grep "$2" |
-        sort | tail -n 1)
+        sort -V | tail -n 1)
 
     if [[ "${apt_ver}" == "" ]]; then
         exit_error "apt_package_version(): Didn't find any apt version for package $1 with version $2 ."

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -49,6 +49,10 @@ if [[ -n ${GITHUB_ACTIONS+x} ]]; then
 
     export APCI_OS_NAME="$RUNNER_OS"
 
+    if [[ -z ${APCI_EXEC_CPU_SERIAL} ]]; then
+        export APCI_EXEC_CPU_SERIAL=OFF
+    fi
+
     # The Github Actions are handwritten, therefore set some undefined variables to default
     # variables. GitLab CI will not do it, because all jobs are generated and default
     # values for undefined variables are an error source.


### PR DESCRIPTION
Disable all executors, which are not related to the enabled dependency. Should reduce test runtime, in special on the GPU runner. Later, add special jobs which tests more than a single enabled executor.

# TODO

- [x] merge #614 before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated build configuration so CPU executor options are enabled more consistently when OpenMP or system threading support is available.
  * Improved handling of GPU and accelerator-related build options during configuration.

* **Documentation**
  * Renamed the documented CMake option for enabling the TBB CPU blocks executor to match the current flag name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->