### PR TITLE
CI: install hwloc via script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
                 echo "APCI_GIT_URL=https://github.com/${{ github.repository }}.git" >> $GITHUB_ENV
                 echo "APCI_BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
             fi
+            ${{ matrix.config.hwloc == 'no' }} && echo "APCI_HWLOC=OFF" >> $GITHUB_ENV || true
       - name: job configuration environment variables
         run: "${APCI_ALPAKA_ROOT}/script/ci/job_info.sh"
       # Install base dependencies
@@ -218,12 +219,8 @@ jobs:
       # hwloc (opt out)
       - name: Install hwloc
         if: matrix.config.hwloc != 'no'
-        run: |
-          apt-get update
-          apt-get install -y libhwloc-dev pkg-config
-          which pkg-config
-          echo "hwlock version:" $(pkg-config --modversion hwloc)
-          dpkg -L libhwloc-dev
+        shell: bash
+        run: "${APCI_ALPAKA_ROOT}/script/ci/install/hwloc.sh"
 
       # Configure CMake with the selected compiler and options
       - name: Configure CMake

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@
     APCI_ALPAKA_ROOT: "$CI_PROJECT_DIR"
     APCI_RUN_CTEST: "ON"
     APCI_EXEC_CPU_SERIAL: "OFF"
+    APCI_HWLOC: "ON"
     APCI_HIP : 0
     APCI_CUDA : 0
     APCI_ONEAPI : 0
@@ -65,6 +66,15 @@ clang-19:
     APCI_DEVICE_COMPILER : clang@19
     APCI_CMAKE: 3.28.3
     APCI_EXEC_CPU_SERIAL: "ON"
+
+clang-20-hwloc-off:
+  image: docker.io/ubuntu:24.04
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : clang@20
+    APCI_CMAKE: 3.28.3
+    APCI_EXEC_CPU_SERIAL: "ON"
+    APCI_HWLOC: "OFF"
 
 clang-21:
   image: docker.io/ubuntu:24.04

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -53,6 +53,11 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
         ap_deps['OMP']=ON
     fi
 
+    if [[ "${APCI_HWLOC}" == "ON" ]]; then
+        ap_deps['HWLOC']=ON
+        CMAKE_ARGS+=(-Dalpaka_HOST_MemPinningCanFail=ON)
+    fi
+
     if [[ "$APCI_HIP" != 0 ]]; then
         load_variable_if_not_exist ROCM_PATH
 

--- a/script/ci/install/hwloc.sh
+++ b/script/ci/install/hwloc.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+# shellcheck source=script/ci/utils/default.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
+
+if [[ "$APCI_OS_NAME" != "Linux" ]]; then
+    exit_error "Install hwloc script does not support Windows or MacOS"
+fi
+
+script_msg "Install APCI_HWLOC"
+
+if [[ "${APCI_HWLOC}" == "ON" ]]; then
+    install_msg "hwloc"
+
+    hwloc_package_list=(libhwloc-dev pkg-config)
+
+    if dpkg -s "${hwloc_package_list[@]}" >/dev/null 2>&1; then
+        echo_yellow "hwloc is already installed via apt. Skip installation."
+    else
+        lazy_apt_update
+        quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install -y "${hwloc_package_list[@]}"
+    fi
+    echo_run which pkg-config
+    echo "hwloc version: $(pkg-config --modversion hwloc)"
+    echo_run dpkg -L libhwloc-dev
+else
+    echo_green "Skipped install hwloc because it is not required for the job."
+fi

--- a/script/ci/install/hwloc.sh
+++ b/script/ci/install/hwloc.sh
@@ -20,6 +20,20 @@ if [[ "${APCI_HWLOC}" == "ON" ]]; then
 
     hwloc_package_list=(libhwloc-dev pkg-config)
 
+    if [[ "$APCI_HIP" != 0 ]]; then
+        case $(cat /etc/os-release) in
+        # Ubuntu 22.04 is fine. No special handling.
+        *"22.04"*) ;;
+        *"24.04"*)
+            # hwloc installs as dependency g++-13. The clang++ of the ROCm SDK detects g++-11 and
+            # g++-13 and tries to use the libstdc++ of g++-13, which is not installed. Therefore
+            # install the libstdc++-13 manually.
+            hwloc_package_list+=(libstdc++-13-dev)
+            ;;
+        *) exit_error "hwloc + ROCm is not supported on this operations system container." ;;
+        esac
+    fi
+
     if dpkg -s "${hwloc_package_list[@]}" >/dev/null 2>&1; then
         echo_yellow "hwloc is already installed via apt. Skip installation."
     else

--- a/script/ci/install/rocm.sh
+++ b/script/ci/install/rocm.sh
@@ -75,8 +75,7 @@ if [[ "$APCI_HIP" != 0 ]]; then
     echo_run "${APCI_C_COMPILER}" --version
     echo_run "${APCI_CXX_COMPILER}" --version
 
-    echo_run "${ROCM_PATH}"/bin/hipconfig --platform
-    echo_run "${ROCM_PATH}"/bin/hipconfig -v
+    echo_run "${ROCM_PATH}"/bin/hipconfig
     echo
 
     store_variable ROCM_PATH

--- a/script/ci/install_dependencies.sh
+++ b/script/ci/install_dependencies.sh
@@ -23,6 +23,8 @@ source "${APCI_ALPAKA_ROOT}/script/ci/install/cmake.sh"
 source "${APCI_ALPAKA_ROOT}/script/ci/install/gcc.sh"
 # shellcheck source=script/ci/install/clang.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/install/clang.sh"
+# shellcheck source=script/ci/install/hwloc.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/install/hwloc.sh"
 # shellcheck source=script/ci/install/rocm.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/install/rocm.sh"
 # shellcheck source=script/ci/install/cuda.sh

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 
+set -eu
+
 # setup environment variables depending on os environment (on local system, GitLab CI, GitHub Action ...)
 
 # set the required memory per build thread in GB
@@ -17,8 +19,12 @@ if [[ -n ${GITHUB_ACTIONS+x} ]]; then
 
     export APCI_OS_NAME="$RUNNER_OS"
 
-    if [[ -z ${APCI_EXEC_CPU_SERIAL} ]]; then
+    if [[ -z ${APCI_EXEC_CPU_SERIAL+x} ]]; then
         export APCI_EXEC_CPU_SERIAL=OFF
+    fi
+
+    if [[ -z ${APCI_HWLOC+x} ]]; then
+        export APCI_HWLOC=ON
     fi
 
     # The Github Actions are handwritten, therefore set some undefined variables to default


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable HWLOC support across CI, including a new CI variant that runs with HWLOC disabled.
  * Introduced a dedicated HWLOC installer/verification script used by CI when enabled.
* **Bug Fixes**
  * Ensured HWLOC-related CMake options are applied when enabled, including adjusted memory pinning behavior.
  * Improved HIP container handling by setting `CMAKE_SYSTEM_NAME=Linux` when needed.
  * Simplified ROCm `hipconfig` post-install verification.
* **Chores**
  * Standardized HWLOC setup behavior in GitHub Actions (defaults to enabled when unset) and hardened CI shell execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->