### PR TITLE
GitHub Actions: use bash scripts to configure, build and run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,38 +117,6 @@ jobs:
           # Use/validate oneAPI-provided oneTBB package with the latest icpx toolchain
           - { compiler: icpx, version: "2026.0", cuda: "no", hip: "no", container: "intel/oneapi:2026.0.0-devel-ubuntu24.04", tbb: "on",
               env: { APCI_DEVICE_COMPILER: icpx@2026.0, APCI_CMAKE: 3.28.3, APCI_ONEAPI: 2026.0, APCI_ONEAPI_TARGET: cpu, APCI_TBB: ON, APCI_RUN_CTEST: ON} }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "asan",
-              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: ON} }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "asan" , simd: "EMULATION", hwloc: "no",
-              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: ON} }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "tsan",
-              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: ON} }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "tsan" , simd: "EMULATION", hwloc: "no",
-              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: ON} }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "lsan",
-              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: ON} }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "lsan" , simd: "EMULATION", hwloc: "no",
-              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: ON} }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "ubsan",
-              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: ON} }
-          - { compiler: clang, version: "21", cuda: "no", hip: "no", container: "ubuntu:24.04", sanitizer: "ubsan" , simd: "EMULATION", hwloc: "no",
-              env : {APCI_DEVICE_COMPILER : clang@21, APCI_CMAKE : 3.28.3, APCI_RUN_CTEST: ON} }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "asan",
-              env : {APCI_DEVICE_COMPILER : gcc@15, APCI_CMAKE : 3.25.1, APCI_RUN_CTEST: ON} }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "asan" , simd: "EMULATION", hwloc: "no",
-              env : {APCI_DEVICE_COMPILER : gcc@15, APCI_CMAKE : 3.25.1, APCI_RUN_CTEST: ON} }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "tsan",
-              env : {APCI_DEVICE_COMPILER : gcc@15, APCI_CMAKE : 3.25.1, APCI_RUN_CTEST: ON} }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "tsan" , simd: "EMULATION", hwloc: "no",
-              env : {APCI_DEVICE_COMPILER : gcc@15, APCI_CMAKE : 3.25.1, APCI_RUN_CTEST: ON} }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "lsan",
-              env : {APCI_DEVICE_COMPILER : gcc@15, APCI_CMAKE : 3.25.1, APCI_RUN_CTEST: ON} }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "lsan" , simd: "EMULATION", hwloc: "no",
-              env : {APCI_DEVICE_COMPILER : gcc@15, APCI_CMAKE : 3.25.1, APCI_RUN_CTEST: ON} }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "ubsan",
-              env : {APCI_DEVICE_COMPILER : gcc@15, APCI_CMAKE : 3.25.1, APCI_RUN_CTEST: ON} }
-          - { compiler: gcc, version: "15", cuda: "no", hip: "no", container: "gcc:15.1.0", sanitizer: "ubsan" , simd: "EMULATION", hwloc: "no",
-              env : {APCI_DEVICE_COMPILER : gcc@15, APCI_CMAKE : 3.25.1, APCI_RUN_CTEST: ON} }
       fail-fast: false
 
     # Specify the container to use based on the matrix configuration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,22 +177,18 @@ jobs:
             ${{ matrix.config.sanitizer == 'lsan' }}  && echo 'APCI_SANITIZER_LSAN=ON'  >> $GITHUB_ENV || true
             ${{ matrix.config.sanitizer == 'ubsan' }} && echo 'APCI_SANITIZER_UBSAN=ON' >> $GITHUB_ENV || true
             ${{ matrix.config.simd != '' }} && echo 'APCI_SIMD=${{matrix.config.simd}}'  >> $GITHUB_ENV || true
+
       - name: job configuration environment variables
         run: "${APCI_ALPAKA_ROOT}/script/ci/job_info.sh"
+
       # Install base dependencies
       - name: Install base dependencies
         run: |
-          apt-get update
-          apt-get install -y build-essential ninja-build git
-          export "SANITIZERS_DIR=$(pwd)/sanitizer"
-          echo "ASAN_OPTIONS=suppressions=${SANITIZERS_DIR}/asan_suppressions.txt" >> $GITHUB_ENV
-          echo "TSAN_OPTIONS=suppressions=${SANITIZERS_DIR}/tsan_suppressions.txt,ignore_noninstrumented_modules=1" >> $GITHUB_ENV
-          echo "LSAN_OPTIONS=suppressions=${SANITIZERS_DIR}/lsan_suppressions.txt" >> $GITHUB_ENV
-          echo "UBSAN_OPTIONS=suppressions=${SANITIZERS_DIR}/ubsan_suppressions.txt" >> $GITHUB_ENV
           "${APCI_ALPAKA_ROOT}/script/ci/utils/install_helper_apps.sh"
 
       - name: Install CMake
         run: "${APCI_ALPAKA_ROOT}/script/ci/install/cmake.sh"
+
       - name: Install GCC
         run: "${APCI_ALPAKA_ROOT}/script/ci/install/gcc.sh"
 
@@ -234,77 +230,13 @@ jobs:
       # Configure CMake with the selected compiler and options
       - name: Configure CMake
         run: "${APCI_ALPAKA_ROOT}/script/ci/configure.sh"
+
       - name: Compile Code
         run: "${APCI_ALPAKA_ROOT}/script/ci/build.sh"
+
       - name: Run tests
         if: matrix.config.cuda == 'no' && matrix.config.hip == 'no'
         run: "${APCI_ALPAKA_ROOT}/script/ci/test.sh"
-      - name: Configure CMake (old solution)
-        run: |
-          mkdir build && cd build
-          if [ "${{ matrix.config.compiler }}" = "gcc" ]; then
-            if [ $(which gcc-${{ matrix.config.version }}) ] ; then
-              export CC=gcc-${{ matrix.config.version }}
-              export CXX=g++-${{ matrix.config.version }}
-            else
-              # if gcc is pre installed gcc can not be called with the version number as postfix
-              export CC=gcc
-              export CXX=g++
-            fi
-          elif [ "${{ matrix.config.compiler }}" = "clang" ]; then
-            if [ "${{ matrix.config.hip }}" = "no" ]; then
-              echo "set clang as host compiler"
-              export CC=/usr/bin/clang-${{ matrix.config.version }}
-              export CXX=/usr/bin/clang++-${{ matrix.config.version }}
-            else
-              export ROCM_PATH=/opt/rocm
-              export CMAKE_PREFIX_PATH=$ROCM_PATH:$CMAKE_PREFIX_PATH
-              export HIP_PLATFORM="amd"
-              export HIP_DEVICE_LIB_PATH=${ROCM_PATH}/amdgcn/bitcode
-              export HSA_PATH=$ROCM_PATH
-              export PATH=${ROCM_PATH}/bin:$PATH
-              export PATH=${ROCM_PATH}/llvm/bin:$PATH
-
-              echo "set clang as hip compiler"
-              export CC=clang
-              export CXX=clang++
-            fi
-          fi
-          if [ "${{ matrix.config.sanitizer}}" == 'tsan' ]; then
-            # required to to avoid compile error: 'FATAL: ThreadSanitizer: unexpected memory mapping'
-            # see: https://stackoverflow.com/questions/77850769/fatal-threadsanitizer-unexpected-memory-mapping-when-running-on-linux-kernels
-            sysctl vm.mmap_rnd_bits=28
-          fi
-
-          /opt/cmake/${APCI_CMAKE}/bin/cmake -G Ninja \
-                -DCMAKE_BUILD_TYPE=Release \
-                ${alpaka_cmake_flags} -Dalpaka_DEP_OMP=ON \
-                ${{ matrix.config.hwloc == 'no' && '-Dalpaka_DEP_HWLOC=OFF' || '-Dalpaka_DEP_HWLOC=ON -Dalpaka_HOST_MemPinningCanFail=ON'}} \
-                ${{ matrix.config.compiler == 'icpx' && '-DCMAKE_CXX_COMPILER=icpx -Dalpaka_DEP_ONEAPI=ON -Dalpaka_ONEAPI_IntelGpu=OFF -Dalpaka_EXEC_CpuSerial=OFF -Dalpaka_DEP_OMP=OFF' || '' }} \
-                ${{ matrix.config.cuda != 'no' && '-Dalpaka_DEP_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=80' || '' }} \
-                ${{ matrix.config.cuda != 'no' && matrix.config.compiler == 'clang' && '-Dalpaka_DEP_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=80 -DCMAKE_CUDA_COMPILER=$CXX -DCMAKE_CUDA_HOST_COMPILER=$CXX -Dalpaka_SUPPRESS_TARGET_WARNING=ON -Dalpaka_DEP_OMP=OFF' || '' }} \
-                ${{ matrix.config.hip != 'no' && '-DCMAKE_CXX_COMPILER=clang++ -Dalpaka_DEP_HIP=ON -Dalpaka_DEP_OMP=OFF \
-                   -DCMAKE_HIP_ARCHITECTURES=gfx906 -DAMDGPU_TARGETS=gfx906' || '' }} \
-                ${{ matrix.config.tbb == 'on' && '-Dalpaka_DEP_TBB=ON' || '' }} \
-                ${{ matrix.config.simd && format('-Dalpaka_SIMD={0}', matrix.config.simd) || '' }} \
-                ${{ matrix.config.sanitizer == 'asan' && '-Dalpaka_ASAN=ON' || '' }} \
-                ${{ matrix.config.sanitizer == 'tsan' && '-Dalpaka_TSAN=ON' || '' }} \
-                ${{ matrix.config.sanitizer == 'lsan' && '-Dalpaka_LSAN=ON' || '' }} \
-                ${{ matrix.config.sanitizer == 'ubsan' && '-Dalpaka_UBSAN=ON' || '' }} ..
-
-      # Build the project
-      - name: Build (old solution)
-        run: |
-          cd build
-          pwd
-          /opt/cmake/${APCI_CMAKE}/bin/cmake --build . -j
-
-      # Run tests (assuming your project has tests)
-      - name: Run Tests (old solution)
-        if: matrix.config.cuda == 'no' && matrix.config.hip == 'no'
-        run: |
-          cd build
-          /opt/cmake/${APCI_CMAKE}/bin/ctest --output-on-failure
 
   # Check that all generated matrix jobs passed
   # This job allow us to add 'ci-jobmatrix' as required job in GitHub and never miss marking matrix jobs as

--- a/script/ci/build.sh
+++ b/script/ci/build.sh
@@ -92,20 +92,16 @@ for sanitizer in ASAN TSAN LSAN UBSAN; do
 done
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"
-# TODO: remove me, if all install scripts are ported
-if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "nvcc" || "$compiler_name" == "icpx" ]]; then
-    load_variable_if_not_exist APCI_CMAKE_BIN_PATH
+load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 
-    echo_green \
-        "$(echo_if_not_empty LD_LIBRARY_PATH)" \
-        "$(echo_if_not_empty_and_set ASAN_OPTIONS)" \
-        "$(echo_if_not_empty_and_set TSAN_OPTIONS)" \
-        "$(echo_if_not_empty_and_set LSAN_OPTIONS)" \
-        "$(echo_if_not_empty_and_set UBSAN_OPTIONS)" \
-        "${APCI_CMAKE_BIN_PATH}/cmake" \
-        --build /build \
-        "-j${APCI_BUILD_THREADS}"
-    if [[ -z ${GITHUB_ACTIONS+x} ]]; then
-        "${APCI_CMAKE_BIN_PATH}/cmake" --build /build "-j${APCI_BUILD_THREADS}"
-    fi
-fi
+echo_green \
+    "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+    "$(echo_if_not_empty_and_set ASAN_OPTIONS)" \
+    "$(echo_if_not_empty_and_set TSAN_OPTIONS)" \
+    "$(echo_if_not_empty_and_set LSAN_OPTIONS)" \
+    "$(echo_if_not_empty_and_set UBSAN_OPTIONS)" \
+    "${APCI_CMAKE_BIN_PATH}/cmake" \
+    --build /build \
+    "-j${APCI_BUILD_THREADS}"
+
+"${APCI_CMAKE_BIN_PATH}/cmake" --build /build "-j${APCI_BUILD_THREADS}"

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -121,7 +121,7 @@ if [[ "$APCI_ONEAPI" != 0 ]]; then
     fi
 
     if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
-        export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${APCI_ONEAPI}/lib/:${APCI_ONEAPI}"
+        export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${APCI_ONEAPI}/lib/:${LD_LIBRARY_PATH}"
     fi
 
     for target in "${!ap_sycl_targets[@]}"; do

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -15,165 +15,161 @@ parse_compiler_version "$APCI_DEVICE_COMPILER"
 CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:-""}
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-""}
 
-# TODO: remove me, if all install scripts are ported
-if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "nvcc" || "$compiler_name" == "icpx" ]]; then
-    load_variable_if_not_exist APCI_CMAKE_BIN_PATH
-    load_variable_if_not_exist APCI_C_COMPILER
-    load_variable_if_not_exist APCI_CXX_COMPILER
+load_variable_if_not_exist APCI_CMAKE_BIN_PATH
+load_variable_if_not_exist APCI_C_COMPILER
+load_variable_if_not_exist APCI_CXX_COMPILER
 
-    CMAKE_ARGS=(
-        -S "${APCI_ALPAKA_ROOT}"
-        -B "/build"
-        -G Ninja
-        -DCMAKE_BUILD_TYPE=Release
-        -Dalpaka_COMPILE_PEDANTIC=ON
-        -Dalpaka_DOCS=ON
-        -Dalpaka_TESTS=ON
-        -Dalpaka_BENCHMARKS=ON
-        -Dalpaka_EXAMPLES=ON
-        -DBUILD_TESTING=ON
-        -Dalpaka_HEADERCHECKS=ON
-        -Dalpaka_LOG=dynamic
-        -Dalpaka_FAST_MATH=OFF
-        "-DCMAKE_C_COMPILER=$APCI_C_COMPILER"
-        "-DCMAKE_CXX_COMPILER=$APCI_CXX_COMPILER"
-        -Dalpaka_SIMD="${APCI_SIMD}"
-    )
+CMAKE_ARGS=(
+    -S "${APCI_ALPAKA_ROOT}"
+    -B "/build"
+    -G Ninja
+    -DCMAKE_BUILD_TYPE=Release
+    -Dalpaka_COMPILE_PEDANTIC=ON
+    -Dalpaka_DOCS=ON
+    -Dalpaka_TESTS=ON
+    -Dalpaka_BENCHMARKS=ON
+    -Dalpaka_EXAMPLES=ON
+    -DBUILD_TESTING=ON
+    -Dalpaka_HEADERCHECKS=ON
+    -Dalpaka_LOG=dynamic
+    -Dalpaka_FAST_MATH=OFF
+    "-DCMAKE_C_COMPILER=$APCI_C_COMPILER"
+    "-DCMAKE_CXX_COMPILER=$APCI_CXX_COMPILER"
+    -Dalpaka_SIMD="${APCI_SIMD}"
+)
 
-    declare -A ap_deps=(
-        ["OMP"]=OFF
-        ["HWLOC"]=OFF
-        ["TBB"]=OFF
-        ["CUDA"]=OFF
-        ["HIP"]=OFF
-        ["ONEAPI"]=OFF
-    )
+declare -A ap_deps=(
+    ["OMP"]=OFF
+    ["HWLOC"]=OFF
+    ["TBB"]=OFF
+    ["CUDA"]=OFF
+    ["HIP"]=OFF
+    ["ONEAPI"]=OFF
+)
 
-    # if no GPU SDK is used
-    if [[ ("$APCI_HIP" == 0) && "$APCI_TBB" == OFF && ("$compiler_name" == "gcc" || "$compiler_name" == "clang") ]]; then
-        ap_deps['OMP']=ON
-    fi
+# if no GPU SDK is used
+if [[ ("$APCI_HIP" == 0) && "$APCI_TBB" == OFF && ("$compiler_name" == "gcc" || "$compiler_name" == "clang") ]]; then
+    ap_deps['OMP']=ON
+fi
 
-    if [[ "${APCI_HWLOC}" == "ON" ]]; then
-        ap_deps['HWLOC']=ON
-        CMAKE_ARGS+=(-Dalpaka_HOST_MemPinningCanFail=ON)
-    fi
+if [[ "${APCI_HWLOC}" == "ON" ]]; then
+    ap_deps['HWLOC']=ON
+    CMAKE_ARGS+=(-Dalpaka_HOST_MemPinningCanFail=ON)
+fi
 
-    if [[ "$APCI_HIP" != 0 ]]; then
-        load_variable_if_not_exist ROCM_PATH
+if [[ "$APCI_HIP" != 0 ]]; then
+    load_variable_if_not_exist ROCM_PATH
 
-        export PATH=${ROCM_PATH}/bin:$PATH
-        export PATH=${ROCM_PATH}/llvm/bin:$PATH
-        export CMAKE_PREFIX_PATH=$ROCM_PATH:$CMAKE_PREFIX_PATH
+    export PATH=${ROCM_PATH}/bin:$PATH
+    export PATH=${ROCM_PATH}/llvm/bin:$PATH
+    export CMAKE_PREFIX_PATH=$ROCM_PATH:$CMAKE_PREFIX_PATH
 
-        ap_deps['HIP']=ON
+    ap_deps['HIP']=ON
 
-        if [[ -n ${APCI_AMD_GPU_ARCH+x} ]]; then
-            CMAKE_ARGS+=(
-                -DCMAKE_HIP_ARCHITECTURES="${APCI_AMD_GPU_ARCH}"
-                -DGPU_TARGETS="${APCI_AMD_GPU_ARCH}")
-        fi
-    fi
-
-    if [[ "$APCI_CUDA" != 0 ]]; then
-        load_variable_if_not_exist CMAKE_CUDA_COMPILER
-
-        ap_deps['CUDA']=ON
-
+    if [[ -n ${APCI_AMD_GPU_ARCH+x} ]]; then
         CMAKE_ARGS+=(
-            -DCMAKE_CUDA_COMPILER="${CMAKE_CUDA_COMPILER}"
-            -Dalpaka_SUPPRESS_TARGET_WARNING=ON
-        )
-
-        if [[ -n ${APCI_CUDA_SM_LEVEL+x} ]]; then
-            CMAKE_ARGS+=(-DCMAKE_CUDA_ARCHITECTURES="${APCI_CUDA_SM_LEVEL}")
-        fi
-
-        if [[ "${CMAKE_CUDA_COMPILER}" =~ "nvcc" ]]; then
-            CMAKE_ARGS+=(-DCMAKE_CUDA_HOST_COMPILER="$APCI_CXX_COMPILER")
-        fi
-    fi
-
-    if [[ "$APCI_ONEAPI" != 0 ]]; then
-        load_variable_if_not_exist ONEAPI_PATH
-
-        # shellcheck source=script/ci/install/oneapi/setvars.sh
-        source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi/setvars.sh"
-
-        ap_deps['ONEAPI']=ON
-
-        declare -A ap_sycl_targets=(
-            ["alpaka_ONEAPI_Cpu"]=OFF
-            ["alpaka_ONEAPI_IntelGpu"]=OFF
-            ["alpaka_ONEAPI_NvidiaGpu"]=OFF
-            ["alpaka_ONEAPI_AmdGpu"]=OFF
-        )
-
-        if [[ "${APCI_ONEAPI_TARGET}" == "cpu" ]]; then
-            ap_sycl_targets['alpaka_ONEAPI_Cpu']=ON
-        elif [[ "${APCI_ONEAPI_TARGET}" == "intel_gpu" ]]; then
-            ap_sycl_targets['alpaka_ONEAPI_IntelGpu']=ON
-        else
-            exit_error "APCI_ONEAPI_TARGET unknown value: ${APCI_ONEAPI_TARGET}.\n" \
-                "Only supported values are: cpu, intel_gpu"
-        fi
-
-        if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
-            export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${APCI_ONEAPI}/lib/:${APCI_ONEAPI}"
-        fi
-
-        for target in "${!ap_sycl_targets[@]}"; do
-            CMAKE_ARGS+=("-D${target}=${ap_sycl_targets[$target]}")
-        done
-    fi
-
-    if [[ "$APCI_TBB" == "ON" ]]; then
-        ap_deps['TBB']=ON
-
-        parse_compiler_version "$APCI_DEVICE_COMPILER"
-        if [[ "$compiler_name" == "icpx" ]]; then
-            if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
-                load_variable_if_not_exist ONEAPI_PATH
-                # shellcheck source=script/ci/install/oneapi/setvars.sh
-                source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi/setvars.sh"
-            fi
-        fi
-    fi
-
-    for sanitizer in ASAN TSAN LSAN UBSAN; do
-        flag="APCI_SANITIZER_${sanitizer}"
-        opt="${sanitizer}_OPTIONS"
-
-        if [[ "${!flag}" == "ON" ]]; then
-            load_variable_if_not_exist "${opt}"
-            CMAKE_ARGS+=("-Dalpaka_${sanitizer}=ON")
-        fi
-    done
-
-    # enable dependencies
-    for dep in "${!ap_deps[@]}"; do
-        CMAKE_ARGS+=("-Dalpaka_DEP_${dep}=${ap_deps[$dep]}")
-    done
-
-    # enable executor
-    CMAKE_ARGS+=(
-        -Dalpaka_EXEC_CpuSerial="${APCI_EXEC_CPU_SERIAL}"
-        -Dalpaka_EXEC_CpuOmpBlocks=ON
-        -Dalpaka_EXEC_TbbBlocks=ON
-        -Dalpaka_EXEC_GpuCuda=ON
-        -Dalpaka_EXEC_GpuHip=ON
-        -Dalpaka_EXEC_OneApi=ON
-    )
-
-    echo_green \
-        "$(echo_if_not_empty LD_LIBRARY_PATH)" \
-        "$(echo_if_not_empty_and_set ASAN_OPTIONS)" \
-        "$(echo_if_not_empty_and_set TSAN_OPTIONS)" \
-        "$(echo_if_not_empty_and_set LSAN_OPTIONS)" \
-        "$(echo_if_not_empty_and_set UBSAN_OPTIONS)" \
-        "${APCI_CMAKE_BIN_PATH}/cmake" \
-        "${CMAKE_ARGS[*]}"
-    if [[ -z ${GITHUB_ACTIONS+x} ]]; then
-        "${APCI_CMAKE_BIN_PATH}/cmake" "${CMAKE_ARGS[@]}"
+            -DCMAKE_HIP_ARCHITECTURES="${APCI_AMD_GPU_ARCH}"
+            -DGPU_TARGETS="${APCI_AMD_GPU_ARCH}")
     fi
 fi
+
+if [[ "$APCI_CUDA" != 0 ]]; then
+    load_variable_if_not_exist CMAKE_CUDA_COMPILER
+
+    ap_deps['CUDA']=ON
+
+    CMAKE_ARGS+=(
+        -DCMAKE_CUDA_COMPILER="${CMAKE_CUDA_COMPILER}"
+        -Dalpaka_SUPPRESS_TARGET_WARNING=ON
+    )
+
+    if [[ -n ${APCI_CUDA_SM_LEVEL+x} ]]; then
+        CMAKE_ARGS+=(-DCMAKE_CUDA_ARCHITECTURES="${APCI_CUDA_SM_LEVEL}")
+    fi
+
+    if [[ "${CMAKE_CUDA_COMPILER}" =~ "nvcc" ]]; then
+        CMAKE_ARGS+=(-DCMAKE_CUDA_HOST_COMPILER="$APCI_CXX_COMPILER")
+    fi
+fi
+
+if [[ "$APCI_ONEAPI" != 0 ]]; then
+    load_variable_if_not_exist ONEAPI_PATH
+
+    # shellcheck source=script/ci/install/oneapi/setvars.sh
+    source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi/setvars.sh"
+
+    ap_deps['ONEAPI']=ON
+
+    declare -A ap_sycl_targets=(
+        ["alpaka_ONEAPI_Cpu"]=OFF
+        ["alpaka_ONEAPI_IntelGpu"]=OFF
+        ["alpaka_ONEAPI_NvidiaGpu"]=OFF
+        ["alpaka_ONEAPI_AmdGpu"]=OFF
+    )
+
+    if [[ "${APCI_ONEAPI_TARGET}" == "cpu" ]]; then
+        ap_sycl_targets['alpaka_ONEAPI_Cpu']=ON
+    elif [[ "${APCI_ONEAPI_TARGET}" == "intel_gpu" ]]; then
+        ap_sycl_targets['alpaka_ONEAPI_IntelGpu']=ON
+    else
+        exit_error "APCI_ONEAPI_TARGET unknown value: ${APCI_ONEAPI_TARGET}.\n" \
+            "Only supported values are: cpu, intel_gpu"
+    fi
+
+    if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
+        export LD_LIBRARY_PATH="/opt/intel/oneapi/compiler/${APCI_ONEAPI}/lib/:${APCI_ONEAPI}"
+    fi
+
+    for target in "${!ap_sycl_targets[@]}"; do
+        CMAKE_ARGS+=("-D${target}=${ap_sycl_targets[$target]}")
+    done
+fi
+
+if [[ "$APCI_TBB" == "ON" ]]; then
+    ap_deps['TBB']=ON
+
+    parse_compiler_version "$APCI_DEVICE_COMPILER"
+    if [[ "$compiler_name" == "icpx" ]]; then
+        if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
+            load_variable_if_not_exist ONEAPI_PATH
+            # shellcheck source=script/ci/install/oneapi/setvars.sh
+            source "${APCI_ALPAKA_ROOT}/script/ci/install/oneapi/setvars.sh"
+        fi
+    fi
+fi
+
+for sanitizer in ASAN TSAN LSAN UBSAN; do
+    flag="APCI_SANITIZER_${sanitizer}"
+    opt="${sanitizer}_OPTIONS"
+
+    if [[ "${!flag}" == "ON" ]]; then
+        load_variable_if_not_exist "${opt}"
+        CMAKE_ARGS+=("-Dalpaka_${sanitizer}=ON")
+    fi
+done
+
+# enable dependencies
+for dep in "${!ap_deps[@]}"; do
+    CMAKE_ARGS+=("-Dalpaka_DEP_${dep}=${ap_deps[$dep]}")
+done
+
+# enable executor
+CMAKE_ARGS+=(
+    -Dalpaka_EXEC_CpuSerial="${APCI_EXEC_CPU_SERIAL}"
+    -Dalpaka_EXEC_CpuOmpBlocks=ON
+    -Dalpaka_EXEC_TbbBlocks=ON
+    -Dalpaka_EXEC_GpuCuda=ON
+    -Dalpaka_EXEC_GpuHip=ON
+    -Dalpaka_EXEC_OneApi=ON
+)
+
+echo_green \
+    "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+    "$(echo_if_not_empty_and_set ASAN_OPTIONS)" \
+    "$(echo_if_not_empty_and_set TSAN_OPTIONS)" \
+    "$(echo_if_not_empty_and_set LSAN_OPTIONS)" \
+    "$(echo_if_not_empty_and_set UBSAN_OPTIONS)" \
+    "${APCI_CMAKE_BIN_PATH}/cmake" \
+    "${CMAKE_ARGS[*]}"
+
+"${APCI_CMAKE_BIN_PATH}/cmake" "${CMAKE_ARGS[@]}"

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -70,6 +70,10 @@ if [[ "$APCI_HIP" != 0 ]]; then
         CMAKE_ARGS+=(
             -DCMAKE_HIP_ARCHITECTURES="${APCI_AMD_GPU_ARCH}"
             -DGPU_TARGETS="${APCI_AMD_GPU_ARCH}")
+        if [ "$(version "${APCI_HIP}")" -lt "$(version "6.4.0")" ]; then
+            # since ROCm 6.4 deprecated, use GPU_TARGETS instead
+            CMAKE_ARGS+=(-DAMDGPU_TARGETS="${APCI_AMD_GPU_ARCH}")
+        fi
     fi
 fi
 

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -43,11 +43,6 @@ if [[ "$compiler_name" == "gcc" ]]; then
                 echo_run sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
                 retry_cmd sudo DEBIAN_FRONTEND=noninteractive apt update
                 quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y "gcc-${compiler_version}" "g++-${compiler_version}"
-                # select requested GCC as default
-                # TODO: Remove me, if APCI_CXX_COMPILER is used in production.
-                # Changing the system host compiler is pretty dangerous and error prone.
-                update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-${compiler_version}" 100 \
-                    --slave /usr/bin/g++ g++ "/usr/bin/g++-${compiler_version}"
             fi
         fi
 

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -46,8 +46,15 @@ if [[ "$compiler_name" == "gcc" ]]; then
             fi
         fi
 
-        gcc_base_path=/usr/bin/
-
+        # we use different base container (e.g. Ubuntu, Debian), therefore search for the g++
+        if command -v "g++-${compiler_version}"; then
+            gcc_base_path="$(dirname "$(which "g++-${compiler_version}")")"
+        elif command -v g++; then
+            gcc_base_path=$(dirname "$(which g++)")
+        else
+            # default path in Ubuntu container
+            gcc_base_path=/usr/bin/
+        fi
         # workaround for gcc container
         # there is no g++-<version> executable
         for exe_name in gcc g++; do

--- a/script/ci/install/gcc.sh
+++ b/script/ci/install/gcc.sh
@@ -46,8 +46,7 @@ if [[ "$compiler_name" == "gcc" ]]; then
             fi
         fi
 
-        # we assume gcc, g++, gcc-<version> and g++-<version> are in the same folder
-        gcc_base_path="$(dirname "$(which gcc)")"
+        gcc_base_path=/usr/bin/
 
         # workaround for gcc container
         # there is no g++-<version> executable

--- a/script/ci/install/oneapi/setvars.sh
+++ b/script/ci/install/oneapi/setvars.sh
@@ -6,29 +6,33 @@
 #
 
 : "${ONEAPI_PATH?'ONEAPI_PATH path is not set'}"
+: "${APCI_IMAGE_NAME?'APCI_IMAGE_NAME image name is not set'}"
 
-# the OneAPI setvars.sh script has unbound variable and does not catch every non zero return value
-unset_set_e=false
-if echo "$-" | grep -q 'e'; then
-    set +e
-    unset_set_e=true
-fi
-
-unset_set_u=false
-if echo "$-" | grep -q 'u'; then
-    set +u
-    unset_set_u=true
-fi
-
-# shellcheck source=/dev/null
-source "${ONEAPI_PATH}/setvars.sh"
-
-if [[ $unset_set_e == true ]]; then
-    set -e
+# the official image source the oneapi setvars.sh script by default
+if [[ ! "${APCI_IMAGE_NAME}" =~ "intel/oneapi" ]]; then
+    # the OneAPI setvars.sh script has unbound variable and does not catch every non zero return value
     unset_set_e=false
-fi
+    if echo "$-" | grep -q 'e'; then
+        set +e
+        unset_set_e=true
+    fi
 
-if [[ $unset_set_u == true ]]; then
-    set -u
     unset_set_u=false
+    if echo "$-" | grep -q 'u'; then
+        set +u
+        unset_set_u=true
+    fi
+
+    # shellcheck source=/dev/null
+    source "${ONEAPI_PATH}/setvars.sh"
+
+    if [[ $unset_set_e == true ]]; then
+        set -e
+        unset_set_e=false
+    fi
+
+    if [[ $unset_set_u == true ]]; then
+        set -u
+        unset_set_u=false
+    fi
 fi

--- a/script/ci/test.sh
+++ b/script/ci/test.sh
@@ -33,24 +33,20 @@ for sanitizer in ASAN TSAN LSAN UBSAN; do
 done
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"
-# TODO: remove me, if all install scripts are ported
-# HIP jobs will be tested
-if [[ "$compiler_name" == "gcc" || "$compiler_name" == "clang" || "$compiler_name" == "nvcc" || "$compiler_name" == "icpx" ]]; then
-    if [[ "${APCI_RUN_CTEST}" == "ON" ]]; then
-        load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 
-        echo_green \
-            "$(echo_if_not_empty LD_LIBRARY_PATH)" \
-            "$(echo_if_not_empty_and_set ASAN_OPTIONS)" \
-            "$(echo_if_not_empty_and_set TSAN_OPTIONS)" \
-            "$(echo_if_not_empty_and_set LSAN_OPTIONS)" \
-            "$(echo_if_not_empty_and_set UBSAN_OPTIONS)" \
-            "${APCI_CMAKE_BIN_PATH}/ctest" \
-            "--test-dir /build --output-on-failure"
-        if [[ -z ${GITHUB_ACTIONS+x} ]]; then
-            "${APCI_CMAKE_BIN_PATH}/ctest" --test-dir /build --output-on-failure
-        fi
-    else
-        echo_yellow "Skip running ctest"
-    fi
+if [[ "${APCI_RUN_CTEST}" == "ON" ]]; then
+    load_variable_if_not_exist APCI_CMAKE_BIN_PATH
+
+    echo_green \
+        "$(echo_if_not_empty LD_LIBRARY_PATH)" \
+        "$(echo_if_not_empty_and_set ASAN_OPTIONS)" \
+        "$(echo_if_not_empty_and_set TSAN_OPTIONS)" \
+        "$(echo_if_not_empty_and_set LSAN_OPTIONS)" \
+        "$(echo_if_not_empty_and_set UBSAN_OPTIONS)" \
+        "${APCI_CMAKE_BIN_PATH}/ctest" \
+        "--test-dir /build --output-on-failure"
+
+    "${APCI_CMAKE_BIN_PATH}/ctest" --test-dir /build --output-on-failure
+else
+    echo_yellow "Skip running ctest"
 fi

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -160,8 +160,17 @@ quiet_run() {
 # ATTENTION: If you add a new ppa no 'apt update' is performed. Instead call directly
 # `DEBIAN_FRONTEND=noninteractive apt update`.
 lazy_apt_update() {
-    if [[ -z "$(ls -A '/var/lib/apt/lists/')" ]]; then
+    if [[ -n ${TMPDIR+x} ]]; then
+        local laze_update_file="${TMPDIR}/lazy_apt_update"
+    elif [[ -n ${TMP+x} ]]; then
+        local laze_update_file="${TMP}/lazy_apt_update"
+    else
+        local laze_update_file=/tmp/lazy_apt_update
+    fi
+
+    if [[ ! -f "${laze_update_file}" ]]; then
         DEBIAN_FRONTEND=noninteractive retry_cmd apt update
+        touch ${laze_update_file}
     fi
 }
 

--- a/script/ci/utils/misc.sh
+++ b/script/ci/utils/misc.sh
@@ -170,7 +170,7 @@ lazy_apt_update() {
 
     if [[ ! -f "${laze_update_file}" ]]; then
         DEBIAN_FRONTEND=noninteractive retry_cmd apt update
-        touch ${laze_update_file}
+        touch "${laze_update_file}"
     fi
 }
 


### PR DESCRIPTION
- This PR finish the transition from a pure GitHub Actions Yaml script to bash scripts which can be used on GitHub Actions, GitLab CI or locally.
- Does the last step and remove the GitHub Action specific CMake configure, build and test steps and uses the generic bash scripts instead.

# TODO
- [x] fix gcc install
- [x] guard rerunning `/opt/intel/oneapi/setvars.sh`
- [x] clarify `CMAKE_HIP_ARCHITECTURES`, `GPU_TARGET` and `AMDGPU_TARGETS` https://github.com/alpaka-group/alpaka3/actions/runs/29402404207/job/87309813072?pr=638    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HIP/ROCm architecture handling for older platforms.
  * Stabilized OneAPI environment initialization for non-oneapi images.
  * Improved CI GCC setup to avoid system-wide compiler default changes.
  * Enhanced CI test execution consistency when running CTest.
* **Chores**
  * Standardized CI to always run configure/build/test via the same script-driven flow.
  * Simplified CI execution by removing extra conditionals around build and sanitizer-related coverage.
  * Improved apt update performance/reliability using a persistent sentinel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->