### PR TITLE
CI: set sanitizer in scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,10 @@ jobs:
                 echo "APCI_BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
             fi
             ${{ matrix.config.hwloc == 'no' }} && echo "APCI_HWLOC=OFF" >> $GITHUB_ENV || true
+            ${{ matrix.config.sanitizer == 'asan' }}  && echo 'APCI_SANITIZER_ASAN=ON'  >> $GITHUB_ENV || true
+            ${{ matrix.config.sanitizer == 'tsan' }}  && echo 'APCI_SANITIZER_TSAN=ON'  >> $GITHUB_ENV || true
+            ${{ matrix.config.sanitizer == 'lsan' }}  && echo 'APCI_SANITIZER_LSAN=ON'  >> $GITHUB_ENV || true
+            ${{ matrix.config.sanitizer == 'ubsan' }} && echo 'APCI_SANITIZER_UBSAN=ON' >> $GITHUB_ENV || true
       - name: job configuration environment variables
         run: "${APCI_ALPAKA_ROOT}/script/ci/job_info.sh"
       # Install base dependencies
@@ -221,6 +225,10 @@ jobs:
         if: matrix.config.hwloc != 'no'
         shell: bash
         run: "${APCI_ALPAKA_ROOT}/script/ci/install/hwloc.sh"
+
+      - name: Setup Sanitizer
+        if: matrix.config.sanitizer
+        run: "${APCI_ALPAKA_ROOT}/script/ci/install/sanitizer.sh"
 
       # Configure CMake with the selected compiler and options
       - name: Configure CMake

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,10 @@
     APCI_ONEAPI : 0
     APCI_ONEAPI_TARGET: none
     APCI_TBB : "OFF"
+    APCI_SANITIZER_ASAN : "OFF"
+    APCI_SANITIZER_TSAN : "OFF"
+    APCI_SANITIZER_LSAN : "OFF"
+    APCI_SANITIZER_UBSAN : "OFF"
   script:
     - $APCI_ALPAKA_ROOT/script/ci/job_info.sh
     - $APCI_ALPAKA_ROOT/script/ci/install_dependencies.sh
@@ -352,3 +356,67 @@ icpx-21-tbb-intel-container:
     APCI_DEVICE_COMPILER : icpx@2026.0
     APCI_CMAKE: 3.28.3
     APCI_TBB: "ON"
+
+gcc-15-asan:
+  image: docker.io/ubuntu:24.04
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : gcc@15
+    APCI_CMAKE: 3.28.3
+    APCI_SANITIZER_ASAN: "ON"
+
+gcc-15-tsan:
+  image: docker.io/ubuntu:24.04
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : gcc@15
+    APCI_CMAKE: 3.28.3
+    APCI_SANITIZER_TSAN: "ON"
+
+gcc-15-lsan:
+  image: docker.io/ubuntu:24.04
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : gcc@15
+    APCI_CMAKE: 3.28.3
+    APCI_SANITIZER_LSAN: "ON"
+
+gcc-15-ubsan:
+  image: docker.io/ubuntu:24.04
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : gcc@15
+    APCI_CMAKE: 3.28.3
+    APCI_SANITIZER_UBSAN: "ON"
+
+clang-21-asan:
+  image: docker.io/ubuntu:24.04
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : clang@21
+    APCI_CMAKE: 3.28.3
+    APCI_SANITIZER_ASAN: "ON"
+
+clang-21-tsan:
+  image: docker.io/ubuntu:24.04
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : clang@21
+    APCI_CMAKE: 3.28.3
+    APCI_SANITIZER_TSAN: "ON"
+
+clang-21-lsan:
+  image: docker.io/ubuntu:24.04
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : clang@21
+    APCI_CMAKE: 3.28.3
+    APCI_SANITIZER_LSAN: "ON"
+
+clang-21-ubsan:
+  image: docker.io/ubuntu:24.04
+  extends: .base
+  variables:
+    APCI_DEVICE_COMPILER : clang@21
+    APCI_CMAKE: 3.28.3
+    APCI_SANITIZER_UBSAN: "ON"

--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -82,12 +82,26 @@ else
     echo_yellow "Use number of build threads set via APCI_BUILD_THREADS=${APCI_BUILD_THREADS}."
 fi
 
+for sanitizer in ASAN TSAN LSAN UBSAN; do
+    flag="APCI_SANITIZER_${sanitizer}"
+    opt="${sanitizer}_OPTIONS"
+
+    if [[ "${!flag}" == "ON" ]]; then
+        load_variable_if_not_exist "${opt}"
+    fi
+done
+
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 # TODO: remove me, if all install scripts are ported
 if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "nvcc" || "$compiler_name" == "icpx" ]]; then
     load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 
-    echo_green "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+    echo_green \
+        "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+        "$(echo_if_not_empty_and_set ASAN_OPTIONS)" \
+        "$(echo_if_not_empty_and_set TSAN_OPTIONS)" \
+        "$(echo_if_not_empty_and_set LSAN_OPTIONS)" \
+        "$(echo_if_not_empty_and_set UBSAN_OPTIONS)" \
         "${APCI_CMAKE_BIN_PATH}/cmake" \
         --build /build \
         "-j${APCI_BUILD_THREADS}"

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -139,6 +139,16 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
         fi
     fi
 
+    for sanitizer in ASAN TSAN LSAN UBSAN; do
+        flag="APCI_SANITIZER_${sanitizer}"
+        opt="${sanitizer}_OPTIONS"
+
+        if [[ "${!flag}" == "ON" ]]; then
+            load_variable_if_not_exist "${opt}"
+            CMAKE_ARGS+=("-Dalpaka_${sanitizer}=ON")
+        fi
+    done
+
     # enable dependencies
     for dep in "${!ap_deps[@]}"; do
         CMAKE_ARGS+=("-Dalpaka_DEP_${dep}=${ap_deps[$dep]}")
@@ -154,7 +164,12 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
         -Dalpaka_EXEC_OneApi=ON
     )
 
-    echo_green "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+    echo_green \
+        "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+        "$(echo_if_not_empty_and_set ASAN_OPTIONS)" \
+        "$(echo_if_not_empty_and_set TSAN_OPTIONS)" \
+        "$(echo_if_not_empty_and_set LSAN_OPTIONS)" \
+        "$(echo_if_not_empty_and_set UBSAN_OPTIONS)" \
         "${APCI_CMAKE_BIN_PATH}/cmake" \
         "${CMAKE_ARGS[*]}"
     if [[ -z ${GITHUB_ACTIONS+x} ]]; then

--- a/script/ci/install/sanitizer.sh
+++ b/script/ci/install/sanitizer.sh
@@ -28,17 +28,17 @@ if [[ "${APCI_SANITIZER_TSAN}" == "ON" ]]; then
     rnd_bits=$(sudo sysctl -n vm.mmap_rnd_bits)
     if [[ -z ${GITHUB_ACTIONS+x} ]] && [[ -z ${GITLAB_CI+x} ]]; then
         # local container
-        if [[ "${rnd_bits}" != 28 ]]; then
+        if [[ ${rnd_bits} -gt 28 ]]; then
             echo_yellow "[WARNING]: vm.mmap_rnd_bits is set to ${rnd_bits}. The TSAN may fail." \
                 "Run 'sudo sysctl vm.mmap_rnd_bits=28' on the host to fix the issue."
         fi
     else
-        if [[ "${rnd_bits}" == 28 ]]; then
-            echo_green "vm.mmap_rnd_bits=28 is set"
+        if [[ ${rnd_bits} -le 28 ]]; then
+            echo_green "vm.mmap_rnd_bits=${rnd_bits} is set"
         else
             echo_run sudo sysctl vm.mmap_rnd_bits=28
-            if [[ $(sudo sysctl -n vm.mmap_rnd_bits) != 28 ]]; then
-                exit_error "Cannot set vm.mmap_rnd_bits to 28"
+            if [[ $(sudo sysctl -n vm.mmap_rnd_bits) -ne 28 ]]; then
+                exit_error "Cannot set vm.mmap_rnd_bits from ${rnd_bits} to 28"
             fi
         fi
     fi

--- a/script/ci/install/sanitizer.sh
+++ b/script/ci/install/sanitizer.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2026 Simeon Ehrig
+# SPDX-License-Identifier: MPL-2.0
+#
+
+: "${APCI_ALPAKA_ROOT?'APCI_ALPAKA_ROOT is not defined. Root directory of the alpaka project'}"
+# shellcheck source=script/ci/utils/default.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/utils/default.sh"
+
+if [[ "$APCI_OS_NAME" != "Linux" ]]; then
+    exit_error "Install ROCm script does not support Windows or MacOS"
+fi
+
+script_msg "Setup Sanitizer"
+
+export ASAN_OPTIONS="suppressions=${APCI_ALPAKA_ROOT}/sanitizer/asan_suppressions.txt"
+export TSAN_OPTIONS="suppressions=${APCI_ALPAKA_ROOT}/sanitizer/tsan_suppressions.txt,ignore_noninstrumented_modules=1"
+export LSAN_OPTIONS="suppressions=${APCI_ALPAKA_ROOT}/sanitizer/lsan_suppressions.txt"
+export UBSAN_OPTIONS="suppressions=${APCI_ALPAKA_ROOT}/sanitizer/ubsan_suppressions.txt"
+store_variable ASAN_OPTIONS
+store_variable TSAN_OPTIONS
+store_variable LSAN_OPTIONS
+store_variable UBSAN_OPTIONS
+
+if [[ "${APCI_SANITIZER_TSAN}" == "ON" ]]; then
+    rnd_bits=$(sudo sysctl -n vm.mmap_rnd_bits)
+    if [[ -z ${GITHUB_ACTIONS+x} ]] && [[ -z ${GITLAB_CI+x} ]]; then
+        # local container
+        if [[ "${rnd_bits}" != 28 ]]; then
+            echo_yellow "[WARNING]: vm.mmap_rnd_bits is set to ${rnd_bits}. The TSAN may fail." \
+                "Run 'sudo sysctl vm.mmap_rnd_bits=28' on the host to fix the issue."
+        fi
+    else
+        if [[ "${rnd_bits}" == 28 ]]; then
+            echo_green "vm.mmap_rnd_bits=28 is set"
+        else
+            echo_run sudo sysctl vm.mmap_rnd_bits=28
+            if [[ $(sudo sysctl -n vm.mmap_rnd_bits) != 28 ]]; then
+                exit_error "Cannot set vm.mmap_rnd_bits to 28"
+            fi
+        fi
+    fi
+fi

--- a/script/ci/install_dependencies.sh
+++ b/script/ci/install_dependencies.sh
@@ -33,3 +33,5 @@ source "${APCI_ALPAKA_ROOT}/script/ci/install/cuda.sh"
 source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi.sh"
 # shellcheck source=script/ci/install/tbb.sh
 source "${APCI_ALPAKA_ROOT}/script/ci/install/tbb.sh"
+# shellcheck source=script/ci/install/sanitizer.sh
+source "${APCI_ALPAKA_ROOT}/script/ci/install/sanitizer.sh"

--- a/script/ci/test.sh
+++ b/script/ci/test.sh
@@ -23,6 +23,15 @@ if [[ "$APCI_ONEAPI" != 0 ]]; then
     sycl-ls
 fi
 
+for sanitizer in ASAN TSAN LSAN UBSAN; do
+    flag="APCI_SANITIZER_${sanitizer}"
+    opt="${sanitizer}_OPTIONS"
+
+    if [[ "${!flag}" == "ON" ]]; then
+        load_variable_if_not_exist "${opt}"
+    fi
+done
+
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 # TODO: remove me, if all install scripts are ported
 # HIP jobs will be tested
@@ -30,7 +39,12 @@ if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_nam
     if [[ "${APCI_RUN_CTEST}" == "ON" ]]; then
         load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 
-        echo_green "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+        echo_green \
+            "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+            "$(echo_if_not_empty_and_set ASAN_OPTIONS)" \
+            "$(echo_if_not_empty_and_set TSAN_OPTIONS)" \
+            "$(echo_if_not_empty_and_set LSAN_OPTIONS)" \
+            "$(echo_if_not_empty_and_set UBSAN_OPTIONS)" \
             "${APCI_CMAKE_BIN_PATH}/ctest" \
             "--test-dir /build --output-on-failure"
         if [[ -z ${GITHUB_ACTIONS+x} ]]; then

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -232,7 +232,7 @@ echo_if_not_empty() {
 
     local var_name="$1"
     if [[ "${!var_name}" != "" ]]; then
-        echo "${var_name}=${!var_name}"
+        echo -n "${var_name}=${!var_name}"
     fi
 }
 
@@ -246,6 +246,6 @@ echo_if_not_empty_and_set() {
 
     local var_name="$1"
     if [[ -n "${!var_name+x}" && "${!var_name}" != "" ]]; then
-        echo "${var_name}=${!var_name}"
+        echo -n "${var_name}=${!var_name}"
     fi
 }

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -235,3 +235,17 @@ echo_if_not_empty() {
         echo "${var_name}=${!var_name}"
     fi
 }
+
+# print a variable in the format `name=value`, if the value is not empty
+# ignores unbound variables
+# usage: echo_if_not_empty_and_set <variable_name>
+echo_if_not_empty_and_set() {
+    if [[ $# -lt 1 ]]; then
+        exit_error "echo_if_not_empty_and_set(): no variable name set."
+    fi
+
+    local var_name="$1"
+    if [[ -n "${!var_name+x}" && "${!var_name}" != "" ]]; then
+        echo "${var_name}=${!var_name}"
+    fi
+}

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -56,6 +56,19 @@ if [[ -n ${GITHUB_ACTIONS+x} ]]; then
     if [[ -z ${APCI_TBB+x} ]]; then
         export APCI_TBB="OFF"
     fi
+
+    if [[ -z ${APCI_SANITIZER_ASAN+x} ]]; then
+        export APCI_SANITIZER_ASAN="OFF"
+    fi
+    if [[ -z ${APCI_SANITIZER_TSAN+x} ]]; then
+        export APCI_SANITIZER_TSAN="OFF"
+    fi
+    if [[ -z ${APCI_SANITIZER_LSAN+x} ]]; then
+        export APCI_SANITIZER_LSAN="OFF"
+    fi
+    if [[ -z ${APCI_SANITIZER_UBSAN+x} ]]; then
+        export APCI_SANITIZER_UBSAN="OFF"
+    fi
 fi
 
 if [[ -n ${GITLAB_CI+x} ]]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded CI test runs to cover ASAN, TSAN, LSAN, and UBSAN, including sanitizer-specific runtime option setup and suppression handling.
  * Enhanced CTest output to show sanitizer runtime options when enabled.

* **CI Enhancements**
  * Added sanitizer selection to the CI matrix and introduced dedicated GCC/Clang jobs that enable exactly one sanitizer per job.

* **Chores**
  * Sanitizers are disabled by default and can be enabled via CI/environment toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->