### PR TITLE
fix set preprocessor variable ALPAKA_COMP_ICPX

### DIFF
--- a/include/alpaka/core/config.hpp
+++ b/include/alpaka/core/config.hpp
@@ -215,7 +215,7 @@
 
 // Intel LLVM compiler detection
 #if !defined(ALPAKA_COMP_ICPX)
-#    if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
+#    if defined(__INTEL_LLVM_COMPILER)
 // The version string for icpx 2023.1.0 is 20230100. In Boost.Predef this becomes (53,1,0).
 #        define ALPAKA_COMP_ICPX ALPAKA_YYYYMMDD_TO_VERSION(__INTEL_LLVM_COMPILER)
 #    else
@@ -268,7 +268,7 @@
 #    else
 #        define ALPAKA_LANG_SYCL ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif
-#    if (ALPAKA_COMP_ICPX)
+#    if (ALPAKA_COMP_ICPX) && defined(SYCL_LANGUAGE_VERSION)
 // ONE API must be detected via the ICPX compiler see
 // https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2023-2/use-predefined-macros-to-specify-intel-compilers.html
 #        define ALPAKA_LANG_ONEAPI ALPAKA_COMP_ICPX


### PR DESCRIPTION
The ICPX compiler version was only set, if sycl is enabled. But if there is the use case where ICPX is used to compile the Intel TBB api. In this case, sycl is not enabled and the preprocessor variable `SYCL_LANGUAGE_VERSION` is not defined. Move the check if `SYCL_LANGUAGE_VERSION` is defined to the correct position.

Found bug during PR #641 in CI job: https://gitlab.com/hzdr/crp/alpaka3/-/jobs/15516408241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler and language detection for Intel LLVM and OneAPI SYCL environments.
  * Prevented incorrect OneAPI SYCL configuration when the SYCL language version is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->