### PR TITLE
fix compile issue if clang is used as host compiler for CUDA

### DIFF
--- a/include/alpaka/api/unifiedCudaHip/ComputeApi.hpp
+++ b/include/alpaka/api/unifiedCudaHip/ComputeApi.hpp
@@ -49,7 +49,14 @@ namespace alpaka::onAcc::internalCompute
     requires alpaka::concepts::UnifiedCudaHipExecutor<ALPAKA_TYPEOF(std::declval<T_Acc>()[object::exec])>
     struct SharedMemory::Dynamic<T, T_Acc>
     {
-        __device__ decltype(auto) operator()(auto const& acc) const
+        /** Get dynamic shared memory as pointer.
+         *
+         * @tparam T_Defer is deferring the evaluation to avoid CUDA compile errors e.g. for CUDA 12.9 with clang 19 as
+         * host compiler: error #20093-D: address of a __shared__ variable "shMem" cannot be directly taken in a host
+         * function
+         */
+        template<typename T_Defer = T>
+        __device__ auto operator()(auto const& acc) const -> T*
         {
             alpaka::unused(acc);
             // Because unaligned access to variables is not allowed in device code,
@@ -67,6 +74,13 @@ namespace alpaka::onAcc::internalCompute
     requires alpaka::concepts::UnifiedCudaHipExecutor<ALPAKA_TYPEOF(std::declval<T_Acc>()[object::exec])>
     struct SharedMemory::Static<T, T_uniqueId, T_Acc>
     {
+        /** Get a static shared memory object as reference.
+         *
+         * @tparam T_Defer is deferring the evaluation to avoid CUDA compile errors e.g. for CUDA 12.9 with clang 19 as
+         * host compiler: error #20093-D: address of a __shared__ variable "shMem" cannot be directly taken in a host
+         * function
+         */
+        template<typename T_Defer = T>
         __device__ decltype(auto) operator()(auto const& acc) const
         {
             alpaka::unused(acc);

--- a/include/alpaka/api/util.hpp
+++ b/include/alpaka/api/util.hpp
@@ -23,7 +23,7 @@ namespace alpaka::api::util
             std::integral auto T_limit,
             std::integral auto T_index,
             std::integral auto T_increment,
-            std::integral auto... T_idx>
+            size_t... T_idx>
         consteval auto adjustToLimit(concepts::CVector auto const input, std::index_sequence<T_idx...>)
         {
             if constexpr(input.product() <= static_cast<typename ALPAKA_TYPEOF(input)::type>(T_limit))
@@ -63,7 +63,9 @@ namespace alpaka::api::util
     template<std::integral auto T_limit, std::integral auto T_index, std::integral auto T_increment>
     consteval auto adjustToLimit(concepts::CVector auto const input)
     {
-        return detail::adjustToLimit<T_limit, 0u, 1u>(input, std::make_index_sequence<input.dim()>{});
+        return detail::adjustToLimit<T_limit, T_index, T_increment>(
+            input,
+            std::make_index_sequence<ALPAKA_TYPEOF(input)::dim()>{});
     }
 
     /** adjust the input vector to a given limit by halving the largest dimension until the product of all components

--- a/include/alpaka/mem/FlatIdxContainer.hpp
+++ b/include/alpaka/mem/FlatIdxContainer.hpp
@@ -39,7 +39,7 @@ namespace alpaka::onAcc
         static constexpr uint32_t dim = T_IdxRange::dim();
         using IdxVecType = Vec<IdxType, dim>;
 
-        ALPAKA_FN_ACC inline FlatIdxContainer(
+        ALPAKA_FN_ACC constexpr FlatIdxContainer(
             T_IdxRange const& idxRange,
             T_ThreadSpace const& threadSpace,
             T_IdxMapperFn idxMapping,
@@ -71,7 +71,7 @@ namespace alpaka::onAcc
                 static_assert(std::input_iterator<const_iterator_end>);
             }
 
-            ALPAKA_FN_ACC inline const_iterator_end(IdxType const& end) : m_extentSlowDim{end}
+            ALPAKA_FN_ACC constexpr const_iterator_end(IdxType const& end) : m_extentSlowDim{end}
             {
             }
 
@@ -149,14 +149,14 @@ namespace alpaka::onAcc
             }
 
             // pre-increment the iterator
-            ALPAKA_FN_ACC inline const_iterator& operator++()
+            ALPAKA_FN_ACC constexpr const_iterator& operator++()
             {
                 m_current += m_stride;
                 return *this;
             }
 
             // post-increment the iterator
-            ALPAKA_FN_ACC inline const_iterator operator++(int)
+            ALPAKA_FN_ACC constexpr const_iterator operator++(int)
             {
                 const_iterator old = *this;
                 ++(*this);
@@ -194,7 +194,7 @@ namespace alpaka::onAcc
             IterIdxVecType m_strideMD;
         };
 
-        ALPAKA_FN_ACC inline const_iterator begin() const
+        ALPAKA_FN_ACC constexpr const_iterator begin() const
         {
             constexpr auto selectedDims = T_CSelect{};
             auto [threadIdx, numThreads] = m_threadSpace.mapTo(selectedDims);
@@ -250,7 +250,7 @@ namespace alpaka::onAcc
             }
         }
 
-        ALPAKA_FN_ACC inline const_iterator_end end() const
+        ALPAKA_FN_ACC constexpr const_iterator_end end() const
         {
             constexpr auto selectedDims = T_CSelect{};
             auto [threadIdx, numThreads] = m_threadSpace.mapTo(selectedDims);

--- a/include/alpaka/mem/TiledIdxContainer.hpp
+++ b/include/alpaka/mem/TiledIdxContainer.hpp
@@ -78,7 +78,7 @@ namespace alpaka::onAcc
         static constexpr uint32_t dim = T_IdxRange::dim();
         using IdxVecType = Vec<IdxType, dim>;
 
-        ALPAKA_FN_ACC inline TiledIdxContainer(
+        ALPAKA_FN_ACC constexpr TiledIdxContainer(
             T_IdxRange const& idxRange,
             T_ThreadSpace const& threadSpace,
             T_IdxMapperFn idxMapping,
@@ -108,7 +108,7 @@ namespace alpaka::onAcc
                 static_assert(std::forward_iterator<const_iterator_end>);
             }
 
-            ALPAKA_FN_ACC inline const_iterator_end(alpaka::concepts::Vector auto const& extent)
+            ALPAKA_FN_ACC constexpr const_iterator_end(alpaka::concepts::Vector auto const& extent)
                 : m_extentSlowDim{extent[T_CSelect{}][0]}
             {
             }
@@ -193,7 +193,7 @@ namespace alpaka::onAcc
             }
 
             // pre-increment the iterator
-            ALPAKA_FN_ACC inline const_iterator& operator++()
+            ALPAKA_FN_ACC constexpr const_iterator& operator++()
             {
                 for(uint32_t d = 0; d < iterDim; ++d)
                 {
@@ -213,7 +213,7 @@ namespace alpaka::onAcc
             }
 
             // post-increment the iterator
-            ALPAKA_FN_ACC inline const_iterator operator++(int)
+            ALPAKA_FN_ACC constexpr const_iterator operator++(int)
             {
                 const_iterator old = *this;
                 ++(*this);
@@ -249,7 +249,7 @@ namespace alpaka::onAcc
             detail::ReducedVector<IdxType, iterDim> m_first;
         };
 
-        ALPAKA_FN_ACC inline const_iterator begin() const
+        ALPAKA_FN_ACC constexpr const_iterator begin() const
         {
             constexpr auto selectedDims = T_CSelect{};
             auto [threadIdx, numThreads] = m_threadSpace.mapTo(selectedDims);
@@ -284,7 +284,7 @@ namespace alpaka::onAcc
             }
         }
 
-        ALPAKA_FN_ACC inline const_iterator_end end() const
+        ALPAKA_FN_ACC constexpr const_iterator_end end() const
         {
             constexpr auto selectedDims = T_CSelect{};
             auto [threadIdx, numThreads] = m_threadSpace.mapTo(selectedDims);


### PR DESCRIPTION
For full nvcc+clang support the PR #650 is required.

Fix compile issues like:

```
ComputeApi.hpp(62): error #20093-D: address of a __shared__ variable "shMem" cannot be directly taken in a host function
286
19:54:35
              return reinterpret_cast<T*>(shMem);
```

```
api/util.hpp:66:8: error: no matching function for call to 'adjustToLimit'
   66 | return detail::adjustToLimit< T_limit, T_index, T_increment> (input, std::make_index_sequence< std::template decay< __decltype(input)> ::type::dim()> {});
```