### PR TITLE
workeround HIP CI issue

### DIFF
--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -56,10 +56,14 @@ fi
 
 if [[ "$APCI_HIP" != 0 ]]; then
     load_variable_if_not_exist ROCM_PATH
+    load_variable_if_not_exist HSA_ENABLE_SDMA
+    load_variable_if_not_exist HSA_XNACK
 
     export PATH=${ROCM_PATH}/bin:$PATH
     export PATH=${ROCM_PATH}/llvm/bin:$PATH
     export CMAKE_PREFIX_PATH=$ROCM_PATH:$CMAKE_PREFIX_PATH
+
+    echo_run "${ROCM_PATH}"/bin/hipconfig
 
     ap_deps['HIP']=ON
 

--- a/script/ci/install/rocm.sh
+++ b/script/ci/install/rocm.sh
@@ -71,6 +71,11 @@ if [[ "$APCI_HIP" != 0 ]]; then
     export ROCM_PATH
     export APCI_CXX_COMPILER="${ROCM_PATH}/llvm/bin/clang++"
 
+    # Disable SDMA to avoid an issues causing ROCm stuck because of a data race
+    # https://github.com/ROCm/ROCm/issues/6527
+    export HSA_ENABLE_SDMA=0
+    export HSA_XNACK=1
+
     echo_run "${APCI_CXX_COMPILER}" --version
 
     echo_run "${ROCM_PATH}"/bin/hipconfig
@@ -78,6 +83,8 @@ if [[ "$APCI_HIP" != 0 ]]; then
 
     store_variable ROCM_PATH
     store_variable APCI_CXX_COMPILER
+    store_variable HSA_ENABLE_SDMA
+    store_variable HSA_XNACK
 else
     echo_green "Skipped install ROCm because it is not required for the job."
 fi

--- a/script/ci/test.sh
+++ b/script/ci/test.sh
@@ -34,6 +34,8 @@ done
 
 parse_compiler_version "$APCI_DEVICE_COMPILER"
 
+echo_run hipconfig
+
 if [[ "${APCI_RUN_CTEST}" == "ON" ]]; then
     load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 


### PR DESCRIPTION
fix https://github.com/ROCm/ROCm/issues/6527

This should fix the issue that some jobs get stuck during testing because of an internal data race in ROCm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ROCm compatibility by disabling SDMA during setup, helping prevent related runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->