### PR TITLE
add missing `setDevice` for HIP/CUDA

### DIFF
--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -149,6 +149,7 @@ namespace alpaka::onHost
             {
                 std::size_t freeGlobalMemBytes(0u);
                 std::size_t globalMemCapacityBytes(0u);
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::setDevice(getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ApiInterface,
                     ApiInterface::memGetInfo(&freeGlobalMemBytes, &globalMemCapacityBytes));
@@ -191,6 +192,9 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 using ApiInterface = typename T_Platform::ApiInterface;
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+                    ApiInterface,
+                    ApiInterface::setDevice(device.getNativeHandle()));
 
                 T_Type* ptr = nullptr;
                 auto pitches = typename T_Extents::UniVec{sizeof(T_Type)};
@@ -234,8 +238,11 @@ namespace alpaka::onHost
 
                 auto deviceDependency = onHost::Device{device.getSharedPtr()};
 
-                auto deleter = [ptr, deviceDependency]()
-                { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::free(toVoidPtr(ptr))); };
+                auto deleter = [ptr, deviceIdx = device.getNativeHandle(), deviceDependency]()
+                {
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::setDevice(deviceIdx));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::free(toVoidPtr(ptr)));
+                };
 
                 /** Each CUDA/HIP allocation is aligned to at least 128 byte but typically to 256byte
                  *
@@ -262,6 +269,9 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 using ApiInterface = typename T_Platform::ApiInterface;
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+                    ApiInterface,
+                    ApiInterface::setDevice(device.getNativeHandle()));
 
                 /** Each CUDA/HIP allocation is aligned to at least 128 byte but typically to 256byte
                  *
@@ -284,8 +294,11 @@ namespace alpaka::onHost
                         ApiInterface::mallocManaged((void**) &ptr, memSizeInByte));
                 }
 
-                auto deleter = [ptr, deviceDependency]()
-                { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::free(toVoidPtr(ptr))); };
+                auto deleter = [ptr, deviceIdx = device.getNativeHandle(), deviceDependency]()
+                {
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::setDevice(deviceIdx));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::free(toVoidPtr(ptr)));
+                };
 
                 auto sharedBuffer = onHost::SharedBuffer{
                     deviceDependency,
@@ -305,6 +318,9 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 using ApiInterface = typename T_Platform::ApiInterface;
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+                    ApiInterface,
+                    ApiInterface::setDevice(device.getNativeHandle()));
 
                 /** Each CUDA/HIP allocation is aligned to at least 128 byte but typically to 256byte
                  *
@@ -324,8 +340,11 @@ namespace alpaka::onHost
                         memSizeInByte,
                         ApiInterface::hostMallocMapped | ApiInterface::hostMallocPortable));
 
-                auto deleter = [ptr, deviceDependency]()
-                { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::hostFree(toVoidPtr(ptr))); };
+                auto deleter = [ptr, deviceIdx = device.getNativeHandle(), deviceDependency]()
+                {
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::setDevice(deviceIdx));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::hostFree(toVoidPtr(ptr)));
+                };
 
                 auto sharedBuffer = onHost::SharedBuffer{
                     deviceDependency,
@@ -346,6 +365,7 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 using ApiInterface = typename T_Platform::ApiInterface;
                 typename ApiInterface::PointerAttr_t ptrAttributes;
+
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ApiInterface,
                     ApiInterface::pointerGetAttributes(&ptrAttributes, onHost::data(view)));

--- a/include/alpaka/api/unifiedCudaHip/Event.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Event.hpp
@@ -72,6 +72,9 @@ namespace alpaka::onHost
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::event);
                 onHost::internal::wait(*this);
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+                    ApiInterface,
+                    ApiInterface::setDevice(internal::getNativeHandle(*m_device.get())));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ApiInterface, ApiInterface::eventDestroy(getNativeHandle()));
             }
 

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -66,6 +66,9 @@ namespace alpaka::onHost
                 onHost::internal::wait(*this);
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
                     ApiInterface,
+                    ApiInterface::setDevice(onHost::getNativeHandle(m_device)));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+                    ApiInterface,
                     ApiInterface::streamDestroy(getNativeHandle()));
             }
 
@@ -107,7 +110,9 @@ namespace alpaka::onHost
             void conditionalWait() const noexcept
             {
                 if(m_isBlocking)
+                {
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ApiInterface, ApiInterface::streamSynchronize(getNativeHandle()));
+                }
             }
 
             friend struct alpaka::internal::GetName;
@@ -177,6 +182,9 @@ namespace alpaka::onHost
             void enqueueNativeFn(auto const& fn)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::setDevice(onHost::getNativeHandle(m_device)));
                 fn(getNativeHandle());
                 conditionalWait();
             }
@@ -648,6 +656,10 @@ namespace alpaka::onHost
                     ALPAKA_TYPEOF(extentMd)::dim() == ALPAKA_TYPEOF(destPitchesOriginal)::dim()
                     && ALPAKA_TYPEOF(extentMd)::dim() == ALPAKA_TYPEOF(srcPitchesOriginal)::dim());
 
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    T_ApiInterface,
+                    T_ApiInterface::setDevice(onHost::getNativeHandle(queue.m_device)));
+
                 meta::ndLoopIncIdx(
                     repetitions,
                     [&](auto const& idx)
@@ -695,6 +707,10 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
 
                 using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::setDevice(onHost::getNativeHandle(queue.m_device)));
+
                 auto queueApi = alpaka::internal::getApi(queue);
                 auto copyKind = unifiedCudaHip::
                     MemcpyKind<ApiInterface, ALPAKA_TYPEOF(queueApi), ALPAKA_TYPEOF(api::host)>::kind;
@@ -731,6 +747,10 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
 
                 using ApiInterface = typename unifiedCudaHip::Queue<T_Device>::ApiInterface;
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::setDevice(onHost::getNativeHandle(queue.m_device)));
+
                 auto queueApi = alpaka::internal::getApi(queue);
                 auto copyKind = unifiedCudaHip::
                     MemcpyKind<ApiInterface, ALPAKA_TYPEOF(api::host), ALPAKA_TYPEOF(queueApi)>::kind;
@@ -896,6 +916,10 @@ namespace alpaka::onHost
                 static_assert(ALPAKA_TYPEOF(repetitions)::dim() == ALPAKA_TYPEOF(destPitchJump)::dim());
                 static_assert(ALPAKA_TYPEOF(extentMd)::dim() == ALPAKA_TYPEOF(destPitchesOriginal)::dim());
 
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    T_ApiInterface,
+                    T_ApiInterface::setDevice(onHost::getNativeHandle(queue.m_device)));
+
                 meta::ndLoopIncIdx(
                     repetitions,
                     [&](auto const& idx)
@@ -956,6 +980,10 @@ namespace alpaka::onHost
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
                 using ApiInterface = typename T_Device::ApiInterface;
 
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ApiInterface,
+                    ApiInterface::setDevice(onHost::getNativeHandle(queue.m_device)));
+
                 /** Each CUDA/HIP allocation is aligned to at least 128 byte but typically to 256byte
                  *
                  * @todo check if this value can be derived from the device properties
@@ -977,6 +1005,9 @@ namespace alpaka::onHost
 
                 auto deleter = [ptr, queueDependency]()
                 {
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+                        ApiInterface,
+                        ApiInterface::setDevice(onHost::getNativeHandle(queueDependency->m_device)));
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
                         ApiInterface,
                         ApiInterface::freeAsync(toVoidPtr(ptr), queueDependency->getNativeHandle()));


### PR DESCRIPTION
Most cuda/hip functions requires that the device is selected. If the user is using multiple devices from a single process we need to select the correct device before applying the native API call.


note: Same as in alpaka mainline, we do not have multi-GPU tests at the moment and cannot test it in the CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when using multiple CUDA/HIP devices.
  * Memory allocations, transfers, deallocations, and memory queries now consistently operate on the correct device.
  * Queue, stream, event, and synchronization operations now target their associated device reliably.
  * Host tasks and deferred operations execute with the appropriate device context.
  * Device property and pointer accessibility queries now return more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->