### PR TITLE
fix event contract violation

### DIFF
--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -218,7 +218,16 @@ namespace alpaka::onHost
             void enqueueHostFnDeferred(auto const& task)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::queue);
-                m_sharedCallbackThread->submit(task);
+                if(m_isBlocking)
+                {
+                    // a blocking queue must acquire this lock to ensure that all pending host tasks have finished
+                    std::lock_guard lock(m_mutex);
+                    m_sharedCallbackThread->submit(task);
+                }
+                else
+                {
+                    m_sharedCallbackThread->submit(task);
+                }
             }
 
             void enqueueNativeFn(auto const& fn)
@@ -268,7 +277,7 @@ namespace alpaka::onHost
                 }
             }
 
-            friend struct onHost::internal::GetDevice;
+            friend struct internal::GetDevice;
 
             friend struct internal::Wait;
             friend struct internal::WaitFor;
@@ -308,7 +317,8 @@ namespace alpaka::onHost
                 // open a scope to avoid logging during we hold the lock for this class
                 {
                     // Setting the event state (e.g. the future) and enqueuing it has to be atomic.
-                    std::lock_guard<std::mutex> lk(event.m_mutex);
+                    std::lock_guard<std::mutex> eventLock(event.m_mutex);
+
 
                     ++event.m_enqueueCount;
 
@@ -319,6 +329,10 @@ namespace alpaka::onHost
                      */
                     if(queue.m_isBlocking)
                     {
+                        /* a blocking queue must acquire this lock to ensure that all pending host tasks
+                         * have finished
+                         */
+                        std::lock_guard<std::mutex> queueLock(queue.m_mutex);
                         // Nothing to do if it has been re-enqueued to a later position in the queue.
                         if(enqueueCount == event.m_enqueueCount)
                         {
@@ -364,7 +378,7 @@ namespace alpaka::onHost
                 // open a scope to avoid logging during we hold the lock for this class
                 {
                     // Setting the event state and enqueuing it has to be atomic.
-                    std::unique_lock<std::mutex> lk(event.m_mutex);
+                    std::unique_lock<std::mutex> eventLock(event.m_mutex);
 
                     if(!event.isReady())
                     {
@@ -373,8 +387,12 @@ namespace alpaka::onHost
                          */
                         if(queue.m_isBlocking)
                         {
+                            /* a blocking queue must acquire this lock to ensure that all pending host tasks
+                             * have finished
+                             */
+                            std::lock_guard<std::mutex> queueLock(queue.m_mutex);
                             std::shared_future sFuture = event.m_future;
-                            lk.unlock();
+                            eventLock.unlock();
                             sFuture.get();
                         }
                         else
@@ -383,7 +401,7 @@ namespace alpaka::onHost
                             auto oldFuture = event.m_future;
 
                             // unlock here to avoid keeping the look during the maybe expensive enqueue of the task
-                            lk.unlock();
+                            eventLock.unlock();
                             // Enqueue a task that waits for the given future of the event.
                             queue.submit([sharedEvent, oldFuture]() { oldFuture.get(); });
                         }

--- a/include/alpaka/core/CallbackThread.hpp
+++ b/include/alpaka/core/CallbackThread.hpp
@@ -128,7 +128,7 @@ namespace alpaka::core
 
         bool isEmpty() const
         {
-            std::unique_lock<std::mutex> lock{m_state->m_mutex};
+            std::unique_lock lock{m_state->m_mutex};
             return m_state->m_tasks.empty();
         }
 

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -177,6 +177,11 @@ namespace alpaka::onHost
          * lead into deadlocks. Do NOT capture @see MangedView because view actions could perform blocking operations
          * e.g. onHost::wait() in the destructor which could lead to deadlocks too.
          *
+         * @attention A host function must not block internally, while waiting for another host function,
+         * even if that function is enqueued on a different queue.
+         * Some backends may not guarantee concurrent progress on host tasks from different queues.
+         * Violating this requirement can therefore lead to deadlocks, for example with oneAPI/SYCL.
+         *
          * @param task Task to be executed on the host side.
          */
         void enqueueHostFn(auto const& task) const
@@ -193,6 +198,11 @@ namespace alpaka::onHost
          * @attention Deferred tasks are not synchronized by `wait()`.
          * A subsequent `wait()` on the queue does not guarantee that enqueued
          * deferred host tasks have completed their execution.
+         *
+         * @attention A host function must not block internally, while waiting for another host function,
+         * even if that function is enqueued on a different queue.
+         * Some backends may not guarantee concurrent progress on host tasks from different queues.
+         * Violating this requirement can therefore lead to deadlocks, for example with oneAPI/SYCL.
          *
          * @param task Task to be executed asynchronously on the host side.
          */

--- a/test/unit/event/event.cpp
+++ b/test/unit/event/event.cpp
@@ -1,7 +1,7 @@
 /* Copyright 2023 Axel Hübl, Benjamin Worpitz, Bernhard Manfred Gruber, Jan Stephan, René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
-
+#include "alpaka/api/host/OmpCollectiveQueue.hpp"
 #include "eventHelper.hpp"
 
 #include <alpaka/alpaka.hpp>
@@ -10,7 +10,10 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <atomic>
+#include <chrono>
 #include <future>
+#include <thread>
 
 /** @file
  *
@@ -35,6 +38,16 @@ using namespace alpaka;
 using namespace alpaka::test::event;
 
 using TestApis = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
+
+static constexpr auto optionalQueueKind =
+#if ALPAKA_OMP
+    std::tuple{queueKind::ompCollective};
+#else
+    std::tuple{};
+#endif
+
+static constexpr auto testQueueKinds
+    = std::tuple_cat(std::tuple{queueKind::blocking, queueKind::nonBlocking}, optionalQueueKind);
 
 template<typename T_Queue, typename T_Event>
 concept CanEnqueueEvent = requires(T_Queue const& queue, T_Event const& event) { queue.enqueue(event); };
@@ -211,6 +224,165 @@ TEMPLATE_LIST_TEST_CASE("basic queue wait for event", "", TestApis)
     queue1.waitFor(ev);
     onHost::wait(queue1);
     CHECK(ev.isComplete() == true);
+}
+
+TEMPLATE_LIST_TEST_CASE("wait for event enqueued concurrently on a queue with a long-running host task", "", TestApis)
+{
+    auto testSingleQueueKind = [&](auto queueKind)
+    {
+        DYNAMIC_SECTION("Ran with the following queueKind: " << alpaka::onHost::getName(queueKind))
+        {
+            onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
+
+            onHost::Queue producerQueue = device.makeQueue(queueKind);
+            onHost::Queue consumerQueue = device.makeQueue(queueKind);
+            onHost::Event event = device.makeEvent();
+            std::atomic_bool hostTaskDoneSignal = false;
+            std::promise<void> hostTaskStartSignalPromise;
+            auto hostTaskStartSignalFuture = hostTaskStartSignalPromise.get_future();
+            std::jthread hostTaskEnqueueThread(
+                [&]
+                {
+                    producerQueue.enqueueHostFn(
+                        [&]
+                        {
+                            // signal to the outside host thread, that the enqueued host function has started
+                            hostTaskStartSignalPromise.set_value();
+                            // some duration of waiting say 100ms sleep
+                            // set some boolean global flag
+                            std::this_thread::sleep_for(std::chrono::milliseconds(100u));
+                            hostTaskDoneSignal.store(true);
+                        });
+                });
+            // make sure that the long-running task was actually started
+            hostTaskStartSignalFuture.wait();
+            // if the implementation is correct the producerQueue has to block until hostTaskDoneSignal is true
+            producerQueue.enqueue(event);
+            consumerQueue.waitFor(event);
+            onHost::wait(consumerQueue);
+            REQUIRE(hostTaskDoneSignal.load());
+        }
+        return 0;
+    };
+    onHost::executeForEach(testSingleQueueKind, testQueueKinds);
+}
+
+TEMPLATE_LIST_TEST_CASE("wait for event preserves consumer queue order", "", TestApis)
+{
+    onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
+    INFO(device.getApi().getName() << " on " << device.getName());
+
+    bool hasConcurrentKernelQueues = checkIfDeviceCanExecuteEventTests(device);
+    if(!hasConcurrentKernelQueues)
+    {
+        /* We cannot execute the event tests with OneApi on Intel GPU because the emulated kernel trigger via another
+         * kernel in a separate queue. The second reason is that kernel, memory operation enqueued in different queues
+         * will not run out of order which is assumed for some of the tests.
+         */
+        SKIP(
+            "Event tests can not be executed with " << device.getName()
+                                                    << " because the device does not support concurrent queues.");
+    }
+    if(device.getApi() == api::oneApi && device.getDeviceKind() == deviceKind::intelGpu)
+    {
+        SKIP("Skip test for " << device.getName() << " because the test is typically deadlocking.");
+    }
+
+    auto testSingleQueueKind = [&](auto queueKind)
+    {
+        DYNAMIC_SECTION("Ran with the following queueKind: " << alpaka::onHost::getName(queueKind))
+        {
+            onHost::Queue producerQueue = device.makeQueue(queueKind::nonBlocking);
+            onHost::Queue consumerQueue = device.makeQueue(queueKind);
+
+            auto produceKernel = TriggerKernel{device};
+            onHost::Event event = device.makeEvent();
+
+            std::promise<void> releaseEventPromise;
+            auto releaseEventFuture = releaseEventPromise.get_future().share();
+            // producer queue must be non-blocking
+            produceKernel.submit(producerQueue);
+
+            producerQueue.enqueue(event);
+
+            std::atomic_bool consumerTaskDoneSignal = false;
+            std::promise<void> consumerTaskStartSignalPromise;
+            auto consumerTaskStartSignalFuture = consumerTaskStartSignalPromise.get_future();
+            std::jthread consumerTaskEnqueueThread(
+                [&]
+                {
+                    consumerQueue.enqueueHostFn(
+                        [&]
+                        {
+                            consumerTaskStartSignalPromise.set_value();
+                            std::this_thread::sleep_for(std::chrono::milliseconds(100u));
+                            consumerTaskDoneSignal.store(true);
+                        });
+                });
+
+            consumerTaskStartSignalFuture.wait();
+            std::jthread eventReleaseThread(
+                [&]
+                {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(10u));
+                    produceKernel.trigger();
+                });
+
+            // Waiting for the event must not overtake the consumer queue's preceding host task.
+            consumerQueue.waitFor(event);
+            if constexpr(queueKind.isBlocking())
+                REQUIRE(consumerTaskDoneSignal.load());
+            else
+            {
+                std::promise<bool> observerTaskResultPromise;
+                auto observerTaskResultFuture = observerTaskResultPromise.get_future();
+                consumerQueue.enqueueHostFn([&]
+                                            { observerTaskResultPromise.set_value(consumerTaskDoneSignal.load()); });
+                REQUIRE(observerTaskResultFuture.get());
+            }
+        }
+        return 0;
+    };
+    onHost::executeForEach(testSingleQueueKind, testQueueKinds);
+}
+
+TEMPLATE_LIST_TEST_CASE("deferred host task preserves queue order", "", TestApis)
+{
+    auto testSingleQueueKind = [&](auto queueKind)
+    {
+        DYNAMIC_SECTION("Ran with the following queueKind: " << alpaka::onHost::getName(queueKind))
+        {
+            onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
+            onHost::Queue queue = device.makeQueue(queueKind);
+
+            std::atomic_bool hostTaskDoneSignal = false;
+            std::promise<void> hostTaskStartSignalPromise;
+            auto hostTaskStartSignalFuture = hostTaskStartSignalPromise.get_future();
+            std::jthread hostTaskEnqueueThread(
+                [&]
+                {
+                    queue.enqueueHostFn(
+                        [&]
+                        {
+                            // Ensure that the deferred task is enqueued while this task is still running.
+                            hostTaskStartSignalPromise.set_value();
+                            std::this_thread::sleep_for(std::chrono::milliseconds(100u));
+                            hostTaskDoneSignal.store(true);
+                        });
+                });
+
+            hostTaskStartSignalFuture.wait();
+            std::promise<bool> deferredTaskResultPromise;
+            auto deferredTaskResultFuture = deferredTaskResultPromise.get_future();
+            // A deferred host task may execute after later queue operations, but never before an earlier task.
+            // In particular, a blocking queue must finish the running task before submitting this callback.
+            queue.enqueueHostFnDeferred([&] { deferredTaskResultPromise.set_value(hostTaskDoneSignal.load()); });
+
+            REQUIRE(deferredTaskResultFuture.get());
+        }
+        return 0;
+    };
+    onHost::executeForEach(testSingleQueueKind, testQueueKinds);
 }
 
 TEMPLATE_LIST_TEST_CASE("test trigger event", "", TestApis)


### PR DESCRIPTION
This is more a recent issue me and @SimeonEhrig encountered, rather then a ready to merge PR, therefore I suggest keeping it as a draft, while working on a solution. 

I added a small unit test the that showcases the failing behavior.
First of all the assumption is that the queue - blocking queues should support concurrent access by multiple threads. This assumption is justified, because in the documentation under https://alpaka3.readthedocs.io/en/latest/tutorial/queue.html#queue it is stated that: "The use of the same queue by different host threads is supported". This statement does not differentiate the kind of queue. 

Under that premise the test uses two threads T1 and T2. 
T1 enqueues a long running task in `producerQueue`. 
While T2 is running concurrently as the host control thread. 
Therefore if T2 enqueues an event and another queue waits on that event. 

Since `waitFor()` completes before the long-running host task finished - the event synchronization and queue ordering contract is broken.

The reason this currently breaks, is that hostTasks are executed immediately without actually deferring the task execution to a background thread for blocking queues, this paradigm does not establish a fixed syncronization order for a blocking queue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event synchronization and state updates for blocking host queues.
  * Preserved submission order for deferred host tasks.
  * Improved event propagation and ordering across supported queue types.

* **Tests**
  * Added coverage for concurrent event operations and long-running host tasks.
  * Added timing-event tests for queued work, dependencies, host tasks, and queue-created events.
  * Verified appropriate errors for unrecorded events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->