### PR TITLE
add algorithm tutorial

### DIFF
--- a/docs/snippets/example/130_algorithms.cpp
+++ b/docs/snippets/example/130_algorithms.cpp
@@ -16,15 +16,240 @@
 using namespace alpaka;
 
 // BEGIN-TUTORIAL-transformFunctor
-struct SquareValue
+struct SquareValueScalar
 {
-    ALPAKA_FN_ACC auto operator()(int const& value) const -> int
+    // int is the data type of the input buffer and float the type of the output buffer
+    ALPAKA_FN_ACC auto operator()(int const& value) const -> float
     {
-        return value * value;
+        return static_cast<float>(value * value);
     }
 };
 
 // END-TUTORIAL-transformFunctor
+
+TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms - transform", "[docs]", docs::test::TestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto selector = onHost::makeDeviceSelector(cfg);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    auto exec = cfg[object::exec];
+
+    constexpr size_t size = 10;
+    Vec extents(size);
+
+    // BEGIN-TUTORIAL-transformCall
+    // we are free to combine different data types for the in- and output
+    auto inputBuffer = onHost::alloc<int>(device, extents);
+    auto outputBuffer = onHost::alloc<float>(device, extents);
+
+    onHost::fill(queue, inputBuffer, 2);
+    onHost::fill(queue, outputBuffer, 0.f);
+
+    // call transform with ScalarFunc wrapper
+    onHost::transform(queue, exec, outputBuffer, ScalarFunc{SquareValueScalar{}}, inputBuffer);
+    // END-TUTORIAL-transformCall
+
+
+    auto hostOutput = onHost::allocHost<float>(extents);
+    onHost::memcpy(queue, hostOutput, outputBuffer);
+    onHost::wait(queue);
+
+    for(size_t i = 0; i < size; ++i)
+    {
+        REQUIRE(hostOutput[i] == 4.f);
+    }
+}
+
+// BEGIN-TUTORIAL-transformFunctorDefaultFunc
+struct SquareValue
+{
+    ALPAKA_FN_ACC auto operator()(concepts::Simd auto const& value) const -> concepts::Simd auto
+    {
+        // SIMD operation
+        // For example, int is 32 bit and the processor support AVX (128 bit),
+        // 4 multiplications are done in one operation.
+        return value * value;
+    }
+};
+
+// END-TUTORIAL-transformFunctorDefaultFunc
+
+TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms - transform default functor", "[docs]", docs::test::TestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto selector = onHost::makeDeviceSelector(cfg);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    auto exec = cfg[object::exec];
+
+    constexpr size_t size = 10;
+    Vec extents(size);
+
+    // BEGIN-TUTORIAL-transformCallDefaultFunc
+    auto inputBuffer = onHost::alloc<int>(device, extents);
+    auto outputBuffer = onHost::alloc<int>(device, extents);
+
+    onHost::fill(queue, inputBuffer, 2);
+    onHost::fill(queue, outputBuffer, 0);
+
+    // call transform without wrapper -> enables SIMD support
+    onHost::transform(queue, exec, outputBuffer, SquareValue{}, inputBuffer);
+    // END-TUTORIAL-transformCallDefaultFunc
+
+    auto hostOutput = onHost::allocHost<int>(extents);
+    onHost::memcpy(queue, hostOutput, outputBuffer);
+    onHost::wait(queue);
+
+    for(size_t i = 0; i < size; ++i)
+    {
+        REQUIRE(hostOutput[i] == 4);
+    }
+}
+
+// BEGIN-TUTORIAL-transformFunctorStencilFunc
+struct SumNeighbors
+{
+    ALPAKA_FN_ACC auto operator()(concepts::SimdPtr auto const& in) const
+    {
+        using ResultType = ALPAKA_TYPEOF(in.load());
+        ResultType result = ResultType::fill(0);
+
+        using VecIdxType = typename ALPAKA_TYPEOF(in)::IdxType;
+        // the functor is written for a 2D stencil
+        static_assert(VecIdxType::dim() == 2);
+
+        // top neighbor
+        result += in[VecIdxType{-1, 0}].load();
+        // right neighbor
+        result += in[VecIdxType{0, 1}].load();
+        // bottom neighbor
+        result += in[VecIdxType{1, 0}].load();
+        // left neighbor
+        result += in[VecIdxType{0, -1}].load();
+
+        return result;
+    }
+};
+
+// END-TUTORIAL-transformFunctorStencilFunc
+
+TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms - transform stencil functor", "[docs]", docs::test::TestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto selector = onHost::makeDeviceSelector(cfg);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    auto exec = cfg[object::exec];
+
+    constexpr int size = 10;
+
+    // BEGIN-TUTORIAL-transformCallStencilFunc
+    Vec extents(size, size);
+    auto inputBuffer = onHost::alloc<int>(device, extents);
+    auto outputBuffer = onHost::alloc<int>(device, extents);
+
+    // we use a 2D stencil code
+    STATIC_REQUIRE(inputBuffer.dim() == 2);
+    STATIC_REQUIRE(outputBuffer.dim() == 2);
+
+    onHost::fill(queue, inputBuffer, 1);
+    onHost::fill(queue, outputBuffer, 0);
+
+    onHost::transform(
+        queue,
+        exec,
+        // the user must provide a subview that takes the halo into account.
+        outputBuffer.getView().getSubView(Vec{1, 1}, Vec{size - 2, size - 2}),
+        // use stencil wrapper
+        StencilFunc{SumNeighbors{}},
+        // both input and output needs to take the halo into account
+        inputBuffer.getView().getSubView(Vec{1, 1}, Vec{size - 2, size - 2}));
+    // END-TUTORIAL-transformCallStencilFunc
+
+    auto hostOutput = onHost::allocHost<int>(extents);
+    onHost::memcpy(queue, hostOutput, outputBuffer);
+    onHost::wait(queue);
+
+    for(int y = 0; y < size; ++y)
+    {
+        for(int x = 0; x < size; ++x)
+        {
+            if(y == 0 || y == (size - 1) || x == 0 || x == (size - 1))
+            {
+                CHECK(hostOutput[Vec{y, x}] == 0);
+            }
+            else
+            {
+                CHECK(hostOutput[Vec{y, x}] == 4);
+            }
+        }
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms - iota", "[docs]", docs::test::TestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto selector = onHost::makeDeviceSelector(cfg);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    auto exec = cfg[object::exec];
+
+    constexpr size_t size = 8;
+    Vec extents(size);
+
+    // BEGIN-TUTORIAL-iota
+    auto outputBuffer = onHost::alloc<int>(device, extents);
+    onHost::iota<int>(queue, exec, 10, outputBuffer);
+    // END-TUTORIAL-iota
+
+    auto hostOutput = onHost::allocHost<int>(extents);
+    onHost::memcpy(queue, hostOutput, outputBuffer);
+    onHost::wait(queue);
+    for(size_t i = 0; i < size; ++i)
+    {
+        REQUIRE(hostOutput[i] == static_cast<int>(i) + 10);
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms - reduce", "[docs]", docs::test::TestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto selector = onHost::makeDeviceSelector(cfg);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    auto exec = cfg[object::exec];
+
+    constexpr size_t size = 8;
+    Vec extents(size);
+
+    std::array<int, size> data{1, 2, 3, 4, 5, 6, 7, 8};
+
+    // BEGIN-TUTORIAL-reduce
+    auto inputBuffer = onHost::alloc<int>(device, extents);
+    onHost::memcpy(queue, inputBuffer, data);
+
+    auto reduceBuffer = onHost::alloc<int>(device, Vec{1u});
+    int neutral_element = 0;
+    onHost::reduce(queue, exec, neutral_element, reduceBuffer, std::plus{}, inputBuffer);
+    // END-TUTORIAL-reduce
+
+    auto hostOutput = onHost::allocHost<int>(size_t{1});
+    onHost::memcpy(queue, hostOutput, reduceBuffer);
+    onHost::wait(queue);
+
+    REQUIRE(hostOutput[0] == 36);
+}
 
 // BEGIN-TUTORIAL-transformReduceFunctor
 struct MultiplyValues
@@ -37,6 +262,141 @@ struct MultiplyValues
 
 // END-TUTORIAL-transformReduceFunctor
 
+TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms - tranformReduce", "[docs]", docs::test::TestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto selector = onHost::makeDeviceSelector(cfg);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    auto exec = cfg[object::exec];
+
+    constexpr size_t size = 8;
+    Vec extents(size);
+
+    std::array<int, size> data{1, 2, 3, 4, 5, 6, 7, 8};
+
+    auto inputBuffer1 = onHost::alloc<int>(device, extents);
+    auto inputBuffer2 = onHost::alloc<int>(device, extents);
+    onHost::memcpy(queue, inputBuffer1, data);
+    onHost::memcpy(queue, inputBuffer2, data);
+
+    // BEGIN-TUTORIAL-transformReduceCall
+    auto resultBuffer = onHost::alloc<int>(device, Vec{1u});
+    onHost::transformReduce(
+        queue,
+        exec,
+        // neutral element
+        0,
+        resultBuffer,
+        // reduce functor
+        std::plus{},
+        // transform functor
+        MultiplyValues{},
+        // At least one input is required, we use two
+        inputBuffer1,
+        inputBuffer2);
+    // END-TUTORIAL-transformReduceCall
+
+    auto hostOutput = onHost::allocHost<int>(size_t{1});
+    onHost::memcpy(queue, hostOutput, resultBuffer);
+    onHost::wait(queue);
+
+    REQUIRE(hostOutput[0] == 204);
+}
+
+// BEGIN-TUTORIAL-concurrentFunctor
+struct MultiOutput
+{
+    ALPAKA_FN_ACC void operator()(concepts::SimdPtr auto a, concepts::SimdPtr auto const& b, concepts::SimdPtr auto c)
+        const
+    {
+        a = a.load() + b.load();
+        c = b.load() * b.load();
+    }
+};
+
+// END-TUTORIAL-concurrentFunctor
+
+TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms - concurrent", "[docs]", docs::test::TestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto selector = onHost::makeDeviceSelector(cfg);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    auto exec = cfg[object::exec];
+
+    constexpr size_t size = 8;
+    Vec extents(size);
+
+    std::array<int, size> data{1, 2, 3, 4, 5, 6, 7, 8};
+
+    // BEGIN-TUTORIAL-concurrentCall
+    auto bufferA = onHost::alloc<int>(device, extents);
+    auto bufferB = onHost::alloc<int>(device, extents);
+    auto bufferC = onHost::alloc<int>(device, extents);
+    onHost::memcpy(queue, bufferA, data);
+    onHost::memcpy(queue, bufferB, data);
+    onHost::fill(queue, bufferC, 0);
+
+    onHost::concurrent<int>(queue, exec, bufferA.getExtents(), MultiOutput{}, bufferA, bufferB, bufferC);
+    // END-TUTORIAL-concurrentCall
+
+    auto hostOutputA = onHost::allocHost<int>(extents);
+    auto hostOutputC = onHost::allocHost<int>(extents);
+    onHost::memcpy(queue, hostOutputA, bufferA);
+    onHost::memcpy(queue, hostOutputC, bufferC);
+    onHost::wait(queue);
+
+    for(size_t i = 0; i < size; ++i)
+    {
+        int const v = static_cast<int>(i) + 1;
+        CHECK(hostOutputA[i] == v * 2);
+        CHECK(hostOutputC[i] == v * v);
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms - scan", "[docs]", docs::test::TestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto selector = onHost::makeDeviceSelector(cfg);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    auto exec = cfg[object::exec];
+
+    constexpr size_t size = 8;
+    Vec extents(size);
+
+    std::array<int, size> data{1, 2, 3, 4, 5, 6, 7, 8};
+
+    auto inputBuffer = onHost::alloc<int>(device, extents);
+    onHost::memcpy(queue, inputBuffer, data);
+
+    // BEGIN-TUTORIAL-scan
+    auto outputBuffer = onHost::alloc<int>(device, extents);
+    auto tmpBuffer = onHost::alloc<std::byte>(device, onHost::getScanBufferSize<int>(inputBuffer.getExtents()));
+    onHost::inclusiveScan(queue, exec, tmpBuffer, outputBuffer, inputBuffer);
+    // END-TUTORIAL-scan
+
+    auto hostOutput = onHost::allocHost<int>(extents);
+    onHost::memcpy(queue, hostOutput, outputBuffer);
+    onHost::wait(queue);
+
+    CHECK(hostOutput[0] == 1);
+    CHECK(hostOutput[1] == 3);
+    CHECK(hostOutput[2] == 6);
+    CHECK(hostOutput[3] == 10);
+    CHECK(hostOutput[4] == 15);
+    CHECK(hostOutput[5] == 21);
+    CHECK(hostOutput[6] == 28);
+    CHECK(hostOutput[7] == 36);
+}
+
 // BEGIN-TUTORIAL-generatorFunctor
 struct AddLinearIdx
 {
@@ -48,49 +408,7 @@ struct AddLinearIdx
 
 // END-TUTORIAL-generatorFunctor
 
-// BEGIN-TUTORIAL-concurrentFunctor
-struct AddInPlace
-{
-    ALPAKA_FN_ACC void operator()(concepts::SimdPtr auto a, concepts::SimdPtr auto const& b) const
-    {
-        a = a.load() + b.load();
-    }
-};
-
-// END-TUTORIAL-concurrentFunctor
-
-// BEGIN-TUTORIAL-stencilFunctor
-struct CrossStencil
-{
-    ALPAKA_FN_ACC auto operator()(concepts::SimdPtr auto const& in) const
-    {
-        using SimdPtrType = ALPAKA_TYPEOF(in);
-        using VecIdxType = typename SimdPtrType::IdxType;
-
-        concepts::Simd auto result = in.load();
-
-        using SimdType = ALPAKA_TYPEOF(result);
-        concepts::Simd auto const value = SimdType::fill(42);
-        result += value;
-
-        for(uint32_t d = 0u; d < VecIdxType::dim(); ++d)
-        {
-            concepts::Vector auto negative = VecIdxType::fill(0);
-            concepts::Vector auto positive = VecIdxType::fill(0);
-            negative[d] = -1;
-            positive[d] = 1;
-
-            result += in[negative].load() * 3;
-            result += in[positive].load() * 5;
-        }
-
-        return result;
-    }
-};
-
-// END-TUTORIAL-stencilFunctor
-
-TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms", "[docs]", docs::test::TestBackends)
+TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms - linear generator", "[docs]", docs::test::TestBackends)
 {
     auto cfg = TestType::makeDict();
     auto selector = onHost::makeDeviceSelector(cfg);
@@ -100,125 +418,25 @@ TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms", "[docs]", docs::test::Test
     onHost::Queue queue = device.makeQueue(queueKind::blocking);
     auto exec = cfg[object::exec];
 
-    std::array<int, 8u> hostInput{1, 2, 3, 4, 5, 6, 7, 8};
-    std::array<int, 8u> hostIota{};
-    std::array<int, 8u> hostTransform{};
-    std::array<int, 8u> hostScan{};
-    std::array<int, 8u> hostGenerator{};
-    std::array<int, 8u> hostConcurrent{};
+    constexpr size_t size = 8;
+    Vec extents(size);
 
-
-    auto inputBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
-    onHost::memcpy(queue, inputBuffer, hostInput);
-
-    // BEGIN-TUTORIAL-iota
-    auto iotaBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
-    onHost::iota<int>(queue, exec, 10, iotaBuffer);
-    // END-TUTORIAL-iota
-
-    // BEGIN-TUTORIAL-transformCall
-    auto transformBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
-    onHost::transform(queue, exec, transformBuffer, ScalarFunc{SquareValue{}}, inputBuffer);
-    // END-TUTORIAL-transformCall
-
-    // BEGIN-TUTORIAL-transformStencilCall
-    // Stencil operations need proper halo setup; see unit tests for a complete example.
-    // END-TUTORIAL-transformStencilCall
-
-    // BEGIN-TUTORIAL-reduce
-    auto reduceBuffer = onHost::alloc<int>(device, Vec{1u});
-    onHost::reduce(queue, exec, 0, reduceBuffer, std::plus{}, inputBuffer);
-    // END-TUTORIAL-reduce
-    auto reduceHost = onHost::allocHostLike(reduceBuffer);
-
-    // BEGIN-TUTORIAL-scan
-    auto scanBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
-    auto tmpBuffer = onHost::alloc<std::byte>(device, onHost::getScanBufferSize<int>(inputBuffer.getExtents()));
-    onHost::inclusiveScan(queue, exec, tmpBuffer, scanBuffer, inputBuffer);
-    // END-TUTORIAL-scan
-
-    // BEGIN-TUTORIAL-transformReduceCall
-    auto transformReduceBuffer = onHost::alloc<int>(device, Vec{1u});
-    onHost::transformReduce(
-        queue,
-        exec,
-        0,
-        transformReduceBuffer,
-        std::plus{},
-        MultiplyValues{},
-        inputBuffer,
-        inputBuffer);
-    // END-TUTORIAL-transformReduceCall
-    auto transformReduceHost = onHost::allocHostLike(transformReduceBuffer);
-
-    // BEGIN-TUTORIAL-transformReduceStencilCall
-    // Stencil operations need proper halo setup; see unit tests for a complete example.
-    // END-TUTORIAL-transformReduceStencilCall
-
-    // BEGIN-TUTORIAL-transformReduceScalarCall
-    // ScalarFunc in transformReduce requires matching number of inputs; see unit tests for examples.
-    // END-TUTORIAL-transformReduceScalarCall
+    std::array<int, size> data{1, 2, 3, 4, 5, 6, 7, 8};
+    auto inputBuffer = onHost::alloc<int>(device, extents);
+    onHost::memcpy(queue, inputBuffer, data);
 
     // BEGIN-TUTORIAL-generatorCall
-    auto generator = LinearizedIdxGenerator{inputBuffer.getExtents()};
-    auto generatorBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
-    onHost::transform(queue, exec, generatorBuffer, ScalarFunc{AddLinearIdx{}}, inputBuffer, generator);
+    auto generator = LinearizedIdxGenerator{extents};
+    auto outputBuffer = onHost::alloc<int>(device, extents);
+    onHost::transform(queue, exec, outputBuffer, ScalarFunc{AddLinearIdx{}}, inputBuffer, generator);
     // END-TUTORIAL-generatorCall
 
-    // BEGIN-TUTORIAL-concurrentCall
-    auto concurrentBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
-    onHost::memcpy(queue, concurrentBuffer, inputBuffer);
-    onHost::concurrent<int>(queue, exec, inputBuffer.getExtents(), AddInPlace{}, concurrentBuffer, inputBuffer);
-    // END-TUTORIAL-concurrentCall
-
-    // Copy data to the host instance to verify the results.
-    onHost::memcpy(queue, hostIota, iotaBuffer);
-    onHost::memcpy(queue, hostTransform, transformBuffer);
-    onHost::memcpy(queue, hostScan, scanBuffer);
-    onHost::memcpy(queue, hostGenerator, generatorBuffer);
-    onHost::memcpy(queue, hostConcurrent, concurrentBuffer);
-    onHost::memcpy(queue, reduceHost, reduceBuffer);
-    onHost::memcpy(queue, transformReduceHost, transformReduceBuffer);
+    auto hostOutput = onHost::allocHost<int>(extents);
+    onHost::memcpy(queue, hostOutput, outputBuffer);
     onHost::wait(queue);
 
-    int offset = 10;
-    for(int const& v : hostIota)
-        CHECK(v == offset++);
-
-    CHECK(hostTransform[0] == 1);
-    CHECK(hostTransform[1] == 4);
-    CHECK(hostTransform[2] == 9);
-    CHECK(hostTransform[3] == 16);
-    CHECK(hostTransform[4] == 25);
-    CHECK(hostTransform[5] == 36);
-    CHECK(hostTransform[6] == 49);
-    CHECK(hostTransform[7] == 64);
-
-    CHECK(reduceHost[0] == 36);
-
-    CHECK(hostScan[0] == 1);
-    CHECK(hostScan[1] == 3);
-    CHECK(hostScan[2] == 6);
-    CHECK(hostScan[3] == 10);
-    CHECK(hostScan[4] == 15);
-    CHECK(hostScan[5] == 21);
-    CHECK(hostScan[6] == 28);
-    CHECK(hostScan[7] == 36);
-
-
-    int idx = 0;
-    for(int const& v : hostGenerator)
+    for(size_t i = 0; i < size; ++i)
     {
-        CHECK(v == (hostInput[idx] + static_cast<int>(generator[idx])));
-        ++idx;
+        CHECK(hostOutput[i] == (data[i] + static_cast<int>(generator[i])));
     }
-
-    idx = 0;
-    for(int const& v : hostConcurrent)
-    {
-        CHECK(v == hostInput[idx] * 2);
-        ++idx;
-    }
-
-    CHECK(transformReduceHost[0] == 204);
 }

--- a/docs/snippets/example/130_algorithms.cpp
+++ b/docs/snippets/example/130_algorithms.cpp
@@ -1,0 +1,224 @@
+/* Copyright 2026 René Widera
+ * SPDX-License-Identifier: ISC
+ */
+
+
+#include "docsTest.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <functional>
+
+using namespace alpaka;
+
+// BEGIN-TUTORIAL-transformFunctor
+struct SquareValue
+{
+    ALPAKA_FN_ACC auto operator()(int const& value) const -> int
+    {
+        return value * value;
+    }
+};
+
+// END-TUTORIAL-transformFunctor
+
+// BEGIN-TUTORIAL-transformReduceFunctor
+struct MultiplyValues
+{
+    ALPAKA_FN_ACC auto operator()(concepts::Simd auto const& a, concepts::Simd auto const& b) const
+    {
+        return a * b;
+    }
+};
+
+// END-TUTORIAL-transformReduceFunctor
+
+// BEGIN-TUTORIAL-generatorFunctor
+struct AddLinearIdx
+{
+    ALPAKA_FN_ACC auto operator()(int const& value, size_t const& linearIdx) const -> int
+    {
+        return value + static_cast<int>(linearIdx);
+    }
+};
+
+// END-TUTORIAL-generatorFunctor
+
+// BEGIN-TUTORIAL-concurrentFunctor
+struct AddInPlace
+{
+    ALPAKA_FN_ACC void operator()(concepts::SimdPtr auto a, concepts::SimdPtr auto const& b) const
+    {
+        a = a.load() + b.load();
+    }
+};
+
+// END-TUTORIAL-concurrentFunctor
+
+// BEGIN-TUTORIAL-stencilFunctor
+struct CrossStencil
+{
+    ALPAKA_FN_ACC auto operator()(concepts::SimdPtr auto const& in) const
+    {
+        using SimdPtrType = ALPAKA_TYPEOF(in);
+        using VecIdxType = typename SimdPtrType::IdxType;
+
+        concepts::Simd auto result = in.load();
+
+        using SimdType = ALPAKA_TYPEOF(result);
+        concepts::Simd auto const value = SimdType::fill(42);
+        result += value;
+
+        for(uint32_t d = 0u; d < VecIdxType::dim(); ++d)
+        {
+            concepts::Vector auto negative = VecIdxType::fill(0);
+            concepts::Vector auto positive = VecIdxType::fill(0);
+            negative[d] = -1;
+            positive[d] = 1;
+
+            result += in[negative].load() * 3;
+            result += in[positive].load() * 5;
+        }
+
+        return result;
+    }
+};
+
+// END-TUTORIAL-stencilFunctor
+
+TEMPLATE_LIST_TEST_CASE("tutorial onHost algorithms", "[docs]", docs::test::TestBackends)
+{
+    auto cfg = TestType::makeDict();
+    auto selector = onHost::makeDeviceSelector(cfg);
+    if(!selector.isAvailable())
+        return;
+    onHost::concepts::Device auto device = selector.makeDevice(0);
+    onHost::Queue queue = device.makeQueue(queueKind::blocking);
+    auto exec = cfg[object::exec];
+
+    std::array<int, 8u> hostInput{1, 2, 3, 4, 5, 6, 7, 8};
+    std::array<int, 8u> hostIota{};
+    std::array<int, 8u> hostTransform{};
+    std::array<int, 8u> hostScan{};
+    std::array<int, 8u> hostGenerator{};
+    std::array<int, 8u> hostConcurrent{};
+
+
+    auto inputBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
+    onHost::memcpy(queue, inputBuffer, hostInput);
+
+    // BEGIN-TUTORIAL-iota
+    auto iotaBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
+    onHost::iota<int>(queue, exec, 10, iotaBuffer);
+    // END-TUTORIAL-iota
+
+    // BEGIN-TUTORIAL-transformCall
+    auto transformBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
+    onHost::transform(queue, exec, transformBuffer, ScalarFunc{SquareValue{}}, inputBuffer);
+    // END-TUTORIAL-transformCall
+
+    // BEGIN-TUTORIAL-transformStencilCall
+    // Stencil operations need proper halo setup; see unit tests for a complete example.
+    // END-TUTORIAL-transformStencilCall
+
+    // BEGIN-TUTORIAL-reduce
+    auto reduceBuffer = onHost::alloc<int>(device, Vec{1u});
+    onHost::reduce(queue, exec, 0, reduceBuffer, std::plus{}, inputBuffer);
+    // END-TUTORIAL-reduce
+    auto reduceHost = onHost::allocHostLike(reduceBuffer);
+
+    // BEGIN-TUTORIAL-scan
+    auto scanBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
+    auto tmpBuffer = onHost::alloc<std::byte>(device, onHost::getScanBufferSize<int>(inputBuffer.getExtents()));
+    onHost::inclusiveScan(queue, exec, tmpBuffer, scanBuffer, inputBuffer);
+    // END-TUTORIAL-scan
+
+    // BEGIN-TUTORIAL-transformReduceCall
+    auto transformReduceBuffer = onHost::alloc<int>(device, Vec{1u});
+    onHost::transformReduce(
+        queue,
+        exec,
+        0,
+        transformReduceBuffer,
+        std::plus{},
+        MultiplyValues{},
+        inputBuffer,
+        inputBuffer);
+    // END-TUTORIAL-transformReduceCall
+    auto transformReduceHost = onHost::allocHostLike(transformReduceBuffer);
+
+    // BEGIN-TUTORIAL-transformReduceStencilCall
+    // Stencil operations need proper halo setup; see unit tests for a complete example.
+    // END-TUTORIAL-transformReduceStencilCall
+
+    // BEGIN-TUTORIAL-transformReduceScalarCall
+    // ScalarFunc in transformReduce requires matching number of inputs; see unit tests for examples.
+    // END-TUTORIAL-transformReduceScalarCall
+
+    // BEGIN-TUTORIAL-generatorCall
+    auto generator = LinearizedIdxGenerator{inputBuffer.getExtents()};
+    auto generatorBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
+    onHost::transform(queue, exec, generatorBuffer, ScalarFunc{AddLinearIdx{}}, inputBuffer, generator);
+    // END-TUTORIAL-generatorCall
+
+    // BEGIN-TUTORIAL-concurrentCall
+    auto concurrentBuffer = onHost::alloc<int>(device, onHost::getExtents(hostInput));
+    onHost::memcpy(queue, concurrentBuffer, inputBuffer);
+    onHost::concurrent<int>(queue, exec, inputBuffer.getExtents(), AddInPlace{}, concurrentBuffer, inputBuffer);
+    // END-TUTORIAL-concurrentCall
+
+    // Copy data to the host instance to verify the results.
+    onHost::memcpy(queue, hostIota, iotaBuffer);
+    onHost::memcpy(queue, hostTransform, transformBuffer);
+    onHost::memcpy(queue, hostScan, scanBuffer);
+    onHost::memcpy(queue, hostGenerator, generatorBuffer);
+    onHost::memcpy(queue, hostConcurrent, concurrentBuffer);
+    onHost::memcpy(queue, reduceHost, reduceBuffer);
+    onHost::memcpy(queue, transformReduceHost, transformReduceBuffer);
+    onHost::wait(queue);
+
+    int offset = 10;
+    for(int const& v : hostIota)
+        CHECK(v == offset++);
+
+    CHECK(hostTransform[0] == 1);
+    CHECK(hostTransform[1] == 4);
+    CHECK(hostTransform[2] == 9);
+    CHECK(hostTransform[3] == 16);
+    CHECK(hostTransform[4] == 25);
+    CHECK(hostTransform[5] == 36);
+    CHECK(hostTransform[6] == 49);
+    CHECK(hostTransform[7] == 64);
+
+    CHECK(reduceHost[0] == 36);
+
+    CHECK(hostScan[0] == 1);
+    CHECK(hostScan[1] == 3);
+    CHECK(hostScan[2] == 6);
+    CHECK(hostScan[3] == 10);
+    CHECK(hostScan[4] == 15);
+    CHECK(hostScan[5] == 21);
+    CHECK(hostScan[6] == 28);
+    CHECK(hostScan[7] == 36);
+
+
+    int idx = 0;
+    for(int const& v : hostGenerator)
+    {
+        CHECK(v == (hostInput[idx] + static_cast<int>(generator[idx])));
+        ++idx;
+    }
+
+    idx = 0;
+    for(int const& v : hostConcurrent)
+    {
+        CHECK(v == hostInput[idx] * 2);
+        ++idx;
+    }
+
+    CHECK(transformReduceHost[0] == 204);
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -80,6 +80,7 @@ Individual chapters are based on the information of the chapters before.
    tutorial/warp.rst
    tutorial/kernelFn.rst
    tutorial/vendorInterop.rst
+   tutorial/algorithms.rst
 
 .. toctree::
    :caption: Advanced

--- a/docs/source/tutorial/algorithms.rst
+++ b/docs/source/tutorial/algorithms.rst
@@ -1,14 +1,105 @@
-Host Algorithms
-===============
+Host-Side Algorithms
+====================
 
 *alpaka* provides host-side algorithms that execute on the selected :ref:`backend <backend>` through an *alpaka* queue and :ref:`executor <executor>`.
-They operate on *alpaka* `buffers, views, MdSpan <../doxygen/conceptalpaka_1_1concepts_1_1impl_1_1IMdSpan.html>`_ and `generators <../doxygen/conceptalpaka_1_1concepts_1_1impl_1_1IDataSource.html>`_.
-You can always skip the :ref:`executor`, in this case *alpaka* is using a fitting executor depending on the API of the backend.
+They operate on *alpaka* :ref:`basic-data-storage`.
 All algorithms except ``scan`` can operate on n-dimensional data.
 They are implemented to use `SIMD data packs <https://en.wikipedia.org/wiki/Single_instruction,_multiple_data>`_ to improve the memory bandwidth and compute utilization.
 SIMD is often explicitly exposed to provide you the full control and optimization potential.
 
-iota
+General
+-------
+
+A host-side algorithm consists of the following components:
+
+- **Algorithm**: The function itself determines how the input data or configuration is processed.
+- **Queue**: An *alpaka* queue for organizing the execution order along with other operations.
+- **Executor**: Determines the level of parallelism used to execute the algorithm. The :ref:`executor` is optional. If not specified, *alpaka* is using a fitting executor depending on the API of the backend.
+- **Output**: A :ref:`basic-data-storage` that contains the result of the algorithm’s execution.
+- **Input(s) or configuration**: Depending on the algorithm, one or more input :ref:`basic-data-storage` are supported, or an initial configuration is required, as is the case with the :ref:`algo_iota` algorithm, for example.
+- **Functor**: The functor defines how each element of the input is processed. The signature of the required functor varies depending on the algorithm and functor type. The :ref:`algo_transform` illustrates the different functors. Some algorithms, such as :ref:`algo_iota`, do not require a functor because they use a configuration.
+
+.. _algo_transform:
+
+Transform (ScalarFunc)
+----------------------
+
+``onHost::transform`` is the host-side algorithm equivalent of an element-wise kernel.
+It applies a functor to one or more inputs and writes the result into an output buffer.
+The data type of the input and output buffers can differ.
+
+    .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+        :language: cpp
+        :start-after: BEGIN-TUTORIAL-transformFunctor
+        :end-before: END-TUTORIAL-transformFunctor
+        :dedent:
+
+    .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+        :language: cpp
+        :start-after: BEGIN-TUTORIAL-transformCall
+        :end-before: END-TUTORIAL-transformCall
+        :dedent:
+
+Functor Types
+~~~~~~~~~~~~~
+
+The algorithm determines how many input arguments are available in the kernel.
+The data type is defined by the :ref:`basic-data-storage` for input and output.
+The function type defines the wrapper type around the data types of the kernel arguments.
+
+The default functor provides SIMD support.
+The sample code above already modifies this functor.
+Instead of a SIMD type, we use the scalar types ``int`` and ``float``.
+This functor is typically used, if operations are used that do not work on SIMD types (e.g. ``math::min``, ``math::max``, ...).
+To use scalar types instead of SIMD types, the functor object is wrapped in the ``ScalarFunc`` object when the ``onHost::transform`` algorithm is called.
+The next section shows the default functor with SIMD support.
+
+Default Functor (SIMD)
+``````````````````````
+
+The functor takes SIMD packs as input and returns SIMD packs.
+Although the operations are still written as if they were working with scalar types, but they are applied in parallel to many elements.
+
+    .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+        :language: cpp
+        :start-after: BEGIN-TUTORIAL-transformFunctorDefaultFunc
+        :end-before: END-TUTORIAL-transformFunctorDefaultFunc
+        :dedent:
+
+The ``onHost::transform`` algorithm is executed without a wrapper around the functor.
+
+    .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+        :language: cpp
+        :start-after: BEGIN-TUTORIAL-transformCallDefaultFunc
+        :end-before: END-TUTORIAL-transformCallDefaultFunc
+        :dedent:
+
+StencilFunc
+```````````
+
+The ``StencilFunc`` functor accepts ``SimdPtr`` as arguments.
+A ``SimdPtr`` supports ``operator[]`` for relative indexing, enabling stencil operations.
+The dimension of the ``SimdPtr`` arguments is the same like the in- and output :ref:`basic-data-storage` object.
+
+The following example is a 2D stencil code.
+
+    .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+        :language: cpp
+        :start-after: BEGIN-TUTORIAL-transformFunctorStencilFunc
+        :end-before: END-TUTORIAL-transformFunctorStencilFunc
+        :dedent:
+
+You must ensure memory accesses stay in bounds. Typically a sub-view of the in- und output buffer is created that excludes the halo.
+
+    .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+        :language: cpp
+        :start-after: BEGIN-TUTORIAL-transformCallStencilFunc
+        :end-before: END-TUTORIAL-transformCallStencilFunc
+        :dedent:
+
+.. _algo_iota:
+
+Iota
 ----
 
 ``onHost::iota`` fills one or more output buffers with a linear sequence of scalar indies.
@@ -27,7 +118,7 @@ Reduction
 Reduction writes its result into the first element of the output buffer.
 The neutral element of the operation binary reduce functor must be provided explicitly.
 This allows keeping the data in device memory without going at any time to host memory.
-That is different compared to ``std::reduce``.
+That is different compared to `std::reduce <https://en.cppreference.com/cpp/algorithm/reduce>`_.
 
   .. literalinclude:: ../../snippets/example/130_algorithms.cpp
     :language: cpp
@@ -35,49 +126,15 @@ That is different compared to ``std::reduce``.
     :end-before: END-TUTORIAL-reduce
     :dedent:
 
-Transform
----------
-
-``onHost::transform`` is the host-side algorithm equivalent of an element-wise kernel.
-It applies a functor to one or more inputs and writes the result into an output buffer.
-The data type of the input and output buffers can differ.
-
-  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
-    :language: cpp
-    :start-after: BEGIN-TUTORIAL-transformFunctor
-    :end-before: END-TUTORIAL-transformFunctor
-    :dedent:
-
-  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
-    :language: cpp
-    :start-after: BEGIN-TUTORIAL-transformCall
-    :end-before: END-TUTORIAL-transformCall
-    :dedent:
-
-ScalarFunc and StencilFunc
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The functor can be wrapped to control how it is executed:
-
-- ``ScalarFunc`` forces scalar (element-wise) execution even when the algorithm could use SIMD packs internally.
-  Use this when your functor uses operations that do not work on SIMD types (e.g., branching, ``math::min``, ``math::max``).
-
-- ``StencilFunc`` signals that the functor accepts ``SimdPtr`` arguments.
-  A ``SimdPtr`` supports ``operator[]`` for relative indexing, enabling stencil operations.
-  When you use ``StencilFunc``, all arguments are passed as ``SimdPtr``.
-  You must ensure memory accesses stay in bounds — typically by operating on a sub-view that excludes the halo.
-  See the unit tests for a complete stencil example.
-
-- For all transform algorithms, not wrapping the transform functor as ``ScalarFunc`` or ``StencilFunc`` requires the functor to accept ``alpaka::Simd`` as its input arguments. This will be shown in the next example.
-
 
 Transform-Reduce
 ----------------
 
 ``transformReduce`` combines a data transformation step with a reduction step.
 It is used for dot products, weighted sums, norms, and many "compute a value per element and then accumulate it" patterns.
-The first functor is the binary reduction operator. The second one is the element-wise transform and must accept as many arguments as there are input views/MdSpans passed to ``onHost::transformReduce``.
-Compared to ``std::transform_reduce`` the function support any amount of input views/MdSpans.
+The first functor is the binary reduction operator. The second one is the element-wise transform and must accept as many arguments as there are input :ref:`basic-data-storage` object passed to ``onHost::transformReduce``.
+Compared to ``std::transform_reduce`` the function support any amount of input :ref:`basic-data-storage` object.
+The following example iterates through ``inputBuffer1`` and ``inputBuffer2``, multiplies ``inputBuffer1[i]`` by ``inputBuffer2[i]``, and accumulate the products.
 
   .. literalinclude:: ../../snippets/example/130_algorithms.cpp
     :language: cpp
@@ -102,10 +159,15 @@ However, the user is responsible for ensuring no data races occur — the algori
 Concurrent
 ----------
 
-``onHost::concurrent`` executes an n-ary functor on each element of all input/output buffers.
+``onHost::concurrent`` executes an n-ary functor on each element of all buffers.
+There is no restriction on whether a buffer is used for read operations, write operations, or both.
 This lets you implement a transform with a free number of outputs, or fuse multiple reads and writes into a single kernel launch.
 The functor receives ``SimdPtr`` arguments, so stencil-style indexing works without wrapping in ``StencilFunc``.
-You can also pass generators as inputs (see unit tests for examples).
+You can also pass generators as inputs, see the :ref:`generator section <algo_generators>`.
+
+The following example uses three buffers.
+The first buffer is used for both reading and writing.
+The second buffer is read-only, and the third buffer is used only for writing (but can also be read).
 
   .. literalinclude:: ../../snippets/example/130_algorithms.cpp
     :language: cpp
@@ -118,6 +180,10 @@ You can also pass generators as inputs (see unit tests for examples).
     :start-after: BEGIN-TUTORIAL-concurrentCall
     :end-before: END-TUTORIAL-concurrentCall
     :dedent:
+
+**Note:** The template parameter ``T_DataType`` is an optimization parameter for SIMD support.
+If all buffers have the same data type, use that data type.
+Otherwise, you'll need to run tests and take measurements to achieve the best performance.
 
 Scan
 ----
@@ -132,11 +198,18 @@ This examples uses an explicit temporary storage where the size is provided via 
     :end-before: END-TUTORIAL-scan
     :dedent:
 
+*alpaka* provides the following scan variants:
+
+- ``inclusiveScan`` and ``exclusiveScan``: `Explanation on Wikipedia <https://en.wikipedia.org/wiki/Prefix_sum#Inclusive_and_exclusive_scans>`_
+- ``inclusiveScanInPlace`` and ``exclusiveScanInPlace``: same as ``inclusiveScan`` and ``exclusiveScan``, but the result is written to the input buffer instead of an extra output buffer
+
+.. _algo_generators:
+
 Generators Instead of Input Buffers
 -----------------------------------
 
-Several alpaka algorithms also accept generators as inputs.
-That is useful when one input is synthetic, such as a linear index, and you do not want to materialize another buffer just to hold it.
+Several *alpaka* algorithms also accept generators as inputs.
+That is useful when one input is synthetic, such as a linear index, and you do not want to materialize another buffer that consumes memory just to hold it.
 ``LinearizedIdxGenerator`` generates scalar indexes from n-dimensional indexes and behaves like a `IDataSource <../doxygen/conceptalpaka_1_1concepts_1_1impl_1_1IDataSource.html>`_.
 It behaves like a virtual buffer whose value at each position is the corresponding linear index.
 In this example, we add a value from one input buffer to the generated index.

--- a/docs/source/tutorial/algorithms.rst
+++ b/docs/source/tutorial/algorithms.rst
@@ -1,0 +1,171 @@
+Host Algorithms
+===============
+
+*alpaka* provides host-side algorithms that execute on the selected :ref:`backend <backend>` through an *alpaka* queue and :ref:`executor <executor>`.
+They operate on *alpaka* `buffers, views, MdSpan <../doxygen/conceptalpaka_1_1concepts_1_1impl_1_1IMdSpan.html>`_ and `generators <../doxygen/conceptalpaka_1_1concepts_1_1impl_1_1IDataSource.html>`_.
+You can always skip the :ref:`executor`, in this case *alpaka* is using a fitting executor depending on the API of the backend.
+All algorithms except ``scan`` can operate on n-dimensional data.
+They are implemented to use `SIMD data packs <https://en.wikipedia.org/wiki/Single_instruction,_multiple_data>`_ to improve the memory bandwidth and compute utilization.
+SIMD is often explicitly exposed to provide you the full control and optimization potential.
+
+iota
+----
+
+``onHost::iota`` fills one or more output buffers with a linear sequence of scalar indies.
+For multidimensional buffers, the linear value increases fastest in the last dimension.
+In this example we start the enumeration with 10.
+
+  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-iota
+    :end-before: END-TUTORIAL-iota
+    :dedent:
+
+Reduction
+---------
+
+Reduction writes its result into the first element of the output buffer.
+The neutral element of the operation binary reduce functor must be provided explicitly.
+This allows keeping the data in device memory without going at any time to host memory.
+That is different compared to ``std::reduce``.
+
+  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-reduce
+    :end-before: END-TUTORIAL-reduce
+    :dedent:
+
+Transform
+---------
+
+``onHost::transform`` is the host-side algorithm equivalent of an element-wise kernel.
+It applies a functor to one or more inputs and writes the result into an output buffer.
+The data type of the input and output buffers can differ.
+
+  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-transformFunctor
+    :end-before: END-TUTORIAL-transformFunctor
+    :dedent:
+
+  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-transformCall
+    :end-before: END-TUTORIAL-transformCall
+    :dedent:
+
+ScalarFunc and StencilFunc
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The functor can be wrapped to control how it is executed:
+
+- ``ScalarFunc`` forces scalar (element-wise) execution even when the algorithm could use SIMD packs internally.
+  Use this when your functor uses operations that do not work on SIMD types (e.g., branching, ``math::min``, ``math::max``).
+
+- ``StencilFunc`` signals that the functor accepts ``SimdPtr`` arguments.
+  A ``SimdPtr`` supports ``operator[]`` for relative indexing, enabling stencil operations.
+  When you use ``StencilFunc``, all arguments are passed as ``SimdPtr``.
+  You must ensure memory accesses stay in bounds — typically by operating on a sub-view that excludes the halo.
+  See the unit tests for a complete stencil example.
+
+- For all transform algorithms, not wrapping the transform functor as ``ScalarFunc`` or ``StencilFunc`` requires the functor to accept ``alpaka::Simd`` as its input arguments. This will be shown in the next example.
+
+
+Transform-Reduce
+----------------
+
+``transformReduce`` combines a data transformation step with a reduction step.
+It is used for dot products, weighted sums, norms, and many "compute a value per element and then accumulate it" patterns.
+The first functor is the binary reduction operator. The second one is the element-wise transform and must accept as many arguments as there are input views/MdSpans passed to ``onHost::transformReduce``.
+Compared to ``std::transform_reduce`` the function support any amount of input views/MdSpans.
+
+  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-transformReduceFunctor
+    :end-before: END-TUTORIAL-transformReduceFunctor
+    :dedent:
+
+  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-transformReduceCall
+    :end-before: END-TUTORIAL-transformReduceCall
+    :dedent:
+
+Writing to input arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both ``transform`` and ``transformReduce`` can write to their input arguments when the functor is wrapped in ``StencilFunc``.
+The ``SimdPtr`` passed to a stencil functor supports assignment (``operator=``), allowing in-place modification of the input data.
+This is useful for algorithms that need to update their inputs as they process them.
+However, the user is responsible for ensuring no data races occur — the algorithm does not enforce ordering between reads and writes to the same element.
+
+Concurrent
+----------
+
+``onHost::concurrent`` executes an n-ary functor on each element of all input/output buffers.
+This lets you implement a transform with a free number of outputs, or fuse multiple reads and writes into a single kernel launch.
+The functor receives ``SimdPtr`` arguments, so stencil-style indexing works without wrapping in ``StencilFunc``.
+You can also pass generators as inputs (see unit tests for examples).
+
+  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-concurrentFunctor
+    :end-before: END-TUTORIAL-concurrentFunctor
+    :dedent:
+
+  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-concurrentCall
+    :end-before: END-TUTORIAL-concurrentCall
+    :dedent:
+
+Scan
+----
+
+Unlike the other algorithms in this chapter, the current scan implementation is restricted to one-dimensional data.
+That fits common `prefix-sum <https://en.wikipedia.org/wiki/Prefix_sum>`_ use cases such as offsets, compaction maps, and cumulative counters, where the logical input is already a linear sequence.
+This examples uses an explicit temporary storage where the size is provided via ``getScanBufferSize``, this can be used to optimize the performance in cases where scan is called multiple times.
+
+  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-scan
+    :end-before: END-TUTORIAL-scan
+    :dedent:
+
+Generators Instead of Input Buffers
+-----------------------------------
+
+Several alpaka algorithms also accept generators as inputs.
+That is useful when one input is synthetic, such as a linear index, and you do not want to materialize another buffer just to hold it.
+``LinearizedIdxGenerator`` generates scalar indexes from n-dimensional indexes and behaves like a `IDataSource <../doxygen/conceptalpaka_1_1concepts_1_1impl_1_1IDataSource.html>`_.
+It behaves like a virtual buffer whose value at each position is the corresponding linear index.
+In this example, we add a value from one input buffer to the generated index.
+
+  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-generatorFunctor
+    :end-before: END-TUTORIAL-generatorFunctor
+    :dedent:
+
+  .. literalinclude:: ../../snippets/example/130_algorithms.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-generatorCall
+    :end-before: END-TUTORIAL-generatorCall
+    :dedent:
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>130_algorithms.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/130_algorithms.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>
+   <br/>


### PR DESCRIPTION
Showthe usage of all `onHost` algorithms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an advanced tutorial covering host-side algorithms, including `iota`, `transform`, `transformReduce`, `reduce`, scans, generators, and concurrent updates.
  * Added examples for scalar, SIMD, and stencil-based transformations, plus multi-output operations.
* **Documentation**
  * Expanded guidance on functors, multi-input usage, generators, scans, temporary storage, and data-race considerations.
  * Added the algorithms tutorial to the advanced tutorial navigation.
* **Tests**
  * Reorganized the runnable example into focused tests for each algorithm, with expanded result validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->