### PR TITLE
fix `keepAlive()` and queue destruction

### DIFF
--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -38,9 +38,9 @@ namespace alpaka::onHost
         public:
             Queue(internal::concepts::DeviceHandle auto device, uint32_t const idx, uint32_t numIdx, bool isBlocking)
                 : m_device(std::move(device))
+                , m_sharedCallbackThread{std::make_shared<alpaka::core::CallbackThread>(numIdx)}
                 , m_idx(idx)
                 , m_numaIdx(numIdx)
-                , m_workerThread(numIdx)
                 , m_isBlocking(isBlocking)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
@@ -49,7 +49,6 @@ namespace alpaka::onHost
             ~Queue()
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                internal::wait(*this);
             }
 
             Queue(Queue const&) = delete;
@@ -75,10 +74,11 @@ namespace alpaka::onHost
             }
 
             Handle<T_Device> m_device;
+            std::shared_ptr<core::CallbackThread> m_sharedCallbackThread;
             uint32_t m_idx = 0u;
             uint32_t m_numaIdx = 0u;
-            core::CallbackThread m_workerThread;
             bool m_isBlocking{false};
+
             /** Flag to show if a blocking tasks is executed
              *
              * This variable is only used if m_isBlocking == true.
@@ -128,7 +128,7 @@ namespace alpaka::onHost
                     return f;
                 }
                 // enqueue the task into the worker thread, callers can wait/chain later.
-                return m_workerThread.submit(std::forward<T_Fn>(fn));
+                return m_sharedCallbackThread->submit(std::forward<T_Fn>(fn));
             }
 
             friend struct alpaka::internal::GetName;
@@ -208,13 +208,13 @@ namespace alpaka::onHost
             void enqueueHostFn(auto const& task)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                submit([task]() { task(); });
+                submit(task);
             }
 
             void enqueueHostFnDeferred(auto const& task)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                m_workerThread.submit(task);
+                m_sharedCallbackThread->submit(task);
             }
 
             void enqueueNativeFn(auto const& fn)
@@ -260,7 +260,7 @@ namespace alpaka::onHost
                 }
                 else
                 {
-                    return m_workerThread.isEmpty();
+                    return m_sharedCallbackThread->isEmpty();
                 }
             }
 

--- a/include/alpaka/api/oneApi/Queue.hpp
+++ b/include/alpaka/api/oneApi/Queue.hpp
@@ -106,8 +106,6 @@ namespace alpaka::onHost::internal
             }
 
             queue.setLastEvent(ev);
-            if(queue.isBlocking())
-                ev.wait_and_throw();
         }
 
         /** Memset which calls multiple times the memset2D.
@@ -266,8 +264,6 @@ namespace alpaka::onHost::internal
             }
 
             queue.setLastEvent(ev);
-            if(queue.isBlocking())
-                ev.wait_and_throw();
         }
 
         /** Memcopy which calls multiple times the 2D memcpy.
@@ -358,8 +354,6 @@ namespace alpaka::onHost::internal
                 srcPtr = toVoidPtr(alpaka::onHost::data(source));
             sycl::event ev = sycl_queue.memcpy(dest.getHandle(alpaka::api::oneApi), srcPtr);
             queue.setLastEvent(ev);
-            if(queue.isBlocking())
-                ev.wait_and_throw();
         }
     };
 
@@ -382,8 +376,6 @@ namespace alpaka::onHost::internal
                 destPtr = toVoidPtr(alpaka::onHost::data(dest));
             sycl::event ev = sycl_queue.memcpy(destPtr, source.getHandle(alpaka::api::oneApi));
             queue.setLastEvent(ev);
-            if(queue.isBlocking())
-                ev.wait_and_throw();
         }
     };
 
@@ -574,7 +566,7 @@ namespace alpaka::onHost::internal
                         ALPAKA_TYPEOF(warpSize)::value>,
                     ALPAKA_TYPEOF(warpSize)>
                 {
-                    return queue.m_queue.submit(
+                    return queue.getNativeHandle().submit(
                         [warpSize, threadSpec, kernelBundle, blockDynSharedMemBytes](sycl::handler& cgh)
                         {
                             using ApiType = decltype(getApi(queue));
@@ -607,8 +599,6 @@ namespace alpaka::onHost::internal
                 });
 
             queue.setLastEvent(ev);
-            if(queue.isBlocking())
-                ev.wait_and_throw();
         }
     };
 
@@ -651,7 +641,7 @@ namespace alpaka::onHost::internal
                         ALPAKA_TYPEOF(warpSize)::value>,
                     ALPAKA_TYPEOF(warpSize)>
                 {
-                    return queue.m_queue.submit(
+                    return queue.getNativeHandle().submit(
                         [warpSize, threadBlocking, kernelBundle, blockDynSharedMemBytes](sycl::handler& cgh)
                         {
                             using ApiType = decltype(getApi(queue));
@@ -681,8 +671,7 @@ namespace alpaka::onHost::internal
                                 DictEntry(object::warpSize, warpSize));
                         });
                 });
-            if(queue.isBlocking())
-                ev.wait_and_throw();
+            queue.setLastEvent(ev);
         }
     };
 

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -177,11 +177,11 @@ namespace alpaka::onHost
         public:
             Queue(internal::concepts::DeviceHandle auto device, uint32_t const idx, bool isBlocking)
                 : m_device(std::move(device))
+                , m_SharedNativeQueue{std::make_shared<NativeQueue>(
+                      onHost::getNativeHandle(m_device).first,
+                      onHost::getNativeHandle(m_device).second)}
+                , m_sharedCallbackThread{std::make_shared<alpaka::core::CallbackThread>()}
                 , m_idx(idx)
-                , m_queue(
-                      m_device->getNativeHandle().second,
-                      m_device->getNativeHandle().first,
-                      {sycl::property::queue::in_order{}})
                 , m_isBlocking(isBlocking)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
@@ -201,20 +201,6 @@ namespace alpaka::onHost
             ~Queue()
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                try
-                {
-                    m_queue.wait_and_throw();
-                }
-                catch(sycl::exception const& err)
-                {
-                    std::cerr << "Caught SYCL exception while destructing a SYCL queue: " << err.what() << " ("
-                              << err.code() << ')' << std::endl;
-                }
-                catch(std::exception const& err)
-                {
-                    std::cerr << "The following runtime error(s) occurred while destructing a SYCL queue:"
-                              << err.what() << std::endl;
-                }
             }
 
             std::shared_ptr<Queue> getSharedPtr()
@@ -224,12 +210,12 @@ namespace alpaka::onHost
 
             [[nodiscard]] auto getNativeHandle() const noexcept
             {
-                return m_queue;
+                return m_SharedNativeQueue->getQueue();
             }
 
             void wait()
             {
-                m_queue.wait_and_throw();
+                getNativeHandle().wait_and_throw();
             }
 
             std::string getName() const
@@ -263,10 +249,9 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::event + onHost::logger::queue);
                 sycl::event sycl_event = event.getNativeHandle();
-                sycl::event ev = m_queue.submit([sycl_event](sycl::handler& cgh) { cgh.depends_on(sycl_event); });
+                sycl::event ev
+                    = getNativeHandle().submit([sycl_event](sycl::handler& cgh) { cgh.depends_on(sycl_event); });
                 setLastEvent(ev);
-                if(isBlocking())
-                    ev.wait_and_throw();
             }
 
             friend struct internal::IsQueueEmpty;
@@ -287,18 +272,19 @@ namespace alpaka::onHost
             //! Thread safe getter for the last sycl event.
             sycl::event getLastEvent() const
             {
-                std::shared_lock<std::shared_mutex> lock{m_eventGuard};
-                return m_lastEvent;
+                return m_SharedNativeQueue->getLastEvent();
             }
 
             /** Thread safe setter for the last sycl event
              *
              * To track dependencies this method must be called with any event returned by native sycl calls.
+             * The operation is blocking the caller in case the queue is a blocking queue.
              */
-            void setLastEvent(sycl::event const& ev) const
+            void setLastEvent(sycl::event& ev) const
             {
-                std::unique_lock<std::shared_mutex> lock{m_eventGuard};
-                m_lastEvent = ev;
+                m_SharedNativeQueue->setLastEvent(ev);
+                if(isBlocking())
+                    ev.wait_and_throw();
             }
 
             void enqueueNativeFn(auto const& fn)
@@ -306,8 +292,6 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
                 sycl::event ev = fn(getNativeHandle());
                 setLastEvent(ev);
-                if(isBlocking())
-                    ev.wait_and_throw();
             }
 
             friend struct alpaka::onHost::internal::Memset;
@@ -318,20 +302,81 @@ namespace alpaka::onHost
             friend struct alpaka::onHost::internal::AllocMapped;
             friend struct alpaka::onHost::internal::Fill;
 
-            Handle<T_Device> m_device;
-            uint32_t m_idx = 0u;
-            sycl::queue m_queue;
-            // secure that two threads can change the event at the same time
-            mutable std::shared_mutex m_eventGuard;
-            /** Event which is representing the last enqueued task/action by alpaka
+            /** RAII Sycl queue
              *
-             * @attention You should not use the event directly, use always getLastEvent() or setLastEvent().
-             * Tasks enqueued via the native handle outside of alpaka, will not be tracked by this event, therefore it
-             * can be possible that the queue is not empty but the event is already marked as complete. If you need to
-             * track also tasks enqueued outside of alpaka you should use onHost::wait(auto&&).
+             * Use this implementation via shared pointer to manage the lifetime independent of the queue and
+             * callback thread.
              */
-            mutable sycl::event m_lastEvent;
-            core::CallbackThread m_callBackThread;
+            struct NativeQueue
+            {
+                NativeQueue(sycl::device device, sycl::context context)
+                    : m_queue(context, device, {sycl::property::queue::in_order{}})
+                {
+                    ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                }
+
+                ~NativeQueue()
+                {
+                    ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                    try
+                    {
+                        m_queue.wait_and_throw();
+                    }
+                    catch(sycl::exception const& err)
+                    {
+                        std::cerr << "Caught SYCL exception while destructing a SYCL queue: " << err.what() << " ("
+                                  << err.code() << ')' << std::endl;
+                    }
+                    catch(std::exception const& err)
+                    {
+                        std::cerr << "The following runtime error(s) occurred while destructing a SYCL queue:"
+                                  << err.what() << std::endl;
+                    }
+                }
+
+                sycl::queue getQueue() const
+                {
+                    return m_queue;
+                }
+
+                //! Thread safe getter for the last sycl event.
+                sycl::event getLastEvent() const
+                {
+                    std::shared_lock<std::shared_mutex> lock{m_eventGuard};
+                    return m_lastEvent;
+                }
+
+                /** Thread safe setter for the last sycl event
+                 *
+                 * To track dependencies this method must be called with any event returned by native sycl calls.
+                 */
+                void setLastEvent(sycl::event const& ev) const
+                {
+                    std::unique_lock<std::shared_mutex> lock{m_eventGuard};
+                    m_lastEvent = ev;
+                }
+
+                sycl::queue m_queue;
+
+            private:
+                /** Event which is representing the last enqueued task/action by alpaka
+                 *
+                 * @attention You should not use the event directly, use always getLastEvent() or setLastEvent().
+                 * Tasks enqueued via the native handle outside of alpaka, will not be tracked by this event, therefore
+                 * it can be possible that the queue is not empty but the event is already marked as complete. If you
+                 * need to track also tasks enqueued outside of alpaka you should use onHost::wait(auto&&).
+                 */
+                mutable sycl::event m_lastEvent;
+                // secure that two threads can change the event at the same time
+                mutable std::shared_mutex m_eventGuard;
+            };
+
+            Handle<T_Device> m_device;
+
+            std::shared_ptr<NativeQueue> m_SharedNativeQueue;
+            std::shared_ptr<core::CallbackThread> m_sharedCallbackThread;
+
+            uint32_t m_idx = 0u;
             bool m_isBlocking{false};
         };
 
@@ -343,25 +388,17 @@ namespace alpaka::onHost
         void operator()(syclGeneric::Queue<T_Device>& queue, T_Task const& task) const
         {
             ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-            /* Using the queue by reference is fine here, because if the queue is destroyed during the native sycl host
-             * task is executed the sycl queue is still valid, in the destructure of the alpaka queue we wait until all
-             * native sycl queue tasks are processed. Accessing the callback thread is still allowed att his point in
-             * time. Capturing the queue as handle (shared pointer) will result into a deadlock because the native sycl
-             * host task is not allowed to destruct the alpaka3, we call in the destructor of the queue 'wait for the
-             * native sycl queue' which is than producing the deadlock.*/
-            sycl::event ev = queue.m_queue.submit(
-                [&queue, task](sycl::handler& cgh)
+            sycl::event ev = queue.getNativeHandle().submit(
+                [task, sharedCallbackThread = queue.m_sharedCallbackThread](sycl::handler& cgh)
                 {
                     cgh.host_task(
-                        [&queue, task]
+                        [sharedCallbackThread = std::move(sharedCallbackThread), task]
                         {
-                            auto f = queue.m_callBackThread.submit([t = std::move(task)] { t(); });
+                            auto f = sharedCallbackThread->submit([t = std::move(task)] { t(); });
                             f.wait();
                         });
                 });
             queue.setLastEvent(ev);
-            if(queue.isBlocking())
-                ev.wait_and_throw();
         }
     };
 
@@ -372,20 +409,13 @@ namespace alpaka::onHost
         void operator()(syclGeneric::Queue<T_Device>& queue, T_Task const& task) const
         {
             ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-            /* Using the queue by reference is fine here, because if the queue is destroyed during the native sycl host
-             * task is executed the sycl queue is still valid, in the destructure of the alpaka queue we wait until all
-             * native sycl queue tasks are processed. Accessing the callback thread is still allowed att his point in
-             * time. Capturing the queue as handle (shared pointer) will result into a deadlock because the native sycl
-             * host task is not allowed to destruct the alpaka3, we call in the destructor of the queue 'wait for the
-             * native sycl queue' which is than producing the deadlock.*/
-            sycl::event ev = queue.m_queue.submit(
-                [&queue, task](sycl::handler& cgh)
+            sycl::event ev = queue.getNativeHandle().submit(
+                [task, sharedCallbackThread = queue.m_sharedCallbackThread](sycl::handler& cgh)
                 {
-                    cgh.host_task([&queue, task]() { queue.m_callBackThread.submit([t = std::move(task)] { t(); }); });
+                    cgh.host_task([sharedCallbackThread = std::move(sharedCallbackThread), task]
+                                  { sharedCallbackThread->submit([t = std::move(task)] { t(); }); });
                 });
             queue.setLastEvent(ev);
-            if(queue.isBlocking())
-                ev.wait_and_throw();
         }
     };
 
@@ -398,10 +428,12 @@ namespace alpaka::onHost
 
             /* We do not use the last event of the queue itself because creating an emulated event allows to see newly
              * submitted tasks add to the native sycl queue outside alpaka. */
-            sycl::event emulatedEvent = queue.m_queue.submit([](sycl::handler& cgh) { cgh.single_task([]() {}); });
+            sycl::event emulatedEvent
+                = queue.getNativeHandle().submit([](sycl::handler& cgh) { cgh.single_task([]() {}); });
+            // update event
             event.setEvent(emulatedEvent);
-            if(queue.isBlocking())
-                emulatedEvent.wait_and_throw();
+            // set last event in the queue
+            queue.setLastEvent(emulatedEvent);
         }
     };
 
@@ -420,8 +452,6 @@ namespace alpaka::onHost
                 byteValue,
                 extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
             queue.setLastEvent(ev);
-            if(queue.isBlocking())
-                ev.wait_and_throw();
         }
     };
 
@@ -443,8 +473,6 @@ namespace alpaka::onHost
                 toVoidPtr(internal::Data::data(source)),
                 extents.x() * sizeof(alpaka::trait::GetValueType_t<T_Dest>));
             queue.setLastEvent(ev);
-            if(queue.isBlocking())
-                ev.wait_and_throw();
         }
     };
 
@@ -464,8 +492,6 @@ namespace alpaka::onHost
             sycl::queue sycl_queue = queue.getNativeHandle();
             sycl::event ev = sycl_queue.fill(internal::Data::data(dest), elementValue, extents.x());
             queue.setLastEvent(ev);
-            if(queue.isBlocking())
-                ev.wait_and_throw();
         }
     };
 
@@ -495,9 +521,10 @@ namespace alpaka::onHost
             if(queue.isBlocking())
                 sycl_queue.wait_and_throw();
 
-            auto deleter = [queueDep = std::move(queueDependency), ptr]()
+            auto deleter = [ptr,
+                            sharedCallbackThread = queue.m_sharedCallbackThread,
+                            sharedNativeQueue = queue.m_SharedNativeQueue]()
             {
-                sycl::queue sycl_queue = queueDep->getNativeHandle();
                 /* in cases where the deleter lifetime is extended e.g. by using keepAlive() on a buffer it can be that
                  * the queue callback thread is holding the last instance of the deleter. keepAlive() is executed
                  * within a sycl host tasks, it is forbidden to create another host task in a host task, result will be
@@ -507,11 +534,15 @@ namespace alpaka::onHost
                  * memory will be freed a little bit later than it could in cases other threads enqueue now kernel,
                  * tasks into the sycl queue while the callback thread is creating the host tasks.
                  */
-                queueDep->m_callBackThread.submit(
-                    [sycl_queue, ptr]() mutable
+                sharedCallbackThread->submit(
+                    [ptr, sharedNativeQueue]()
                     {
-                        sycl_queue.submit([&](sycl::handler& cgh)
-                                          { cgh.host_task([=]() { sycl::free(toVoidPtr(ptr), sycl_queue); }); });
+                        sharedNativeQueue->getQueue().submit(
+                            [&](sycl::handler& cgh)
+                            {
+                                cgh.host_task([ptr, syclQueue = sharedNativeQueue->getQueue()]()
+                                              { sycl::free(toVoidPtr(ptr), syclQueue); });
+                            });
                     });
             };
 

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -192,9 +192,7 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 using ApiInterface = typename T_Platform::ApiInterface;
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
-                    ApiInterface,
-                    ApiInterface::setDevice(device.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::setDevice(device.getNativeHandle()));
 
                 T_Type* ptr = nullptr;
                 auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};

--- a/include/alpaka/api/unifiedCudaHip/Platform.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Platform.hpp
@@ -127,17 +127,11 @@ namespace alpaka::onHost
                 typename ApiInterface::DeviceProp_t devProp;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::getDeviceProperties(&devProp, deviceIdx));
 
-                std::size_t freeGlobalMemBytes(0u);
-                std::size_t globalMemCapacityBytes(0u);
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ApiInterface,
-                    ApiInterface::memGetInfo(&freeGlobalMemBytes, &globalMemCapacityBytes));
-
                 auto prop = DeviceProperties{};
                 prop.name = devProp.name;
                 prop.warpSize = devProp.warpSize;
                 prop.multiProcessorCount = devProp.multiProcessorCount;
-                prop.globalMemCapacityBytes = globalMemCapacityBytes;
+                prop.globalMemCapacityBytes = devProp.totalGlobalMem;
                 prop.sharedMemPerBlockBytes = devProp.sharedMemPerBlock;
 
                 prop.maxThreadsPerBlock = devProp.maxThreadsPerBlock;

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -144,11 +144,23 @@ namespace alpaka::onHost
              * native CUDA/HIP queue. There is no need to call this method before enqueuing because the queues are
              * in-order queues and even if another thread is enqueued something before the order is guaranteed.
              */
-            void conditionalWait() const noexcept
+            void conditionalWait() const
             {
                 if(m_isBlocking)
                 {
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::streamSynchronize(getNativeHandle()));
+                }
+            }
+
+            /** Waits until the event is complete if the queue is blocking.
+             *
+             * For a non-blocking queue this operation is a no-Op.
+             */
+            void conditionalWait([[maybe_unused]] typename ApiInterface::Event_t nativeEvent) const
+            {
+                if(m_isBlocking)
+                {
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::eventSynchronize(nativeEvent));
                 }
             }
 
@@ -198,7 +210,7 @@ namespace alpaka::onHost
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ApiInterface,
                     ApiInterface::streamWaitEvent(getNativeHandle(), internal::getNativeHandle(event), 0));
-
+                // Wait for the stream only, the event should be finished after the stream operation is finished.
                 conditionalWait();
             }
 
@@ -460,11 +472,12 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::event + onHost::logger::queue);
                 using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
+                typename ApiInterface::Event_t nativeEvent = internal::getNativeHandle(event);
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ApiInterface,
-                    ApiInterface::eventRecord(event.getNativeHandle(), queue.getNativeHandle()));
+                    ApiInterface::eventRecord(nativeEvent, queue.getNativeHandle()));
 
-                queue.conditionalWait();
+                queue.conditionalWait(nativeEvent);
             }
         };
 
@@ -1040,8 +1053,8 @@ namespace alpaka::onHost
                 auto deleter
                     = [ptr, sharedStream = queue.m_SharedStream, devIdx = onHost::getNativeHandle(deviceDependency)]()
                 {
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::setDevice(devIdx));
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::setDevice(devIdx));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
                         ApiInterface,
                         ApiInterface::freeAsync(toVoidPtr(ptr), sharedStream->getStream()));
                 };

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -48,28 +48,22 @@ namespace alpaka::onHost
         public:
             Queue(internal::concepts::DeviceHandle auto device, uint32_t const idx, bool isBlocking)
                 : m_device(std::move(device))
+                , m_sharedCallbackThread{std::make_shared<alpaka::core::CallbackThread>()}
+                , m_SharedStream{std::make_shared<Stream>(m_device)}
                 , m_idx(idx)
                 , m_isBlocking(isBlocking)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ApiInterface,
-                    ApiInterface::setDevice(onHost::getNativeHandle(m_device)));
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ApiInterface,
-                    ApiInterface::streamCreateWithFlags(&m_UniformCudaHipQueue, ApiInterface::streamNonBlocking));
             }
 
             ~Queue()
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                onHost::internal::wait(*this);
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
-                    ApiInterface,
-                    ApiInterface::setDevice(onHost::getNativeHandle(m_device)));
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
-                    ApiInterface,
-                    ApiInterface::streamDestroy(getNativeHandle()));
+                /* Ensure that the callback thread is destroyed before the stream to flush already enqueued tasked
+                 * which could submit to the stream.
+                 */
+                m_sharedCallbackThread.reset();
+                m_SharedStream.reset();
             }
 
             Queue(Queue const&) = delete;
@@ -94,10 +88,53 @@ namespace alpaka::onHost
                 static_assert(internal::concepts::Queue<Queue>);
             }
 
+            /** RAII CUDA/HIP stream
+             *
+             * Use this implementation via shared pointer to manage the lifetime independent of the queue and
+             * callback thread.
+             */
+            struct Stream
+            {
+                Stream(Handle<T_Device> device) : m_device{std::move(device)}
+                {
+                    ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ApiInterface,
+                        ApiInterface::setDevice(onHost::getNativeHandle(m_device)));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ApiInterface,
+                        ApiInterface::streamCreateWithFlags(&m_stream, ApiInterface::streamNonBlocking));
+                }
+
+                ~Stream()
+                {
+                    ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+                        ApiInterface,
+                        ApiInterface::setDevice(onHost::getNativeHandle(m_device)));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::streamSynchronize(m_stream));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::streamDestroy(m_stream));
+                }
+
+                using Stream_t = typename ApiInterface::Stream_t;
+
+                Stream_t getStream() const
+                {
+                    return m_stream;
+                }
+
+                // hold the device to avoid that the device is fully reset before the queue is destroyed
+                Handle<T_Device> m_device;
+                Stream_t m_stream;
+            };
+
             Handle<T_Device> m_device;
+            /* The callback thread must outlive the stream. Stream destruction synchronizes the native stream and may
+             * execute pending host callbacks which submit work to this callback thread.
+             */
+            std::shared_ptr<core::CallbackThread> m_sharedCallbackThread;
+            std::shared_ptr<Stream> m_SharedStream;
             uint32_t m_idx = 0u;
-            typename ApiInterface::Stream_t m_UniformCudaHipQueue;
-            core::CallbackThread m_callBackThread;
             bool m_isBlocking{false};
 
             /** Waits until all operations are finished depending on whether the queue is blocking or non-blocking.
@@ -126,7 +163,7 @@ namespace alpaka::onHost
 
             [[nodiscard]] auto getNativeHandle() const noexcept
             {
-                return m_UniformCudaHipQueue;
+                return m_SharedStream->getStream();
             }
 
             friend struct onHost::internal::Enqueue;
@@ -348,21 +385,18 @@ namespace alpaka::onHost
         {
             struct HostFuncData
             {
-                // We don't need to keep the queue alive, because in its dtor it will synchronize with the CUDA/HIP
-                // stream and wait until all host functions and the CallbackThread are done. It's actually an error to
-                // copy the queue into the host function. Destroying it here would call CUDA/HIP APIs from the host
-                // function. Passing it further to the Callback thread, would make the Callback thread hold a task
-                // containing the queue with the CallbackThread itself. Destroying the task if no other queue instance
-                // exists will make the CallbackThread join itself and crash.
-                unifiedCudaHip::Queue<T_Device>& q;
+                std::shared_ptr<core::CallbackThread> sharedCallbackThread;
                 T_Task t;
             };
 
             static void uniformCudaHipRtHostFunc(void* arg)
             {
+                // take care data is deleted after the usage
                 auto data = std::unique_ptr<HostFuncData>(reinterpret_cast<HostFuncData*>(arg));
-                auto& queue = data->q;
-                auto f = queue.m_callBackThread.submit([d = std::move(data)] { d->t(); });
+                auto sharedCallbackThread = std::move(data->sharedCallbackThread);
+                auto task = std::move(data->t);
+                data.reset();
+                auto f = sharedCallbackThread->submit([task = std::move(task)]() mutable { task(); });
                 f.wait();
             }
 
@@ -376,7 +410,7 @@ namespace alpaka::onHost
                     ApiInterface::launchHostFunc(
                         queue.getNativeHandle(),
                         uniformCudaHipRtHostFunc,
-                        new HostFuncData{queue, task}));
+                        new HostFuncData{queue.m_sharedCallbackThread, task}));
 
                 queue.conditionalWait();
             }
@@ -388,16 +422,18 @@ namespace alpaka::onHost
             // same as for Enqueue::HostTask, but not waiting for the task to finish
             struct HostFuncData
             {
-                unifiedCudaHip::Queue<T_Device>& q;
+                std::shared_ptr<core::CallbackThread> sharedCallbackThread;
                 T_Task t;
             };
 
             static void uniformCudaHipRtHostFuncAsync(void* arg)
             {
+                // take care data is deleted after the usage
                 auto data = std::unique_ptr<HostFuncData>(reinterpret_cast<HostFuncData*>(arg));
-                auto& queue = data->q;
-                auto queueDependency = queue.getSharedPtr();
-                queue.m_callBackThread.submit([d = std::move(data), queueDependency] { d->t(); });
+                auto sharedCallbackThread = std::move(data->sharedCallbackThread);
+                auto task = std::move(data->t);
+                data.reset();
+                auto f = sharedCallbackThread->submit([task = std::move(task)]() mutable { task(); });
                 // don't wait, we're async
             }
 
@@ -411,7 +447,7 @@ namespace alpaka::onHost
                     ApiInterface::launchHostFunc(
                         queue.getNativeHandle(),
                         uniformCudaHipRtHostFuncAsync,
-                        new HostFuncData{queue, task}));
+                        new HostFuncData{queue.m_sharedCallbackThread, task}));
 
                 queue.conditionalWait();
             }
@@ -1000,17 +1036,14 @@ namespace alpaka::onHost
                 queue.conditionalWait();
 
                 auto deviceDependency = onHost::Device{queue.getDevice()->getSharedPtr()};
-                // it is the shared pointer to the internal queue, NOT onHost::Queue
-                auto queueDependency = queue.getSharedPtr();
 
-                auto deleter = [ptr, queueDependency]()
+                auto deleter
+                    = [ptr, sharedStream = queue.m_SharedStream, devIdx = onHost::getNativeHandle(deviceDependency)]()
                 {
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::setDevice(devIdx));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                         ApiInterface,
-                        ApiInterface::setDevice(onHost::getNativeHandle(queueDependency->m_device)));
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
-                        ApiInterface,
-                        ApiInterface::freeAsync(toVoidPtr(ptr), queueDependency->getNativeHandle()));
+                        ApiInterface::freeAsync(toVoidPtr(ptr), sharedStream->getStream()));
                 };
 
                 auto sharedBuffer = onHost::SharedBuffer{

--- a/include/alpaka/onHost/mem/SharedBuffer.hpp
+++ b/include/alpaka/onHost/mem/SharedBuffer.hpp
@@ -244,9 +244,6 @@ namespace alpaka::onHost
          * This differs from `destructorWaitFor`, because that function waits, while `keepAlive` does not block
          * anything, it just extends lifetime.
          *
-         * @attention Do not apply this function to a buffer allocated with alpaka::onHost::allocDeferred, see
-         * https://github.com/alpaka-group/alpaka3/issues/394
-         *
          * @param queue The queue to enqueue to.
          */
         void keepAlive(auto& queue)


### PR DESCRIPTION
The CUDA/HIP keepAlive tests failed randomly.
This PR is refactoring the queue implementations and uses the callback thread and native queues via shared pointer to manage dependencies in critical functions like `enqueueDeferred()` and `enqueueHostFn()`.
For `oneApi` an missing function call to block the queue if blocking is activated was added.
For sycl `setEvent()` is now handling if a queue is required to be block the caller thread.

The refactoring will introduce a little bit of latency for enqueue operations because of the indirection to the callback thread and native queue resources. I have an idea how to avoid it but it is not nice; therefore, I focused on solving the data races.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue shutdown and synchronization across CPU, SYCL, CUDA, and HIP backends.
  * Improved reliability of deferred host task execution and asynchronous memory cleanup.
  * Corrected device memory capacity reporting and strengthened host-side device selection error handling.
  * Streamlined blocking-operation behavior for host and memory transfers while preserving required completion guarantees.
* **Documentation**
  * Clarified buffer lifetime behavior for `keepAlive` and removed an outdated warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->