### PR TITLE
disable runtime tests for HIP<6.4

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,6 +89,7 @@ hipcc-6.2-agc:
     APCI_DEVICE_COMPILER : clang@18
     APCI_CMAKE: 3.31.4
     APCI_HIP : 6.2
+    APCI_RUN_CTEST: "OFF"
 
 hipcc-6.3-rocm-container:
   image: rocm/dev-ubuntu-24.04:6.3.4
@@ -97,6 +98,7 @@ hipcc-6.3-rocm-container:
     APCI_DEVICE_COMPILER : clang@18
     APCI_CMAKE: 3.28.3
     APCI_HIP : 6.3
+    APCI_RUN_CTEST: "OFF"
 
 hipcc-6.4:
   image: docker.io/ubuntu:24.04


### PR DESCRIPTION
Since ROCm 6.4 AMD provides 1 year forward and backward driver support. ROCM before 6.4 is not compatible with the driver 7.2.4 used in our CI, therefore we will run only compile tests for these versions.

see: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/user-kernel-space-compat-matrix.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HIP-related continuous integration jobs to skip CTest execution, streamlining automated build validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->