### PR TITLE
fix assumeComplete test helper function

### DIFF
--- a/test/unit/event/eventHelper.hpp
+++ b/test/unit/event/eventHelper.hpp
@@ -302,7 +302,7 @@ namespace alpaka::test::event
             for(uint32_t i = 0; i < repeat; ++i)
             {
                 result = m_postEvent.isComplete();
-                if(repeat == false)
+                if(result == false)
                     std::this_thread::sleep_for(std::chrono::milliseconds(ms));
                 else
                     break;


### PR DESCRIPTION
Pretty self explanatory - obvious typo or autocomplete mistake. 
Previous version always breaks after the first `m_postEvent.isComplete()` check. Since `repeat > 0` -> `else` branch selected. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event completion checks in test scenarios.
  * Improved polling behavior so retries occur only while completion is still pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->