### PR TITLE
Introduce queue policies

### DIFF
--- a/docs/source/tutorial/events.rst
+++ b/docs/source/tutorial/events.rst
@@ -40,10 +40,11 @@ It is possible that ``queue1`` increments the value ``valueA`` before ``valueA``
 Measuring Queued Work
 ---------------------
 
-Timing is an explicit queue capability and is disabled by default. Events can independently be constructed with
-``timing::enabled`` or ``timing::disabled``; ``queue.makeEvent()`` is also available as a convenience that inherits the
-queue's capability. A timing-enabled event can only be enqueued on a timing-enabled queue. This rule is the same for
-every API, even where a native backend would technically allow a timed event on an ordinary queue.
+Timing is an explicit queue capability and is disabled by default. Enable it by adding ``timing::enabled`` to the
+``onHost::QueuePolicyList`` passed to ``makeQueue``. Events can independently be constructed with ``timing::enabled``
+or ``timing::disabled``; ``queue.makeEvent()`` is also available as a convenience that inherits the queue's capability.
+A timing-enabled event can only be enqueued on a timing-enabled queue. This rule is the same for every API, even where
+a native backend would technically allow a timed event on an ordinary queue.
 
 The elapsed time is obtained from backend event information. CUDA and HIP use native event timestamps, SYCL uses
 profiling timestamps from its profiling-enabled queue, and the host backend records a monotonic timestamp when each

--- a/docs/source/tutorial/queue.rst
+++ b/docs/source/tutorial/queue.rst
@@ -27,7 +27,8 @@ Here is a small example for a *blocking* queue:
     :dedent:
 
 The use of a *non-blocking* queue requires explicit synchronization before accessing the modified data, otherwise a data race will occur.
-If you do not pass ``queueKind`` as an argument, you will get a *non-blocking* queue.
+Queue configuration is passed as ``onHost::QueuePolicyList``. If the policy list does not contain a queue-kind
+policy, or if you call ``makeQueue()`` without policies, you will get a *non-blocking* queue.
 
   .. literalinclude:: ../../snippets/example/030_queue.cpp
     :language: cpp

--- a/include/alpaka/PolicyList.hpp
+++ b/include/alpaka/PolicyList.hpp
@@ -1,0 +1,95 @@
+/* Copyright 2026 René Widera, Tim Hanel
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/common.hpp"
+#include "alpaka/meta/TypeListOps.hpp"
+#include "alpaka/meta/filter.hpp"
+#include "alpaka/unused.hpp"
+
+#include <concepts>
+#include <tuple>
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace trait
+    {
+        /** Identifies compile-time policy tags.
+         *
+         * Specialize this trait with std::true_type for an application-defined policy tag. A policy tag must also be
+         * default-initializable to satisfy alpaka::concepts::Policy.
+         *
+         * @tparam T_Policy Type to inspect.
+         */
+        template<typename T_Policy>
+        struct IsPolicy : std::false_type
+        {
+        };
+    } // namespace trait
+
+    /** Whether a type is registered as a compile-time policy tag. */
+    template<typename T_Policy>
+    constexpr bool isPolicy_v = trait::IsPolicy<std::remove_cvref_t<T_Policy>>::value;
+
+    namespace concepts
+    {
+        /** A registered, default-initializable compile-time policy tag. */
+        template<typename T_Policy>
+        concept Policy = isPolicy_v<T_Policy> && std::default_initializable<std::remove_cvref_t<T_Policy>>;
+    } // namespace concepts
+
+    /** Collection of compile-time policy tags.
+     *
+     * Policy values carry no runtime state. Derived bundles can use search() with a category predicate to select one
+     * policy and provide a category-specific default.
+     *
+     * @tparam T_Policies Registered policy tag types contained in the bundle.
+     */
+    template<concepts::Policy... T_Policies>
+    struct PolicyList
+    {
+    protected:
+        using Args = std::tuple<T_Policies...>;
+
+        /** Select the policy matching a category predicate.
+         *
+         * @param predicate Callable returning true for policies in the requested category.
+         * @param defaultPolicy Policy returned when the bundle contains no match.
+         * @return The matching policy, or defaultPolicy when no policy matches.
+         */
+        template<typename T_Predicate, concepts::Policy T_DefaultPolicy>
+        static constexpr auto search(T_Predicate predicate, T_DefaultPolicy defaultPolicy)
+        {
+            auto const matches = meta::filter(predicate, Args{});
+            static_assert(std::tuple_size_v<ALPAKA_TYPEOF(matches)> <= 1u, "Duplicate policy category.");
+
+            if constexpr(std::tuple_size_v<ALPAKA_TYPEOF(matches)> == 0u)
+                return defaultPolicy;
+            else
+                return meta::Front<ALPAKA_TYPEOF(matches)>{};
+        }
+
+    public:
+        /** Construct a bundle from compile-time policy tags.
+         *
+         * @param policies Policy tags represented by this bundle's type.
+         */
+        constexpr PolicyList(T_Policies... policies)
+        {
+            alpaka::unused(policies...);
+        }
+
+        /** Check whether the bundle contains a policy type.
+         *
+         * @param policy Policy tag whose type is queried.
+         * @return true if the exact policy type is present, otherwise false.
+         */
+        constexpr bool hasPolicy(concepts::Policy auto policy) const
+        {
+            return meta::Contains<Args, ALPAKA_TYPEOF(policy)>::value;
+        }
+    };
+} // namespace alpaka

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -46,6 +46,7 @@
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/onHost/DeviceSelector.hpp"
 #include "alpaka/onHost/Queue.hpp"
+#include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/algo/concurrent.hpp"
 #include "alpaka/onHost/algo/iota.hpp"
 #include "alpaka/onHost/algo/reduce.hpp"

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -140,21 +140,17 @@ namespace alpaka::onHost
 
             friend struct internal::MakeQueue;
 
-            Handle<cpu::Queue<Device>> makeQueue(alpaka::concepts::QueueKind auto kind, alpaka::concepts::Timing auto)
+            Handle<cpu::Queue<Device>> makeQueue(alpaka::concepts::QueuePolicyList auto const& policies)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                static_assert(
-                    kind == queueKind::blocking || kind == queueKind::nonBlocking,
-                    "Unsupported queue kind.");
                 auto thisHandle = this->getSharedPtr();
                 std::lock_guard<std::mutex> lk{queuesGuard};
 
-                constexpr bool isBlocking = kind == queueKind::blocking;
                 auto newQueue = std::make_shared<cpu::Queue<Device>>(
                     std::move(thisHandle),
                     queueWaitFns.size(),
                     m_cpuGroupIdx,
-                    isBlocking);
+                    policies);
 
                 std::weak_ptr<cpu::Queue<Device>> weakPtrToQueue = newQueue;
                 queueWaitFns.emplace_back(

--- a/include/alpaka/api/host/OmpCollectiveQueue.hpp
+++ b/include/alpaka/api/host/OmpCollectiveQueue.hpp
@@ -43,8 +43,13 @@ namespace alpaka
          * The queue can only be used if the dependency OpenMP is available, e.g. by setting the CMake option
          * ALPAKA_DEP_OMP=ON or using the required compiler flags to activate OpenMP.
          */
-        struct OmpCollective : detail::QueueKindBase
+        struct OmpCollective : category::QueueKind
         {
+            static constexpr auto isBlocking()
+            {
+                return true;
+            }
+
             static std::string getName()
             {
                 return "OmpCollective";
@@ -127,8 +132,12 @@ namespace alpaka::onHost
         struct OmpCollectiveQueue : std::enable_shared_from_this<OmpCollectiveQueue<T_Device>>
         {
         public:
-            OmpCollectiveQueue(internal::concepts::DeviceHandle auto device, uint32_t const idx, uint32_t numIdx)
-                : parentQueue(std::make_shared<Queue<T_Device>>(std::move(device), idx, numIdx, true))
+            OmpCollectiveQueue(
+                internal::concepts::DeviceHandle auto device,
+                uint32_t const idx,
+                uint32_t numIdx,
+                alpaka::concepts::QueuePolicyList auto const policies)
+                : parentQueue(std::make_shared<Queue<T_Device>>(std::move(device), idx, numIdx, policies))
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
             }
@@ -312,10 +321,11 @@ namespace alpaka::onHost
             /** @} */
         } // namespace omp
 
-        template<typename T_Platform, alpaka::concepts::Timing T_Timing>
-        struct MakeQueue::Op<cpu::Device<T_Platform>, alpaka::queueKind::OmpCollective, T_Timing>
+        template<typename T_Platform, alpaka::concepts::QueuePolicyList T_QueuePolicyList>
+        requires(T_QueuePolicyList::getQueueKind() == queueKind::ompCollective)
+        struct MakeQueue::Op<cpu::Device<T_Platform>, T_QueuePolicyList>
         {
-            auto operator()(cpu::Device<T_Platform>& device, alpaka::queueKind::OmpCollective, T_Timing) const
+            auto operator()(cpu::Device<T_Platform>& device, T_QueuePolicyList queuePolicies) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
                 auto queueHandle = device.getSharedPtr();
@@ -324,7 +334,8 @@ namespace alpaka::onHost
                 auto newQueue = std::make_shared<cpu::OmpCollectiveQueue<cpu::Device<T_Platform>>>(
                     std::move(queueHandle),
                     device.queueWaitFns.size(),
-                    device.m_cpuGroupIdx);
+                    device.m_cpuGroupIdx,
+                    queuePolicies);
 
                 std::weak_ptr<cpu::OmpCollectiveQueue<cpu::Device<T_Platform>>> weakPtrToQueue = newQueue;
                 device.queueWaitFns.emplace_back(

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -19,6 +19,7 @@
 #include "alpaka/onAcc/internal/globalMem.hpp"
 #include "alpaka/onHost/FrameSpec.hpp"
 #include "alpaka/onHost/Handle.hpp"
+#include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/interface.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
 #include "alpaka/onHost/mem/SharedBuffer.hpp"
@@ -26,7 +27,6 @@
 #include <cstdint>
 #include <cstring>
 #include <future>
-#include <sstream>
 
 namespace alpaka::onHost
 {
@@ -36,12 +36,16 @@ namespace alpaka::onHost
         struct Queue : std::enable_shared_from_this<Queue<T_Device>>
         {
         public:
-            Queue(internal::concepts::DeviceHandle auto device, uint32_t const idx, uint32_t numIdx, bool isBlocking)
+            Queue(
+                internal::concepts::DeviceHandle auto device,
+                uint32_t const idx,
+                uint32_t numIdx,
+                alpaka::concepts::QueuePolicyList auto const& policies)
                 : m_device(std::move(device))
                 , m_sharedCallbackThread{std::make_shared<alpaka::core::CallbackThread>(numIdx)}
                 , m_idx(idx)
                 , m_numaIdx(numIdx)
-                , m_isBlocking(isBlocking)
+                , m_isBlocking(internal::isBlocking(policies.getQueueKind()))
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
             }

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -55,22 +55,14 @@ namespace alpaka::onHost
             }
 
             [[nodiscard]] Handle<syclGeneric::Queue<Device>> makeQueue(
-                alpaka::concepts::QueueKind auto kind,
-                alpaka::concepts::Timing auto timingMode)
+                alpaka::concepts::QueuePolicyList auto const& policies)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue + onHost::logger::device);
-                static_assert(
-                    kind == queueKind::blocking || kind == queueKind::nonBlocking,
-                    "Unsupported queue kind.");
                 auto thisHandle = this->getSharedPtr();
                 std::lock_guard<std::mutex> lk{m_writeGuard};
 
-                constexpr bool isBlocking = kind == queueKind::blocking;
-                auto newQueue = std::make_shared<syclGeneric::Queue<Device>>(
-                    std::move(thisHandle),
-                    queues.size(),
-                    isBlocking,
-                    timingMode);
+                auto newQueue
+                    = std::make_shared<syclGeneric::Queue<Device>>(std::move(thisHandle), queues.size(), policies);
 
                 queues.emplace_back(newQueue);
                 return newQueue;

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/interface.hpp"
 #include "alpaka/internal/interface.hpp"
 #include "alpaka/onAcc/Acc.hpp"
+#include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/concepts.hpp"
 #include "alpaka/onHost/interface.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
@@ -178,16 +179,15 @@ namespace alpaka::onHost
             Queue(
                 internal::concepts::DeviceHandle auto device,
                 uint32_t const idx,
-                bool isBlocking,
-                alpaka::concepts::Timing auto timingMode)
+                alpaka::concepts::QueuePolicyList auto const& policies)
                 : m_device(std::move(device))
                 , m_SharedNativeQueue{std::make_shared<NativeQueue>(
                       onHost::getNativeHandle(m_device).first,
                       onHost::getNativeHandle(m_device).second,
-                      timingMode)}
+                      policies.getTiming())}
                 , m_sharedCallbackThread{std::make_shared<alpaka::core::CallbackThread>()}
                 , m_idx(idx)
-                , m_isBlocking(isBlocking)
+                , m_isBlocking(internal::isBlocking(policies.getQueueKind()))
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
             }

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -106,22 +106,14 @@ namespace alpaka::onHost
 
             friend struct onHost::internal::MakeQueue;
 
-            Handle<unifiedCudaHip::Queue<Device>> makeQueue(
-                alpaka::concepts::QueueKind auto kind,
-                alpaka::concepts::Timing auto)
+            Handle<unifiedCudaHip::Queue<Device>> makeQueue(alpaka::concepts::QueuePolicyList auto const& policies)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                static_assert(
-                    kind == queueKind::blocking || kind == queueKind::nonBlocking,
-                    "Unsupported queue kind.");
                 auto thisHandle = this->getSharedPtr();
                 std::lock_guard<std::mutex> lk{m_writeGuard};
 
-                constexpr bool isBlocking = kind == queueKind::blocking;
-                auto newQueue = std::make_shared<unifiedCudaHip::Queue<Device>>(
-                    std::move(thisHandle),
-                    queues.size(),
-                    isBlocking);
+                auto newQueue
+                    = std::make_shared<unifiedCudaHip::Queue<Device>>(std::move(thisHandle), queues.size(), policies);
 
                 queues.emplace_back(newQueue);
                 return newQueue;

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -23,6 +23,7 @@
 #include "alpaka/onAcc/internal/globalMem.hpp"
 #include "alpaka/onHost/FrameSpec.hpp"
 #include "alpaka/onHost/Handle.hpp"
+#include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/interface.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
 #include "alpaka/onHost/mem/SharedBuffer.hpp"
@@ -46,12 +47,15 @@ namespace alpaka::onHost
             using ApiInterface = typename T_Device::ApiInterface;
 
         public:
-            Queue(internal::concepts::DeviceHandle auto device, uint32_t const idx, bool isBlocking)
+            Queue(
+                internal::concepts::DeviceHandle auto device,
+                uint32_t const idx,
+                alpaka::concepts::QueuePolicyList auto const& policies)
                 : m_device(std::move(device))
                 , m_sharedCallbackThread{std::make_shared<alpaka::core::CallbackThread>()}
                 , m_SharedStream{std::make_shared<Stream>(m_device)}
                 , m_idx(idx)
-                , m_isBlocking(isBlocking)
+                , m_isBlocking(internal::isBlocking(policies.getQueueKind()))
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
             }

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -8,6 +8,7 @@
 #include "alpaka/interface.hpp"
 #include "alpaka/onHost/Event.hpp"
 #include "alpaka/onHost/Queue.hpp"
+#include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/concepts.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
 #include "alpaka/tag.hpp"
@@ -96,37 +97,38 @@ namespace alpaka::onHost
          */
         auto makeQueue()
         {
-            return makeQueue(queueKind::nonBlocking);
+            return makeQueue(QueuePolicyList{});
         }
 
         /** @copydoc makeQueue()
          *
-         * @param kind
-         *   Blocking behaviour:
+         * @param firstPolicy First queue construction policy.
+         * @param policies Additional queue construction policies.
+         */
+        template<alpaka::concepts::QueuePolicy T_FirstPolicy, alpaka::concepts::QueuePolicy... T_Policies>
+        auto makeQueue(T_FirstPolicy firstPolicy, T_Policies... policies)
+        {
+            return makeQueue(QueuePolicyList{firstPolicy, policies...});
+        }
+
+        /** @copydoc makeQueue()
+         *
+         * @param policies Queue construction policies. Supported policies are:
+         *   - Blocking behaviour:
          *    - queueKind::nonBlocking: enqueue returns immediately; completion of the enqueued operation
          * must be ensured via onHost::wait(queue) or by enqueuing dependent operations onto the same queue.
          *    - queueKind::blocking: each enqueue only returns after the operation is complete and its effects are
          * host-visible.
+         *   - timing::disabled or timing::enabled: whether the queue supports timing-enabled events.
          */
-        auto makeQueue(alpaka::concepts::QueueKind auto kind)
-        {
-            return makeQueue(kind, timing::disabled);
-        }
-
-        /** @copydoc makeQueue(alpaka::concepts::QueueKind auto kind)
-         *
-         * @param timingMode Specifies whether the queue supports timing-enabled events.
-         */
-        auto makeQueue(alpaka::concepts::QueueKind auto kind, alpaka::concepts::Timing auto timingMode)
+        template<alpaka::concepts::QueuePolicy... T_Policies>
+        auto makeQueue(QueuePolicyList<T_Policies...> const& policies)
         {
             return Queue{
-                internal::MakeQueue::
-                    Op<ALPAKA_TYPEOF(*m_device.get()), ALPAKA_TYPEOF(kind), ALPAKA_TYPEOF(timingMode)>{}(
-                        *m_device.get(),
-                        kind,
-                        timingMode),
-                kind,
-                timingMode};
+                internal::MakeQueue::Op<ALPAKA_TYPEOF(*m_device.get()), QueuePolicyList<T_Policies...>>{}(
+                    *m_device.get(),
+                    policies),
+                policies};
         }
 
         /** Create an event with an explicit timing capability.
@@ -188,18 +190,6 @@ namespace alpaka::onHost
         }
     };
 
-    namespace concepts
-    {
-        /** @brief Concept to check if something is a device.
-         *
-         * @details
-         * This concept checks for specializations of alpaka::onHost::Device. For more information on devices in
-         * alpaka, refer to the class documentation.
-         */
-        template<typename T_Device>
-        concept Device = alpaka::concepts::SpecializationOf<T_Device, onHost::Device>;
-    } // namespace concepts
-
     template<typename T_Device>
     Device(Handle<T_Device>&&) -> Device<
         ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Device>())),
@@ -258,13 +248,9 @@ namespace alpaka::onHost
      * @param queue queue handle
      * @param extents number of elements for each dimension
      */
-    template<
-        typename T_Type,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename T_Type, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline auto allocUnified(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
         Vec const extentsVec = extents;
@@ -303,13 +289,9 @@ namespace alpaka::onHost
      * @param queue queue handle
      * @param extents number of elements for each dimension
      */
-    template<
-        typename T_Type,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename T_Type, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline auto allocMapped(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
         return allocMapped<T_Type>(queue.getDevice(), extents);
@@ -356,10 +338,8 @@ namespace alpaka::onHost
      *
      * @param queue queue handle
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
-    inline bool isDataAccessible(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
-        alpaka::concepts::IView auto const& view)
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
+    inline bool isDataAccessible(Queue<T_Device, T_Policies> const& queue, alpaka::concepts::IView auto const& view)
     {
         return internal::IsDataAccessible::FirstPath<ALPAKA_TYPEOF(*queue.getDevice().get()), ALPAKA_TYPEOF(view)>{}(
                    *queue.getDevice().get(),

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -9,9 +9,11 @@
 #include "alpaka/executor.hpp"
 #include "alpaka/onHost/Event.hpp"
 #include "alpaka/onHost/FrameSpec.hpp"
+#include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/concepts.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
 #include "alpaka/onHost/trait.hpp"
+#include "alpaka/tag.hpp"
 
 #include <memory>
 
@@ -20,40 +22,34 @@ namespace alpaka::onHost
     template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     struct Device;
 
-    template<
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing = timing::Disabled>
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies = QueuePolicyList<>>
     struct Queue;
 
     template<
         alpaka::concepts::Api T_Api,
         alpaka::concepts::DeviceKind T_DeviceKind,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
-    struct Queue<Device<T_Api, T_DeviceKind>, T_QueueKind, T_Timing>
+        alpaka::concepts::QueuePolicyList T_Policies>
+    struct Queue<Device<T_Api, T_DeviceKind>, T_Policies>
     {
     private:
         using DeviceInterface = Device<T_Api, T_DeviceKind>;
+        using Policies = T_Policies;
+        using Timing = ALPAKA_TYPEOF(std::declval<Policies>().getTiming());
         using QueueHandle = ALPAKA_TYPEOF(
-            internal::MakeQueue::Op<ALPAKA_TYPEOF(*std::declval<DeviceInterface>().get()), T_QueueKind, T_Timing>{}(
+            internal::MakeQueue::Op<ALPAKA_TYPEOF(*std::declval<DeviceInterface>().get()), T_Policies>{}(
                 *std::declval<DeviceInterface>().get(),
-                T_QueueKind{},
-                T_Timing{}));
+                std::declval<Policies const&>()));
 
         QueueHandle m_queue;
+        [[no_unique_address]] Policies m_policies;
 
     public:
         using element_type = typename QueueHandle::element_type;
 
         template<typename T_Queue>
-        Queue(Handle<T_Queue>&& queue, T_QueueKind, T_Timing) : m_queue{std::forward<Handle<T_Queue>>(queue)}
-        {
-        }
-
-        template<typename T_Queue>
-        Queue(Handle<T_Queue>&& queue, T_QueueKind) requires std::same_as<T_Timing, timing::Disabled>
-            : Queue{std::forward<Handle<T_Queue>>(queue), T_QueueKind{}, timing::disabled}
+        Queue(Handle<T_Queue>&& queue, Policies const& policies)
+            : m_queue{std::forward<Handle<T_Queue>>(queue)}
+            , m_policies{policies}
         {
         }
 
@@ -69,12 +65,12 @@ namespace alpaka::onHost
 
         constexpr alpaka::concepts::QueueKind auto getQueueKind() const
         {
-            return T_QueueKind{};
+            return m_policies.getQueueKind();
         }
 
         constexpr alpaka::concepts::Timing auto getTiming() const
         {
-            return T_Timing{};
+            return m_policies.getTiming();
         }
 
         constexpr alpaka::concepts::DeviceKind auto getDeviceKind() const
@@ -124,7 +120,7 @@ namespace alpaka::onHost
         auto makeEvent() const
         {
             auto device = getDevice();
-            return device.makeEvent(T_Timing{});
+            return device.makeEvent(getTiming());
         }
 
         /** Enqueue a kernel functor to a queue.
@@ -234,7 +230,7 @@ namespace alpaka::onHost
          * @param event Event that is to be enqueue in the queue of operations.
          */
         template<alpaka::concepts::Timing T_EventTiming>
-        requires(std::same_as<T_EventTiming, timing::Disabled> || std::same_as<T_Timing, timing::Enabled>)
+        requires(std::same_as<T_EventTiming, timing::Disabled> || std::same_as<Timing, timing::Enabled>)
         void enqueue(Event<Device<T_Api, T_DeviceKind>, T_EventTiming> const& event) const
         {
             internal::Enqueue::Event<ALPAKA_TYPEOF(*m_queue.get()), ALPAKA_TYPEOF(*event.get())>{}(
@@ -267,20 +263,12 @@ namespace alpaka::onHost
         }
     };
 
-    template<typename T_Queue, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
-    Queue(Handle<T_Queue>&&, T_QueueKind, T_Timing) -> Queue<
+    template<typename T_Queue, alpaka::concepts::QueuePolicyList T_Policies>
+    Queue(Handle<T_Queue>&&, T_Policies const&) -> Queue<
         Device<
             ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Queue>())),
             ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Queue>()))>,
-        T_QueueKind,
-        T_Timing>;
-
-    template<typename T_Queue, alpaka::concepts::QueueKind T_QueueKind>
-    Queue(Handle<T_Queue>&&, T_QueueKind) -> Queue<
-        Device<
-            ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Queue>())),
-            ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Queue>()))>,
-        T_QueueKind>;
+        T_Policies>;
 
     /** @{
      * @name Memory modifiers
@@ -295,8 +283,8 @@ namespace alpaka::onHost
      * @param[in,out] dest can be a container/view where the data should be written to
      * @param[in] source can be a container/view from which the data will be copied
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
-    inline void memcpy(Queue<T_Device, T_QueueKind, T_Timing> const& queue, auto&& dest, auto const& source)
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
+    inline void memcpy(Queue<T_Device, T_Policies> const& queue, auto&& dest, auto const& source)
     {
         memcpy(queue, ALPAKA_FORWARD(dest), source, internal::getExtents(dest));
     }
@@ -308,9 +296,9 @@ namespace alpaka::onHost
      * @param[in] source can be a container/view from which the data will be copied
      * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline void memcpy(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         auto&& dest,
         auto const& source,
         alpaka::concepts::VectorOrScalar auto const& extents)
@@ -329,14 +317,9 @@ namespace alpaka::onHost
      * @param[in,out] dest must be device global memory on the device of the queue the data should be written to
      * @param[in] source can be a container/view or host accessible pointer from which the data will be copied
      */
-    template<
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing,
-        typename T_Storage,
-        typename T>
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies, typename T_Storage, typename T>
     inline void memcpy(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> dest,
         auto&& source)
     {
@@ -352,14 +335,9 @@ namespace alpaka::onHost
      * @param[in,out] dest can be a container/view or host accessible pointer the data should be written to
      * @param[in] source must be device global memory on the device of the queue from which the data will be copied
      */
-    template<
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing,
-        typename T_Storage,
-        typename T>
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies, typename T_Storage, typename T>
     inline void memcpy(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         auto&& dest,
         onAcc::internal::GlobalDeviceMemoryWrapper<T_Storage, T> source)
     {
@@ -377,8 +355,8 @@ namespace alpaka::onHost
      * is finished.
      * @param byteValue value to be written to each byte
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
-    inline void memset(Queue<T_Device, T_QueueKind, T_Timing> const& queue, auto&& dest, uint8_t byteValue)
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
+    inline void memset(Queue<T_Device, T_Policies> const& queue, auto&& dest, uint8_t byteValue)
     {
         memset(queue, ALPAKA_FORWARD(dest), byteValue, internal::getExtents(dest));
     }
@@ -392,9 +370,9 @@ namespace alpaka::onHost
      * @param byteValue value to be written to each byte
      * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline void memset(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         auto&& dest,
         uint8_t byteValue,
         alpaka::concepts::VectorOrScalar auto const& extents)
@@ -414,12 +392,8 @@ namespace alpaka::onHost
      * is finished.
      * @param elementValue value to be written to each element
      */
-    template<
-        typename T_Value,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
-    inline void fill(Queue<T_Device, T_QueueKind, T_Timing> const& queue, auto&& dest, T_Value elementValue) requires(
+    template<typename T_Value, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
+    inline void fill(Queue<T_Device, T_Policies> const& queue, auto&& dest, T_Value elementValue) requires(
         std::same_as<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(dest)>, T_Value>
         && std::same_as<ALPAKA_TYPEOF(alpaka::internal::getApi(queue)), ALPAKA_TYPEOF(alpaka::internal::getApi(dest))>)
     {
@@ -436,13 +410,9 @@ namespace alpaka::onHost
      * @param extents M-dimensional data extents in elements, can be smaller than the container capacity
      */
 
-    template<
-        typename T_Value,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename T_Value, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline void fill(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         auto&& dest,
         T_Value elementValue,
         alpaka::concepts::VectorOrScalar auto const& extents)
@@ -486,13 +456,9 @@ namespace alpaka::onHost
      * memory is destroyed. The deallocation is asynchronous performed in the queue which is used for the
      * allocation.
      */
-    template<
-        typename T_Type,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename T_Type, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline auto allocDeferred(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
         Vec const extentsVec = extents;
@@ -520,8 +486,8 @@ namespace alpaka::onHost
      * memory is destroyed. The deallocation is asynchronous performed in the queue which is used for the
      * allocation.
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
-    inline auto allocLikeDeferred(Queue<T_Device, T_QueueKind, T_Timing> const& queue, auto const& view)
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
+    inline auto allocLikeDeferred(Queue<T_Device, T_Policies> const& queue, auto const& view)
     {
         return allocDeferred<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(queue, internal::getExtents(view));
     }

--- a/include/alpaka/onHost/QueuePolicyList.hpp
+++ b/include/alpaka/onHost/QueuePolicyList.hpp
@@ -1,0 +1,104 @@
+/* Copyright 2026 René Widera, Tim Hanel
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/PolicyList.hpp"
+#include "alpaka/tag.hpp"
+#include "alpaka/utility.hpp"
+
+namespace alpaka::trait
+{
+    /** Identifies compile-time queue policy tags.
+     *
+     * Specialize this trait with std::true_type to register an application-defined queue policy. Every queue policy is
+     * also registered as a general policy through IsPolicy.
+     *
+     * @tparam T_Policy Type to inspect.
+     */
+    template<typename T_Policy>
+    struct IsQueuePolicy : std::false_type
+    {
+    };
+
+    template<alpaka::concepts::QueueKind T_QueueKind>
+    struct IsQueuePolicy<T_QueueKind> : std::true_type
+    {
+    };
+
+    template<alpaka::concepts::Timing T_Timing>
+    struct IsQueuePolicy<T_Timing> : std::true_type
+    {
+    };
+} // namespace alpaka::trait
+
+namespace alpaka
+{
+    /** Whether a type is registered as a compile-time queue policy tag. */
+    template<typename T_Policy>
+    constexpr bool isQueuePolicy_v = trait::IsQueuePolicy<std::remove_cvref_t<T_Policy>>::value;
+
+    namespace concepts
+    {
+        /** A registered, default-initializable compile-time queue policy tag. */
+        template<typename T_Policy>
+        concept QueuePolicy = isQueuePolicy_v<T_Policy> && std::default_initializable<std::remove_cvref_t<T_Policy>>;
+    } // namespace concepts
+
+    namespace trait
+    {
+        template<alpaka::concepts::QueuePolicy T_Policy>
+        struct IsPolicy<T_Policy> : std::true_type
+        {
+        };
+    } // namespace trait
+} // namespace alpaka
+
+namespace alpaka::onHost
+{
+    /** Collection of compile-time policies used to construct a queue.
+     *
+     * Policies can be supplied in any order. At most one policy from each category may be present. The queue kind
+     * defaults to queueKind::nonBlocking and timing defaults to timing::disabled when their policies are omitted.
+     *
+     * @tparam T_Policies Queue policy tag types contained in the bundle.
+     */
+    template<alpaka::concepts::QueuePolicy... T_Policies>
+    struct QueuePolicyList : PolicyList<T_Policies...>
+    {
+        using Base = PolicyList<T_Policies...>;
+
+        /** Construct a queue policy bundle.
+         *
+         * @param policies Compile-time queue policy tags.
+         */
+        constexpr QueuePolicyList(T_Policies... policies) : Base{policies...}
+        {
+        }
+
+        /** Return the selected queue kind, or queueKind::nonBlocking if none was supplied. */
+        static constexpr alpaka::concepts::QueueKind auto getQueueKind()
+        {
+            return Base::search(category::QueueKind{}, queueKind::nonBlocking);
+        }
+
+        /** Return the selected timing policy, or timing::disabled if none was supplied. */
+        static constexpr alpaka::concepts::Timing auto getTiming()
+        {
+            return Base::search(category::Timing{}, timing::disabled);
+        }
+
+        using Base::hasPolicy;
+    };
+
+    template<typename... T_Policies>
+    QueuePolicyList(T_Policies...) -> QueuePolicyList<T_Policies...>;
+} // namespace alpaka::onHost
+
+namespace alpaka::concepts
+{
+    /** A specialization of onHost::QueuePolicyList. */
+    template<typename T_Policies>
+    concept QueuePolicyList = SpecializationOf<T_Policies, onHost::QueuePolicyList>;
+} // namespace alpaka::concepts

--- a/include/alpaka/onHost/algo/concurrent.hpp
+++ b/include/alpaka/onHost/algo/concurrent.hpp
@@ -41,13 +41,9 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<
-        typename T_DataType,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename T_DataType, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline void concurrent(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         alpaka::concepts::Executor auto const exec,
         alpaka::concepts::VectorOrScalar auto const& extents,
         auto&& fn,
@@ -70,13 +66,9 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is an executor with most
      * parallelism/performance.
      */
-    template<
-        typename T_DataType,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename T_DataType, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline void concurrent(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents,
         auto&& fn,
         alpaka::concepts::IDataSource auto&&... inOut)

--- a/include/alpaka/onHost/algo/iota.hpp
+++ b/include/alpaka/onHost/algo/iota.hpp
@@ -26,14 +26,10 @@ namespace alpaka::onHost
      * kind of alpaka View/MdSpan is supported.
      * @{
      */
-    template<
-        typename T_DataType,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename T_DataType, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     requires(std::is_fundamental_v<T_DataType>)
     inline void iota(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         alpaka::concepts::Executor auto const exec,
         T_DataType const& initValue,
         alpaka::concepts::IMdSpan auto&& out0,
@@ -67,14 +63,10 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is the executor with the most
      * parallelism/performance.
      */
-    template<
-        typename T_DataType,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename T_DataType, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     requires(std::is_fundamental_v<T_DataType>)
     inline void iota(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         T_DataType const& initValue,
         alpaka::concepts::IMdSpan auto&& out0,
         alpaka::concepts::IMdSpan auto&&... outOther)

--- a/include/alpaka/onHost/algo/reduce.hpp
+++ b/include/alpaka/onHost/algo/reduce.hpp
@@ -25,13 +25,9 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<
-        typename DataType,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename DataType, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline void reduce(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         alpaka::concepts::Executor auto const exec,
         DataType const& neutralElement,
         alpaka::concepts::IMdSpan auto out,
@@ -64,13 +60,9 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is an executor with most
      * parallelism/performance.
      */
-    template<
-        typename DataType,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename DataType, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline void reduce(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         DataType const& neutralElement,
         alpaka::concepts::IMdSpan auto out,
         auto&& binaryReduceFn,

--- a/include/alpaka/onHost/algo/transform.hpp
+++ b/include/alpaka/onHost/algo/transform.hpp
@@ -47,9 +47,9 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline void transform(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         alpaka::concepts::Executor auto const exec,
         alpaka::concepts::IMdSpan auto&& out,
         auto&& fn,
@@ -72,9 +72,9 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is an executor with most
      * parallelism/performance.
      */
-    template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline void transform(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         alpaka::concepts::IMdSpan auto&& out,
         auto&& fn,
         alpaka::concepts::IDataSource auto&&... in)

--- a/include/alpaka/onHost/algo/transformReduce.hpp
+++ b/include/alpaka/onHost/algo/transformReduce.hpp
@@ -56,13 +56,9 @@ namespace alpaka::onHost
      *
      * @{
      */
-    template<
-        typename DataType,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename DataType, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline void transformReduce(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         alpaka::concepts::Executor auto const exec,
         DataType const& neutralElement,
         alpaka::concepts::IMdSpan auto out,
@@ -97,13 +93,9 @@ namespace alpaka::onHost
      * An available default executor will be selected automatically. The default executor is the executor with the most
      * parallelism/performance.
      */
-    template<
-        typename DataType,
-        typename T_Device,
-        alpaka::concepts::QueueKind T_QueueKind,
-        alpaka::concepts::Timing T_Timing>
+    template<typename DataType, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
     inline void transformReduce(
-        Queue<T_Device, T_QueueKind, T_Timing> const& queue,
+        Queue<T_Device, T_Policies> const& queue,
         DataType const& neutralElement,
         alpaka::concepts::IMdSpan auto out,
         auto&& binaryReduceFn,

--- a/include/alpaka/onHost/concepts.hpp
+++ b/include/alpaka/onHost/concepts.hpp
@@ -7,12 +7,17 @@
 #include "alpaka/concepts.hpp"
 #include "alpaka/internal/interface.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
+#include "alpaka/utility.hpp"
 
 #include <concepts>
 #include <string>
 
 namespace alpaka::onHost
 {
+    // forward declaration to make the Device concept available without include cycles
+    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
+    struct Device;
+
     namespace internal::concepts
     {
         template<typename T>
@@ -55,6 +60,10 @@ namespace alpaka::onHost
 
     namespace concepts
     {
+        /** A specialization of onHost::Device. */
+        template<typename T_Device>
+        concept Device = alpaka::concepts::SpecializationOf<T_Device, onHost::Device>;
+
         template<typename T>
         concept NameHandle = requires(T t) {
             typename T::element_type;

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/onHost/DeviceProperties.hpp"
 #include "alpaka/onHost/FrameSpec.hpp"
 #include "alpaka/onHost/Handle.hpp"
+#include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/ThreadSpec.hpp"
 #include "alpaka/tag.hpp"
 
@@ -99,12 +100,12 @@ namespace alpaka::onHost
 
         struct MakeQueue
         {
-            template<typename T_Device, alpaka::concepts::QueueKind T_QueueKind, alpaka::concepts::Timing T_Timing>
+            template<typename T_Device, alpaka::concepts::QueuePolicyList T_QueuePolicyList>
             struct Op
             {
-                auto operator()(T_Device& device, T_QueueKind queueKind, T_Timing timing) const
+                auto operator()(T_Device& device, T_QueuePolicyList const& policies) const
                 {
-                    return device.makeQueue(queueKind, timing);
+                    return device.makeQueue(policies);
                 }
             };
         };
@@ -266,6 +267,24 @@ namespace alpaka::onHost
                 queue,
                 launchCfg,
                 kernelBundle);
+        }
+
+        struct IsBlocking
+        {
+            template<::alpaka::concepts::QueueKind T>
+            struct Op
+            {
+                constexpr bool operator()(T const&) const
+                {
+                    return T::isBlocking();
+                }
+            };
+        };
+
+        template<::alpaka::concepts::QueueKind T>
+        constexpr bool isBlocking(T const& policy)
+        {
+            return IsBlocking::Op<ALPAKA_TYPEOF(policy)>{}(policy);
         }
 
         struct AdjustThreadSpec

--- a/include/alpaka/tag.hpp
+++ b/include/alpaka/tag.hpp
@@ -15,6 +15,23 @@
 
 namespace alpaka
 {
+    namespace category
+    {
+        /** Category tag for queue-kind policies. */
+        struct QueueKind
+        {
+            template<typename T_Policy>
+            constexpr bool operator()(T_Policy) const;
+        };
+
+        /** Category tag for timing policies. */
+        struct Timing
+        {
+            template<typename T_Policy>
+            constexpr bool operator()(T_Policy) const;
+        };
+    } // namespace category
+
     namespace object
     {
         struct Api
@@ -44,17 +61,10 @@ namespace alpaka
 
     namespace queueKind
     {
-        namespace detail
-        {
-            struct QueueKindBase
-            {
-            };
-        } // namespace detail
-
         namespace trait
         {
             template<typename T_QueueKind>
-            struct IsQueueKind : std::is_base_of<detail::QueueKindBase, T_QueueKind>
+            struct IsQueueKind : std::is_base_of<category::QueueKind, T_QueueKind>
             {
             };
         } // namespace trait
@@ -88,8 +98,13 @@ namespace alpaka
 
         /** Queue should block during the task execution
          */
-        struct Blocking : detail::QueueKindBase
+        struct Blocking : category::QueueKind
         {
+            static constexpr bool isBlocking()
+            {
+                return true;
+            }
+
             static std::string getName()
             {
                 return "Blocking";
@@ -100,8 +115,13 @@ namespace alpaka
 
         /** Queue should process task asynchronously
          */
-        struct NonBlocking : detail::QueueKindBase
+        struct NonBlocking : category::QueueKind
         {
+            static constexpr bool isBlocking()
+            {
+                return false;
+            }
+
             static std::string getName()
             {
                 return "NonBlocking";
@@ -113,17 +133,10 @@ namespace alpaka
 
     namespace timing
     {
-        namespace detail
-        {
-            struct TimingBase
-            {
-            };
-        } // namespace detail
-
         namespace trait
         {
             template<typename T_Timing>
-            struct IsTiming : std::is_base_of<detail::TimingBase, T_Timing>
+            struct IsTiming : std::is_base_of<category::Timing, T_Timing>
             {
             };
         } // namespace trait
@@ -152,7 +165,7 @@ namespace alpaka
         }
 
         /** Backend timing information is available. */
-        struct Enabled : detail::TimingBase
+        struct Enabled : category::Timing
         {
             static std::string getName()
             {
@@ -163,7 +176,7 @@ namespace alpaka
         constexpr auto enabled = Enabled{};
 
         /** Backend timing information is not requested. */
-        struct Disabled : detail::TimingBase
+        struct Disabled : category::Timing
         {
             static std::string getName()
             {
@@ -358,4 +371,19 @@ namespace alpaka
         alpaka::unused(exec);
         return exec::isSeqExecutor_v<T_Exec>;
     }
+
+    namespace category
+    {
+        template<typename T_Policy>
+        constexpr bool QueueKind::operator()(T_Policy) const
+        {
+            return alpaka::concepts::QueueKind<T_Policy>;
+        }
+
+        template<typename T_Policy>
+        constexpr bool Timing::operator()(T_Policy) const
+        {
+            return alpaka::concepts::Timing<T_Policy>;
+        }
+    } // namespace category
 } // namespace alpaka

--- a/test/unit/queue/ompCollectiveQueue.cpp
+++ b/test/unit/queue/ompCollectiveQueue.cpp
@@ -180,7 +180,7 @@ TEMPLATE_LIST_TEST_CASE("OmpCollectiveQueue", "[queue][OmpCollectiveQueue]", Tes
     auto deviceExec = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     onHost::Device device = test::getDevice(deviceExec);
     concepts::Executor auto exec = test::getExecutor(deviceExec);
-    onHost::Queue queue = device.makeQueue(queueKind::ompCollective);
+    onHost::Queue queue = device.makeQueue(::alpaka::queueKind::ompCollective);
 
     auto extents = std::make_tuple(
         // 1D

--- a/test/unit/queue/queue.cpp
+++ b/test/unit/queue/queue.cpp
@@ -12,6 +12,31 @@ using namespace alpaka;
 
 using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
+/** Test-only tag verifying that applications can register additional queue policies. */
+struct TestQueuePolicy
+{
+};
+
+template<>
+struct alpaka::trait::IsQueuePolicy<TestQueuePolicy> : std::true_type
+{
+};
+
+static_assert(alpaka::concepts::QueuePolicy<TestQueuePolicy>);
+
+constexpr auto defaultQueuePolicies = onHost::QueuePolicyList{};
+static_assert(alpaka::concepts::QueuePolicyList<decltype(defaultQueuePolicies)>);
+static_assert(defaultQueuePolicies.getQueueKind() == queueKind::nonBlocking);
+static_assert(defaultQueuePolicies.getTiming() == timing::disabled);
+
+constexpr auto testQueuePolicies = onHost::QueuePolicyList{queueKind::blocking, timing::enabled, TestQueuePolicy{}};
+static_assert(alpaka::concepts::QueuePolicyList<decltype(testQueuePolicies)>);
+static_assert(!alpaka::concepts::QueuePolicyList<TestQueuePolicy>);
+static_assert(testQueuePolicies.getQueueKind() == queueKind::blocking);
+static_assert(testQueuePolicies.getTiming() == timing::enabled);
+static_assert(testQueuePolicies.hasPolicy(TestQueuePolicy{}));
+static_assert(!testQueuePolicies.hasPolicy(queueKind::nonBlocking));
+
 struct NoArgumentsKernel
 {
     ALPAKA_FN_ACC void operator()(onAcc::concepts::Acc auto const&) const


### PR DESCRIPTION
This PR introduces onHost::QueuePolicyBundle, which supplies compile-time queue policies in any order:
```
  auto queue = device.makeQueue(
      onHost::QueuePolicyBundle{
          queueKind::nonBlocking,
          timing::enabled});
```
  Using a policy bundle instead of fixed positional arguments makes queue construction extensible. Additional
  policies can be introduced later without adding further `makeQueue` overloads or breaking the new API.

  The policy bundle is forwarded unchanged through the queue interface and unpacked only by the backend that
  requires a specific policy. The queue also retains the bundle so its configuration, including its timing
  capability, remains available.

  Key changes:

  - Add the generic `PolicyBundle` infrastructure and policy registration traits.
  - Add `QueuePolicyBundle`, `QueuePolicy`, and the corresponding concepts.
  - Allow custom queue policies through `trait::IsQueuePolicy`.
  - Preserve the existing defaults:
      - `queueKind::nonBlocking`
      - `timing::disabled`
  - Forward the complete policy bundle to the host, CUDA, HIP, and SYCL backends.
  
  Note: This PR should only be considered ready for merge once #658 is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flexible queue policy configuration, including blocking/non-blocking behavior and optional timing.
  * Added support for timing-enabled events and elapsed-time measurement.
  * Added reusable policy-list support for custom queue policies.
  * Updated queue operations and algorithms to work with configured policy lists.

* **Documentation**
  * Updated queue and event tutorials with the new policy-based configuration and timing instructions.

* **Bug Fixes**
  * Improved event timestamp capture for blocking and non-blocking queue operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->