### PR TITLE
fix inline assembler issue with clang as CUDA host compiler

### DIFF
--- a/include/alpaka/api/cuda/warp.hpp
+++ b/include/alpaka/api/cuda/warp.hpp
@@ -31,7 +31,7 @@ namespace alpaka::onAcc::warp::internal
         {
             unsigned lIdx;
 #    if ALPAKA_COMP_NVCC
-            asm volatile("mov.u32 %0, %laneid;" : "=r"(lIdx));
+            asm volatile("mov.u32 %0, %%laneid;" : "=r"(lIdx));
 #    else
             asm("mov.u32 %0, %%laneid;" : "=r"(lIdx));
 #    endif


### PR DESCRIPTION
When using clang as host compiler it is complaining about the assembler syntax.

```
api/cuda/warp.hpp:34:33: error: invalid % escape in inline assembly string
302
19:54:25
   34 | __asm__ volatile("mov.u32 %0, %laneid;" : "=r" (lIdx) :);
303
19:54:25
      |                  ~~~~~~~~~~~~~~~^~~~~~
api/cuda/warp.hpp:34:33: error: invalid % escape in inline assembly
string
302
19:54:25
   34 | __asm__ volatile("mov.u32 %0, %laneid;" : "=r" (lIdx) :);
303
19:54:25
      |                  ~~~~~~~~~~~~~~~^~~~~~~~
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CUDA lane identification for NVCC builds, ensuring warp-level operations retrieve the correct lane index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->