### PR TITLE
add timed queue and events

### DIFF
--- a/docs/snippets/example/165_eventTiming.cpp
+++ b/docs/snippets/example/165_eventTiming.cpp
@@ -1,0 +1,47 @@
+/* Copyright 2026 Tim Hanel
+ * SPDX-License-Identifier: ISC
+ */
+
+#include "docsTest.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+
+using namespace alpaka;
+
+struct TimedKernel
+{
+    ALPAKA_FN_ACC void operator()(onAcc::concepts::Acc auto const&) const
+    {
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("tutorial event timing", "[docs]", docs::test::TestBackends)
+{
+    auto selector = onHost::makeDeviceSelector(TestType::makeDict());
+    if(!selector.isAvailable())
+        return;
+    auto device = selector.makeDevice(0);
+
+    // BEGIN-TUTORIAL-eventTiming
+    // Timing is an explicit queue capability and is disabled by default.
+    auto queue = device.makeQueue(queueKind::nonBlocking, timing::enabled);
+    auto start = device.makeEvent(timing::enabled);
+    auto end = device.makeEvent(timing::enabled);
+
+    auto const frameSpec = onHost::getFrameSpec(device, alpaka::getExecutor(TestType::makeDict()), Vec{1u});
+
+    queue.enqueue(start);
+    queue.enqueue(frameSpec, KernelBundle{TimedKernel{}});
+    queue.enqueue(end);
+
+    // This waits for the end marker and returns a duration expressed in seconds.
+    auto const elapsed = onHost::getElapsedTime(start, end);
+    // END-TUTORIAL-eventTiming
+
+    CHECK(elapsed >= std::chrono::duration<double>::zero());
+}

--- a/docs/source/tutorial/events.rst
+++ b/docs/source/tutorial/events.rst
@@ -37,6 +37,29 @@ It is possible that ``queue1`` increments the value ``valueA`` before ``valueA``
     :end-before: END-TUTORIAL-event
     :dedent:
 
+Measuring Queued Work
+---------------------
+
+Timing is an explicit queue capability and is disabled by default. Events can independently be constructed with
+``timing::enabled`` or ``timing::disabled``; ``queue.makeEvent()`` is also available as a convenience that inherits the
+queue's capability. A timing-enabled event can only be enqueued on a timing-enabled queue. This rule is the same for
+every API, even where a native backend would technically allow a timed event on an ordinary queue.
+
+The elapsed time is obtained from backend event information. CUDA and HIP use native event timestamps, SYCL uses
+profiling timestamps from its profiling-enabled queue, and the host backend records a monotonic timestamp when each
+event marker is reached.
+
+  .. literalinclude:: ../../snippets/example/165_eventTiming.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-eventTiming
+    :end-before: END-TUTORIAL-eventTiming
+    :dedent:
+
+``onHost::getElapsedTime()`` returns a ``std::chrono::duration<double>``. The measured interval excludes the timing
+markers themselves and includes all queue work between them. Consequently, a host task placed between the markers is
+part of the queue elapsed time even though it is not GPU-active time. The result is always calculated as
+``end - start``. If the end marker is reached before the start marker, the returned duration is negative.
+
 Complete Source File
 --------------------
 

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -140,7 +140,7 @@ namespace alpaka::onHost
 
             friend struct internal::MakeQueue;
 
-            Handle<cpu::Queue<Device>> makeQueue(alpaka::concepts::QueueKind auto kind)
+            Handle<cpu::Queue<Device>> makeQueue(alpaka::concepts::QueueKind auto kind, alpaka::concepts::Timing auto)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
                 static_assert(
@@ -168,12 +168,12 @@ namespace alpaka::onHost
 
             friend struct internal::MakeEvent;
 
-            Handle<cpu::Event<Device>> makeEvent()
+            Handle<cpu::Event<Device>> makeEvent(alpaka::concepts::Timing auto timingMode)
             {
                 ALPAKA_LOG_FUNCTION(alpaka::onHost::logger::event);
                 auto thisHandle = this->getSharedPtr();
                 std::lock_guard<std::mutex> lk{queuesGuard};
-                auto newEvent = std::make_shared<cpu::Event<Device>>(std::move(thisHandle), events.size());
+                auto newEvent = std::make_shared<cpu::Event<Device>>(std::move(thisHandle), events.size(), timingMode);
 
                 events.emplace_back(newEvent);
                 return newEvent;

--- a/include/alpaka/api/host/Event.hpp
+++ b/include/alpaka/api/host/Event.hpp
@@ -12,6 +12,7 @@
 #include "alpaka/onHost/internal/interface.hpp"
 #include "alpaka/onHost/logger/logger.hpp"
 
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <future>
@@ -25,9 +26,13 @@ namespace alpaka::onHost
         struct Event : std::enable_shared_from_this<Event<T_Device>>
         {
         public:
-            Event(internal::concepts::DeviceHandle auto device, uint32_t const idx)
+            Event(
+                internal::concepts::DeviceHandle auto device,
+                uint32_t const idx,
+                alpaka::concepts::Timing auto timingMode)
                 : m_device(std::move(device))
                 , m_idx(idx)
+                , m_timingEnabled(timingMode == timing::enabled)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::event);
             }
@@ -69,6 +74,8 @@ namespace alpaka::onHost
             //!< (not enqueued or already completed). If m_enqueueCount ==
             //!< m_LastReadyEnqueueCount, the event is currently not enqueued
             std::size_t m_LastReadyEnqueueCount = 0u;
+            bool m_timingEnabled = false;
+            std::chrono::steady_clock::time_point m_timestamp;
 
             friend struct alpaka::internal::GetName;
 
@@ -127,6 +134,8 @@ namespace alpaka::onHost
 
             friend struct internal::WaitFor;
             friend struct internal::Wait;
+            template<typename, typename>
+            friend struct internal::GetElapsedTime::Op;
 
             void wait()
             {
@@ -145,7 +154,34 @@ namespace alpaka::onHost
 
             friend struct alpaka::internal::GetApi;
         };
+
     } // namespace cpu
+
+    template<typename T_Device>
+    struct internal::GetElapsedTime::Op<cpu::Event<T_Device>, cpu::Event<T_Device>>
+    {
+        auto operator()(cpu::Event<T_Device>& start, cpu::Event<T_Device>& end) const -> std::chrono::duration<double>
+        {
+            start.wait();
+            end.wait();
+            if(&start == &end)
+            {
+                std::lock_guard<std::mutex> lock{start.m_mutex};
+                if(start.m_enqueueCount == 0u)
+                    throw std::logic_error{"Elapsed time requires recorded events"};
+                if(!start.m_timingEnabled)
+                    throw std::logic_error{"Elapsed time requires timing-enabled events"};
+                return std::chrono::duration<double>::zero();
+            }
+
+            std::scoped_lock lock{start.m_mutex, end.m_mutex};
+            if(start.m_enqueueCount == 0u || end.m_enqueueCount == 0u)
+                throw std::logic_error{"Elapsed time requires recorded events"};
+            if(!start.m_timingEnabled || !end.m_timingEnabled)
+                throw std::logic_error{"Elapsed time requires timing-enabled events"};
+            return end.m_timestamp - start.m_timestamp;
+        }
+    };
 } // namespace alpaka::onHost
 
 namespace alpaka::internal

--- a/include/alpaka/api/host/OmpCollectiveQueue.hpp
+++ b/include/alpaka/api/host/OmpCollectiveQueue.hpp
@@ -312,10 +312,10 @@ namespace alpaka::onHost
             /** @} */
         } // namespace omp
 
-        template<typename T_Platform>
-        struct MakeQueue::Op<cpu::Device<T_Platform>, alpaka::queueKind::OmpCollective>
+        template<typename T_Platform, alpaka::concepts::Timing T_Timing>
+        struct MakeQueue::Op<cpu::Device<T_Platform>, alpaka::queueKind::OmpCollective, T_Timing>
         {
-            auto operator()(cpu::Device<T_Platform>& device, alpaka::queueKind::OmpCollective) const
+            auto operator()(cpu::Device<T_Platform>& device, alpaka::queueKind::OmpCollective, T_Timing) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
                 auto queueHandle = device.getSharedPtr();

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -318,6 +318,8 @@ namespace alpaka::onHost
                         // Nothing to do if it has been re-enqueued to a later position in the queue.
                         if(enqueueCount == event.m_enqueueCount)
                         {
+                            if(event.m_timingEnabled)
+                                event.m_timestamp = std::chrono::steady_clock::now();
                             event.m_LastReadyEnqueueCount = std::max(enqueueCount, event.m_LastReadyEnqueueCount);
                         }
                         // apply a fulfilled future
@@ -332,11 +334,14 @@ namespace alpaka::onHost
                         event.m_future = queue.submit(
                             [sharedEvent, enqueueCount]() mutable
                             {
+                                auto const timestamp = std::chrono::steady_clock::now();
                                 std::unique_lock<std::mutex> lk2(sharedEvent->m_mutex);
 
                                 // Nothing to do if it has been re-enqueued to a later position in the queue.
                                 if(enqueueCount == sharedEvent->m_enqueueCount)
                                 {
+                                    if(sharedEvent->m_timingEnabled)
+                                        sharedEvent->m_timestamp = timestamp;
                                     sharedEvent->m_LastReadyEnqueueCount
                                         = std::max(enqueueCount, sharedEvent->m_LastReadyEnqueueCount);
                                 }

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -54,7 +54,9 @@ namespace alpaka::onHost
                 return this->shared_from_this();
             }
 
-            [[nodiscard]] Handle<syclGeneric::Queue<Device>> makeQueue(alpaka::concepts::QueueKind auto kind)
+            [[nodiscard]] Handle<syclGeneric::Queue<Device>> makeQueue(
+                alpaka::concepts::QueueKind auto kind,
+                alpaka::concepts::Timing auto timingMode)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue + onHost::logger::device);
                 static_assert(
@@ -64,8 +66,11 @@ namespace alpaka::onHost
                 std::lock_guard<std::mutex> lk{m_writeGuard};
 
                 constexpr bool isBlocking = kind == queueKind::blocking;
-                auto newQueue
-                    = std::make_shared<syclGeneric::Queue<Device>>(std::move(thisHandle), queues.size(), isBlocking);
+                auto newQueue = std::make_shared<syclGeneric::Queue<Device>>(
+                    std::move(thisHandle),
+                    queues.size(),
+                    isBlocking,
+                    timingMode);
 
                 queues.emplace_back(newQueue);
                 return newQueue;
@@ -97,12 +102,13 @@ namespace alpaka::onHost
         private:
             friend struct internal::MakeEvent;
 
-            Handle<syclGeneric::Event<Device>> makeEvent()
+            Handle<syclGeneric::Event<Device>> makeEvent(alpaka::concepts::Timing auto timingMode)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::event + onHost::logger::device);
                 auto thisHandle = this->getSharedPtr();
                 std::lock_guard<std::mutex> lk{m_writeGuard};
-                auto newEvent = std::make_shared<syclGeneric::Event<Device>>(std::move(thisHandle), events.size());
+                auto newEvent
+                    = std::make_shared<syclGeneric::Event<Device>>(std::move(thisHandle), events.size(), timingMode);
 
                 events.emplace_back(newEvent);
                 return newEvent;

--- a/include/alpaka/api/syclGeneric/Event.hpp
+++ b/include/alpaka/api/syclGeneric/Event.hpp
@@ -21,6 +21,8 @@
 
 #    include <sycl/sycl.hpp>
 
+#    include <chrono>
+
 namespace alpaka::onHost
 {
     namespace syclGeneric
@@ -32,7 +34,7 @@ namespace alpaka::onHost
             friend struct alpaka::internal::GetApi;
 
         public:
-            Event(internal::concepts::DeviceHandle auto device, uint32_t const idx)
+            Event(internal::concepts::DeviceHandle auto device, uint32_t const idx, alpaka::concepts::Timing auto)
                 : m_device(std::move(device))
                 , m_idx(idx)
             {
@@ -119,6 +121,9 @@ namespace alpaka::onHost
             friend struct internal::WaitFor;
             friend struct internal::Wait;
 
+            template<typename, typename>
+            friend struct internal::GetElapsedTime::Op;
+
             void setEvent(sycl::event const& event)
             {
                 std::unique_lock<std::shared_mutex> lock{m_eventGuard};
@@ -142,6 +147,27 @@ namespace alpaka::onHost
 
 
     } // namespace syclGeneric
+
+    template<typename T_Device>
+    struct internal::GetElapsedTime::Op<syclGeneric::Event<T_Device>, syclGeneric::Event<T_Device>>
+    {
+        auto operator()(syclGeneric::Event<T_Device>& start, syclGeneric::Event<T_Device>& end) const
+            -> std::chrono::duration<double>
+        {
+            start.wait();
+            end.wait();
+            if(&start == &end)
+                return std::chrono::duration<double>::zero();
+
+            auto const startEnd
+                = start.getEvent().template get_profiling_info<sycl::info::event_profiling::command_end>();
+            auto const endStart
+                = end.getEvent().template get_profiling_info<sycl::info::event_profiling::command_start>();
+            if(endStart < startEnd)
+                return -std::chrono::duration<double, std::nano>{startEnd - endStart};
+            return std::chrono::duration<double, std::nano>{endStart - startEnd};
+        }
+    };
 } // namespace alpaka::onHost
 
 namespace alpaka::internal

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -175,11 +175,16 @@ namespace alpaka::onHost
 
 
         public:
-            Queue(internal::concepts::DeviceHandle auto device, uint32_t const idx, bool isBlocking)
+            Queue(
+                internal::concepts::DeviceHandle auto device,
+                uint32_t const idx,
+                bool isBlocking,
+                alpaka::concepts::Timing auto timingMode)
                 : m_device(std::move(device))
                 , m_SharedNativeQueue{std::make_shared<NativeQueue>(
                       onHost::getNativeHandle(m_device).first,
-                      onHost::getNativeHandle(m_device).second)}
+                      onHost::getNativeHandle(m_device).second,
+                      timingMode)}
                 , m_sharedCallbackThread{std::make_shared<alpaka::core::CallbackThread>()}
                 , m_idx(idx)
                 , m_isBlocking(isBlocking)
@@ -309,8 +314,17 @@ namespace alpaka::onHost
              */
             struct NativeQueue
             {
-                NativeQueue(sycl::device device, sycl::context context)
+                NativeQueue(sycl::device device, sycl::context context, timing::Disabled)
                     : m_queue(context, device, {sycl::property::queue::in_order{}})
+                {
+                    ALPAKA_LOG_FUNCTION(onHost::logger::queue);
+                }
+
+                NativeQueue(sycl::device device, sycl::context context, timing::Enabled)
+                    : m_queue(
+                          context,
+                          device,
+                          {sycl::property::queue::in_order{}, sycl::property::queue::enable_profiling{}})
                 {
                     ALPAKA_LOG_FUNCTION(onHost::logger::queue);
                 }

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -106,7 +106,9 @@ namespace alpaka::onHost
 
             friend struct onHost::internal::MakeQueue;
 
-            Handle<unifiedCudaHip::Queue<Device>> makeQueue(alpaka::concepts::QueueKind auto kind)
+            Handle<unifiedCudaHip::Queue<Device>> makeQueue(
+                alpaka::concepts::QueueKind auto kind,
+                alpaka::concepts::Timing auto)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
                 static_assert(
@@ -127,12 +129,15 @@ namespace alpaka::onHost
 
             friend struct onHost::internal::MakeEvent;
 
-            Handle<unifiedCudaHip::Event<Device>> makeEvent()
+            Handle<unifiedCudaHip::Event<Device>> makeEvent(alpaka::concepts::Timing auto timingMode)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::event);
                 auto thisHandle = this->getSharedPtr();
                 std::lock_guard<std::mutex> lk{m_writeGuard};
-                auto newEvent = std::make_shared<unifiedCudaHip::Event<Device>>(std::move(thisHandle), events.size());
+                auto newEvent = std::make_shared<unifiedCudaHip::Event<Device>>(
+                    std::move(thisHandle),
+                    events.size(),
+                    timingMode);
 
                 events.emplace_back(newEvent);
                 return newEvent;

--- a/include/alpaka/api/unifiedCudaHip/Event.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Event.hpp
@@ -28,6 +28,7 @@
 
 #    include "alpaka/core/ApiCudaRt.hpp"
 
+#    include <chrono>
 #    include <cstdint>
 #    include <sstream>
 
@@ -41,7 +42,10 @@ namespace alpaka::onHost
             using ApiInterface = typename T_Device::ApiInterface;
 
         public:
-            Event(internal::concepts::DeviceHandle auto device, uint32_t const idx)
+            Event(
+                internal::concepts::DeviceHandle auto device,
+                uint32_t const idx,
+                alpaka::concepts::Timing auto timingMode)
                 : m_device(std::move(device))
                 , m_idx(idx)
             {
@@ -65,7 +69,9 @@ namespace alpaka::onHost
                     ApiInterface,
                     ApiInterface::eventCreateWithFlags(
                         &m_nativeEvent,
-                        ApiInterface::eventDefault | ApiInterface::eventDisableTiming));
+                        timingMode == timing::enabled
+                            ? ApiInterface::eventDefault
+                            : ApiInterface::eventDefault | ApiInterface::eventDisableTiming));
             }
 
             ~Event()
@@ -154,10 +160,30 @@ namespace alpaka::onHost
 
             friend struct onHost::internal::GetDevice;
 
+            template<typename, typename>
+            friend struct onHost::internal::GetElapsedTime::Op;
+
             friend struct alpaka::internal::GetApi;
         };
 
     } // namespace unifiedCudaHip
+
+    template<typename T_Device>
+    struct internal::GetElapsedTime::Op<unifiedCudaHip::Event<T_Device>, unifiedCudaHip::Event<T_Device>>
+    {
+        auto operator()(unifiedCudaHip::Event<T_Device>& start, unifiedCudaHip::Event<T_Device>& end) const
+            -> std::chrono::duration<double>
+        {
+            start.wait();
+            end.wait();
+            auto milliseconds = 0.0F;
+            using ApiInterface = typename T_Device::ApiInterface;
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                ApiInterface,
+                ApiInterface::eventElapsedTime(&milliseconds, start.getNativeHandle(), end.getNativeHandle()));
+            return std::chrono::duration<double, std::milli>{static_cast<double>(milliseconds)};
+        }
+    };
 } // namespace alpaka::onHost
 
 namespace alpaka::internal

--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -157,6 +157,11 @@ namespace alpaka
             return ::cudaEventDestroy(event);
         }
 
+        static inline Error_t eventElapsedTime(float* milliseconds, Event_t start, Event_t end)
+        {
+            return ::cudaEventElapsedTime(milliseconds, start, end);
+        }
+
         static inline Error_t eventQuery(Event_t event)
         {
             return ::cudaEventQuery(event);

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -173,6 +173,11 @@ namespace alpaka
             return ::hipEventDestroy(event);
         }
 
+        static inline Error_t eventElapsedTime(float* milliseconds, Event_t start, Event_t end)
+        {
+            return ::hipEventElapsedTime(milliseconds, start, end);
+        }
+
         static inline Error_t eventQuery(Event_t event)
         {
             return ::hipEventQuery(event);

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -89,30 +89,69 @@ namespace alpaka::onHost
          * Running tasks from different tasks sequentially is valid behavior. Enqueuing into two individual queues only
          * signifies that the tasks are independent of each other and their order of execution is independent.
          *
-         * @param kind
-         *   Blocking behaviour:
-         *    - queueKind::nonBlocking (default): enqueue returns immediately; completion of the enqueued operation
-         * must be ensured via onHost::wait(queue) or by enqueuing dependent operations onto the same queue.
-         *    - queueKind::blocking: each enqueue only returns after the operation is complete and its effects are
-         * host-visible.
+         * By default, the queue is non-blocking and timing is disabled. It accepts synchronization-only events, which
+         * do not provide timing information.
          *
          * @return A onHost::Queue that tasks and memory operations can be enqueued on.
          */
-        auto makeQueue(alpaka::concepts::QueueKind auto kind)
-        {
-            return Queue{
-                internal::MakeQueue::Op<ALPAKA_TYPEOF(*m_device.get()), ALPAKA_TYPEOF(kind)>{}(*m_device.get(), kind),
-                kind};
-        }
-
         auto makeQueue()
         {
             return makeQueue(queueKind::nonBlocking);
         }
 
+        /** @copydoc makeQueue()
+         *
+         * @param kind
+         *   Blocking behaviour:
+         *    - queueKind::nonBlocking: enqueue returns immediately; completion of the enqueued operation
+         * must be ensured via onHost::wait(queue) or by enqueuing dependent operations onto the same queue.
+         *    - queueKind::blocking: each enqueue only returns after the operation is complete and its effects are
+         * host-visible.
+         */
+        auto makeQueue(alpaka::concepts::QueueKind auto kind)
+        {
+            return makeQueue(kind, timing::disabled);
+        }
+
+        /** @copydoc makeQueue(alpaka::concepts::QueueKind auto kind)
+         *
+         * @param timingMode Specifies whether the queue supports timing-enabled events.
+         */
+        auto makeQueue(alpaka::concepts::QueueKind auto kind, alpaka::concepts::Timing auto timingMode)
+        {
+            return Queue{
+                internal::MakeQueue::
+                    Op<ALPAKA_TYPEOF(*m_device.get()), ALPAKA_TYPEOF(kind), ALPAKA_TYPEOF(timingMode)>{}(
+                        *m_device.get(),
+                        kind,
+                        timingMode),
+                kind,
+                timingMode};
+        }
+
+        /** Create an event with an explicit timing capability.
+         *
+         * Timing-enabled events can only be enqueued on timing-enabled queues.
+         *
+         * @param timingMode Specifies whether the event records timing information.
+         */
+        auto makeEvent(alpaka::concepts::Timing auto timingMode)
+        {
+            return Event{
+                internal::MakeEvent::Op<ALPAKA_TYPEOF(*m_device.get()), ALPAKA_TYPEOF(timingMode)>{}(
+                    *m_device.get(),
+                    timingMode),
+                timingMode};
+        }
+
+        /** Create a synchronization-only event.
+         *
+         * Timing support is by default disabled:
+         *
+         */
         auto makeEvent()
         {
-            return Event{internal::MakeEvent::Op<std::decay_t<decltype(*m_device.get())>>{}(*m_device.get())};
+            return makeEvent(timing::disabled);
         }
 
         /** Blocks the caller until the given handle executes all work
@@ -219,9 +258,13 @@ namespace alpaka::onHost
      * @param queue queue handle
      * @param extents number of elements for each dimension
      */
-    template<typename T_Type, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename T_Type,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     inline auto allocUnified(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
         Vec const extentsVec = extents;
@@ -260,9 +303,13 @@ namespace alpaka::onHost
      * @param queue queue handle
      * @param extents number of elements for each dimension
      */
-    template<typename T_Type, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename T_Type,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     inline auto allocMapped(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
         return allocMapped<T_Type>(queue.getDevice(), extents);
@@ -309,8 +356,10 @@ namespace alpaka::onHost
      *
      * @param queue queue handle
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
-    inline bool isDataAccessible(Queue<T_Device, T_QueueKind> const& queue, alpaka::concepts::IView auto const& view)
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
+    inline bool isDataAccessible(
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        alpaka::concepts::IView auto const& view)
     {
         return internal::IsDataAccessible::FirstPath<ALPAKA_TYPEOF(*queue.getDevice().get()), ALPAKA_TYPEOF(view)>{}(
                    *queue.getDevice().get(),

--- a/include/alpaka/onHost/Event.hpp
+++ b/include/alpaka/onHost/Event.hpp
@@ -8,24 +8,27 @@
 #include "alpaka/api/trait.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
 
+#include <chrono>
 #include <memory>
+#include <stdexcept>
 
 namespace alpaka::onHost
 {
     template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     struct Device;
 
-    template<typename T_Device>
+    template<typename T_Device, alpaka::concepts::Timing T_Timing = timing::Disabled>
     struct Event;
 
-    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
-    struct Event<Device<T_Api, T_DeviceKind>>
+    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind, alpaka::concepts::Timing T_Timing>
+    struct Event<Device<T_Api, T_DeviceKind>, T_Timing>
     {
     private:
         using DeviceInterface = Device<T_Api, T_DeviceKind>;
         using EventHandle = ALPAKA_TYPEOF(
-            internal::MakeEvent::Op<ALPAKA_TYPEOF(*std::declval<DeviceInterface>().get())>{}(
-                *std::declval<DeviceInterface>().get()));
+            internal::MakeEvent::Op<ALPAKA_TYPEOF(*std::declval<DeviceInterface>().get()), T_Timing>{}(
+                *std::declval<DeviceInterface>().get(),
+                T_Timing{}));
 
         EventHandle m_event;
 
@@ -33,7 +36,13 @@ namespace alpaka::onHost
         using element_type = typename EventHandle::element_type;
 
         template<typename T_Event>
-        Event(Handle<T_Event>&& event) : m_event{std::forward<Handle<T_Event>>(event)}
+        Event(Handle<T_Event>&& event, T_Timing) : m_event{std::forward<Handle<T_Event>>(event)}
+        {
+        }
+
+        template<typename T_Event>
+        Event(Handle<T_Event>&& event) requires std::same_as<T_Timing, timing::Disabled>
+            : Event{std::forward<Handle<T_Event>>(event), timing::disabled}
         {
         }
 
@@ -45,6 +54,11 @@ namespace alpaka::onHost
         constexpr auto getApi() const
         {
             return alpaka::internal::getApi(*m_event.get());
+        }
+
+        constexpr alpaka::concepts::Timing auto getTiming() const
+        {
+            return T_Timing{};
         }
 
         std::string getName() const
@@ -82,9 +96,37 @@ namespace alpaka::onHost
         }
     };
 
+    template<typename T_Event, alpaka::concepts::Timing T_Timing>
+    Event(Handle<T_Event>&&, T_Timing) -> Event<
+        Device<
+            ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Event>())),
+            ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Event>()))>,
+        T_Timing>;
+
     template<typename T_Event>
     Event(Handle<T_Event>&&) -> Event<Device<
         ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Event>())),
         ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Event>()))>>;
+
+    /** Return the elapsed time between two timing-enabled queue markers.
+     *
+     * Both events must have been recorded on timing-enabled queues belonging to
+     * the same device. Timing-disabled events intentionally have no overload.
+     * The returned duration is always calculated as `end - start`. The events do
+     * not need to be chronologically ordered; the duration is negative if the end
+     * marker is reached before the start marker.
+     */
+    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
+    auto getElapsedTime(
+        Event<Device<T_Api, T_DeviceKind>, timing::Enabled> const& start,
+        Event<Device<T_Api, T_DeviceKind>, timing::Enabled> const& end) -> std::chrono::duration<double>
+    {
+        if(start.getDevice() != end.getDevice())
+            throw std::invalid_argument{"Elapsed time requires events from the same device"};
+
+        return internal::GetElapsedTime::Op<ALPAKA_TYPEOF(*start.get()), ALPAKA_TYPEOF(*end.get())>{}(
+            *start.get(),
+            *end.get());
+    }
 
 } // namespace alpaka::onHost

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -20,21 +20,26 @@ namespace alpaka::onHost
     template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     struct Device;
 
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing = timing::Disabled>
     struct Queue;
 
     template<
         alpaka::concepts::Api T_Api,
         alpaka::concepts::DeviceKind T_DeviceKind,
-        alpaka::concepts::QueueKind T_QueueKind>
-    struct Queue<Device<T_Api, T_DeviceKind>, T_QueueKind>
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
+    struct Queue<Device<T_Api, T_DeviceKind>, T_QueueKind, T_Timing>
     {
     private:
         using DeviceInterface = Device<T_Api, T_DeviceKind>;
         using QueueHandle = ALPAKA_TYPEOF(
-            internal::MakeQueue::Op<ALPAKA_TYPEOF(*std::declval<DeviceInterface>().get()), T_QueueKind>{}(
+            internal::MakeQueue::Op<ALPAKA_TYPEOF(*std::declval<DeviceInterface>().get()), T_QueueKind, T_Timing>{}(
                 *std::declval<DeviceInterface>().get(),
-                T_QueueKind{}));
+                T_QueueKind{},
+                T_Timing{}));
 
         QueueHandle m_queue;
 
@@ -42,7 +47,13 @@ namespace alpaka::onHost
         using element_type = typename QueueHandle::element_type;
 
         template<typename T_Queue>
-        Queue(Handle<T_Queue>&& queue, T_QueueKind) : m_queue{std::forward<Handle<T_Queue>>(queue)}
+        Queue(Handle<T_Queue>&& queue, T_QueueKind, T_Timing) : m_queue{std::forward<Handle<T_Queue>>(queue)}
+        {
+        }
+
+        template<typename T_Queue>
+        Queue(Handle<T_Queue>&& queue, T_QueueKind) requires std::same_as<T_Timing, timing::Disabled>
+            : Queue{std::forward<Handle<T_Queue>>(queue), T_QueueKind{}, timing::disabled}
         {
         }
 
@@ -59,6 +70,11 @@ namespace alpaka::onHost
         constexpr alpaka::concepts::QueueKind auto getQueueKind() const
         {
             return T_QueueKind{};
+        }
+
+        constexpr alpaka::concepts::Timing auto getTiming() const
+        {
+            return T_Timing{};
         }
 
         constexpr alpaka::concepts::DeviceKind auto getDeviceKind() const
@@ -98,6 +114,17 @@ namespace alpaka::onHost
         auto getDevice() const
         {
             return Device<T_Api, T_DeviceKind>{internal::getDevice(*m_queue.get())};
+        }
+
+        /** Create an event carrying this queue's timing capability.
+         *
+         * An event created by a timing-enabled queue can only be enqueued on
+         * another timing-enabled queue.
+         */
+        auto makeEvent() const
+        {
+            auto device = getDevice();
+            return device.makeEvent(T_Timing{});
         }
 
         /** Enqueue a kernel functor to a queue.
@@ -206,7 +233,9 @@ namespace alpaka::onHost
          *
          * @param event Event that is to be enqueue in the queue of operations.
          */
-        void enqueue(Event<Device<T_Api, T_DeviceKind>> const& event) const
+        template<alpaka::concepts::Timing T_EventTiming>
+        requires(std::same_as<T_EventTiming, timing::Disabled> || std::same_as<T_Timing, timing::Enabled>)
+        void enqueue(Event<Device<T_Api, T_DeviceKind>, T_EventTiming> const& event) const
         {
             internal::Enqueue::Event<ALPAKA_TYPEOF(*m_queue.get()), ALPAKA_TYPEOF(*event.get())>{}(
                 *m_queue.get(),
@@ -217,7 +246,8 @@ namespace alpaka::onHost
          *
          * The caller will be blocked until all previously queued operations have been completed.
          */
-        void waitFor(Event<Device<T_Api, T_DeviceKind>> const& event) const
+        template<alpaka::concepts::Timing T_EventTiming>
+        void waitFor(Event<Device<T_Api, T_DeviceKind>, T_EventTiming> const& event) const
         {
             internal::waitFor(*m_queue.get(), *event.get());
         }
@@ -236,6 +266,14 @@ namespace alpaka::onHost
             return internal::isQueueEmpty(*m_queue.get());
         }
     };
+
+    template<typename T_Queue, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
+    Queue(Handle<T_Queue>&&, T_QueueKind, T_Timing) -> Queue<
+        Device<
+            ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Queue>())),
+            ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Queue>()))>,
+        T_QueueKind,
+        T_Timing>;
 
     template<typename T_Queue, alpaka::concepts::QueueKind T_QueueKind>
     Queue(Handle<T_Queue>&&, T_QueueKind) -> Queue<
@@ -257,8 +295,8 @@ namespace alpaka::onHost
      * @param[in,out] dest can be a container/view where the data should be written to
      * @param[in] source can be a container/view from which the data will be copied
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
-    inline void memcpy(Queue<T_Device, T_QueueKind> const& queue, auto&& dest, auto const& source)
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
+    inline void memcpy(Queue<T_Device, T_QueueKind, T_Timing> const& queue, auto&& dest, auto const& source)
     {
         memcpy(queue, ALPAKA_FORWARD(dest), source, internal::getExtents(dest));
     }
@@ -270,9 +308,9 @@ namespace alpaka::onHost
      * @param[in] source can be a container/view from which the data will be copied
      * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
     inline void memcpy(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         auto&& dest,
         auto const& source,
         alpaka::concepts::VectorOrScalar auto const& extents)
@@ -291,9 +329,14 @@ namespace alpaka::onHost
      * @param[in,out] dest must be device global memory on the device of the queue the data should be written to
      * @param[in] source can be a container/view or host accessible pointer from which the data will be copied
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, typename T_Storage, typename T>
+    template<
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing,
+        typename T_Storage,
+        typename T>
     inline void memcpy(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> dest,
         auto&& source)
     {
@@ -309,9 +352,14 @@ namespace alpaka::onHost
      * @param[in,out] dest can be a container/view or host accessible pointer the data should be written to
      * @param[in] source must be device global memory on the device of the queue from which the data will be copied
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, typename T_Storage, typename T>
+    template<
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing,
+        typename T_Storage,
+        typename T>
     inline void memcpy(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         auto&& dest,
         onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> source)
     {
@@ -329,8 +377,8 @@ namespace alpaka::onHost
      * is finished.
      * @param byteValue value to be written to each byte
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
-    inline void memset(Queue<T_Device, T_QueueKind> const& queue, auto&& dest, uint8_t byteValue)
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
+    inline void memset(Queue<T_Device, T_QueueKind, T_Timing> const& queue, auto&& dest, uint8_t byteValue)
     {
         memset(queue, ALPAKA_FORWARD(dest), byteValue, internal::getExtents(dest));
     }
@@ -344,9 +392,9 @@ namespace alpaka::onHost
      * @param byteValue value to be written to each byte
      * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
     inline void memset(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         auto&& dest,
         uint8_t byteValue,
         alpaka::concepts::VectorOrScalar auto const& extents)
@@ -366,8 +414,12 @@ namespace alpaka::onHost
      * is finished.
      * @param elementValue value to be written to each element
      */
-    template<typename T_Value, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
-    inline void fill(Queue<T_Device, T_QueueKind> const& queue, auto&& dest, T_Value elementValue) requires(
+    template<
+        typename T_Value,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
+    inline void fill(Queue<T_Device, T_QueueKind, T_Timing> const& queue, auto&& dest, T_Value elementValue) requires(
         std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
         && std::same_as<ALPAKA_TYPEOF(alpaka::internal::getApi(queue)), ALPAKA_TYPEOF(alpaka::internal::getApi(dest))>)
     {
@@ -384,9 +436,13 @@ namespace alpaka::onHost
      * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
      */
 
-    template<typename T_Value, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename T_Value,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     inline void fill(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         auto&& dest,
         T_Value elementValue,
         alpaka::concepts::VectorOrScalar auto const& extents)
@@ -430,9 +486,13 @@ namespace alpaka::onHost
      * memory is destroyed. The deallocation is asynchronous performed in the queue which is used for the
      * allocation.
      */
-    template<typename T_Type, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename T_Type,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     inline auto allocDeferred(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
         Vec const extentsVec = extents;
@@ -460,8 +520,8 @@ namespace alpaka::onHost
      * memory is destroyed. The deallocation is asynchronous performed in the queue which is used for the
      * allocation.
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
-    inline auto allocLikeDeferred(Queue<T_Device, T_QueueKind> const& queue, auto const& view)
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
+    inline auto allocLikeDeferred(Queue<T_Device, T_QueueKind, T_Timing> const& queue, auto const& view)
     {
         return allocDeferred<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(queue, internal::getExtents(view));
     }

--- a/include/alpaka/onHost/algo/concurrent.hpp
+++ b/include/alpaka/onHost/algo/concurrent.hpp
@@ -41,9 +41,13 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<typename T_DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename T_DataType,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     inline void concurrent(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         alpaka::concepts::Executor auto const exec,
         alpaka::concepts::VectorOrScalar auto const& extents,
         auto&& fn,
@@ -66,9 +70,13 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is an executor with most
      * parallelism/performance.
      */
-    template<typename T_DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename T_DataType,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     inline void concurrent(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents,
         auto&& fn,
         alpaka::concepts::IDataSource auto&&... inOut)

--- a/include/alpaka/onHost/algo/iota.hpp
+++ b/include/alpaka/onHost/algo/iota.hpp
@@ -26,10 +26,14 @@ namespace alpaka::onHost
      * kind of alpaka View/MdSpan is supported.
      * @{
      */
-    template<typename T_DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename T_DataType,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     requires(std::is_fundamental_v<T_DataType>)
     inline void iota(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         alpaka::concepts::Executor auto const exec,
         T_DataType const& initValue,
         alpaka::concepts::IMdSpan auto&& out0,
@@ -63,10 +67,14 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is the executor with the most
      * parallelism/performance.
      */
-    template<typename T_DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename T_DataType,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     requires(std::is_fundamental_v<T_DataType>)
     inline void iota(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         T_DataType const& initValue,
         alpaka::concepts::IMdSpan auto&& out0,
         alpaka::concepts::IMdSpan auto&&... outOther)

--- a/include/alpaka/onHost/algo/reduce.hpp
+++ b/include/alpaka/onHost/algo/reduce.hpp
@@ -25,9 +25,13 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<typename DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename DataType,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     inline void reduce(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         alpaka::concepts::Executor auto const exec,
         DataType const& neutralElement,
         alpaka::concepts::IMdSpan auto out,
@@ -60,9 +64,13 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is an executor with most
      * parallelism/performance.
      */
-    template<typename DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename DataType,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     inline void reduce(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         DataType const& neutralElement,
         alpaka::concepts::IMdSpan auto out,
         auto&& binaryReduceFn,

--- a/include/alpaka/onHost/algo/transform.hpp
+++ b/include/alpaka/onHost/algo/transform.hpp
@@ -47,9 +47,9 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
     inline void transform(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         alpaka::concepts::Executor auto const exec,
         alpaka::concepts::IMdSpan auto&& out,
         auto&& fn,
@@ -72,9 +72,9 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is an executor with most
      * parallelism/performance.
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
     inline void transform(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         alpaka::concepts::IMdSpan auto&& out,
         auto&& fn,
         alpaka::concepts::IDataSource auto&&... in)

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -56,9 +56,13 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<typename DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename DataType,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     inline void transformReduce(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         alpaka::concepts::Executor auto const exec,
         DataType const& neutralElement,
         alpaka::concepts::IMdSpan auto out,
@@ -93,9 +97,13 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is the executor with the most
      * parallelism/performance.
      */
-    template<typename DataType, typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+    template<
+        typename DataType,
+        typename T_Device,
+        alpaka::concepts::QueueKind T_QueueKind,
+        alpaka::concepts::Timing T_Timing>
     inline void transformReduce(
-        Queue<T_Device, T_QueueKind> const& queue,
+        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
         DataType const& neutralElement,
         alpaka::concepts::IMdSpan auto out,
         auto&& binaryReduceFn,

--- a/include/alpaka/onHost/concepts.hpp
+++ b/include/alpaka/onHost/concepts.hpp
@@ -18,7 +18,7 @@ namespace alpaka::onHost
         template<typename T>
         concept Device = requires(T device) {
             { alpaka::internal::GetName::Op<T>{}(device) } -> std::convertible_to<std::string>;
-            { internal::MakeEvent::Op<T>{}(device) };
+            { internal::MakeEvent::Op<T, timing::Disabled>{}(device, timing::disabled) };
             { internal::GetNativeHandle::Op<T>{}(device) };
             { internal::GetDeviceProperties::Op<T>{}(device) };
         };

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -99,26 +99,32 @@ namespace alpaka::onHost
 
         struct MakeQueue
         {
-            template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind>
+            template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
             struct Op
             {
-                auto operator()(T_Device& device, T_QueueKind) const
+                auto operator()(T_Device& device, T_QueueKind queueKind, T_Timing timing) const
                 {
-                    return device.makeQueue(T_QueueKind{});
+                    return device.makeQueue(queueKind, timing);
                 }
             };
         };
 
         struct MakeEvent
         {
-            template<typename T_Device>
+            template<typename T_Device, alpaka::concepts::Timing T_Timing>
             struct Op
             {
-                auto operator()(T_Device& device) const
+                auto operator()(T_Device& device, T_Timing timing) const
                 {
-                    return device.makeEvent();
+                    return device.makeEvent(timing);
                 }
             };
+        };
+
+        struct GetElapsedTime
+        {
+            template<typename T_StartEvent, typename T_EndEvent>
+            struct Op;
         };
 
         struct Wait

--- a/include/alpaka/tag.hpp
+++ b/include/alpaka/tag.hpp
@@ -111,6 +111,69 @@ namespace alpaka
         constexpr auto nonBlocking = NonBlocking{};
     } // namespace queueKind
 
+    namespace timing
+    {
+        namespace detail
+        {
+            struct TimingBase
+            {
+            };
+        } // namespace detail
+
+        namespace trait
+        {
+            template<typename T_Timing>
+            struct IsTiming : std::is_base_of<detail::TimingBase, T_Timing>
+            {
+            };
+        } // namespace trait
+
+        template<typename T_Timing>
+        constexpr bool isTiming_v = trait::IsTiming<T_Timing>::value;
+    } // namespace timing
+
+    namespace concepts
+    {
+        /** Concept to check if a type selects whether timing is enabled. */
+        template<typename T_Timing>
+        concept Timing = timing::isTiming_v<T_Timing>;
+    } // namespace concepts
+
+    namespace timing
+    {
+        constexpr bool operator==(alpaka::concepts::Timing auto lhs, alpaka::concepts::Timing auto rhs)
+        {
+            return std::is_same_v<ALPAKA_TYPEOF(lhs), ALPAKA_TYPEOF(rhs)>;
+        }
+
+        constexpr bool operator!=(alpaka::concepts::Timing auto lhs, alpaka::concepts::Timing auto rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        /** Backend timing information is available. */
+        struct Enabled : detail::TimingBase
+        {
+            static std::string getName()
+            {
+                return "Enabled";
+            }
+        };
+
+        constexpr auto enabled = Enabled{};
+
+        /** Backend timing information is not requested. */
+        struct Disabled : detail::TimingBase
+        {
+            static std::string getName()
+            {
+                return "Disabled";
+            }
+        };
+
+        constexpr auto disabled = Disabled{};
+    } // namespace timing
+
     namespace deviceKind
     {
         namespace detail

--- a/test/unit/event/event.cpp
+++ b/test/unit/event/event.cpp
@@ -10,6 +10,8 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <future>
+
 /** @file
  *
  * This tests evaluated if events in a queue follows a defined behaviour. Events used to describe dependencies
@@ -33,6 +35,9 @@ using namespace alpaka;
 using namespace alpaka::test::event;
 
 using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
+
+template<typename T_Queue, typename T_Event>
+concept CanEnqueueEvent = requires(T_Queue const& queue, T_Event const& event) { queue.enqueue(event); };
 
 /** This test takes care that kernel in different queues can run concurrent and if we can communicate between host and
  * the device via mapped memory. Even if the concurrent queue test says true it could be that kernels can run under the
@@ -66,6 +71,128 @@ TEMPLATE_LIST_TEST_CASE("event creation and enqueue", "", TestApis)
     queue.enqueue(ev);
     onHost::wait(ev);
     CHECK(ev.isComplete() == true);
+}
+
+struct EmptyTimingKernel
+{
+    ALPAKA_FN_ACC void operator()(onAcc::concepts::Acc auto const&) const
+    {
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("timing-enabled events measure queued work", "", TestApis)
+{
+    auto [device, executor] = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
+    auto queue = device.makeQueue(queueKind::nonBlocking, timing::enabled);
+    auto untimedQueue = device.makeQueue();
+    auto start = device.makeEvent(timing::enabled);
+    auto end = device.makeEvent(timing::enabled);
+    auto untimedEvent = device.makeEvent(timing::disabled);
+    onHost::concepts::FrameSpec auto const frameSpec = onHost::getFrameSpec(device, executor, Vec{1u});
+
+    static_assert(ALPAKA_TYPEOF(queue.getTiming()){} == timing::enabled);
+    static_assert(ALPAKA_TYPEOF(start.getTiming()){} == timing::enabled);
+    static_assert(ALPAKA_TYPEOF(untimedEvent.getTiming()){} == timing::disabled);
+    static_assert(!CanEnqueueEvent<ALPAKA_TYPEOF(untimedQueue), ALPAKA_TYPEOF(start)>);
+
+    queue.enqueue(start);
+    queue.enqueue(frameSpec, KernelBundle{EmptyTimingKernel{}});
+    queue.enqueue(end);
+
+    auto const elapsed = onHost::getElapsedTime(start, end);
+    CHECK(elapsed >= std::chrono::duration<double>::zero());
+}
+
+TEMPLATE_LIST_TEST_CASE("elapsed-time query waits for both events", "", TestApis)
+{
+    // This test makes the end timing event finish before the start event by using two separate queues.
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
+    auto startQueue = device.makeQueue(queueKind::nonBlocking, timing::enabled);
+    auto endQueue = device.makeQueue(queueKind::nonBlocking, timing::enabled);
+    auto start = device.makeEvent(timing::enabled);
+    auto end = device.makeEvent(timing::enabled);
+
+    std::promise<void> releaseStartPromise;
+    auto releaseStart = releaseStartPromise.get_future().share();
+    startQueue.enqueueHostFn([releaseStart]() { releaseStart.wait(); });
+    startQueue.enqueue(start);
+    endQueue.enqueue(end);
+    // This ensures that the end event completes before getElapsedTime is called.
+    onHost::wait(end);
+
+    std::promise<void> elapsedStartedPromise;
+    auto elapsedStarted = elapsedStartedPromise.get_future();
+    auto elapsedFuture = std::async(
+        std::launch::async,
+        [&]()
+        {
+            elapsedStartedPromise.set_value();
+            return onHost::getElapsedTime(start, end);
+        });
+    elapsedStarted.wait();
+
+    // The start queue is blocked, so getElapsedTime should remain blocked in the asynchronous task.
+    auto const elapsedStatus = elapsedFuture.wait_for(std::chrono::milliseconds{100});
+    CHECK(elapsedStatus == std::future_status::timeout);
+
+    // Release the start queue task.
+    releaseStartPromise.set_value();
+    // Since the start event is no longer blocked, getElapsedTime should continue and return the measurement.
+    auto const elapsed = elapsedFuture.get();
+    CHECK(alpaka::math::abs(elapsed) >= std::chrono::milliseconds{100});
+}
+
+TEST_CASE("host elapsed-time query rejects unrecorded events", "")
+{
+    auto device = onHost::makeHostDevice();
+    auto queue = device.makeQueue(queueKind::nonBlocking, timing::enabled);
+    auto recorded = device.makeEvent(timing::enabled);
+    auto unrecorded = device.makeEvent(timing::enabled);
+
+    queue.enqueue(recorded);
+    onHost::wait(recorded);
+
+    CHECK_THROWS_AS(onHost::getElapsedTime(unrecorded, recorded), std::logic_error);
+    CHECK_THROWS_AS(onHost::getElapsedTime(recorded, unrecorded), std::logic_error);
+    CHECK_THROWS_AS(onHost::getElapsedTime(unrecorded, unrecorded), std::logic_error);
+}
+
+TEMPLATE_LIST_TEST_CASE("queue-created timing-enabled events measure queued work", "", TestApis)
+{
+    auto [device, executor] = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
+    auto queue = device.makeQueue(queueKind::nonBlocking, timing::enabled);
+    auto start = queue.makeEvent();
+    auto end = queue.makeEvent();
+    onHost::concepts::FrameSpec auto const frameSpec = onHost::getFrameSpec(device, executor, Vec{1u});
+
+    static_assert(ALPAKA_TYPEOF(start.getTiming()){} == timing::enabled);
+    static_assert(ALPAKA_TYPEOF(end.getTiming()){} == timing::enabled);
+
+    queue.enqueue(start);
+    queue.enqueue(frameSpec, KernelBundle{EmptyTimingKernel{}});
+    queue.enqueue(end);
+
+    auto const elapsed = onHost::getElapsedTime(start, end);
+    CHECK(elapsed >= std::chrono::duration<double>::zero());
+}
+
+TEMPLATE_LIST_TEST_CASE("timing-enabled events include host tasks", "", TestApis)
+{
+    auto [device, executor] = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
+    auto queue = device.makeQueue(queueKind::nonBlocking, timing::enabled);
+    auto start = device.makeEvent(timing::enabled);
+    auto end = device.makeEvent(timing::enabled);
+    onHost::concepts::FrameSpec auto const frameSpec = onHost::getFrameSpec(device, executor, Vec{1u});
+    constexpr auto hostTaskDuration = std::chrono::seconds{1};
+
+    queue.enqueue(start);
+    queue.enqueue(frameSpec, KernelBundle{EmptyTimingKernel{}});
+    queue.enqueueHostFn([hostTaskDuration]() { std::this_thread::sleep_for(hostTaskDuration); });
+    queue.enqueue(frameSpec, KernelBundle{EmptyTimingKernel{}});
+    queue.enqueue(end);
+
+    auto const elapsed = onHost::getElapsedTime(start, end);
+    CHECK(elapsed > hostTaskDuration);
 }
 
 TEMPLATE_LIST_TEST_CASE("basic queue wait for event", "", TestApis)


### PR DESCRIPTION
This PR adds timing events and a timing-capable queue. Both features simply extend the existing objects with a timing policy.

Because CUDA and HIP attach the timing property to events, while SYCL requires profiling to be enabled when the queue is constructed (via `sycl::property::queue::enable_profiling{}`), the policy is retained on both abstractions (queue + events): this preserves alpaka’s existing support for standalone event creation while providing the queue-level configuration required by SYCL.

To enforce consistent behavior across all APIs, timed events can therefore only be enqueued into timing-enabled queues.
A call to:
`queue.makeEvent()`
constructs an appropriate event based on the queue's timing policy. 
This is a shorthand to avoid having to specify the same timing policy redundantly.

Default events and queues remain non-timed to preserve backward compatibility and avoid the additional launch overhead.

This PR adds the policy in the form of two discrete object tags:
`timing::enabled`
`timing::disabled`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in queue/event timing using `timing::enabled`/`timing::disabled`, with timing-aware queue/event creation across backends.
  * `getElapsedTime` now measures queued work for timing-enabled events, including host-side queued tasks between markers.
  * Enforced correctness: timing-enabled events can only be enqueued on timing-enabled queues.
* **Documentation**
  * Updated the “Events and Synchronization” tutorial with a “Measuring Queued Work” section and timing example.
* **Tests**
  * Added unit tests for queued-work timing, host synchronization behavior, enqueue restrictions, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->