### PR TITLE
refactor `concepts::Backend`

### DIFF
--- a/benchmark/HACCmk/src/main_alpaka.cpp
+++ b/benchmark/HACCmk/src/main_alpaka.cpp
@@ -330,13 +330,6 @@ auto main(int argc, char* argv[]) -> int
      */
     return onHost::executeForEachIfHasDevice(
         [=](auto const& backend)
-        {
-            return haccmkAlpaka::example(
-                backend[alpaka::object::deviceSpec],
-                backend[alpaka::object::exec],
-                n2,
-                n1,
-                repeat);
-        },
+        { return haccmkAlpaka::example(onHost::makeDeviceSpec(backend), getExecutor(backend), n2, n1, repeat); },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/benchmark/babelstream/src/babelStreamMainTest.cpp
+++ b/benchmark/babelstream/src/babelStreamMainTest.cpp
@@ -513,7 +513,7 @@ TEMPLATE_LIST_TEST_CASE("TEST: Babelstream Kernels<Float>", "[benchmark-test]", 
 {
     auto backend = TestType::makeDict();
     // Run tests for the float data type
-    testKernels<float>(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]);
+    testKernels<float>(alpaka::onHost::DeviceSpec{backend}, alpaka::getExecutor(backend));
 }
 
 // Run for all Accs given by the argument
@@ -521,5 +521,5 @@ TEMPLATE_LIST_TEST_CASE("TEST: Babelstream Kernels<Double>", "[benchmark-test]",
 {
     auto backend = TestType::makeDict();
     // Run tests for the double data type
-    testKernels<double>(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]);
+    testKernels<double>(alpaka::onHost::DeviceSpec{backend}, alpaka::getExecutor(backend));
 }

--- a/docs/snippets/example/030_queue.cpp
+++ b/docs/snippets/example/030_queue.cpp
@@ -15,7 +15,7 @@ using namespace alpaka;
 
 TEMPLATE_LIST_TEST_CASE("non blocking queue", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);
@@ -32,7 +32,7 @@ TEMPLATE_LIST_TEST_CASE("non blocking queue", "[docs]", docs::test::TestBackends
 
 TEMPLATE_LIST_TEST_CASE("blocking queue", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/041_memoryOperations.cpp
+++ b/docs/snippets/example/041_memoryOperations.cpp
@@ -15,8 +15,7 @@ using namespace alpaka;
 
 TEMPLATE_LIST_TEST_CASE("memory", "[docs]", docs::test::TestBackends)
 {
-    auto computeDevSpec = TestType::makeDict()[object::deviceSpec];
-    auto computeDevSelector = alpaka::onHost::makeDeviceSelector(computeDevSpec);
+    auto computeDevSelector = alpaka::onHost::makeDeviceSelector(TestType::makeDict());
     if(!computeDevSelector.isAvailable())
         return;
 
@@ -92,7 +91,7 @@ TEMPLATE_LIST_TEST_CASE("memory", "[docs]", docs::test::TestBackends)
 
 TEMPLATE_LIST_TEST_CASE("memory using std::vector", "[docs]", docs::test::TestBackends)
 {
-    auto computeDevSpec = TestType::makeDict()[object::deviceSpec];
+    auto computeDevSpec = alpaka::onHost::DeviceSpec{TestType::makeDict()};
     auto computeDevSelector = alpaka::onHost::makeDeviceSelector(computeDevSpec);
     if(!computeDevSelector.isAvailable())
         return;

--- a/docs/snippets/example/050_kernel.cpp
+++ b/docs/snippets/example/050_kernel.cpp
@@ -37,7 +37,7 @@ struct VectorAddKernel
 
 TEMPLATE_LIST_TEST_CASE("tutorial kernel intro vector add", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/070_views.cpp
+++ b/docs/snippets/example/070_views.cpp
@@ -15,7 +15,7 @@ using namespace alpaka;
 
 TEMPLATE_LIST_TEST_CASE("tutorial views and subviews", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/080_multidim.cpp
+++ b/docs/snippets/example/080_multidim.cpp
@@ -44,7 +44,7 @@ struct FivePointAverageKernel
 
 TEMPLATE_LIST_TEST_CASE("tutorial multidimensional stencil kernel", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/090_kernelParallelism.cpp
+++ b/docs/snippets/example/090_kernelParallelism.cpp
@@ -65,7 +65,7 @@ struct ImageTileHierarchyKernel
 
 TEMPLATE_LIST_TEST_CASE("tutorial hierarchy blocks threads warps", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);
@@ -183,7 +183,7 @@ struct ChunkedVectorAddKernel
 
 TEMPLATE_LIST_TEST_CASE("tutorial chunked frames kernel", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/110_synchronization.cpp
+++ b/docs/snippets/example/110_synchronization.cpp
@@ -55,7 +55,7 @@ struct NeighborReuseKernel
 
 TEMPLATE_LIST_TEST_CASE("tutorial in-kernel synchronization", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/120_sharedMemory.cpp
+++ b/docs/snippets/example/120_sharedMemory.cpp
@@ -199,7 +199,7 @@ namespace alpaka::onHost::trait
 
 TEMPLATE_LIST_TEST_CASE("tutorial shared memory chunk", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);
@@ -234,7 +234,7 @@ TEMPLATE_LIST_TEST_CASE("tutorial shared memory chunk", "[docs]", docs::test::Te
 
 TEMPLATE_LIST_TEST_CASE("tutorial shared memory scalar value", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);
@@ -262,7 +262,7 @@ TEMPLATE_LIST_TEST_CASE("tutorial shared memory scalar value", "[docs]", docs::t
 
 TEMPLATE_LIST_TEST_CASE("tutorial dynamic shared memory via member", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);
@@ -304,7 +304,7 @@ TEMPLATE_LIST_TEST_CASE("tutorial dynamic shared memory via member", "[docs]", d
 
 TEMPLATE_LIST_TEST_CASE("tutorial dynamic shared memory via trait", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/140_math.cpp
+++ b/docs/snippets/example/140_math.cpp
@@ -55,7 +55,7 @@ struct DistanceKernel
 
 TEMPLATE_LIST_TEST_CASE("tutorial math functions on device", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/150_atomics.cpp
+++ b/docs/snippets/example/150_atomics.cpp
@@ -33,7 +33,7 @@ struct HistogramKernel
 
 TEMPLATE_LIST_TEST_CASE("tutorial atomics histogram", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/160_events.cpp
+++ b/docs/snippets/example/160_events.cpp
@@ -13,7 +13,7 @@ using namespace alpaka;
 
 TEMPLATE_LIST_TEST_CASE("tutorial events and synchronization", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/170_random.cpp
+++ b/docs/snippets/example/170_random.cpp
@@ -94,10 +94,9 @@ struct NormalNoiseKernel
 TEMPLATE_LIST_TEST_CASE("tutorial random numbers", "[docs]", docs::test::TestBackends)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
+    auto exec = alpaka::getExecutor(cfg);
 
-    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    auto selector = onHost::makeDeviceSelector(cfg);
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);
@@ -129,10 +128,9 @@ TEMPLATE_LIST_TEST_CASE("tutorial random numbers", "[docs]", docs::test::TestBac
 TEMPLATE_LIST_TEST_CASE("tutorial random intervals", "[docs]", docs::test::TestBackends)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
+    auto exec = alpaka::getExecutor(cfg);
 
-    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    auto selector = onHost::makeDeviceSelector(cfg);
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);
@@ -173,10 +171,9 @@ TEMPLATE_LIST_TEST_CASE("tutorial random intervals", "[docs]", docs::test::TestB
 TEMPLATE_LIST_TEST_CASE("tutorial random normal distribution", "[docs]", docs::test::TestBackends)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
+    auto exec = alpaka::getExecutor(cfg);
 
-    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    auto selector = onHost::makeDeviceSelector(cfg);
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);
@@ -233,10 +230,9 @@ struct MonteCarloPiKernel
 TEMPLATE_LIST_TEST_CASE("tutorial monte carlo pi", "[docs]", docs::test::TestBackends)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
+    auto exec = alpaka::getExecutor(cfg);
 
-    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    auto selector = onHost::makeDeviceSelector(cfg);
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/180_memFence.cpp
+++ b/docs/snippets/example/180_memFence.cpp
@@ -96,10 +96,9 @@ struct ProducerConsumerFenceKernel
 TEMPLATE_LIST_TEST_CASE("tutorial memFence block scope", "[docs]", docs::test::TestBackends)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
+    auto exec = alpaka::getExecutor(cfg);
 
-    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    auto selector = onHost::makeDeviceSelector(cfg);
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);
@@ -119,10 +118,9 @@ TEMPLATE_LIST_TEST_CASE("tutorial memFence block scope", "[docs]", docs::test::T
 TEMPLATE_LIST_TEST_CASE("tutorial memFence device scope", "[docs]", docs::test::TestBackends)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
+    auto exec = alpaka::getExecutor(cfg);
 
-    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    auto selector = onHost::makeDeviceSelector(cfg);
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/190_warp.cpp
+++ b/docs/snippets/example/190_warp.cpp
@@ -54,10 +54,9 @@ struct WarpSumKernel
 TEMPLATE_LIST_TEST_CASE("tutorial warp shuffle reduction", "[docs]", docs::test::TestBackends)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
+    auto exec = alpaka::getExecutor(cfg);
 
-    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    auto selector = onHost::makeDeviceSelector(cfg);
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/191_intrinsics.cpp
+++ b/docs/snippets/example/191_intrinsics.cpp
@@ -43,10 +43,9 @@ struct BitIntrinsicKernel
 TEMPLATE_LIST_TEST_CASE("tutorial intrinsics", "[docs]", docs::test::TestBackends)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
+    auto exec = alpaka::getExecutor(cfg);
 
-    auto selector = onHost::makeDeviceSelector(deviceSpec);
+    auto selector = onHost::makeDeviceSelector(cfg);
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/200_vendorInterop.cpp
+++ b/docs/snippets/example/200_vendorInterop.cpp
@@ -98,7 +98,7 @@ namespace vendorTutorial
 
 TEMPLATE_LIST_TEST_CASE("tutorial vendor interop dispatch", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/snippets/example/230_kernelFn.cpp
+++ b/docs/snippets/example/230_kernelFn.cpp
@@ -83,7 +83,7 @@ namespace tutorial
 
 TEMPLATE_LIST_TEST_CASE("tutorial kernel as function vector add", "[docs]", docs::test::TestBackends)
 {
-    auto selector = onHost::makeDeviceSelector(TestType::makeDict()[object::deviceSpec]);
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
     if(!selector.isAvailable())
         return;
     onHost::concepts::Device auto device = selector.makeDevice(0);

--- a/docs/source/basic/terms.rst
+++ b/docs/source/basic/terms.rst
@@ -223,11 +223,16 @@ Executor
 
 .. _backend:
 
-Backend
--------
+Backend Spec
+------------
 
-A ``Backend`` is the combination of a ``DeviceSpec`` and an ``Executor``. It is typically returned by ``onHost::allBackends(...)``.
+A ``BackendSpec`` (backend specification) provides three properties:
 
+The ``api`` and ``deviceKind``, which describe a ``DeviceSpec``.
+The ``executor``, which describes how thread parallelism is mapped onto the device according to the device specification.
+
+It is typically returned by ``onHost::allBackends(...)``.
+Use ``alpaka::getExecutor(backend)`` to query its executor, and ``alpaka::onHost::DeviceSpec{backend}`` to recover its device specification.
 .. _thread_spec:
 
 Thread Spec

--- a/docs/source/basic/terms.rst
+++ b/docs/source/basic/terms.rst
@@ -221,18 +221,16 @@ Kernel
 Executor
 --------
 
+The ``executor``, which describes how thread parallelism is mapped onto the device according to the device specification.
+
 .. _backend:
 
 Backend Spec
 ------------
 
-A ``BackendSpec`` (backend specification) provides three properties:
+A ``BackendSpec`` (backend specification) provides two properties:
+The :ref:`DeviceSpec <device_kind>` and the :ref:`executor`, it is typically returned by ``onHost::allBackends(...)``.
 
-The ``api`` and ``deviceKind``, which describe a ``DeviceSpec``.
-The ``executor``, which describes how thread parallelism is mapped onto the device according to the device specification.
-
-It is typically returned by ``onHost::allBackends(...)``.
-Use ``alpaka::getExecutor(backend)`` to query its executor, and ``alpaka::onHost::DeviceSpec{backend}`` to recover its device specification.
 .. _thread_spec:
 
 Thread Spec

--- a/example/boundaryIter/src/boundaryIter.cpp
+++ b/example/boundaryIter/src/boundaryIter.cpp
@@ -171,8 +171,13 @@ auto main() -> int
      * A list of executors can be found
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
-    return onHost::executeForEachIfHasDevice(
-        [=](alpaka::concepts::Backend auto const& backend)
-        { return example(backend[object::deviceSpec], backend[object::exec]); },
+    return onHost::executeForEach(
+        [=](alpaka::concepts::BackendSpec auto const& backend)
+        {
+            auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+            if(!selector.isAvailable())
+                return EXIT_SUCCESS;
+            return example(alpaka::onHost::DeviceSpec{backend}, alpaka::getExecutor(backend));
+        },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/grayScale/src/grayScale.cpp
+++ b/example/grayScale/src/grayScale.cpp
@@ -123,8 +123,8 @@ auto example(T_Cfg const& cfg, size_t numElements, size_t numberOfRuns, bool ena
 {
     using IdxVec = Vec<std::size_t, 1u>;
 
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
+    auto deviceSpec = alpaka::onHost::DeviceSpec{cfg};
+    auto exec = alpaka::getExecutor(cfg);
 
     // Define the buffer element type.
     // Use uint32_t for packed ARGB values
@@ -350,8 +350,13 @@ auto main(int argc, char* argv[]) -> int
      * A list of executors can be found
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
-    return onHost::executeForEachIfHasDevice(
-        [=](alpaka::concepts::Backend auto const& backend)
-        { return example(backend, numElements, numberOfRuns, enableStdForEach); },
+    return onHost::executeForEach(
+        [=](alpaka::concepts::BackendSpec auto const& backend)
+        {
+            auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+            if(!selector.isAvailable())
+                return EXIT_SUCCESS;
+            return example(backend, numElements, numberOfRuns, enableStdForEach);
+        },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -342,12 +342,15 @@ auto main(int argc, char* argv[]) -> int
      * A list of executors can be found
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
-    return onHost::executeForEachIfHasDevice(
-        [=](alpaka::concepts::Backend auto const& backend)
+    return onHost::executeForEach(
+        [=](alpaka::concepts::BackendSpec auto const& backend)
         {
+            auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+            if(!selector.isAvailable())
+                return EXIT_SUCCESS;
             return alpaka::example::heatEquation::example(
-                backend[object::deviceSpec],
-                backend[object::exec],
+                alpaka::onHost::DeviceSpec{backend},
+                alpaka::getExecutor(backend),
                 sideLength,
                 numTimeSteps,
                 tMax,

--- a/example/nBody/src/nBody.cpp
+++ b/example/nBody/src/nBody.cpp
@@ -378,19 +378,30 @@ auto main(int argc, char* argv[]) -> int
 
     if(benchmarkMode)
     {
-        return onHost::executeForEachIfHasDevice(
-            [=](alpaka::concepts::Backend auto const& backend)
-            { return alpaka::example::nBody::benchmark(backend[object::deviceSpec], backend[object::exec], dt); },
+        return onHost::executeForEach(
+            [=](alpaka::concepts::BackendSpec auto const& backend)
+            {
+                auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+                if(!selector.isAvailable())
+                    return EXIT_SUCCESS;
+                return alpaka::example::nBody::benchmark(
+                    alpaka::onHost::DeviceSpec{backend},
+                    alpaka::getExecutor(backend),
+                    dt);
+            },
             onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
     }
     else
     {
-        return onHost::executeForEachIfHasDevice(
-            [=](alpaka::concepts::Backend auto const& backend)
+        return onHost::executeForEach(
+            [=](alpaka::concepts::BackendSpec auto const& backend)
             {
+                auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+                if(!selector.isAvailable())
+                    return EXIT_SUCCESS;
                 return alpaka::example::nBody::example(
-                    backend[object::deviceSpec],
-                    backend[object::exec],
+                    alpaka::onHost::DeviceSpec{backend},
+                    alpaka::getExecutor(backend),
                     writePngs,
                     benchmarkMode,
                     numParticles,

--- a/example/randomInit/src/randomInit.cpp
+++ b/example/randomInit/src/randomInit.cpp
@@ -307,8 +307,8 @@ int exampleUniformDist(auto const cfg, size_t numElements)
 {
     using namespace alpaka;
 
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto computeExec = cfg[object::exec];
+    auto deviceSpec = alpaka::onHost::DeviceSpec{cfg};
+    auto computeExec = alpaka::getExecutor(cfg);
 
 
     // Use the single host device
@@ -391,9 +391,12 @@ auto main(int argc, char* argv[]) -> int
 
     using namespace alpaka;
     // Execute the example once for each enabled API and executor.
-    return onHost::executeForEachIfHasDevice(
-        [=](alpaka::concepts::Backend auto const& backend)
+    return onHost::executeForEach(
+        [=](alpaka::concepts::BackendSpec auto const& backend)
         {
+            auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+            if(!selector.isAvailable())
+                return EXIT_SUCCESS;
             bool retVal = exampleUniformDist(backend, numElements) || exampleNormalDist(backend, numElementsNormal);
             return retVal == false ? EXIT_SUCCESS : EXIT_FAILURE;
         },

--- a/example/randomInit/src/randomInitNormal.hpp
+++ b/example/randomInit/src/randomInitNormal.hpp
@@ -113,8 +113,8 @@ int exampleDispatch(auto const cfg, uint32_t numElements, auto const& mean, auto
     }
     using namespace alpaka;
 
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto computeExec = cfg[object::exec];
+    auto deviceSpec = alpaka::onHost::DeviceSpec{cfg};
+    auto computeExec = alpaka::getExecutor(cfg);
 
 
     // Use the single host device

--- a/example/scan/src/scan_main.hpp
+++ b/example/scan/src/scan_main.hpp
@@ -198,12 +198,15 @@ auto main(int argc, char* argv[]) -> int
     using namespace alpaka;
 
     // Execute the example once for each enabled API and executor.
-    auto result = onHost::executeForEachIfHasDevice(
-        [=](alpaka::concepts::Backend auto const& backend)
+    auto result = onHost::executeForEach(
+        [=](alpaka::concepts::BackendSpec auto const& backend)
         {
+            auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+            if(!selector.isAvailable())
+                return EXIT_SUCCESS;
             return alpaka::example::scan::example(
-                backend[alpaka::object::deviceSpec],
-                backend[alpaka::object::exec],
+                alpaka::onHost::DeviceSpec{backend},
+                alpaka::getExecutor(backend),
                 numElements,
                 enableStdScan,
                 enableCheck,

--- a/example/tutorial/src/05_kernel.cpp
+++ b/example/tutorial/src/05_kernel.cpp
@@ -264,8 +264,13 @@ auto main() -> int
     example(onHost::DeviceSpec{api::host, deviceKind::cpu}, exec::cpuSerial);
 
     // Execute the example once for each enabled API, device kind, and executor.
-    return onHost::executeForEachIfHasDevice(
-        [=](alpaka::concepts::Backend auto const& backend)
-        { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
+    return onHost::executeForEach(
+        [=](alpaka::concepts::BackendSpec auto const& backend)
+        {
+            auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+            if(!selector.isAvailable())
+                return EXIT_SUCCESS;
+            return example(alpaka::onHost::DeviceSpec{backend}, alpaka::getExecutor(backend));
+        },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/tutorial/src/06_cudaLikeKernel.cpp
+++ b/example/tutorial/src/06_cudaLikeKernel.cpp
@@ -285,8 +285,13 @@ auto main() -> int
      * A list of executors can be found
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
-    return onHost::executeForEachIfHasDevice(
-        [=](alpaka::concepts::Backend auto const& backend)
-        { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
+    return onHost::executeForEach(
+        [=](alpaka::concepts::BackendSpec auto const& backend)
+        {
+            auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+            if(!selector.isAvailable())
+                return EXIT_SUCCESS;
+            return example(alpaka::onHost::DeviceSpec{backend}, alpaka::getExecutor(backend));
+        },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/tutorial/src/07_chunkedData.cpp
+++ b/example/tutorial/src/07_chunkedData.cpp
@@ -335,8 +335,13 @@ auto main() -> int
      * A list of executors can be found
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
-    return onHost::executeForEachIfHasDevice(
-        [=](alpaka::concepts::Backend auto const& backend)
-        { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec]); },
+    return onHost::executeForEach(
+        [=](alpaka::concepts::BackendSpec auto const& backend)
+        {
+            auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+            if(!selector.isAvailable())
+                return EXIT_SUCCESS;
+            return example(alpaka::onHost::DeviceSpec{backend}, alpaka::getExecutor(backend));
+        },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -268,12 +268,15 @@ auto main(int argc, char* argv[]) -> int
      * A list of executors can be found
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
-    return onHost::executeForEachIfHasDevice(
-        [=](alpaka::concepts::Backend auto const& backend)
+    return onHost::executeForEach(
+        [=](alpaka::concepts::BackendSpec auto const& backend)
         {
+            auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+            if(!selector.isAvailable())
+                return EXIT_SUCCESS;
             return example(
-                backend[alpaka::object::deviceSpec],
-                backend[alpaka::object::exec],
+                alpaka::onHost::DeviceSpec{backend},
+                alpaka::getExecutor(backend),
                 numElements,
                 numberOfRuns);
         },

--- a/example/vendorApi/src/main.cpp
+++ b/example/vendorApi/src/main.cpp
@@ -178,8 +178,13 @@ auto main(int argc, char* argv[]) -> int
      * A list of executors can be found
      * https://alpaka3.readthedocs.io/en/latest/basic/cheatsheet.html#executors
      */
-    return onHost::executeForEachIfHasDevice(
-        [=](alpaka::concepts::Backend auto const& backend)
-        { return example(backend[alpaka::object::deviceSpec], backend[alpaka::object::exec], numElements); },
+    return onHost::executeForEach(
+        [=](alpaka::concepts::BackendSpec auto const& backend)
+        {
+            auto selector = onHost::makeDeviceSelector(alpaka::onHost::DeviceSpec{backend});
+            if(!selector.isAvailable())
+                return EXIT_SUCCESS;
+            return example(alpaka::onHost::DeviceSpec{backend}, alpaka::getExecutor(backend), numElements);
+        },
         onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors));
 }

--- a/include/alpaka/concepts.hpp
+++ b/include/alpaka/concepts.hpp
@@ -7,7 +7,6 @@
 #include "alpaka/api/concepts/api.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/concepts/hasName.hpp"
-#include "alpaka/core/common.hpp"
 #include "alpaka/mem/concepts/AssignableFrom.hpp"
 #include "alpaka/mem/concepts/ExpectedValueType.hpp"
 #include "alpaka/mem/concepts/IBuffer.hpp"
@@ -61,12 +60,13 @@ namespace alpaka
             { internal::getDeviceKind(t) } -> alpaka::concepts::DeviceKind;
         };
 
-        /** Concept to check for a backend object containing a device specification and executor.
+        /** Concept to check for a backend specification
+         *
+         * The object must provide the possibility for querying the device specification properties and the executor.
          */
         template<typename T>
-        concept Backend = requires(T t) {
-            requires std::decay_t<T>::hasKey(object::deviceSpec);
-            requires alpaka::concepts::DeviceSpec<ALPAKA_TYPEOF(t[object::deviceSpec])>;
+        concept BackendSpec = requires(T t) {
+            requires DeviceSpec<T>;
             { internal::getExecutor(t) } -> alpaka::concepts::Executor;
         };
     } // namespace concepts

--- a/include/alpaka/core/Dict.hpp
+++ b/include/alpaka/core/Dict.hpp
@@ -5,9 +5,7 @@
 #pragma once
 
 #include "alpaka/Tuple.hpp"
-#include "alpaka/core/common.hpp"
 #include "alpaka/core/util.hpp"
-#include "alpaka/tag.hpp"
 #include "alpaka/unused.hpp"
 #include "alpaka/utility.hpp"
 
@@ -172,20 +170,6 @@ namespace alpaka
 
     template<typename... T_Keys, typename... T_Values>
     ALPAKA_FN_HOST_ACC Dict(DictEntry<T_Keys, T_Values> const&...) -> Dict<DictEntry<T_Keys, T_Values>...>;
-
-    namespace internal
-    {
-        template<typename... T_Entries>
-        requires(Dict<T_Entries...>::hasKey(object::exec))
-        struct GetExecutor::Op<Dict<T_Entries...>>
-        {
-            inline constexpr auto operator()(auto&& any) const
-            {
-                return any[object::exec];
-            }
-        };
-    } // namespace internal
-
 } // namespace alpaka
 
 namespace std

--- a/include/alpaka/core/DictTraits.hpp
+++ b/include/alpaka/core/DictTraits.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2024 René Widera, Tim Hanel
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/Dict.hpp"
+#include "alpaka/internal/interface.hpp"
+#include "alpaka/tag.hpp"
+
+namespace alpaka::internal
+{
+    template<typename... T_Entries>
+    requires(Dict<T_Entries...>::hasKey(object::api))
+    struct GetApi::Op<Dict<T_Entries...>>
+    {
+        inline constexpr auto operator()(auto&& any) const
+        {
+            return any[object::api];
+        }
+    };
+
+    template<typename... T_Entries>
+    requires(Dict<T_Entries...>::hasKey(object::exec))
+    struct GetExecutor::Op<Dict<T_Entries...>>
+    {
+        inline constexpr auto operator()(auto&& any) const
+        {
+            return any[object::exec];
+        }
+    };
+
+    template<typename... T_Entries>
+    requires(Dict<T_Entries...>::hasKey(object::deviceKind))
+    struct GetDeviceType::Op<Dict<T_Entries...>>
+    {
+        inline constexpr auto operator()(auto&& any) const
+        {
+            return any[object::deviceKind];
+        }
+    };
+} // namespace alpaka::internal

--- a/include/alpaka/core/DictTraits.hpp
+++ b/include/alpaka/core/DictTraits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 René Widera, Tim Hanel
+/* Copyright 2026 René Widera, Tim Hanel
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/include/alpaka/core/common.hpp
+++ b/include/alpaka/core/common.hpp
@@ -8,18 +8,6 @@
 
 #include <type_traits>
 
-namespace alpaka::internal
-{
-    // Forward declaration to avoid a circular include between Dict and the interface helpers.
-    struct GetExecutor
-    {
-        template<typename T_Any>
-        struct Op;
-    };
-
-    template<typename T_Any>
-    inline constexpr auto getExecutor(T_Any&& any) -> decltype(GetExecutor::Op<std::decay_t<T_Any>>{}(any));
-} // namespace alpaka::internal
 
 #if ALPAKA_LANG_HIP
 // HIP defines some keywords like __forceinline__ in header files.

--- a/include/alpaka/interface.hpp
+++ b/include/alpaka/interface.hpp
@@ -49,11 +49,6 @@ namespace alpaka
         return alpaka::internal::getApi(*any.get());
     }
 
-    inline constexpr decltype(auto) getApi(alpaka::concepts::Backend auto&& backend)
-    {
-        return getApi(ALPAKA_FORWARD(backend)[object::deviceSpec]);
-    }
-
     namespace concepts
     {
         /** Concept to check if the given type implements the `getExecutor(T x)` function returning an
@@ -88,11 +83,6 @@ namespace alpaka
     inline constexpr decltype(auto) getDeviceKind(alpaka::concepts::HasGet auto&& any)
     {
         return alpaka::internal::getDeviceKind(*any.get());
-    }
-
-    inline constexpr decltype(auto) getDeviceKind(alpaka::concepts::Backend auto&& backend)
-    {
-        return getDeviceKind(ALPAKA_FORWARD(backend)[object::deviceSpec]);
     }
 
     /** @} */

--- a/include/alpaka/internal/interface.hpp
+++ b/include/alpaka/internal/interface.hpp
@@ -52,14 +52,14 @@ namespace alpaka
             template<typename T_Any>
             struct Op
             {
-                inline constexpr auto operator()(auto&& any) const
+                inline constexpr auto operator()(auto&& any) const -> decltype(any.getApi())
                 {
                     return any.getApi();
                 }
             };
         };
 
-        inline constexpr auto getApi(auto&& any)
+        inline constexpr auto getApi(auto&& any) -> decltype(GetApi::Op<ALPAKA_TYPEOF(any)>{}(any))
         {
             return GetApi::Op<std::decay_t<decltype(any)>>{}(any);
         }
@@ -70,17 +70,20 @@ namespace alpaka
             return GetApi::Op<ALPAKA_TYPEOF(*anyHandle.get())>{}(*anyHandle.get());
         }
 
-        template<typename T_Any>
-        struct GetExecutor::Op
+        struct GetExecutor
         {
-            inline constexpr auto operator()(auto&& any) const -> decltype(any.getExecutor())
+            template<typename T_Any>
+            struct Op
             {
-                return any.getExecutor();
-            }
+                inline constexpr auto operator()(auto&& any) const -> decltype(any.getExecutor())
+                {
+                    return any.getExecutor();
+                }
+            };
         };
 
         template<typename T_Any>
-        inline constexpr auto getExecutor(T_Any&& any) -> decltype(GetExecutor::Op<std::decay_t<T_Any>>{}(any))
+        inline constexpr auto getExecutor(T_Any&& any) -> decltype(GetExecutor::Op<ALPAKA_TYPEOF(any)>{}(any))
         {
             return GetExecutor::Op<std::decay_t<T_Any>>{}(ALPAKA_FORWARD(any));
         }
@@ -96,16 +99,16 @@ namespace alpaka
             template<typename T_Any>
             struct Op
             {
-                inline constexpr auto operator()(auto&& any) const
+                inline constexpr auto operator()(auto&& any) const -> decltype(any.getDeviceKind())
                 {
                     return any.getDeviceKind();
                 }
             };
         };
 
-        inline constexpr auto getDeviceKind(auto&& any)
+        inline constexpr auto getDeviceKind(auto&& any) -> decltype(GetDeviceType::Op<ALPAKA_TYPEOF(any)>{}(any))
         {
-            return GetDeviceType::Op<std::decay_t<decltype(any)>>{}(any);
+            return GetDeviceType::Op<ALPAKA_TYPEOF(any)>{}(any);
         }
 
         struct GetAlignment

--- a/include/alpaka/onHost/DeviceSelector.hpp
+++ b/include/alpaka/onHost/DeviceSelector.hpp
@@ -20,12 +20,8 @@ namespace alpaka::onHost
             "Invalid combination of device kind and api. The api does not know how to talk to the device or the "
             "required dependencies to enable the api are not fulfilled.");
 
-        constexpr DeviceSelector(alpaka::concepts::Backend auto backend) : DeviceSelector(backend[object::deviceSpec])
-        {
-        }
-
-        constexpr DeviceSelector(DeviceSpec<T_Api, T_DeviceKind> deviceSpec)
-            : m_platform(internal::makePlatform(deviceSpec.getApi(), deviceSpec.getDeviceKind()))
+        constexpr DeviceSelector(alpaka::concepts::DeviceSpec auto deviceSpec)
+            : m_platform(internal::makePlatform(getApi(deviceSpec), getDeviceKind(deviceSpec)))
             , m_deviceSpec(deviceSpec)
         {
         }
@@ -73,16 +69,14 @@ namespace alpaka::onHost
         DeviceSpec<T_Api, T_DeviceKind> m_deviceSpec;
     };
 
-    /** create an object to get access to devices */
-    template<typename T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
-    inline auto makeDeviceSelector(DeviceSpec<T_Api, T_DeviceKind> deviceSpec)
-    {
-        return DeviceSelector{deviceSpec};
-    }
+    template<alpaka::concepts::DeviceSpec T_DeviceSpec>
+    DeviceSelector(T_DeviceSpec const& deviceSpec)
+        -> DeviceSelector<ALPAKA_TYPEOF(getApi(deviceSpec)), ALPAKA_TYPEOF(getDeviceKind(deviceSpec))>;
 
-    inline auto makeDeviceSelector(alpaka::concepts::Backend auto backend)
+    /** create an object to get access to devices */
+    template<alpaka::concepts::DeviceSpec T_DeviceSpec>
+    inline auto makeDeviceSelector(T_DeviceSpec deviceSpec)
     {
-        auto deviceSpec = backend[object::deviceSpec];
         return DeviceSelector{deviceSpec};
     }
 

--- a/include/alpaka/onHost/DeviceSpec.hpp
+++ b/include/alpaka/onHost/DeviceSpec.hpp
@@ -6,6 +6,7 @@
 
 #include "alpaka/api/api.hpp"
 #include "alpaka/api/host/hwloc/hwlocConfig.hpp"
+#include "alpaka/concepts.hpp"
 #include "alpaka/core/config.hpp"
 #include "alpaka/tag.hpp"
 
@@ -28,6 +29,13 @@ namespace alpaka::onHost
     {
     public:
         constexpr DeviceSpec(T_Api api, T_DeviceKind deviceType) : m_api(api), m_deviceType(deviceType)
+        {
+        }
+
+        template<alpaka::concepts::DeviceSpec T_DeviceSpec>
+        constexpr DeviceSpec(T_DeviceSpec any)
+            : m_api(alpaka::internal::getApi(any))
+            , m_deviceType(alpaka::internal::getDeviceKind(any))
         {
         }
 
@@ -67,6 +75,20 @@ namespace alpaka::onHost
         T_Api m_api;
         T_DeviceKind m_deviceType;
     };
+
+    template<alpaka::concepts::DeviceSpec T_DeviceSpec>
+    DeviceSpec(T_DeviceSpec const& deviceSpec)
+        -> DeviceSpec<ALPAKA_TYPEOF(getApi(deviceSpec)), ALPAKA_TYPEOF(getDeviceKind(deviceSpec))>;
+
+    /** Create a device specification object.
+     *
+     * @param any Any device specification description providing an api and device kind.
+     */
+    template<alpaka::concepts::DeviceSpec T_DeviceSpec>
+    inline auto makeDeviceSpec(T_DeviceSpec any)
+    {
+        return DeviceSpec{any};
+    }
 
     /** list of enabled device specifications
      *
@@ -109,13 +131,5 @@ namespace alpaka::onHost
         std::tuple{DeviceSpec{api::hip, deviceKind::amdGpu}}
 #endif
     );
-
-    namespace concepts
-    {
-        /** Concept to check for specializations of alpaka::onHost::DeviceSpec
-         */
-        template<typename T>
-        concept DeviceSpec = alpaka::concepts::SpecializationOf<T, onHost::DeviceSpec>;
-    } // namespace concepts
 
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/executeForEach.hpp
+++ b/include/alpaka/onHost/executeForEach.hpp
@@ -43,35 +43,6 @@ namespace alpaka::onHost
                    : EXIT_FAILURE;
     }
 
-    /**! execute a callable for each backend if there is a device available
-     *
-     * The function contains a runtime check if at least one device is available, if there is no device the callable
-     * will not be executed. Not executed combinations will return EXIT_SUCCESS.
-     *
-     * @attention: Execution is short-circuited and stops after the first error.
-     *
-     * @param callable Callable that can be invoked with each backend and returns an execution status.
-     *        A return value of zero (`EXIT_SUCCESS`) indicates success; any non-zero value indicates a failure.
-     * @param tuple Tuple like list of backends used to invoke the callable.
-     *         otherwise, at least one failure occurred.
-     * @return The disjunction of all returned error codes. If false, the result is `EXIT_SUCCESS`;
-     *          otherwise, at least a failure occurred.
-     */
-    template<alpaka::concepts::Backend... T_Backends>
-    inline int executeForEachIfHasDevice(auto&& callable, std::tuple<T_Backends...> const& tupleOfBackends)
-    {
-        auto exe = [=](alpaka::concepts::Backend auto const& backend)
-        {
-            auto devSelector = onHost::makeDeviceSelector(backend[object::deviceSpec]);
-            if(devSelector.isAvailable())
-            {
-                return callable(backend);
-            }
-            return EXIT_SUCCESS;
-        };
-        return executeForEach(exe, tupleOfBackends);
-    }
-
     /**! execute a callable for each device specification if there is a device available
      *
      * The function contains a runtime check if at least one device is available, if there is no device the callable
@@ -86,7 +57,7 @@ namespace alpaka::onHost
      * @return The disjunction of all returned error codes. If false, the result is `EXIT_SUCCESS`;
      *          otherwise, at least a failure occurred.
      */
-    template<onHost::concepts::DeviceSpec... T_DeviceSpecs>
+    template<alpaka::concepts::DeviceSpec... T_DeviceSpecs>
     inline int executeForEachIfHasDevice(auto&& callable, std::tuple<T_DeviceSpecs...> const& tupleOfDeviceSpecs)
     {
         auto exe = [=](auto const& devSpec)

--- a/include/alpaka/onHost/interface.hpp
+++ b/include/alpaka/onHost/interface.hpp
@@ -272,8 +272,8 @@ namespace alpaka::onHost
     /** Build a tuple of backends for a single device specification.
      *
      * A backend is the combination of a device specification and an executor.
-     * Each dictionary stores a `deviceSpec`(query: foo[object::deviceSpec]) entry and an `exec`(query:
-     * foo[object::exec]) entry for the corresponding executor.
+     * Query its executor via `alpaka::getExecutor(backend)` and recover its device
+     * specification via `alpaka::onHost::DeviceSpec{backend}`.
      *
      * @param deviceSpec the device specification to associate with the executors
      * @param listOfExecutors tuple of executor types
@@ -285,7 +285,10 @@ namespace alpaka::onHost
             [deviceSpec](auto... executor) constexpr
             {
                 return std::make_tuple(
-                    Dict{DictEntry{object::deviceSpec, deviceSpec}, DictEntry{object::exec, executor}}...);
+                    Dict{
+                        DictEntry{object::api, getApi(deviceSpec)},
+                        DictEntry{object::deviceKind, getDeviceKind(deviceSpec)},
+                        DictEntry{object::exec, executor}}...);
             },
             listOfExecutors);
     }
@@ -331,7 +334,7 @@ namespace alpaka::onHost
      * @param listOfExecutors tuple of executor types
      * @return a tuple of backend dictionaries covering all device kinds and executors
      */
-    template<concepts::DeviceSpec... T_DevicesSpecs>
+    template<alpaka::concepts::DeviceSpec... T_DevicesSpecs>
     consteval auto allBackends(std::tuple<T_DevicesSpecs...> const& usedDeviceSpecs, auto const& listOfExecutors)
     {
         return std::tuple_cat(createBackendList(usedDeviceSpecs, listOfExecutors));

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -6,6 +6,7 @@
 #include "alpaka/KernelBundle.hpp"
 #include "alpaka/api/trait.hpp"
 #include "alpaka/core/Assert.hpp"
+#include "alpaka/core/DictTraits.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/onHost/DeviceProperties.hpp"
 #include "alpaka/onHost/FrameSpec.hpp"

--- a/include/alpaka/tag.hpp
+++ b/include/alpaka/tag.hpp
@@ -33,8 +33,6 @@ namespace alpaka
 
         ALPAKA_TAG(launchedWidthFrameSpec);
 
-        ALPAKA_TAG(deviceSpec);
-
         ALPAKA_TAG(dynSharedMemBytes);
 
         struct WarpSize

--- a/test/include/alpakaTest/deviceHelper.hpp
+++ b/test/include/alpakaTest/deviceHelper.hpp
@@ -36,10 +36,9 @@ namespace alpaka::test
      * @param cfg Test configuration. An entry of the list returned from alpaka::onHost::allBackends().
      * @return The device 0 if available. Otherwise, SKIP() the test.
      */
-    [[nodiscard]] auto getDeviceOrSkipTest(auto const& cfg)
-        -> decltype(onHost::makeDeviceSelector(cfg[object::deviceSpec]).makeDevice(0))
+    [[nodiscard]] auto getDeviceOrSkipTest(auto const& cfg) -> decltype(onHost::makeDeviceSelector(cfg).makeDevice(0))
     {
-        auto deviceSpec = cfg[object::deviceSpec];
+        auto deviceSpec = onHost::makeDeviceSpec(cfg);
         auto devSelector = onHost::makeDeviceSelector(deviceSpec);
         UNSCOPED_INFO("DeviceSpec: " << getName(deviceSpec));
         UNSCOPED_INFO("API: " << deviceSpec.getApi().getName());
@@ -77,11 +76,11 @@ namespace alpaka::test
      * @param cfg Test configuration. An entry of the list returned from alpaka::onHost::allBackends().
      * @return A std::tuple with the device 0 and an executor. If no device is available, SKIP() the test.
      */
-    [[nodiscard]] auto getDeviceExecutorOrSkipTest(auto const& cfg) -> std::
-        tuple<decltype(onHost::makeDeviceSelector(cfg[object::deviceSpec]).makeDevice(0)), decltype(cfg[object::exec])>
+    [[nodiscard]] auto getDeviceExecutorOrSkipTest(auto const& cfg)
+        -> std::tuple<decltype(onHost::makeDeviceSelector(cfg).makeDevice(0)), decltype(alpaka::getExecutor(cfg))>
     {
         auto device = alpaka::test::getDeviceOrSkipTest(cfg);
-        concepts::Executor auto executor = cfg[object::exec];
+        concepts::Executor auto executor = alpaka::getExecutor(cfg);
         UNSCOPED_INFO("Executor: " << executor.getName());
 
         return std::make_tuple(device, executor);

--- a/test/unit/concepts/concepts.cpp
+++ b/test/unit/concepts/concepts.cpp
@@ -15,6 +15,7 @@ using namespace alpaka;
 using Data = std::size_t;
 using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 using DictWithoutDeviceSpecOrExec = Dict<DictEntry<object::Api, api::Host>>;
+using DictWithoutExecutor = Dict<DictEntry<object::Api, api::Host>, DictEntry<object::DeviceKind, deviceKind::Cpu>>;
 
 template<typename TIdx>
 void testVector()
@@ -90,10 +91,12 @@ TEST_CASE("thread spec concepts", "[concepts][threadspec]")
 TEMPLATE_LIST_TEST_CASE("backend concept", "[concepts][backend]", TestBackends)
 {
     auto backend = TestType::makeDict();
+    auto deviceSpec = onHost::DeviceSpec{backend};
 
-    STATIC_CHECK(alpaka::concepts::Backend<TestType>);
-    STATIC_CHECK_FALSE(alpaka::concepts::Backend<DictWithoutDeviceSpecOrExec>);
-    STATIC_CHECK_FALSE(alpaka::concepts::Backend<decltype(backend[alpaka::object::deviceSpec])>);
-    CHECK(alpaka::getApi(backend) == alpaka::getApi(backend[alpaka::object::deviceSpec]));
-    CHECK(alpaka::getDeviceKind(backend) == alpaka::getDeviceKind(backend[alpaka::object::deviceSpec]));
+    STATIC_CHECK(alpaka::concepts::BackendSpec<TestType>);
+    STATIC_CHECK_FALSE(alpaka::concepts::BackendSpec<DictWithoutDeviceSpecOrExec>);
+    STATIC_CHECK_FALSE(alpaka::concepts::BackendSpec<DictWithoutExecutor>);
+    STATIC_CHECK(alpaka::concepts::DeviceSpec<decltype(deviceSpec)>);
+    CHECK(alpaka::getApi(backend) == alpaka::getApi(deviceSpec));
+    CHECK(alpaka::getDeviceKind(backend) == alpaka::getDeviceKind(deviceSpec));
 }

--- a/test/unit/device/deviceProperties.cpp
+++ b/test/unit/device/deviceProperties.cpp
@@ -41,10 +41,10 @@ TEMPLATE_LIST_TEST_CASE("deviceProperties", "[device][property]", TestApis)
 TEMPLATE_LIST_TEST_CASE("device selector from backend", "[device][selector]", TestApis)
 {
     auto backend = TestType::makeDict();
-    STATIC_CHECK(alpaka::concepts::Backend<decltype(backend)>);
+    STATIC_CHECK(alpaka::concepts::BackendSpec<decltype(backend)>);
 
     auto selectorFromBackend = onHost::makeDeviceSelector(backend);
-    auto selectorFromDeviceSpec = onHost::makeDeviceSelector(backend[object::deviceSpec]);
+    auto selectorFromDeviceSpec = onHost::makeDeviceSelector(onHost::DeviceSpec{backend});
 
     STATIC_CHECK(std::is_same_v<decltype(selectorFromBackend), decltype(selectorFromDeviceSpec)>);
     CHECK(selectorFromBackend.isAvailable() == selectorFromDeviceSpec.isAvailable());

--- a/test/unit/event/event.cpp
+++ b/test/unit/event/event.cpp
@@ -89,7 +89,7 @@ TEMPLATE_LIST_TEST_CASE("basic queue wait for event", "", TestApis)
 TEMPLATE_LIST_TEST_CASE("test trigger event", "", TestApis)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
+    auto deviceSpec = onHost::DeviceSpec{cfg};
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
@@ -126,7 +126,7 @@ TEMPLATE_LIST_TEST_CASE("test trigger event", "", TestApis)
 TEMPLATE_LIST_TEST_CASE("eventTestShouldBeFalseWhileInQueueAndTrueAfterBeingProcessed", "", TestApis)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
+    auto deviceSpec = onHost::DeviceSpec{cfg};
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
@@ -165,7 +165,7 @@ TEMPLATE_LIST_TEST_CASE("eventTestShouldBeFalseWhileInQueueAndTrueAfterBeingProc
 TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfNobodyWaitsFor", "", TestApis)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
+    auto deviceSpec = onHost::DeviceSpec{cfg};
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
@@ -241,7 +241,7 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfNobodyWaitsFor", "", Te
 TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "", TestApis)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
+    auto deviceSpec = onHost::DeviceSpec{cfg};
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
@@ -331,7 +331,7 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "", T
 TEMPLATE_LIST_TEST_CASE("waitForEventThatAlreadyFinishedShouldBeSkipped", "", TestApis)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
+    auto deviceSpec = onHost::DeviceSpec{cfg};
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
@@ -418,7 +418,7 @@ TEMPLATE_LIST_TEST_CASE("waitForEventThatAlreadyFinishedShouldBeSkipped", "", Te
 TEMPLATE_LIST_TEST_CASE("evReEnqueueWithSomeoneWaitsForEventInOrderLifetimeRelease", "", TestApis)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
+    auto deviceSpec = onHost::DeviceSpec{cfg};
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())
@@ -545,7 +545,7 @@ TEMPLATE_LIST_TEST_CASE("evReEnqueueWithSomeoneWaitsForEventInOrderLifetimeRelea
 TEMPLATE_LIST_TEST_CASE("EventOutOfOrderLifetimeRelease", "", TestApis)
 {
     auto cfg = TestType::makeDict();
-    auto deviceSpec = cfg[object::deviceSpec];
+    auto deviceSpec = onHost::DeviceSpec{cfg};
 
     auto devSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!devSelector.isAvailable())

--- a/test/unit/interface/executor.cpp
+++ b/test/unit/interface/executor.cpp
@@ -35,7 +35,7 @@ TEMPLATE_LIST_TEST_CASE("get executor", "[interface][executor]", TestApis)
 
     static_assert(concepts::HasExecutor<ALPAKA_TYPEOF(cfg)>);
     static_assert(concepts::Executor<ALPAKA_TYPEOF(executor)>);
-    CHECK((executor == cfg[object::exec]));
+    CHECK((executor == alpaka::getExecutor(cfg)));
 
     onHost::Device device = test::getDeviceOrSkipTest(cfg);
     onHost::Queue queue = device.makeQueue();
@@ -56,7 +56,7 @@ TEMPLATE_LIST_TEST_CASE("get device kind", "[interface][deviceKind]", TestApis)
     auto deviceKind = alpaka::getDeviceKind(cfg);
 
     static_assert(concepts::DeviceKind<ALPAKA_TYPEOF(deviceKind)>);
-    CHECK((deviceKind == cfg[object::deviceSpec].getDeviceKind()));
+    CHECK((deviceKind == getDeviceKind(cfg)));
 
     onHost::Device device = test::getDeviceOrSkipTest(cfg);
     onHost::Queue queue = device.makeQueue();

--- a/test/unit/rand/uniformReal.cpp
+++ b/test/unit/rand/uniformReal.cpp
@@ -227,7 +227,7 @@ TEMPLATE_LIST_TEST_CASE("UniformReal on std engines", "", TestBackends)
 {
     using namespace alpaka;
     auto cfg = TestType::makeDict();
-    auto exec = cfg[object::exec];
+    auto exec = alpaka::getExecutor(cfg);
     using T_ExecType = ALPAKA_TYPEOF(exec);
     using T_SupportedHostExecutors = Tuple<exec::CpuSerial, exec::CpuOmpBlocks, exec::CpuTbbBlocks>;
     using T_Engines = Tuple<std::mt19937, std::mt19937_64>;

--- a/test/unit/wait/device.cpp
+++ b/test/unit/wait/device.cpp
@@ -112,8 +112,8 @@ void executeWaitTest(auto& device, auto const& exec)
 
 void prepareAndExecuteWaitTest(auto cfg)
 {
-    auto deviceSpec = cfg[object::deviceSpec];
-    auto exec = cfg[object::exec];
+    auto deviceSpec = onHost::DeviceSpec{cfg};
+    auto exec = alpaka::getExecutor(cfg);
 
     auto deviceSelector = onHost::makeDeviceSelector(deviceSpec);
     if(!deviceSelector.isAvailable())


### PR DESCRIPTION
- rename to `concepts::BackendSpec`
- update documentation
- add `onHost::makeSpec()` factory
- remove `alpaka::object::deviceSpec`
- refactor `onHost::createBackendsFor()`
- use the refactored interface that supports BackendSpec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined backend/device setup across examples and tests using higher-level helpers to derive device specs and executors.
* **Bug Fixes**
  * Added/standardized explicit device availability checks before executing, preventing unsupported-backend runs.
* **Documentation**
  * Updated tutorials and backend terminology/snippets to match the new backend-spec and device-selector workflow.
* **Breaking Changes**
  * Updated core concepts and selection APIs (e.g., shift toward backend-spec-based dispatch) and removed older conveniences that relied on direct backend dictionary access. 
* **Tests**
  * Refreshed unit tests, benchmarks, and test helpers to use the new selection pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->