### PR TITLE
Use ceiling division for `getFrameSpec`

### DIFF
--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -562,7 +562,7 @@ namespace alpaka::onHost
                 numFrameElements /= IndexType{2};
             }
 
-            ExtentVecType numFrames = divExZero(extentMd, frameExtents);
+            ExtentVecType numFrames = divCeil(extentMd, frameExtents);
             auto frameSpec = FrameSpec{numFrames, frameExtents, executor};
             return frameSpec;
         }

--- a/test/unit/frame/getFrameSpec.cpp
+++ b/test/unit/frame/getFrameSpec.cpp
@@ -37,7 +37,9 @@ void checkFrameSpec(onHost::concepts::FrameSpec auto const& frameSpec, concepts:
     {
         CHECK(numFrames[d] > ElemType{0});
         CHECK(frameExtents[d] > ElemType{0});
-        CHECK(numFrames[d] * frameExtents[d] <= extentMd[d]);
+        auto const coveredExtent = numFrames[d] * frameExtents[d];
+        CHECK(extentMd[d] <= coveredExtent);
+        CHECK(coveredExtent < extentMd[d] + frameExtents[d]);
     }
 }
 


### PR DESCRIPTION
  The PR description is AI generated, but I closely reviewed it and made some edits.
  
  ### Summary

  - calculate non-SIMD `getFrameSpec()` frame counts with `divCeil`
  - update the FrameSpec unit test to require complete problem coverage with less
    than one frame of excess coverage
  - leave the SIMD-specific `getSimdFrameSpec()` behavior unchanged

  ### Motivation

  `getFrameSpec()` currently calculates its number of frames using floor division.
  When the problem extent is not divisible by the selected frame extent, the
  resulting FrameSpec exposes slightly fewer workers than logical elements.

  Correctness is preserved for kernels using `alpaka::makeIdx` to iterate over the number of elements, 
  but the remaining elements must be processed as additional iterations by a small subset
  of worker threads (mainly the last block). This can create a significant execution tail for kernels whose
  per-element workloads vary.

  This was observed by a forward ray-tracing workload on an NVIDIA A100. A ray batch
  containing 85,471 rays received the default FrameSpec `166x512`,
  covering only 84,992 workers. The remaining 479 rays were processed as a
  second grid-stride iteration by threads in one block.

  Configurations providing at least one worker per ray reduced the measured
  kernel median from approximately **1.65 ms to 1.36 ms**. The current implementation
  cannot directly generate the minimally covering `167x512` configuration.

  Using `divCeil` may in fact be the decisive **performance** factor in **cross library comparisons**.  
  
  This bottleneck has been revealed  while using the [alpaka3-tuner]https://github.com/TimHanel00/alpaka3-tuner on [haseongpu](https://github.com/ComputationalRadiationPhysics/haseongpu).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected frame-count calculations so uneven extents are rounded up appropriately.
  - Improved frame coverage validation to ensure requested extents are fully covered without exceeding an additional frame extent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->