### PR TITLE
add CMake option `alpaka_LANGUAGE_SEPARATION`

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -93,7 +93,7 @@ option(alpaka_DEP_TBB "Enable the Intel oneTBB dependency, allows the usage of e
 option(alpaka_DEP_ONEAPI "Enable the Intel oneAPI SYCL dependency, allows using exec::oneApi" OFF)
 option(
     alpaka_LANGUAGE_SEPARATION
-    "Enable that CXX files for CUDA and HIP will be copied to an unique folder and compiled from there, instead of using the original file."
+    "Enable copying C++ source files used for CUDA/HIP compilation to a unique folder and compiled from there, instead of using the original file."
     ON
 )
 

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -91,6 +91,11 @@ option(alpaka_DEP_HIP "Enable the HIP as dependency, allows the usage of api::Hi
 option(alpaka_DEP_OMP "Enable the OpenMP as dependency, allows the usage of exec::cpuOmpBlocks" ON)
 option(alpaka_DEP_TBB "Enable the Intel oneTBB dependency, allows the usage of exec::cpuTbbBlocks" OFF)
 option(alpaka_DEP_ONEAPI "Enable the Intel oneAPI SYCL dependency, allows using exec::oneApi" OFF)
+option(
+    alpaka_LANGUAGE_SEPARATION
+    "Enable that CXX files for CUDA and HIP will be copied to an unique folder and compiled from there, instead of using the original file."
+    ON
+)
 
 set(alpaka_DEP_HWLOC
     "AUTO"

--- a/cmake/finalize.cmake
+++ b/cmake/finalize.cmake
@@ -162,8 +162,8 @@ function(alpaka_internal_finalize target)
     ##  File properties are globally visible, so we cannot just set the LANGUAGE property to CUDA or HIP for the original source file.
     ##  For the target the original file list is copied.
     ##  Files which need to be compiled with CUDA or HIP will be replaced by the copied file, all other files remain unchanged.
-    ##  The copy of files will only be executed in cases where CUDA and HIP backend is activated together.
-    ##  If only CUA or HIP is active the original file will be used.
+    ##  When language separation is enabled, files compiled with language CUDA or HIP are copied to separate build-tree locations; otherwise original files
+    ##  are retained.
     get_target_property(_file_list ${target} SOURCES)
     set(_new_file_list ${_file_list})
     foreach(_file ${_file_list})

--- a/cmake/finalize.cmake
+++ b/cmake/finalize.cmake
@@ -98,7 +98,7 @@ function(copy_with_structure SRC_FILE api_name OUT_VAR)
     # Query all properties actually set on the original file
     get_source_file_property(props ${SRC_FILE} PROPERTY_LIST)
 
-    # Copy properties ove rthe the destination file
+    # Copy properties over the the destination file
     if(props)
         foreach(prop IN LISTS props)
             get_source_file_property(val ${SRC_FILE} ${prop})
@@ -160,7 +160,10 @@ function(alpaka_internal_finalize target)
     ##
     ##  For CUDA and HIP the source files need to be copied to a different location in the build tree because it is not possible to set two languages for a single source file.
     ##  File properties are globally visible, so we cannot just set the LANGUAGE property to CUDA or HIP for the original source file.
-    ##  For the target the original file list is copied. Files which need to be compiled with CUDA or HIP will be replaced by the copied file, all other files remain unchanged.
+    ##  For the target the original file list is copied.
+    ##  Files which need to be compiled with CUDA or HIP will be replaced by the copied file, all other files remain unchanged.
+    ##  The copy of files will only be executed in cases where CUDA and HIP backend is activated together.
+    ##  If only CUA or HIP is active the original file will be used.
     get_target_property(_file_list ${target} SOURCES)
     set(_new_file_list ${_file_list})
     foreach(_file ${_file_list})
@@ -175,10 +178,17 @@ function(alpaka_internal_finalize target)
                 OR (${_file} MATCHES "\\.cc$")
                 OR (${_file} MATCHES "\\.cu$")
             )
-                copy_with_structure(${_file} "cuda" COPIED_FILE)
-                set_source_files_properties(${COPIED_FILE} PROPERTIES LANGUAGE CUDA)
-                list(REMOVE_ITEM _new_file_list ${_file})
-                list(APPEND _new_file_list ${COPIED_FILE})
+                if(alpaka_LANGUAGE_SEPARATION)
+                    copy_with_structure(${_file} "cuda" COPIED_FILE)
+                    set_source_files_properties(${COPIED_FILE} PROPERTIES LANGUAGE CUDA)
+                    list(REMOVE_ITEM _new_file_list ${_file})
+                    list(APPEND _new_file_list ${COPIED_FILE})
+                    # Update the list of files for the target
+                    set_property(TARGET ${target} PROPERTY SOURCES ${_new_file_list})
+                else()
+                    # We do not need to copy the files because the user explicitly ask to use the original CXX file.
+                    set_source_files_properties(${_file} PROPERTIES LANGUAGE CUDA)
+                endif()
             endif()
         endif()
         if(NOT index_hip EQUAL -1)
@@ -188,15 +198,20 @@ function(alpaka_internal_finalize target)
                 OR (${_file} MATCHES "\\.cc$")
                 OR (${_file} MATCHES "\\.hip$")
             )
-                copy_with_structure(${_file} "hip" COPIED_FILE)
-                set_source_files_properties(${COPIED_FILE} PROPERTIES LANGUAGE HIP)
-                list(REMOVE_ITEM _new_file_list ${_file})
-                list(APPEND _new_file_list ${COPIED_FILE})
+                if(alpaka_LANGUAGE_SEPARATION)
+                    copy_with_structure(${_file} "hip" COPIED_FILE)
+                    set_source_files_properties(${COPIED_FILE} PROPERTIES LANGUAGE HIP)
+                    list(REMOVE_ITEM _new_file_list ${_file})
+                    list(APPEND _new_file_list ${COPIED_FILE})
+                    # Update the list of files for the target
+                    set_property(TARGET ${target} PROPERTY SOURCES ${_new_file_list})
+                else()
+                    # We do not need to copy the files because the user explicitly ask to use the original CXX file.
+                    set_source_files_properties(${_file} PROPERTIES LANGUAGE HIP)
+                endif()
             endif()
         endif()
     endforeach()
-    # Update the list of files for the target
-    set_property(TARGET ${target} PROPERTY SOURCES ${_new_file_list})
 
     ### Set target properties
     ##

--- a/docs/source/advanced/cmake.rst
+++ b/docs/source/advanced/cmake.rst
@@ -158,6 +158,14 @@ Arguments
      - `STDSIMD`   - enforce that the CXX compiler supports `std::simd`, if not CMake will fail
      - `EMULATION` - disable the usage of `std::simd` even if supported by the CXX compiler
 
+``alpaka_LANGUAGE_SEPARATION``
+  .. code-block:: markdown
+
+     Enable that C++ files for CUDA and HIP will be copied to an unique folder and compiled from there, instead of using the original file.
+     If this option is set to ``OFF`` and and the same C++ file is used twice in the project within two different CMake targets where one is linking against ``alpaka::host`` and the other to ``alpaka::cuda`` or ``alpaka::hip`` both will use the CUDA/HIP compiler for compilation.
+     In the default case where the option is set to ``ON`` one target is compiled with the native CXX compiler and the other with the CUDA/HIP compiler.
+     CUDA/HIP compiler have sometimes problems to compile any C++ code, therefor try to avoid setting this option to ``OFF`` because you lose the possibility to root heterogeneous code to the native CXX compiler.
+
 Host
 ^^^^
 

--- a/docs/source/advanced/cmake.rst
+++ b/docs/source/advanced/cmake.rst
@@ -166,6 +166,8 @@ Arguments
      In the default case where the option is set to ``ON`` one target is compiled with the native CXX compiler and the other with the CUDA/HIP compiler.
      CUDA/HIP compiler have sometimes problems to compile any C++ code, therefor try to avoid setting this option to ``OFF`` because you lose the possibility to root heterogeneous code to the native CXX compiler.
 
+     **Attention:** Only when this option is enabled can the same source code file be compiled and linked for multiple APIs (CUDA, HIP, ...) within the same build.
+
 Host
 ^^^^
 


### PR DESCRIPTION
alpaka is copying CUDA and HIP ``cpp`` file to a unique location to apply the CMake language to a file.
This allows to compile the same file with different languages. When a IDE is used, this could be cumbersome if you want to click on a file shown in the compiler output and it opens the copied file. The option allows to disabling the separation of languages in `alpaka_finalize()`.

This PR based on a request from our users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `alpaka_LANGUAGE_SEPARATION` CMake option (enabled by default) to control whether CUDA/HIP compilation uses copied sources in a dedicated folder.
  * When enabled, CUDA and HIP are built from separate prepared sources; when disabled, the original source locations are used with compiler language selection.

* **Documentation**
  * Documented the new `alpaka_LANGUAGE_SEPARATION` option, including how it affects CUDA/HIP builds and cases where the same source is compiled for multiple APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->