### PR TITLE
fix numa group selection

### DIFF
--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -32,10 +32,10 @@ namespace alpaka::onHost
         struct Device : std::enable_shared_from_this<Device<T_Platform>>
         {
         public:
-            Device(internal::concepts::PlatformHandle auto platform, uint32_t const idx, uint32_t numaIdx)
+            Device(internal::concepts::PlatformHandle auto platform, uint32_t const idx, uint32_t cpuGroupIdx)
                 : m_platform(std::move(platform))
                 , m_idx(idx)
-                , m_numaIdx(numaIdx)
+                , m_cpuGroupIdx(cpuGroupIdx)
                 , m_properties{internal::getDeviceProperties(*m_platform.get(), m_idx)}
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::device);
@@ -89,7 +89,7 @@ namespace alpaka::onHost
 
             Handle<T_Platform> m_platform;
             uint32_t m_idx = 0u;
-            uint32_t m_numaIdx = internal::hwloc::allNumaDomains;
+            uint32_t m_cpuGroupIdx = internal::hwloc::allDomains;
             DeviceProperties m_properties;
             std::vector<std::weak_ptr<cpu::Queue<Device>>> queues;
             std::vector<std::weak_ptr<cpu::Event<Device>>> events;
@@ -105,18 +105,18 @@ namespace alpaka::onHost
 
             void setThreadAffinity() const
             {
-                internal::hwloc::setThreadAffinity(m_numaIdx);
+                internal::hwloc::setThreadAffinity(m_cpuGroupIdx);
             }
 
             template<typename T>
             void pinPointer(T* const ptr, size_t bytes)
             {
-                internal::hwloc::pinPointer(ptr, bytes, m_numaIdx);
+                internal::hwloc::pinPointer(ptr, bytes, m_cpuGroupIdx);
             }
 
             bool isNumaAware() const
             {
-                return m_numaIdx != internal::hwloc::allNumaDomains;
+                return m_cpuGroupIdx != internal::hwloc::allDomains;
             }
 
             friend struct alpaka::internal::GetName;
@@ -148,7 +148,7 @@ namespace alpaka::onHost
                 auto newQueue = std::make_shared<cpu::Queue<Device>>(
                     std::move(thisHandle),
                     queues.size(),
-                    m_numaIdx,
+                    m_cpuGroupIdx,
                     isBlocking);
 
                 queues.emplace_back(newQueue);
@@ -179,7 +179,7 @@ namespace alpaka::onHost
             {
 #if ALPAKA_HAS_HWLOC
                 if(isNumaAware())
-                    return internal::hwloc::getFreeGlobalMemBytes(m_numaIdx);
+                    return internal::hwloc::getFreeGlobalMemBytes(m_cpuGroupIdx);
 #endif
                 return onHost::getFreeGlobalMemBytes();
             }

--- a/include/alpaka/api/host/Platform.hpp
+++ b/include/alpaka/api/host/Platform.hpp
@@ -66,7 +66,7 @@ namespace alpaka::onHost
                 {
                     if constexpr(T_DeviceKind{} == deviceKind::numaCpu)
                     {
-                        devCount = alpaka::onHost::internal::hwloc::getNumNumaDomains();
+                        devCount = alpaka::onHost::internal::hwloc::getNumCpuDomains();
                     }
                     else
                         devCount = 1;
@@ -101,12 +101,12 @@ namespace alpaka::onHost
                     return sharedPtr;
                 }
                 auto thisHandle = getSharedPtr();
-                uint32_t numaIdx = internal::hwloc::allNumaDomains;
+                uint32_t cpuGroupIdx = internal::hwloc::allDomains;
                 if constexpr(T_DeviceKind{} == deviceKind::numaCpu)
                 {
-                    numaIdx = idx;
+                    cpuGroupIdx = idx;
                 }
-                auto newDevice = std::make_shared<cpu::Device<Platform>>(std::move(thisHandle), idx, numaIdx);
+                auto newDevice = std::make_shared<cpu::Device<Platform>>(std::move(thisHandle), idx, cpuGroupIdx);
                 devices[idx] = newDevice;
                 return newDevice;
             }
@@ -143,13 +143,13 @@ namespace alpaka::onHost
                 auto prop = DeviceProperties{};
                 prop.name = getCpuName();
                 prop.warpSize = 1u;
-                prop.multiProcessorCount = hwloc::getNumCores(hwloc::allNumaDomains);
-                prop.globalMemCapacityBytes = hwloc::getMemCapacityBytes(hwloc::allNumaDomains);
+                prop.multiProcessorCount = hwloc::getNumCores(hwloc::allDomains);
+                prop.globalMemCapacityBytes = hwloc::getMemCapacityBytes(hwloc::allDomains);
                 prop.sharedMemPerBlockBytes = ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB * 1024u;
 
                 if constexpr(T_DeviceKind{} == deviceKind::numaCpu)
                 {
-                    // the deviceIdx is equal to the numa domain index
+                    // the deviceIdx is equal to the cpu group domain index
                     prop.multiProcessorCount = hwloc::getNumCores(deviceIdx);
                     prop.globalMemCapacityBytes = hwloc::getMemCapacityBytes(deviceIdx);
                 }

--- a/include/alpaka/api/host/exec/TbbBlocks.hpp
+++ b/include/alpaka/api/host/exec/TbbBlocks.hpp
@@ -101,7 +101,7 @@ namespace alpaka::onHost
                         });
                 };
 
-                if(m_numaIdx != internal::hwloc::allNumaDomains && m_setThreadAffinity)
+                if(m_numaIdx != internal::hwloc::allDomains && m_setThreadAffinity)
                 {
                     oneapi::tbb::task_arena tbbArena;
 

--- a/include/alpaka/api/host/hwloc/utility.hpp
+++ b/include/alpaka/api/host/hwloc/utility.hpp
@@ -9,26 +9,35 @@
 #include "alpaka/core/util.hpp"
 #include "alpaka/unused.hpp"
 
+#include <cerrno>
+#include <cstring>
 #include <fstream>
+#include <limits>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <thread>
+#include <vector>
 
 /** Implement functions required to set thread affinity and pin memory.
  *
- * There is always a fallback implement to be able to run without hwloc.
- * In this case nume selection is not possible and all cores will taken into account.
+ * There is always a fallback implementation to be able to run without hwloc.
+ * In this case domain selection is not possible and all cores will be taken into account.
+ *
+ * Domain model:
+ *  - A CPU domain is the object used as an alpaka host device.
+ *  - If hwloc Group objects with CPU sets are available, CPU domains are Groups.
+ *  - Otherwise, CPU domains fall back to NUMA nodes with CPU sets.
+ *  - NUMA nodes are memory targets attached to a CPU domain, not necessarily CPU devices themselves.
+ *
+ * This avoids duplicating the same CPU cores as multiple alpaka devices on systems where DDR and HBM are modeled as
+ * separate NUMA nodes below the same Group.
  */
 namespace alpaka::onHost::internal::hwloc
 {
-    /** Constant to select all NUMA domains.
-     *
-     * Within alpaka we work always with the numa domain index.
-     * Any code setting properties based on the numa domain index should compare first against this value and use all
-     * cores if the numa index is equal to this value.
-     */
-    constexpr uint32_t allNumaDomains = std::numeric_limits<uint32_t>::max();
+    /** Constant to select all CPU domains. */
+    constexpr uint32_t allDomains = std::numeric_limits<uint32_t>::max();
 
 #if ALPAKA_HAS_HWLOC
     /** Helper singleton to cache the hwloc topology.
@@ -48,26 +57,6 @@ namespace alpaka::onHost::internal::hwloc
         hwloc_topology_t get() const noexcept
         {
             return m_topology;
-        }
-
-        hwloc_obj_t getNumaObj(uint32_t numaIdx) const
-        {
-            hwloc_obj_t obj = hwloc_get_obj_by_type(m_topology, HWLOC_OBJ_NUMANODE, static_cast<unsigned>(numaIdx));
-            if(obj == nullptr)
-            {
-                throw std::out_of_range("NUMA domain index out of range: " + std::to_string(numaIdx));
-            }
-            return obj;
-        }
-
-        uint32_t getNumNumaDomains() const
-        {
-            int const count = hwloc_get_nbobjs_by_type(m_topology, HWLOC_OBJ_NUMANODE);
-            if(count < 0)
-            {
-                throw std::runtime_error("hwloc_get_nbobjs_by_type(HWLOC_OBJ_NUMANODE) failed");
-            }
-            return static_cast<uint32_t>(count);
         }
 
     private:
@@ -106,36 +95,168 @@ namespace alpaka::onHost::internal::hwloc
         throw std::runtime_error(std::string(what) + ": " + std::strerror(errno));
     }
 
-    /** Shorthand to get the cached hwloc topology */
+    /** Shorthand to get the cached hwloc topology cache */
     inline hwloc_topology_t getTopology()
     {
         return TopologyCache::instance().get();
     }
 
-    /** Get an hwloc NUMA object */
-    inline hwloc_obj_t getNumaObj(uint32_t numaIdx)
+    /** Check if there are CPUs under the object
+     *
+     * It is possible to create numa domains which does not contain CPUs, those we do not want to use.
+     *
+     * @return true if the object has CPUs, else false.
+     */
+    inline bool hasNonEmptyCpuSet(hwloc_obj_t obj)
     {
-        return TopologyCache::instance().getNumaObj(numaIdx);
+        return obj != nullptr && obj->cpuset != nullptr && !hwloc_bitmap_iszero(obj->cpuset);
     }
+
+    /** Check if a hwloc group exists
+     *
+     * With a hwloc group it is possible to combine more than one numa domain together with cores.
+     *
+     * @return true if 'subtreeRoot' contains a group, else false
+     */
+    inline bool isObjectInSubtree(hwloc_obj_t obj, hwloc_obj_t subtreeRoot)
+    {
+        for(hwloc_obj_t current = obj; current != nullptr; current = current->parent)
+        {
+            if(current == subtreeRoot)
+                return true;
+        }
+        return false;
+    }
+
+    /** Search for all hwloc groups.
+     *
+     * @return A list with hwloc objects where each object is a group. Each group guarantees to contain numa domains
+     * and CPUs.
+     */
+    inline std::vector<hwloc_obj_t> getGroupCpuDomains()
+    {
+        std::vector<hwloc_obj_t> domains;
+        hwloc_topology_t const topology = getTopology();
+
+        hwloc_obj_t group = nullptr;
+        while((group = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_GROUP, group)) != nullptr)
+        {
+            // skip if no CPUs are present in the group
+            if(!hasNonEmptyCpuSet(group))
+                continue;
+
+            // Use only groups that actually contain a NUMA node. This avoids selecting artificial grouping levels that
+            // do not describe a CPU/memory locality domain.
+            bool containsNumaNode = false;
+            hwloc_obj_t node = nullptr;
+            while((node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, node)) != nullptr)
+            {
+                if(isObjectInSubtree(node, group))
+                {
+                    containsNumaNode = true;
+                    break;
+                }
+            }
+
+            if(containsNumaNode)
+                domains.push_back(group);
+        }
+
+        return domains;
+    }
+
+    /** Search for all hwloc numa domains.
+     *
+     * @return A list with hwloc objects where each object is a numa domain. Each domain guarantees to contain CPUs.
+     */
+    inline std::vector<hwloc_obj_t> getNumaCpuDomains()
+    {
+        std::vector<hwloc_obj_t> domains;
+        hwloc_topology_t const topology = getTopology();
+
+        hwloc_obj_t node = nullptr;
+        while((node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, node)) != nullptr)
+        {
+            if(hasNonEmptyCpuSet(node))
+                domains.push_back(node);
+        }
+
+        return domains;
+    }
+
+    /** Return the host CPU domains
+     *
+     @return List with hwloc Groups with CPU sets and NUMA children, otherwise fall back to NUMA nodes with CPU sets.
+     */
+    inline std::vector<hwloc_obj_t> getCpuDomains()
+    {
+        std::vector<hwloc_obj_t> domains = getGroupCpuDomains();
+        if(!domains.empty())
+            return domains;
+
+        return getNumaCpuDomains();
+    }
+
+    /** Return the hwloc object for the domain index. */
+    inline hwloc_obj_t getCpuDomainObj(uint32_t domainIdx)
+    {
+        std::vector<hwloc_obj_t> const domains = getCpuDomains();
+        if(domainIdx >= domains.size())
+        {
+            throw std::out_of_range("CPU domain index out of range: " + std::to_string(domainIdx));
+        }
+        return domains[domainIdx];
+    }
+
+    /** Return all hwloc numa domains of an object.
+     *
+     * @return List of all numa domains under an object. It is guaranteed that each object has at least one numa
+     * domain.
+     */
+    inline std::vector<hwloc_obj_t> getMemoryNodes(hwloc_obj_t domainObj)
+    {
+        std::vector<hwloc_obj_t> nodes;
+        hwloc_topology_t const topology = getTopology();
+
+        if(domainObj == nullptr)
+            return nodes;
+
+        if(domainObj->type == HWLOC_OBJ_NUMANODE)
+        {
+            nodes.push_back(domainObj);
+            return nodes;
+        }
+
+        hwloc_obj_t node = nullptr;
+        while((node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, node)) != nullptr)
+        {
+            if(isObjectInSubtree(node, domainObj))
+                nodes.push_back(node);
+        }
+
+        return nodes;
+    }
+
 #endif
 
-    /** Get the number of NUMA domains. */
-    inline uint32_t getNumNumaDomains()
+    /** Get the number of alpaka host CPU domains. */
+    inline uint32_t getNumCpuDomains()
     {
 #if ALPAKA_HAS_HWLOC
-        return TopologyCache::instance().getNumNumaDomains();
+        std::vector<hwloc_obj_t> const domains = getCpuDomains();
+        return static_cast<uint32_t>(domains.size());
 #else
-        return 1;
+        return 1u;
 #endif
     }
 
     /** Parse the OS NUMA information.
      *
-     * hwloc is not providing the available free memory in a numa domain.
-     * Therefor we fall back to check the NUMA node information in the OS directly.
+     * hwloc is not providing the available free memory in a NUMA domain.
+     * Therefore we fall back to check the NUMA node information in the OS directly.
      *
-     * @param osNodeIndex The index of the numa domain in the OS.
-     * @param key The key value you want to read out e.g. 'MemFree:' or 'HugePages_Total:'
+     * @param osNodeIndex The index of the NUMA node in the OS.
+     * @param key The key value you want to read out e.g. 'MemFree:' or 'HugePages_Total:'.
      */
     inline std::optional<size_t> parseNodeMemInfoValueBytes(unsigned osNodeIndex, std::string_view key)
     {
@@ -173,16 +294,16 @@ namespace alpaka::onHost::internal::hwloc
         return std::nullopt;
     }
 
-    /** Set the affinity of the current thread to all cores of the NUMA domain
+    /** Set the affinity of the current thread to all cores of a CPU domain.
      *
-     * @param numaIdx numa index starting with zero, or allNumaDomains to use all cores
+     * @param cpuDomainIdx Legacy name: CPU-domain index starting with zero, or 'allDomains' to use all cores.
      */
-    inline void setThreadAffinity(uint32_t numaIdx)
+    inline void setThreadAffinity(uint32_t cpuDomainIdx)
     {
 #if ALPAKA_HAS_HWLOC
         hwloc_cpuset_t cpuset = nullptr;
 
-        if(numaIdx == allNumaDomains)
+        if(cpuDomainIdx == allDomains)
         {
             hwloc_const_cpuset_t const fullSet = hwloc_topology_get_complete_cpuset(getTopology());
             if(fullSet == nullptr)
@@ -194,13 +315,13 @@ namespace alpaka::onHost::internal::hwloc
         }
         else
         {
-            hwloc_obj_t const node = getNumaObj(numaIdx);
-            if(node->cpuset == nullptr)
+            hwloc_obj_t const domain = getCpuDomainObj(cpuDomainIdx);
+            if(domain->cpuset == nullptr || hwloc_bitmap_iszero(domain->cpuset))
             {
-                throw std::runtime_error("NUMA node has no cpuset");
+                throw std::runtime_error("CPU domain has no cpuset");
             }
 
-            cpuset = hwloc_bitmap_dup(node->cpuset);
+            cpuset = hwloc_bitmap_dup(domain->cpuset);
         }
 
         if(cpuset == nullptr)
@@ -217,30 +338,25 @@ namespace alpaka::onHost::internal::hwloc
             throwErrno("hwloc_set_cpubind failed");
         }
 #else
-        alpaka::unused(numaIdx);
+        alpaka::unused(cpuDomainIdx);
         return;
 #endif
     }
 
-    /** Set the NUMA domain for the memory range described by ptr and bytes
-     *
-     * @attention This method should be called before the memory is touched, else it has no effect.
-     *
-     * @param ptr pointer address to pin, nullptr are valid input
-     * @param bytes the number of bytes to pin starting from the ptr address
-     * @param numaIdx numa index starting with zero, or allNumaDomains to not pin anything.
-     */
-    template<typename T>
-    inline void pinPointer(T* const ptr, size_t bytes, uint32_t numaIdx)
-    {
 #if ALPAKA_HAS_HWLOC
-        if(numaIdx == allNumaDomains)
-            return;
-
+    /** Set the NUMA memory target for the memory range described by ptr and bytes. */
+    template<typename T>
+    inline void pinPointerToNumaNode(T* const ptr, size_t bytes, hwloc_obj_t const node)
+    {
         if(ptr == nullptr || bytes == 0u)
             return;
 
-        hwloc_obj_t const node = getNumaObj(numaIdx);
+        if(node == nullptr)
+            throw std::runtime_error("NUMA node is null");
+
+        if(node->type != HWLOC_OBJ_NUMANODE)
+            throw std::runtime_error("Memory binding target is not a NUMA node");
+
         if(node->nodeset == nullptr)
         {
             throw std::runtime_error("NUMA node has no nodeset");
@@ -265,11 +381,11 @@ namespace alpaka::onHost::internal::hwloc
         if(rc != 0)
         {
 #    ifdef ALPAKA_HOST_MEM_PINNING_CAN_FAIL
-            // missing privileges, e.g. within a container
+            // Missing privileges, e.g. within a container.
             bool const operationNotSupported = errno == EPERM;
-            // unsupported platform
+            // Unsupported platform.
             bool const functionNotImplemented = errno == ENOSYS;
-            // NUMA node is not allowed by cpuset/cgroup
+            // NUMA node is not allowed by cpuset/cgroup.
             bool const operationNotAllowed = errno == EXDEV;
             if(operationNotSupported || functionNotImplemented || operationNotAllowed)
             {
@@ -278,31 +394,64 @@ namespace alpaka::onHost::internal::hwloc
 #    endif
             throwErrno("hwloc_set_area_membind failed");
         }
+    }
+#endif
+
+    /** Set the default NUMA memory node for a CPU-domain memory range.
+     *
+     * @attention This method should be called before the memory is touched, else it may have no effect.
+     *            If a cpuDomainIdx contains more than one numa domain, the first numa domain will be used.
+     *
+     * @param ptr pointer address to pin, nullptr is valid input.
+     * @param bytes the number of bytes to pin starting from the ptr address.
+     * @param cpuDomainIdx Index of the cpu group.
+     */
+    template<typename T>
+    inline void pinPointer(T* const ptr, size_t bytes, uint32_t cpuDomainIdx)
+    {
+#if ALPAKA_HAS_HWLOC
+        if(cpuDomainIdx == allDomains)
+            return;
+
+        if(ptr == nullptr || bytes == 0u)
+            return;
+
+        std::vector<hwloc_obj_t> const nodes = getMemoryNodes(getCpuDomainObj(cpuDomainIdx));
+        if(nodes.empty())
+        {
+            throw std::runtime_error("CPU domain has no associated NUMA memory node");
+        }
+
+        /** take the first numa domain
+         *
+         * @todo: this should be slectable during onHost::alloc()
+         */
+        pinPointerToNumaNode(ptr, bytes, nodes.front());
 #else
-        alpaka::unused(ptr, bytes, numaIdx);
+        alpaka::unused(ptr, bytes, cpuDomainIdx);
         return;
 #endif
     }
 
-    /** Return the number of cores which has direct access to the numa domain
+    /** Return the number of cores in a CPU domain.
      *
-     *  Here "cores" means logical CPUs / processing units, so SMT siblings are counted too.
+     * Here "cores" means logical CPUs / processing units, so SMT siblings are counted too.
      *
-     *  @param numaIdx numa index starting with zero, or allNumaDomains to the C++ hardware concurrency.
+     * @param cpuDomainIdx Index of the cpu group.
      */
-    inline uint32_t getNumCores(uint32_t numaIdx)
+    inline uint32_t getNumCores(uint32_t cpuDomainIdx)
     {
 #if ALPAKA_HAS_HWLOC
-        if(numaIdx == allNumaDomains)
+        if(cpuDomainIdx == allDomains)
             return std::thread::hardware_concurrency();
 
-        hwloc_obj_t const node = getNumaObj(numaIdx);
-        if(node->cpuset == nullptr)
+        hwloc_obj_t const domain = getCpuDomainObj(cpuDomainIdx);
+        if(domain->cpuset == nullptr || hwloc_bitmap_iszero(domain->cpuset))
         {
-            throw std::runtime_error("NUMA node has no cpuset");
+            throw std::runtime_error("CPU domain has no cpuset");
         }
 
-        int const numPUs = hwloc_bitmap_weight(node->cpuset);
+        int const numPUs = hwloc_bitmap_weight(domain->cpuset);
         if(numPUs < 0)
         {
             throw std::runtime_error("hwloc_bitmap_weight failed");
@@ -310,58 +459,70 @@ namespace alpaka::onHost::internal::hwloc
 
         return static_cast<uint32_t>(numPUs);
 #else
-        alpaka::unused(numaIdx);
+        alpaka::unused(cpuDomainIdx);
         return std::thread::hardware_concurrency();
 #endif
     }
 
-    /** Return the number of bytes of the numa domain
+    /** Return the memory capacity of a CPU domain.
      *
-     * @param numaIdx numa index starting with zero, or allNumaDomains to get total CPU memory capacity.
+     * If the CPU domain has multiple attached NUMA memory nodes, e.g. DDR and HBM, the returned value is the sum of
+     * all attached memory nodes.
+     *
+     * @param cpuDomainIdx Index of the cpu group.
      */
-    inline size_t getMemCapacityBytes(uint32_t numaIdx)
+    inline size_t getMemCapacityBytes(uint32_t cpuDomainIdx)
     {
 #if ALPAKA_HAS_HWLOC
-        if(numaIdx == allNumaDomains)
+        if(cpuDomainIdx == allDomains)
             return alpaka::onHost::getGlobalMemCapacityBytes();
 
-        hwloc_obj_t const node = getNumaObj(numaIdx);
-        if(node->attr == nullptr)
+        size_t bytes = 0u;
+        for(hwloc_obj_t const node : getMemoryNodes(getCpuDomainObj(cpuDomainIdx)))
         {
-            throw std::runtime_error("NUMA node has no attributes");
+            if(node->attr == nullptr)
+            {
+                throw std::runtime_error("NUMA node has no attributes");
+            }
+            bytes += static_cast<size_t>(node->attr->numanode.local_memory);
         }
 
-        return static_cast<size_t>(node->attr->numanode.local_memory);
-
+        return bytes;
 #else
-        alpaka::unused(numaIdx);
+        alpaka::unused(cpuDomainIdx);
         return alpaka::onHost::getGlobalMemCapacityBytes();
 #endif
     }
 
-    /** Return the number of free bytes in the numa domain.
+    /** Return the number of free bytes in a CPU domain.
      *
-     *  Linux-only implementation via /sys/devices/system/node/nodeX/meminfo
+     * Linux-only implementation via /sys/devices/system/node/nodeX/meminfo. If the CPU domain has multiple attached
+     * NUMA memory nodes, e.g. DDR and HBM, the returned value is the sum of all attached memory nodes.
      *
-     *  @param numaIdx numa index starting with zero, or allNumaDomains to get total free CPU memory.
+     * @param cpuDomainIdx Index of the cpu group.
      */
-    inline size_t getFreeGlobalMemBytes(uint32_t numaIdx)
+    inline size_t getFreeGlobalMemBytes(uint32_t cpuDomainIdx)
     {
 #if ALPAKA_HAS_HWLOC
-        if(numaIdx == allNumaDomains)
+        if(cpuDomainIdx == allDomains)
             return alpaka::onHost::getFreeGlobalMemBytes();
 
-        hwloc_obj_t const node = getNumaObj(numaIdx);
-        auto const freeBytes = parseNodeMemInfoValueBytes(node->os_index, "MemFree:");
-        if(!freeBytes.has_value())
+        size_t bytes = 0u;
+        for(hwloc_obj_t const node : getMemoryNodes(getCpuDomainObj(cpuDomainIdx)))
         {
-            throw std::runtime_error(
-                "Could not read per-node MemFree from /sys/devices/system/node/node" + std::to_string(node->os_index)
-                + "/meminfo");
+            auto const freeBytes = parseNodeMemInfoValueBytes(node->os_index, "MemFree:");
+            if(!freeBytes.has_value())
+            {
+                throw std::runtime_error(
+                    "Could not read per-node MemFree from /sys/devices/system/node/node"
+                    + std::to_string(node->os_index) + "/meminfo");
+            }
+            bytes += *freeBytes;
         }
-        return *freeBytes;
+
+        return bytes;
 #else
-        alpaka::unused(numaIdx);
+        alpaka::unused(cpuDomainIdx);
         return alpaka::onHost::getFreeGlobalMemBytes();
 #endif
     }

--- a/include/alpaka/core/CallbackThread.hpp
+++ b/include/alpaka/core/CallbackThread.hpp
@@ -68,7 +68,7 @@ namespace alpaka::core
         };
 
     public:
-        CallbackThread(uint32_t numaIdx) : m_state(std::make_shared<State>()), m_numaIdx{numaIdx}
+        CallbackThread(uint32_t cpuGroupIdx) : m_state(std::make_shared<State>()), m_cpuGroupIdx{cpuGroupIdx}
         {
         }
 
@@ -136,15 +136,15 @@ namespace alpaka::core
         std::jthread m_thread;
         /** Hold data shared between this call and the thread processing the tasts. */
         std::shared_ptr<State> m_state;
-        uint32_t m_numaIdx = onHost::internal::hwloc::allNumaDomains;
+        uint32_t m_cpuGroupIdx = onHost::internal::hwloc::allDomains;
 
         auto startWorkerThread() -> void
         {
             m_thread = std::jthread(
-                [state = m_state, numaIdx = m_numaIdx](std::stop_token st)
+                [state = m_state, cpuGroupIdx = m_cpuGroupIdx](std::stop_token st)
                 {
-                    if(numaIdx != onHost::internal::hwloc::allNumaDomains)
-                        onHost::internal::hwloc::setThreadAffinity(numaIdx);
+                    if(cpuGroupIdx != onHost::internal::hwloc::allDomains)
+                        onHost::internal::hwloc::setThreadAffinity(cpuGroupIdx);
 
                     while(true)
                     {


### PR DESCRIPTION
Use hwloc groups to goup cpu to a virtual device if available, else use numa domains.
This is required on systems where a set of CPUs has more than one numa domain e.g. DDR and HBM memory.

A Xeon Max looks now like this; before, it showed 16 devices where cores were used in two different devices because this system has HMP2 and DDR memory.
```
api: Host
        device kind      : Cpu
        number of devices: 1
                id                   : 0
                name                 : Intel(R) Xeon(R) CPU Max 9460
                multi processor count: 160
                warp size            : 1
                max threads per block: 4096
                global memory bytes  : 406836101120
                executors            : CpuOmpBlocks

api: Host
        device kind      : NumaCpu
        number of devices: 8
                id                   : 0
                name                 : Intel(R) Xeon(R) CPU Max 9460
                multi processor count: 20
                warp size            : 1
                max threads per block: 4096
                global memory bytes  : 49917067264
                executors            : CpuOmpBlocks

                id                   : 1
                name                 : Intel(R) Xeon(R) CPU Max 9460
                multi processor count: 20
                warp size            : 1
                max threads per block: 4096
                global memory bytes  : 50952441856
                executors            : CpuOmpBlocks

                id                   : 2
                name                 : Intel(R) Xeon(R) CPU Max 9460
                multi processor count: 20
                warp size            : 1
                max threads per block: 4096
                global memory bytes  : 50997284864
                executors            : CpuOmpBlocks

                id                   : 3
                name                 : Intel(R) Xeon(R) CPU Max 9460
                multi processor count: 20
                warp size            : 1
                max threads per block: 4096
                global memory bytes  : 50997284864
                executors            : CpuOmpBlocks

                id                   : 4
                name                 : Intel(R) Xeon(R) CPU Max 9460
                multi processor count: 20
                warp size            : 1
                max threads per block: 4096
                global memory bytes  : 50997284864
                executors            : CpuOmpBlocks

                id                   : 5
                name                 : Intel(R) Xeon(R) CPU Max 9460
                multi processor count: 20
                warp size            : 1
                max threads per block: 4096
                global memory bytes  : 50997288960
                executors            : CpuOmpBlocks

                id                   : 6
                name                 : Intel(R) Xeon(R) CPU Max 9460
                multi processor count: 20
                warp size            : 1
                max threads per block: 4096
                global memory bytes  : 50997284864
                executors            : CpuOmpBlocks

                id                   : 7
                name                 : Intel(R) Xeon(R) CPU Max 9460
                multi processor count: 20
                warp size            : 1
                max threads per block: 4096
                global memory bytes  : 50980134912
                executors            : CpuOmpBlocks
```