### PR TITLE
add `Queue::enqueueNativeFn()`

### DIFF
--- a/docs/snippets/example/200_vendorInterop.cpp
+++ b/docs/snippets/example/200_vendorInterop.cpp
@@ -81,9 +81,13 @@ namespace vendorTutorial
          * propagated to the data.
          */
         auto outPtr = output.data();
-        // Enqueue the operation via a host function to ensure the order of executions within a non-blocking queue.
-        queue.enqueueHostFn(
-            [=]()
+        /* Enqueue the operation via enqueueNativeFn to ensure the order of executions within a non-blocking queue.
+         * The first argument of the function which is enqueued is the result of queue.getNativeHandle(), it will be
+         * applied by alpaka. For api::Host it is the alpaka internal queue id, for other APIs it is the stream/queue
+         * handle.
+         */
+        queue.enqueueNativeFn(
+            [=](auto /*queueId*/)
             {
                 std::transform(
                     input.data(),

--- a/example/vendorApi/src/cudaFn.hpp
+++ b/example/vendorApi/src/cudaFn.hpp
@@ -31,13 +31,19 @@ namespace vendorExample
         alpaka::concepts::IMdSpan auto&& input1)
     {
         std::cout << "call thrust::transform" << std::endl;
-        thrust::transform(
-            thrust::cuda::par.on(queue.getNativeHandle()),
-            input0.data(),
-            input0.data() + input0.getExtents().x(),
-            input1.data(),
-            output.data(),
-            binaryOp);
+        // ensure the pointer is non const, capturing the span results into const mdspan within the const lambda
+        auto outPtr = output.data();
+        queue.enqueueNativeFn(
+            [=](auto cudaStream)
+            {
+                thrust::transform(
+                    thrust::cuda::par.on(cudaStream),
+                    input0.data(),
+                    input0.data() + input0.getExtents().x(),
+                    input1.data(),
+                    outPtr,
+                    binaryOp);
+            });
     }
 
     /** @} */

--- a/example/vendorApi/src/fn.hpp
+++ b/example/vendorApi/src/fn.hpp
@@ -52,8 +52,8 @@ namespace vendorExample
         std::cout << "call std::transform" << std::endl;
         // ensure the pointer is non const, capturing the span results into const mdspan within the const lambda
         auto outPtr = output.data();
-        queue.enqueueHostFn(
-            [=]()
+        queue.enqueueNativeFn(
+            [=](auto /*queueId*/)
             {
                 std::transform(
                     input0.data(),

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -217,6 +217,12 @@ namespace alpaka::onHost
                 m_workerThread.submit(task);
             }
 
+            void enqueueNativeFn(auto const& fn)
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                submit([queueId = getNativeHandle(), fn]() { fn(queueId); });
+            }
+
             friend struct alpaka::internal::GetDeviceType;
 
             auto getDeviceKind() const

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -301,6 +301,15 @@ namespace alpaka::onHost
                 m_lastEvent = ev;
             }
 
+            void enqueueNativeFn(auto const& fn)
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                sycl::event ev = fn(getNativeHandle());
+                setLastEvent(ev);
+                if(isBlocking())
+                    ev.wait_and_throw();
+            }
+
             friend struct alpaka::onHost::internal::Memset;
             friend struct alpaka::onHost::internal::Memcpy;
             friend struct alpaka::onHost::internal::MemcpyDeviceGlobal;

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -174,6 +174,13 @@ namespace alpaka::onHost
                 return (ret == ApiInterface::success);
             }
 
+            void enqueueNativeFn(auto const& fn)
+            {
+                ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                fn(getNativeHandle());
+                conditionalWait();
+            }
+
             friend struct onHost::internal::GetDevice;
 
             friend struct alpaka::internal::GetApi;

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -176,6 +176,26 @@ namespace alpaka::onHost
                 task);
         }
 
+        /** Enqueue a native Api call.
+         *
+         * To keep the queue behavior e.g. blocking, non-blocking consistent in an application even if a native
+         * function is called it is required that alpaka knows about the function call and how to observe when the
+         * function is finished.
+         * By registering the native function API call alpaka can handle it.
+         * Typically, this method is used to call vendor functions, e.g. NVIDIA thrust.
+         *
+         * @attention fn should not capture arguments by reference because the execution can be deferred.
+         *
+         * @param fn A callable with the native queue handle for the corresponding API as only argument. The return
+         * value must be 'void' except for OneApi where a 'sycl::event' of the last function call must be returned.
+         * The native handle of the queue is passed to fn: HIP/CUDA get the stream, OneApi a sycl::queue and host gets
+         * the alpaka internal index of the queue.
+         */
+        void enqueueNativeFn(auto const& fn) const
+        {
+            internal::Enqueue::NativeFn<ALPAKA_TYPEOF(*m_queue.get()), ALPAKA_TYPEOF(fn)>{}(*m_queue.get(), fn);
+        }
+
         /** Enqueue an event
          *
          * The event will be signaled after all preceding operations in the queue are finished.

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -221,6 +221,15 @@ namespace alpaka::onHost
                 }
             };
 
+            template<typename T_Queue, typename T_Task>
+            struct NativeFn
+            {
+                void operator()(T_Queue& queue, T_Task const& fn) const
+                {
+                    queue.enqueueNativeFn(fn);
+                }
+            };
+
             template<typename T_Queue, typename T_Event>
             struct Event
             {


### PR DESCRIPTION
Add a function so that native API operations on a queue can be exposed to alpaka to keep the alpaka queue behaviour consistent for the user. It ensures that an operation on a blocking queue blocks the execution.

Without this PR Sycl, HIP, Host and CUDA function calls with the function API of alpaka would result in different behaviours. Now anything enqueued in the alpaka queue is known by alpaka and is blocking in cases the queue is blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified way to enqueue “native” vendor operations on host-side queues (CPU, SYCL, CUDA, HIP), passing the underlying native queue/stream handle to the operation.

* **Bug Fixes**
  * Improved ordering and synchronization for queued transforms by routing them through native-enqueue paths.
  * Ensured CUDA/HIP native transform work runs asynchronously on the configured stream.
  * Blocking queues now properly wait for native operations to finish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->