### PR TITLE
fix vendor api example

### DIFF
--- a/example/vendorApi/src/cudaFn.hpp
+++ b/example/vendorApi/src/cudaFn.hpp
@@ -8,7 +8,7 @@
 
 #include <alpaka/alpaka.hpp>
 
-#if __has_include(<thrust/transform.h>)
+#if __has_include(<thrust/transform.h>) && ALPAKA_LANG_CUDA
 #    include <thrust/device_vector.h>
 #    include <thrust/transform.h>
 


### PR DESCRIPTION
On systems with HIP installed it could be that hip is exposing the header `threast/transform.h` therfore the macro check in the example must be guareded with the CUDA language too.

I observed the issue on or developer system fwk388 with HIP 6.2.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA build compatibility by only enabling an optional GPU path when the necessary CUDA support is present.
  * Reduced the risk of build issues in environments where GPU-related tooling is partially available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->