### PR TITLE
Ci: add ROCm 7.14

### DIFF
--- a/cmake/alpakaCompilePedantic.cmake
+++ b/cmake/alpakaCompilePedantic.cmake
@@ -47,6 +47,11 @@ if(TARGET alpaka_target_hip)
     alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-Wextra>")
     alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-Wpedantic>")
     alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-Werror>")
+
+    # disable the warning/error: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
+    if(CMAKE_HIP_COMPILER_ID STREQUAL "Clang" AND CMAKE_HIP_COMPILER_VERSION VERSION_GREATER_EQUAL "22.0")
+        alpaka_set_compiler_options(HOST target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:-Wno-c2y-extensions>")
+    endif()
 endif()
 
 if(TARGET alpaka_target_host)
@@ -63,7 +68,10 @@ if(TARGET alpaka_target_host)
     endif()
 
     # disable the warning/error: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "2026.0")
+    if(
+        (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "22.0")
+        OR (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "2026.0")
+    )
         alpaka_set_compiler_options(HOST target alpaka_target_host "$<$<COMPILE_LANG_AND_ID:CXX,IntelLLVM,Clang>:-Wno-c2y-extensions>")
     endif()
 endif()

--- a/cmake/alpakaHip.cmake
+++ b/cmake/alpakaHip.cmake
@@ -42,6 +42,9 @@ if(CMAKE_HIP_COMPILER)
     if(
         ${_hip_MAJOR_MINOR_VERSION} VERSION_LESS ${_alpaka_HIP_MIN_VER}
         OR ${_hip_MAJOR_MINOR_VERSION} VERSION_GREATER ${_alpaka_HIP_MAX_VER}
+        # pre-releases
+        OR ${_hip_MAJOR_MINOR_VERSION} VERSION_EQUAL "7.13"
+        OR ${_hip_MAJOR_MINOR_VERSION} VERSION_EQUAL "7.9"
     )
         message(
             WARNING

--- a/cmake/alpakaHip.cmake
+++ b/cmake/alpakaHip.cmake
@@ -29,7 +29,7 @@ if(CMAKE_HIP_COMPILER)
     find_package(hip REQUIRED)
 
     set(_alpaka_HIP_MIN_VER 6.0)
-    set(_alpaka_HIP_MAX_VER 7.2)
+    set(_alpaka_HIP_MAX_VER 7.14)
 
     checkcompilercxxsupport(HIP ${alpaka_CXX_STANDARD})
 
@@ -82,6 +82,27 @@ if(CMAKE_HIP_COMPILER)
     elseif(alpaka_RELOCATABLE_DEVICE_CODE STREQUAL OFF)
         alpaka_set_compiler_options(DEVICE target alpaka_target_hip "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-fno-gpu-rdc>")
     endif()
+
+    # workaround linker error with ROCm 7.14 due to the change of the ROCM directories, see https://rocm.docs.amd.com/en/latest/about/transition-guide-TheRock.html#paths-and-linking
+    # The error is appears with the original AMD container rocm/dev-ubuntu-24.04:7.14.0-full
+    # 'error while loading shared libraries: libamdhip64.so.7: cannot open shared object file: No such file or directory'
+    if(_hip_MAJOR_MINOR_VERSION VERSION_EQUAL "7.14")
+        find_library(
+            _alpaka_hip_runtime
+            NAMES amdhip64
+            PATHS ${CMAKE_HIP_IMPLICIT_LINK_DIRECTORIES}
+            NO_DEFAULT_PATH
+            REQUIRED
+        )
+
+        get_filename_component(_alpaka_hip_runtime_dir "${_alpaka_hip_runtime}" DIRECTORY)
+
+        target_link_options(
+            alpaka_target_hip
+            INTERFACE "$<$<LINK_LANGUAGE:HIP>:SHELL:-Wl,-rpath,${_alpaka_hip_runtime_dir}>"
+        )
+    endif()
+
     target_compile_definitions(alpaka_target_hip INTERFACE ALPAKA_CMAKE_TARGET_HIP)
     target_link_libraries(alpaka_target_hip INTERFACE alpaka::headers)
 

--- a/include/alpaka/KernelBundle.hpp
+++ b/include/alpaka/KernelBundle.hpp
@@ -152,7 +152,7 @@ namespace alpaka
     //! \return Kernel function bundle. An instance of KernelBundle which consists the kernel function object and its
     //! arguments.
     template<typename TKernelFn, typename... TArgs>
-    ALPAKA_FN_HOST KernelBundle(TKernelFn const&, TArgs&&...) -> KernelBundle<TKernelFn, TArgs...>;
+    ALPAKA_FN_DG KernelBundle(TKernelFn const&, TArgs&&...) -> KernelBundle<TKernelFn, TArgs...>;
 
     namespace trait
     {

--- a/include/alpaka/Simd.hpp
+++ b/include/alpaka/Simd.hpp
@@ -541,7 +541,7 @@ namespace alpaka
 
     // type deduction guide
     template<typename T_1, typename... T_Args>
-    ALPAKA_FN_HOST_ACC Simd(T_1, T_Args...) -> Simd<T_1, uint32_t(sizeof...(T_Args) + 1u)>;
+    ALPAKA_FN_DG Simd(T_1, T_Args...) -> Simd<T_1, uint32_t(sizeof...(T_Args) + 1u)>;
 
     /** binary operators
      * @{

--- a/include/alpaka/SimdMask.hpp
+++ b/include/alpaka/SimdMask.hpp
@@ -423,7 +423,7 @@ namespace alpaka
 
     // type deduction guide
     template<typename T_1, typename... T_Args>
-    ALPAKA_FN_HOST_ACC SimdMask(T_1, T_Args...) -> SimdMask<T_1, uint32_t(sizeof...(T_Args) + 1u)>;
+    ALPAKA_FN_DG SimdMask(T_1, T_Args...) -> SimdMask<T_1, uint32_t(sizeof...(T_Args) + 1u)>;
 
     /** Creates a mask for the given type
      *

--- a/include/alpaka/Tuple.hpp
+++ b/include/alpaka/Tuple.hpp
@@ -89,7 +89,7 @@ namespace alpaka
     };
 
     template<typename... T_Args>
-    Tuple(T_Args&&...) -> Tuple<T_Args...>;
+    ALPAKA_FN_DG Tuple(T_Args&&...) -> Tuple<T_Args...>;
 
     template<size_t T_idx>
     constexpr decltype(auto) get(concepts::SpecializationOf<Tuple> auto&& t) noexcept

--- a/include/alpaka/Vec.hpp
+++ b/include/alpaka/Vec.hpp
@@ -748,7 +748,7 @@ namespace alpaka
 
     // type deduction guide
     template<typename T_1, typename... T_Args>
-    ALPAKA_FN_HOST_ACC Vec(T_1, T_Args...)
+    ALPAKA_FN_DG Vec(T_1, T_Args...)
         -> Vec<T_1, uint32_t(sizeof...(T_Args) + 1u), ArrayStorage<T_1, uint32_t(sizeof...(T_Args) + 1u)>>;
 
     template<typename Type, uint32_t T_dim, typename T_Storage>

--- a/include/alpaka/api/hip/memFence.hpp
+++ b/include/alpaka/api/hip/memFence.hpp
@@ -32,18 +32,22 @@ namespace alpaka::onAcc::internalCompute
         {
             // Host pass is not allowed.
 #    if ALPAKA_ARCH_AMD
+            /* It is required to have this temporary variable else HIP 7.14 will fail to compiler with code emitting
+             * issues.
+             */
+            constexpr auto memOrder = MemOrderHip::get(order);
             if constexpr(std::is_same_v<T_Scope, scope::Block>)
             {
-                __builtin_amdgcn_fence(MemOrderHip::get(order), "workgroup");
+                __builtin_amdgcn_fence(memOrder, "workgroup");
             }
             else if constexpr(std::is_same_v<T_Scope, scope::Device>)
             {
-                __builtin_amdgcn_fence(MemOrderHip::get(order), "agent");
+                __builtin_amdgcn_fence(memOrder, "agent");
             }
             else if constexpr(std::is_same_v<T_Scope, scope::System>)
             {
                 // empty string refers to system
-                __builtin_amdgcn_fence(MemOrderHip::get(order), "");
+                __builtin_amdgcn_fence(memOrder, "");
             }
 #    endif
         }

--- a/include/alpaka/core/Dict.hpp
+++ b/include/alpaka/core/Dict.hpp
@@ -166,10 +166,10 @@ namespace alpaka
 
     // type deduction guide
     template<typename... T_Keys, typename... T_Values>
-    ALPAKA_FN_HOST_ACC Dict(Tuple<DictEntry<T_Keys, T_Values>...> const&) -> Dict<DictEntry<T_Keys, T_Values>...>;
+    ALPAKA_FN_DG Dict(Tuple<DictEntry<T_Keys, T_Values>...> const&) -> Dict<DictEntry<T_Keys, T_Values>...>;
 
     template<typename... T_Keys, typename... T_Values>
-    ALPAKA_FN_HOST_ACC Dict(DictEntry<T_Keys, T_Values> const&...) -> Dict<DictEntry<T_Keys, T_Values>...>;
+    ALPAKA_FN_DG Dict(DictEntry<T_Keys, T_Values> const&...) -> Dict<DictEntry<T_Keys, T_Values>...>;
 } // namespace alpaka
 
 namespace std

--- a/include/alpaka/core/common.hpp
+++ b/include/alpaka/core/common.hpp
@@ -14,23 +14,47 @@
 #    include <hip/hip_runtime.h>
 #endif
 
+//! Function declaration attributes to provide execution scope information
+//!
 //! All functions that can be used on an accelerator have to be attributed with ALPAKA_FN_ACC or ALPAKA_FN_HOST_ACC.
+//! Deduction guides for objects usable within a kernel should be marked ALPAKA_FN_DG.
+//! ALPAKA_FN_DG declare the guide for on host and acc usage.
 //!
 //! \code{.cpp}
-//! Usage:
-//! ALPAKA_FN_ACC
-//! auto add(std::int32_t a, std::int32_t b)
-//! -> std::int32_t;
+//! // function
+//! ALPAKA_FN_ACC std::int32_t add(std::int32_t a, std::int32_t b);
+//!
+//! // struct with deduction guide
+//! template<typename T>
+//! struct Foo
+//! {
+//!     T bar;
+//!
+//!     template<typename T_ValueType>
+//!     constexpr Foo(T_ValueType const v): bar{static_cast<T>(v)}
+//!     {}
+//! };
+//!
+//! template<typename T_ValueType>
+//! Foo(T_ValueType const) -> Foo<T_ValueType>;
 //! \endcode
 //! @{
 #if ALPAKA_LANG_CUDA || ALPAKA_LANG_HIP
 #    define ALPAKA_FN_ACC __device__ __host__
 #    define ALPAKA_FN_HOST_ACC __device__ __host__
 #    define ALPAKA_FN_HOST __host__
+// Avoid warning: use of CUDA/HIP target attributes on deduction guides is deprecated; they will be rejected in a
+// future version of Clang [-Werror,-Wdeprecated-attributes]
+#    if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(22, 1, 0)
+#        define ALPAKA_FN_DG
+#    else
+#        define ALPAKA_FN_DG __device__ __host__
+#    endif
 #else
 #    define ALPAKA_FN_ACC
 #    define ALPAKA_FN_HOST_ACC
 #    define ALPAKA_FN_HOST
+#    define ALPAKA_FN_DG
 #endif
 //! @}
 

--- a/include/alpaka/functor.hpp
+++ b/include/alpaka/functor.hpp
@@ -27,7 +27,7 @@ namespace alpaka
     };
 
     template<typename T_Func>
-    ALPAKA_FN_HOST_ACC StencilFunc(T_Func&&) -> StencilFunc<T_Func>;
+    ALPAKA_FN_DG StencilFunc(T_Func&&) -> StencilFunc<T_Func>;
 
     /** Marks a functor that can only be executed with scalar types and not SIMD packages.
      *
@@ -45,7 +45,7 @@ namespace alpaka
     };
 
     template<typename T_Func>
-    ALPAKA_FN_HOST_ACC ScalarFunc(T_Func&&) -> ScalarFunc<T_Func>;
+    ALPAKA_FN_DG ScalarFunc(T_Func&&) -> ScalarFunc<T_Func>;
 
     /** Execute the functor with or without an accelerator as first argument
      *

--- a/include/alpaka/mem/IdxRange.hpp
+++ b/include/alpaka/mem/IdxRange.hpp
@@ -188,16 +188,16 @@ namespace alpaka
     } // namespace internal
 
     template<concepts::VectorOrScalar T_Extents>
-    ALPAKA_FN_HOST_ACC IdxRange(T_Extents const&) -> IdxRange<typename trait::getVec_t<T_Extents>::UniVec>;
+    ALPAKA_FN_DG IdxRange(T_Extents const&) -> IdxRange<typename trait::getVec_t<T_Extents>::UniVec>;
 
     template<concepts::VectorOrScalar T_Begin, concepts::VectorOrScalar T_End>
-    ALPAKA_FN_HOST_ACC IdxRange(T_Begin const&, T_End const&) -> IdxRange<
+    ALPAKA_FN_DG IdxRange(T_Begin const&, T_End const&) -> IdxRange<
         typename trait::getVec_t<T_Begin>::UniVec,
         typename trait::getVec_t<T_End>::UniVec,
         typename trait::getVec_t<T_End>::UniVec>;
 
     template<concepts::VectorOrScalar T_Begin, concepts::VectorOrScalar T_End, concepts::VectorOrScalar T_Stride>
-    ALPAKA_FN_HOST_ACC IdxRange(T_Begin const&, T_End const&, T_Stride const&) -> IdxRange<
+    ALPAKA_FN_DG IdxRange(T_Begin const&, T_End const&, T_Stride const&) -> IdxRange<
         typename trait::getVec_t<T_Begin>::UniVec,
         typename trait::getVec_t<T_End>::UniVec,
         typename trait::getVec_t<T_Stride>::UniVec>;

--- a/include/alpaka/mem/LinearizedIdxGenerator.hpp
+++ b/include/alpaka/mem/LinearizedIdxGenerator.hpp
@@ -101,7 +101,7 @@ namespace alpaka
     };
 
     template<concepts::VectorOrScalar T_Extents>
-    ALPAKA_FN_HOST_ACC LinearizedIdxGenerator(T_Extents const&)
+    ALPAKA_FN_DG LinearizedIdxGenerator(T_Extents const&)
         -> LinearizedIdxGenerator<trait::GetValueType_t<T_Extents>, trait::getDim_v<T_Extents>>;
 
     namespace internal

--- a/include/alpaka/mem/MdForwardIter.hpp
+++ b/include/alpaka/mem/MdForwardIter.hpp
@@ -55,7 +55,7 @@ namespace alpaka
     };
 
     template<alpaka::concepts::IMdSpan T_MdSpan>
-    ALPAKA_FN_HOST_ACC MdForwardIterEnd(T_MdSpan const&) -> MdForwardIterEnd<typename T_MdSpan::index_type>;
+    ALPAKA_FN_DG MdForwardIterEnd(T_MdSpan const&) -> MdForwardIterEnd<typename T_MdSpan::index_type>;
 
     template<alpaka::concepts::IMdSpan T_MdSpan>
     class MdForwardIter

--- a/include/alpaka/mem/View.hpp
+++ b/include/alpaka/mem/View.hpp
@@ -275,7 +275,7 @@ namespace alpaka
         alpaka::concepts::Vector T_UserExtents,
         alpaka::concepts::Vector T_UserPitches,
         alpaka::concepts::Alignment T_MemAlignment>
-    ALPAKA_FN_HOST_ACC View(
+    ALPAKA_FN_DG View(
         T_Any const&,
         T_Type*,
         T_UserExtents const&,
@@ -288,7 +288,7 @@ namespace alpaka
         typename T_Type,
         alpaka::concepts::Vector T_UserExtents,
         alpaka::concepts::Vector T_UserPitches>
-    ALPAKA_FN_HOST_ACC View(T_Any, T_Type*, T_UserExtents const&, T_UserPitches const&)
+    ALPAKA_FN_DG View(T_Any, T_Type*, T_UserExtents const&, T_UserPitches const&)
         -> View<ALPAKA_TYPEOF(getApi(std::declval<T_Any>())), T_Type, typename T_UserPitches::UniVec, Alignment<>>;
 } // namespace alpaka
 

--- a/script/job_generator/src/alpaka_bashi/ci_yaml/images.py
+++ b/script/job_generator/src/alpaka_bashi/ci_yaml/images.py
@@ -26,21 +26,6 @@ GITLAB_IMAGE_CACHE: list[str] | None = None
 # is used to display missing image warning one time
 image_warning_cache: list[str] = []
 
-CUSTOM_ROCM_IMAGES: dict[str, str] = {
-    # The alpaka CI container registry does not provide a prebuilt ROCm 7.14 image yet.
-    # Use AMD's official ROCm development image directly from Docker Hub.
-    "7.14": "rocm/dev-ubuntu-24.04:7.14.0-full",
-}
-
-
-@typechecked
-def get_custom_image_name(combination: bashi.Combination) -> str | None:
-    """Return a custom CI image for combinations not covered by the alpaka CI registry."""
-    if combination[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
-        return CUSTOM_ROCM_IMAGES.get(str(combination[DEVICE_COMPILER].version))
-
-    return None
-
 
 @typechecked
 def get_base_image(ubuntu_version) -> str:
@@ -99,10 +84,6 @@ def get_image_name(combination: bashi.Combination, container_version: str) -> st
     Returns:
         str: image name
     """
-    custom_image_name = get_custom_image_name(combination)
-    if custom_image_name is not None:
-        return custom_image_name
-
     image_name = get_base_image(combination[UBUNTU].version)
 
     cuda_ver = combination[ALPAKA_ACC_GPU_CUDA_ENABLE].version
@@ -132,9 +113,6 @@ def get_existing_image(image_name: str, combination: bashi.Combination, containe
     Returns:
         str: If image exist, return `image_name`. Otherwise return base image name.
     """
-    if image_name == get_custom_image_name(combination):
-        return image_name
-
     gitlab_images = get_images_from_registry(container_version)
     if image_name in gitlab_images:
         return image_name

--- a/script/job_generator/src/alpaka_bashi/ci_yaml/images.py
+++ b/script/job_generator/src/alpaka_bashi/ci_yaml/images.py
@@ -26,6 +26,21 @@ GITLAB_IMAGE_CACHE: list[str] | None = None
 # is used to display missing image warning one time
 image_warning_cache: list[str] = []
 
+CUSTOM_ROCM_IMAGES: dict[str, str] = {
+    # The alpaka CI container registry does not provide a prebuilt ROCm 7.14 image yet.
+    # Use AMD's official ROCm development image directly from Docker Hub.
+    "7.14": "rocm/dev-ubuntu-24.04:7.14.0-full",
+}
+
+
+@typechecked
+def get_custom_image_name(combination: bashi.Combination) -> str | None:
+    """Return a custom CI image for combinations not covered by the alpaka CI registry."""
+    if combination[ALPAKA_ACC_GPU_HIP_ENABLE].version != OFF_VER:
+        return CUSTOM_ROCM_IMAGES.get(str(combination[DEVICE_COMPILER].version))
+
+    return None
+
 
 @typechecked
 def get_base_image(ubuntu_version) -> str:
@@ -84,6 +99,10 @@ def get_image_name(combination: bashi.Combination, container_version: str) -> st
     Returns:
         str: image name
     """
+    custom_image_name = get_custom_image_name(combination)
+    if custom_image_name is not None:
+        return custom_image_name
+
     image_name = get_base_image(combination[UBUNTU].version)
 
     cuda_ver = combination[ALPAKA_ACC_GPU_CUDA_ENABLE].version
@@ -113,6 +132,9 @@ def get_existing_image(image_name: str, combination: bashi.Combination, containe
     Returns:
         str: If image exist, return `image_name`. Otherwise return base image name.
     """
+    if image_name == get_custom_image_name(combination):
+        return image_name
+
     gitlab_images = get_images_from_registry(container_version)
     if image_name in gitlab_images:
         return image_name

--- a/script/job_generator/src/alpaka_bashi/versions.py
+++ b/script/job_generator/src/alpaka_bashi/versions.py
@@ -29,7 +29,9 @@ from bashi.globals import (
     ON,
     UBUNTU,
 )
+from bashi.version.dependencies.base_version_support import ClangBase
 from bashi.version.dependencies.clang_cuda import CLANG_CUDA_MAX_CUDA_VERSION, ClangCudaSDKSupport
+from bashi.version.dependencies.hipcc import HIPCC_CLANG_VERSION
 
 from alpaka_bashi.globals import BUILD_TYPE, BUILD_TYPES, HWLOC
 
@@ -37,7 +39,7 @@ ALPAKA_VERSIONS: dict[str, list[str | int | float]] = {
     GCC: [12, 13, 14, 15],
     CLANG: [17, 18, 19, 20, 21],
     NVCC: [12.5, 12.6, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3],
-    HIPCC: [6.3, 6.4, 7.0, 7.1, 7.2],
+    HIPCC: [6.3, 6.4, 7.0, 7.1, 7.2, 7.14],
     ICPX: ["2025.1", "2025.2", "2025.3", "2026.0"],
     UBUNTU: ["24.04"],
     CMAKE: ["3.25.3", "3.26.4", "3.27.9", "3.28.6", "3.29.8", "3.30.3"],
@@ -159,5 +161,11 @@ def get_alpaka_version_relation() -> bashi.VersionRelation:
         ClangCudaSDKSupport("20", "12.8"),
         ClangCudaSDKSupport("22", "13.0"),
     ]
+    hipcc_clang_version = HIPCC_CLANG_VERSION + [
+        ClangBase("7.14", "23"),
+    ]
 
-    return bashi.VersionRelation(clang_cuda_max_cuda_version=clang_cuda_max_cuda_version)
+    return bashi.VersionRelation(
+        clang_cuda_max_cuda_version=clang_cuda_max_cuda_version,
+        hipcc_clang_version=hipcc_clang_version,
+    )


### PR DESCRIPTION
- Add macro `ALPAKA_FN_DG` to for deduction guides valid onHost and onAcc. Since clang 23 marking deduction guides `__host__ __device__` is deprecated.
- Fix code emission when using HIP 7.14 (triggered by memfence).
- Add using a custom ROCm 7.14 image to the Gitlab CI.
# Review:

The PR is split into logical changes, so I suggest looking into each commit separately.
