### PR TITLE
CI: fix bug that no SYCL CPU device was available

### DIFF
--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -14,6 +14,9 @@ LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-""}
 
 if [[ "$APCI_ONEAPI" != 0 ]]; then
     if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
+        load_variable_if_not_exist ONEAPI_PATH
+        # shellcheck source=script/ci/install/oneapi/setvars.sh
+        source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi/setvars.sh"
         export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${APCI_ONEAPI}/lib/:${LD_LIBRARY_PATH}"
     fi
 fi

--- a/script/ci/install/oneapi.sh
+++ b/script/ci/install/oneapi.sh
@@ -57,6 +57,9 @@ if [[ "$APCI_ONEAPI" != 0 ]]; then
     echo_green "${APCI_CXX_COMPILER} --version"
     $APCI_CXX_COMPILER --version
 
+    echo_green "sycl-ls"
+    sycl-ls
+
     export ONEAPI_PATH
     export APCI_C_COMPILER
     export APCI_CXX_COMPILER

--- a/script/ci/test.sh
+++ b/script/ci/test.sh
@@ -14,8 +14,13 @@ LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-""}
 
 if [[ "$APCI_ONEAPI" != 0 ]]; then
     if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
+        load_variable_if_not_exist ONEAPI_PATH
+        # shellcheck source=script/ci/install/oneapi/setvars.sh
+        source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi/setvars.sh"
         export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${APCI_ONEAPI}/lib/:${LD_LIBRARY_PATH}"
     fi
+    echo_green "sycl-ls"
+    sycl-ls
 fi
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"


### PR DESCRIPTION
If the script `/opt/intel/oneapi/setvars.sh` is not sourced, no SYCL CPU device is available and nearly all alpaka tests are skipped, because no device is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved oneAPI environment setup during build and test runs to reduce configuration issues.
  * Added an extra verification step during oneAPI installation and testing to confirm the tooling is available and working.
  * Ensured the required oneAPI paths are initialized before related build and test steps run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->