### PR TITLE
Add clang-tidy CTest target

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,33 @@
+---
+Checks: '-*,clang-analyzer-*,readability-identifier-naming,readability-inconsistent-declaration-parameter-name'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '(^|.*/)include/alpaka/.*'
+SystemHeaders: false
+InheritParentConfig: false
+CheckOptions:
+  readability-identifier-naming.NamespaceCase: camelBack
+  readability-identifier-naming.InlineNamespaceCase: camelBack
+  readability-identifier-naming.ClassCase: CamelCase
+  readability-identifier-naming.StructCase: CamelCase
+  readability-identifier-naming.UnionCase: CamelCase
+  readability-identifier-naming.EnumCase: CamelCase
+  readability-identifier-naming.EnumConstantCase: camelBack
+  readability-identifier-naming.TypeAliasCase: CamelCase
+  readability-identifier-naming.TypedefCase: CamelCase
+  readability-identifier-naming.ConceptCase: CamelCase
+  readability-identifier-naming.FunctionCase: camelBack
+  readability-identifier-naming.MethodCase: camelBack
+  readability-identifier-naming.VariableCase: camelBack
+  readability-identifier-naming.ParameterCase: camelBack
+  readability-identifier-naming.MemberCase: camelBack
+  readability-identifier-naming.PrivateMemberCase: camelBack
+  readability-identifier-naming.PrivateMemberPrefix: m_
+  readability-identifier-naming.MacroDefinitionCase: UPPER_CASE
+  readability-identifier-naming.TypeTemplateParameterPrefix: T_
+  readability-identifier-naming.TypeTemplateParameterIgnoredRegexp: ^[A-Z]$
+  readability-identifier-naming.TypeTemplateParameterCase: CamelCase
+  readability-identifier-naming.ValueTemplateParameterPrefix: T_
+  readability-identifier-naming.ValueTemplateParameterCase: camelBack
+  readability-identifier-naming.TemplateTemplateParameterPrefix: T_
+  readability-identifier-naming.TemplateTemplateParameterCase: CamelCase
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,12 @@ option(alpaka_DOCS "Enable/Disable documentation code snippet testing" OFF)
 option(alpaka_BENCHMARKS "Enable/Disable benchmarks" OFF)
 option(alpaka_EXAMPLES "Enable/Disable examples" OFF)
 option(alpaka_HEADERCHECKS "Enable/Disable header check tests" OFF)
+option(alpaka_CLANG_TIDY "Enable/Disable clang-tidy tests" OFF)
 
 # only check for compiler support if this cmake is called with add_subdirectory or examples, benchmarks, ... should be compiled too
 if(
     NOT PROJECT_NAME STREQUAL CMAKE_PROJECT_NAME
-    OR (alpaka_TESTS OR alpaka_DOCS OR alpaka_BENCHMARKS OR alpaka_EXAMPLES OR alpaka_HEADERCHECKS)
+    OR (alpaka_TESTS OR alpaka_DOCS OR alpaka_BENCHMARKS OR alpaka_EXAMPLES OR alpaka_HEADERCHECKS OR alpaka_CLANG_TIDY)
 )
     include(${_alpaka_CMAKE_DIR}/alpakaCommon.cmake)
 endif()
@@ -90,6 +91,11 @@ endif()
 if(alpaka_HEADERCHECKS)
     enable_testing()
     add_subdirectory("${_alpaka_ROOT_DIR}/headerCheck")
+endif()
+
+if(alpaka_CLANG_TIDY)
+    enable_testing()
+    add_subdirectory("${_alpaka_ROOT_DIR}/clangTidy")
 endif()
 
 # Installation and config

--- a/clangTidy/CMakeLists.txt
+++ b/clangTidy/CMakeLists.txt
@@ -1,0 +1,85 @@
+#
+# Copyright 2026 Tim Hanel
+# SPDX-License-Identifier: MPL-2.0
+#
+
+cmake_minimum_required(VERSION 3.25)
+project(AlpakaClangTidyTest LANGUAGES NONE)
+
+set(_TARGET_NAME "clangTidyTest")
+
+################################################################################
+# Add subdirectories.
+################################################################################
+
+# alpaka
+if(NOT TARGET alpaka::alpaka)
+    # hide alpaka_CLANG_TIDY because it can be OFF since this test is built directly.
+    mark_as_advanced(FORCE alpaka_CLANG_TIDY)
+    add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/.." "${CMAKE_BINARY_DIR}/alpaka")
+endif()
+
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR "alpaka_CLANG_TIDY requires Clang as the C++ compiler.")
+endif()
+
+string(REGEX MATCH "^[0-9]+" _CLANG_TIDY_VERSION "${CMAKE_CXX_COMPILER_VERSION}")
+find_program(CLANG_TIDY_EXECUTABLE NAMES "clang-tidy-${_CLANG_TIDY_VERSION}" clang-tidy REQUIRED)
+
+# fetch catch2
+if(NOT TARGET Catch2::Catch2WithMain)
+    alpaka_install_catch2()
+endif()
+
+################################################################################
+# Enable CTests
+################################################################################
+
+enable_testing()
+
+################################################################################
+# Directory of this file.
+################################################################################
+set(ALPAKA_ROOT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include/alpaka)
+
+# Normalize the path (e.g. remove ../)
+get_filename_component(ALPAKA_ROOT_INCLUDE_DIR "${ALPAKA_ROOT_INCLUDE_DIR}" ABSOLUTE)
+
+#---------------------------------------------------------------------------
+# Create source files.
+set(ALPAKA_SUFFIXED_INCLUDE_DIR "${ALPAKA_ROOT_INCLUDE_DIR}")
+append_recursive_files("${ALPAKA_SUFFIXED_INCLUDE_DIR}" "hpp" "ALPAKA_FILES_HEADER")
+
+set(_GENERATED_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/src")
+
+file(REMOVE_RECURSE ${_GENERATED_SOURCE_DIR})
+
+foreach(_HEADER_FILE ${ALPAKA_FILES_HEADER})
+    # Remove the parent directory from the path.
+    # NOTE: This is not correct because it does not only replace at the beginning of the string.
+    #  "STRING(REGEX REPLACE" would be correct if there was an easy way to escape arbitrary strings.
+    string(REPLACE "${ALPAKA_SUFFIXED_INCLUDE_DIR}/" "" _HEADER_FILE "${_HEADER_FILE}")
+    set(_SOURCE_FILE "${_GENERATED_SOURCE_DIR}/${_HEADER_FILE}.cpp")
+    file(WRITE "${_SOURCE_FILE}" "#include <alpaka/${_HEADER_FILE}>\n#include <alpaka/${_HEADER_FILE}>\n")
+endforeach()
+
+#---------------------------------------------------------------------------
+# Add executable.
+
+append_recursive_files_add_to_src_group("${_GENERATED_SOURCE_DIR}" "${_GENERATED_SOURCE_DIR}" "cpp" "_FILES_SOURCE")
+list(APPEND _FILES_SOURCE "src/main.cpp")
+
+# Always add all files to the target executable build call to add them to the build project.
+add_executable(${_TARGET_NAME} ${_FILES_SOURCE})
+
+target_link_libraries(${_TARGET_NAME} PRIVATE Catch2::Catch2WithMain alpaka::alpaka)
+alpaka_finalize(${_TARGET_NAME})
+
+set_target_properties(
+    ${_TARGET_NAME}
+    PROPERTIES
+        CXX_CLANG_TIDY "${CLANG_TIDY_EXECUTABLE};--config-file=${_alpaka_ROOT_DIR}/.clang-tidy"
+        FOLDER "clangTidy"
+)
+
+add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/clangTidy/src/main.cpp
+++ b/clangTidy/src/main.cpp
@@ -1,0 +1,10 @@
+/* Copyright 2026 Tim Hanel
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("clangTidyTestMain", "[clangTidy]")
+{
+    REQUIRE(true);
+}

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -34,6 +34,7 @@ CMAKE_ARGS=(
     -Dalpaka_FAST_MATH=OFF
     "-DCMAKE_CXX_COMPILER=$APCI_CXX_COMPILER"
     -Dalpaka_SIMD="${APCI_SIMD}"
+    -Dalpaka_CLANG_TIDY="${APCI_CLANG_TIDY}"
 )
 
 declare -A ap_deps=(

--- a/script/ci/install/clang.sh
+++ b/script/ci/install/clang.sh
@@ -46,14 +46,22 @@ if [[ "$compiler_name" == "clang" && "$APCI_HIP" == 0 ]]; then
             echo_run add-apt-repository -y "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main"
             ;;
         esac
+
+        clang_apt_package_list=(
+            "clang-${compiler_version}"
+            "libomp-${compiler_version}-dev"
+            "clang-tools-${compiler_version}"
+            "libclang-rt-${compiler_version}-dev"
+        )
+
+        if [[ "${APCI_CLANG_TIDY}" == "ON" ]]; then
+            clang_apt_package_list+=("clang-tidy-${compiler_version}")
+        fi
+
         DEBIAN_FRONTEND=noninteractive retry_cmd apt update
         # clang-tools is required, that CMake can setup clang as CUDA compiler
         # libclang-rt is required for the sanitizer
-        quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y \
-            "clang-${compiler_version}" \
-            "libomp-${compiler_version}-dev" \
-            "clang-tools-${compiler_version}" \
-            "libclang-rt-${compiler_version}-dev"
+        quiet_run sudo DEBIAN_FRONTEND=noninteractive apt install --no-install-recommends -y "${clang_apt_package_list[@]}"
 
         export APCI_CXX_COMPILER="/usr/bin/clang++-${compiler_version}"
     fi

--- a/script/ci/utils/setup_vars.sh
+++ b/script/ci/utils/setup_vars.sh
@@ -74,6 +74,10 @@ if [[ -n ${GITHUB_ACTIONS+x} ]]; then
         export APCI_SIMD=DEFAULT
     fi
 
+    if [[ -z ${APCI_CLANG_TIDY+x} ]]; then
+        export APCI_CLANG_TIDY=OFF
+    fi
+
     if [[ -z ${APCI_OMP+x} ]]; then
         # if no other backend is enabled, use OpenMP
         if [[ "$APCI_HIP" == 0 && "$APCI_ONEAPI" == 0 && "$APCI_CUDA" == 0 && "$APCI_TBB" == "OFF" ]]; then

--- a/script/job_generator/src/alpaka_bashi/ci_yaml/variables.py
+++ b/script/job_generator/src/alpaka_bashi/ci_yaml/variables.py
@@ -76,6 +76,7 @@ def set_generic_variables(variables: dict[str, Any], combination: bashi.Combinat
     variables["APCI_ALPAKA_ROOT"] = "$CI_PROJECT_DIR"
     variables["APCI_ONEAPI_TARGET"] = "none"
     variables["APCI_SIMD"] = "DEFAULT"
+    variables["APCI_CLANG_TIDY"] = "OFF"
 
     dependencies = ["APCI_OMP", "APCI_TBB"]
     gpu_dependencies = ["APCI_CUDA", "APCI_HIP", "APCI_ONEAPI"]

--- a/script/job_generator/src/alpaka_bashi/jobs.py
+++ b/script/job_generator/src/alpaka_bashi/jobs.py
@@ -16,6 +16,7 @@ from typeguard import typechecked
 
 from alpaka_bashi.ci_yaml.names import get_job_name
 from alpaka_bashi.globals import CI_PIPELINE_NAME, get_version_aliases
+from alpaka_bashi.jobs_builder.clang_tidy import get_clang_tidy_job
 from alpaka_bashi.jobs_builder.default import construct_job_yaml
 from alpaka_bashi.jobs_builder.dummy import get_dummy_job
 from alpaka_bashi.jobs_builder.emulated_simd import get_emulated_simd_job
@@ -170,6 +171,13 @@ def get_special_jobs(
             stage_name=stage_name,
             image_check=image_check,
         )
+
+    special_jobs |= get_clang_tidy_job(
+        compiler_version=packaging.version.parse("21"),
+        container_version=container_version,
+        stage_name=stage_name,
+        image_check=image_check,
+    )
 
     if job_filter:
         compiled_regex = re.compile(job_filter)

--- a/script/job_generator/src/alpaka_bashi/jobs_builder/clang_tidy.py
+++ b/script/job_generator/src/alpaka_bashi/jobs_builder/clang_tidy.py
@@ -1,0 +1,88 @@
+"""Copyright 2026 Simeon Ehrig
+SPDX-License-Identifier: MPL-2.0
+
+Generates Clang Tidy GitLab CI jobs.
+"""
+
+# The linter error is triggered by manually defining a combination
+# pylint: disable=duplicate-code
+
+from typing import Any
+
+import bashi
+from bashi.globals import (
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE,
+    ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE,
+    ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE,
+    ALPAKA_ACC_GPU_CUDA_ENABLE,
+    ALPAKA_ACC_GPU_HIP_ENABLE,
+    ALPAKA_ACC_ONEAPI_CPU_ENABLE,
+    ALPAKA_ACC_ONEAPI_GPU_ENABLE,
+    CLANG,
+    CMAKE,
+    CXX_STANDARD,
+    DEVICE_COMPILER,
+    HOST_COMPILER,
+    OFF,
+    ON,
+    UBUNTU,
+)
+
+from alpaka_bashi.globals import (
+    BUILD_TYPE,
+    CI_PIPELINE_NAME,
+    CI_PIPELINE_SPECIAL_VER,
+    CMAKE_DEBUG,
+    HWLOC,
+    JOB_EXECUTION_RUNTIME,
+    JOB_EXECUTION_TYPE,
+)
+from alpaka_bashi.jobs_builder.default import construct_job_yaml
+
+
+def get_clang_tidy_job(
+    compiler_version: bashi.ValueVersion,
+    container_version: str,
+    stage_name: str,
+    image_check: bool,
+) -> dict[str, Any]:
+    """
+    Create a GitLab CI job where APCI_SIMD=EMULATION is set.
+
+    Args:
+        compiler_version (bashi.ValueVersion): Name of the used compiler.
+        container_version (str): Container version
+        stage_name (str): Stage name. If empty do not set an stage property.
+        image_check (bool): Check if image exist. If not, use fallback image.
+
+    Returns:
+        dict[str, Any]: Description.
+    """
+    job_body = construct_job_yaml(
+        combination=bashi.parse_combination(
+            [
+                (HOST_COMPILER, CLANG, compiler_version),
+                (DEVICE_COMPILER, CLANG, compiler_version),
+                (CMAKE, "3.30.3"),
+                (UBUNTU, "24.04"),
+                (CXX_STANDARD, 20),
+                (BUILD_TYPE, CMAKE_DEBUG),
+                (JOB_EXECUTION_TYPE, JOB_EXECUTION_RUNTIME),
+                (CI_PIPELINE_NAME, CI_PIPELINE_SPECIAL_VER),
+                (ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE, ON),
+                (ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE, OFF),
+                (ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE, ON),
+                (ALPAKA_ACC_GPU_CUDA_ENABLE, OFF),
+                (ALPAKA_ACC_GPU_HIP_ENABLE, OFF),
+                (ALPAKA_ACC_ONEAPI_CPU_ENABLE, OFF),
+                (ALPAKA_ACC_ONEAPI_GPU_ENABLE, OFF),
+                (HWLOC, ON),
+            ]
+        ),
+        stage=stage_name,
+        container_version=container_version,
+        image_check=image_check,
+    )
+    job_body["variables"]["APCI_CLANG_TIDY"] = "ON"
+
+    return {f"linux_clang_{compiler_version}_clang_tidy": job_body}


### PR DESCRIPTION
This PR adds a dedicated clangTidyTest target, enabled with the alpaka_CLANG_TIDY CMake option and registered with CTest.

Similar to headerCheck, the test has its own clangTidy directory. It collects all public Alpaka headers, generates a C++ translation unit for each header, and runs clang-tidy through the CMake CXX_CLANG_TIDY integration.

This is intentionally a draft and is currently expected to fail in CI while the naming conventions and required exceptions are being clarified.

I added an initial set of naming rules to .clang-tidy. @psychocoderHPC, please review and adjust this file; some of the current rules may be unnecessary or may not reflect the intended naming conventions yet.

The currently enabled checks cover:

- Clang Static Analyzer checks
- identifier naming
- inconsistent parameter names between declarations and definitions

These checks complement the diagnostics already provided by the normal Clang compilation. Compiler diagnostic checks are not enabled again explicitly.

For testing this target in CI, the PR currently includes the cherry-picked commit 1d762d7 from #659. This commit can be removed after #659 has been merged.

Thanks to @SimeonEhrig for configuring the CI part quickly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Clang-Tidy analysis workflow for validating project headers.
  * Added CI configuration to run Clang-Tidy checks with a supported Clang version.
  * Added configurable build settings to enable or disable Clang-Tidy checks.

* **Bug Fixes**
  * Clang-Tidy warnings are treated as errors to prevent invalid code from passing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->