### PR TITLE
job-generator: fix filter function

### DIFF
--- a/script/job_generator/src/alpaka_bashi/ci_yaml/misc.py
+++ b/script/job_generator/src/alpaka_bashi/ci_yaml/misc.py
@@ -4,29 +4,16 @@ SPDX-License-Identifier: MPL-2.0
 Different GitLab CI yaml code snippets, which are not in an extra file.
 """
 
-from typing import Any, Dict
+from typing import Any
 
 from typeguard import typechecked
 
 
 @typechecked
-def set_misc_job_properties(job_body: Dict[str, Any]):
+def set_misc_job_properties(job_body: dict[str, Any]):
     """Set different GitLab CI job yaml properties.
 
     Args:
         job_body (Dict[str, Any]): _description_
     """
     job_body["interruptible"] = True
-
-
-@typechecked
-def get_dummy_job() -> Dict:
-    """Return GitLab CI job, which simply prints a message. Can be used, if no job is generated for
-    a CI pipeline."""
-    return {
-        "dummy-job": {
-            "image": "alpine:latest",
-            "interruptible": True,
-            "script": ['echo "This is a dummy job so that the CI does not fail."'],
-        }
-    }

--- a/script/job_generator/src/alpaka_bashi/jobs.py
+++ b/script/job_generator/src/alpaka_bashi/jobs.py
@@ -14,10 +14,10 @@ import packaging.version
 from bashi.globals import CLANG, GCC
 from typeguard import typechecked
 
-from alpaka_bashi.ci_yaml.misc import get_dummy_job
 from alpaka_bashi.ci_yaml.names import get_job_name
 from alpaka_bashi.globals import CI_PIPELINE_NAME, get_version_aliases
 from alpaka_bashi.jobs_builder.default import construct_job_yaml
+from alpaka_bashi.jobs_builder.dummy import get_dummy_job
 from alpaka_bashi.jobs_builder.emulated_simd import get_emulated_simd_job
 from alpaka_bashi.jobs_builder.sanitizer import SanitizerType, get_sanitizer_job
 from alpaka_bashi.versions import get_used_compiler_versions
@@ -178,6 +178,9 @@ def get_special_jobs(
             for job_name, job_body in special_jobs.items()
             if compiled_regex.match(job_name) or job_name == "stages"
         }
+
+    if len(special_jobs) == 0 or (len(special_jobs) == 1 and "stages" in special_jobs):
+        special_jobs = get_dummy_job_yaml(stage_name)
 
     return special_jobs
 

--- a/script/job_generator/src/alpaka_bashi/jobs_builder/dummy.py
+++ b/script/job_generator/src/alpaka_bashi/jobs_builder/dummy.py
@@ -1,0 +1,32 @@
+"""Copyright 2026 Simeon Ehrig
+SPDX-License-Identifier: MPL-2.0
+
+Generate a dummy job, if GitLab CI yaml file would be empty.
+"""
+
+from typeguard import typechecked
+
+
+@typechecked
+def get_dummy_job(stage: str = "") -> dict:
+    """Return GitLab CI job, which simply prints a message. Can be used, if no job is generated for
+    a CI pipeline.
+
+    Args:
+        stage (str, optional): Set stage, if string is not empty. Defaults to "".
+    """
+
+    job_name = "dummy-job"
+
+    job = {
+        job_name: {
+            "image": "alpine:latest",
+            "interruptible": True,
+            "script": ['echo "This is a dummy job so that the CI does not fail."'],
+        }
+    }
+
+    if stage:
+        job[job_name]["stage"] = stage
+
+    return job


### PR DESCRIPTION
- if the filter function removes all special jobs, no dummy job was generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented CI configuration generation from producing an empty job set.
  * Added a fallback job that keeps pipelines valid when no specialized jobs are available.
  * Fallback jobs now respect the specified pipeline stage and can be safely interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->