### PR TITLE
Introduce event policies

### DIFF
--- a/docs/source/tutorial/events.rst
+++ b/docs/source/tutorial/events.rst
@@ -41,8 +41,11 @@ Measuring Queued Work
 ---------------------
 
 Timing is an explicit queue capability and is disabled by default. Enable it by adding ``timing::enabled`` to the
-``onHost::QueuePolicyList`` passed to ``makeQueue``. Events can independently be constructed with ``timing::enabled``
-or ``timing::disabled``; ``queue.makeEvent()`` is also available as a convenience that inherits the queue's capability.
+``onHost::QueuePolicyList`` passed to ``makeQueue``. Events use ``onHost::EventPolicyList`` and can independently be
+constructed with ``timing::enabled`` or ``timing::disabled``. Passing an individual policy directly is shorthand for
+constructing the corresponding policy list. ``queue.makeEvent()`` inherits the queue's timing capability and accepts
+additional non-timing event policies.
+
 A timing-enabled event can only be enqueued on a timing-enabled queue. This rule is the same for every API, even where
 a native backend would technically allow a timed event on an ordinary queue.
 

--- a/include/alpaka/PolicyList.hpp
+++ b/include/alpaka/PolicyList.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/core/common.hpp"
+#include "alpaka/meta/Set.hpp"
 #include "alpaka/meta/TypeListOps.hpp"
 #include "alpaka/meta/filter.hpp"
 #include "alpaka/unused.hpp"
@@ -49,6 +50,7 @@ namespace alpaka
      * @tparam T_Policies Registered policy tag types contained in the bundle.
      */
     template<concepts::Policy... T_Policies>
+    requires(meta::IsParameterPackSet<std::remove_cvref_t<T_Policies>...>::value)
     struct PolicyList
     {
     protected:

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -45,6 +45,7 @@
 #include "alpaka/onAcc/warp.hpp"
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/onHost/DeviceSelector.hpp"
+#include "alpaka/onHost/EventPolicyList.hpp"
 #include "alpaka/onHost/Queue.hpp"
 #include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/algo/concurrent.hpp"

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -164,12 +164,12 @@ namespace alpaka::onHost
 
             friend struct internal::MakeEvent;
 
-            Handle<cpu::Event<Device>> makeEvent(alpaka::concepts::Timing auto timingMode)
+            Handle<cpu::Event<Device>> makeEvent(alpaka::concepts::EventPolicyList auto const& policies)
             {
                 ALPAKA_LOG_FUNCTION(alpaka::onHost::logger::event);
                 auto thisHandle = this->getSharedPtr();
                 std::lock_guard<std::mutex> lk{queuesGuard};
-                auto newEvent = std::make_shared<cpu::Event<Device>>(std::move(thisHandle), events.size(), timingMode);
+                auto newEvent = std::make_shared<cpu::Event<Device>>(std::move(thisHandle), events.size(), policies);
 
                 events.emplace_back(newEvent);
                 return newEvent;

--- a/include/alpaka/api/host/Event.hpp
+++ b/include/alpaka/api/host/Event.hpp
@@ -8,6 +8,7 @@
 #include "alpaka/api/host/Api.hpp"
 #include "alpaka/interface.hpp"
 #include "alpaka/internal/interface.hpp"
+#include "alpaka/onHost/EventPolicyList.hpp"
 #include "alpaka/onHost/Handle.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
 #include "alpaka/onHost/logger/logger.hpp"
@@ -29,10 +30,10 @@ namespace alpaka::onHost
             Event(
                 internal::concepts::DeviceHandle auto device,
                 uint32_t const idx,
-                alpaka::concepts::Timing auto timingMode)
+                alpaka::concepts::EventPolicyList auto const& policies)
                 : m_device(std::move(device))
                 , m_idx(idx)
-                , m_timingEnabled(timingMode == timing::enabled)
+                , m_timingEnabled(policies.getTiming() == timing::enabled)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::event);
             }

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -94,13 +94,13 @@ namespace alpaka::onHost
         private:
             friend struct internal::MakeEvent;
 
-            Handle<syclGeneric::Event<Device>> makeEvent(alpaka::concepts::Timing auto timingMode)
+            Handle<syclGeneric::Event<Device>> makeEvent(alpaka::concepts::EventPolicyList auto const& policies)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::event + onHost::logger::device);
                 auto thisHandle = this->getSharedPtr();
                 std::lock_guard<std::mutex> lk{m_writeGuard};
                 auto newEvent
-                    = std::make_shared<syclGeneric::Event<Device>>(std::move(thisHandle), events.size(), timingMode);
+                    = std::make_shared<syclGeneric::Event<Device>>(std::move(thisHandle), events.size(), policies);
 
                 events.emplace_back(newEvent);
                 return newEvent;

--- a/include/alpaka/api/syclGeneric/Event.hpp
+++ b/include/alpaka/api/syclGeneric/Event.hpp
@@ -34,7 +34,10 @@ namespace alpaka::onHost
             friend struct alpaka::internal::GetApi;
 
         public:
-            Event(internal::concepts::DeviceHandle auto device, uint32_t const idx, alpaka::concepts::Timing auto)
+            Event(
+                internal::concepts::DeviceHandle auto device,
+                uint32_t const idx,
+                [[maybe_unused]] alpaka::concepts::EventPolicyList auto const& policies)
                 : m_device(std::move(device))
                 , m_idx(idx)
             {

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -121,15 +121,13 @@ namespace alpaka::onHost
 
             friend struct onHost::internal::MakeEvent;
 
-            Handle<unifiedCudaHip::Event<Device>> makeEvent(alpaka::concepts::Timing auto timingMode)
+            Handle<unifiedCudaHip::Event<Device>> makeEvent(alpaka::concepts::EventPolicyList auto const& policies)
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::event);
                 auto thisHandle = this->getSharedPtr();
                 std::lock_guard<std::mutex> lk{m_writeGuard};
-                auto newEvent = std::make_shared<unifiedCudaHip::Event<Device>>(
-                    std::move(thisHandle),
-                    events.size(),
-                    timingMode);
+                auto newEvent
+                    = std::make_shared<unifiedCudaHip::Event<Device>>(std::move(thisHandle), events.size(), policies);
 
                 events.emplace_back(newEvent);
                 return newEvent;

--- a/include/alpaka/api/unifiedCudaHip/Event.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Event.hpp
@@ -45,7 +45,7 @@ namespace alpaka::onHost
             Event(
                 internal::concepts::DeviceHandle auto device,
                 uint32_t const idx,
-                alpaka::concepts::Timing auto timingMode)
+                alpaka::concepts::EventPolicyList auto const& policies)
                 : m_device(std::move(device))
                 , m_idx(idx)
             {
@@ -69,7 +69,7 @@ namespace alpaka::onHost
                     ApiInterface,
                     ApiInterface::eventCreateWithFlags(
                         &m_nativeEvent,
-                        timingMode == timing::enabled
+                        policies.getTiming() == timing::enabled
                             ? ApiInterface::eventDefault
                             : ApiInterface::eventDefault | ApiInterface::eventDisableTiming));
             }

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -7,6 +7,7 @@
 #include "Handle.hpp"
 #include "alpaka/interface.hpp"
 #include "alpaka/onHost/Event.hpp"
+#include "alpaka/onHost/EventPolicyList.hpp"
 #include "alpaka/onHost/Queue.hpp"
 #include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/concepts.hpp"
@@ -105,8 +106,7 @@ namespace alpaka::onHost
          * @param firstPolicy First queue construction policy.
          * @param policies Additional queue construction policies.
          */
-        template<alpaka::concepts::QueuePolicy T_FirstPolicy, alpaka::concepts::QueuePolicy... T_Policies>
-        auto makeQueue(T_FirstPolicy firstPolicy, T_Policies... policies)
+        auto makeQueue(alpaka::concepts::QueuePolicy auto firstPolicy, alpaka::concepts::QueuePolicy auto... policies)
         {
             return makeQueue(QueuePolicyList{firstPolicy, policies...});
         }
@@ -121,39 +121,46 @@ namespace alpaka::onHost
          * host-visible.
          *   - timing::disabled or timing::enabled: whether the queue supports timing-enabled events.
          */
-        template<alpaka::concepts::QueuePolicy... T_Policies>
-        auto makeQueue(QueuePolicyList<T_Policies...> const& policies)
+        auto makeQueue(alpaka::concepts::QueuePolicyList auto const& policies)
         {
             return Queue{
-                internal::MakeQueue::Op<ALPAKA_TYPEOF(*m_device.get()), QueuePolicyList<T_Policies...>>{}(
+                internal::MakeQueue::Op<ALPAKA_TYPEOF(*m_device.get()), ALPAKA_TYPEOF(policies)>{}(
                     *m_device.get(),
                     policies),
                 policies};
         }
 
-        /** Create an event with an explicit timing capability.
+        /** Create an event for this device.
          *
-         * Timing-enabled events can only be enqueued on timing-enabled queues.
-         *
-         * @param timingMode Specifies whether the event records timing information.
-         */
-        auto makeEvent(alpaka::concepts::Timing auto timingMode)
-        {
-            return Event{
-                internal::MakeEvent::Op<ALPAKA_TYPEOF(*m_device.get()), ALPAKA_TYPEOF(timingMode)>{}(
-                    *m_device.get(),
-                    timingMode),
-                timingMode};
-        }
-
-        /** Create a synchronization-only event.
-         *
-         * Timing support is by default disabled:
-         *
+         * @return An event that can be used to synchronize multiple queues.
          */
         auto makeEvent()
         {
-            return makeEvent(timing::disabled);
+            return makeEvent(EventPolicyList{});
+        }
+
+        /** @copydoc makeEvent()
+         *
+         * @param firstPolicy First event construction policy.
+         * @param policies Additional event construction policies.
+         */
+        auto makeEvent(alpaka::concepts::EventPolicy auto firstPolicy, alpaka::concepts::EventPolicy auto... policies)
+        {
+            return makeEvent(EventPolicyList{firstPolicy, policies...});
+        }
+
+        /** @copydoc makeEvent()
+         *
+         * @param policies Event construction policies. Supported policies are:
+         *   - timing::disabled or timing::enabled: whether the event records timing information.
+         */
+        auto makeEvent(alpaka::concepts::EventPolicyList auto const& policies)
+        {
+            return Event{
+                internal::MakeEvent::Op<ALPAKA_TYPEOF(*m_device.get()), ALPAKA_TYPEOF(policies)>{}(
+                    *m_device.get(),
+                    policies),
+                policies};
         }
 
         /** Blocks the caller until the given handle executes all work

--- a/include/alpaka/onHost/Event.hpp
+++ b/include/alpaka/onHost/Event.hpp
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include "Handle.hpp"
 #include "alpaka/api/trait.hpp"
+#include "alpaka/onHost/EventPolicyList.hpp"
+#include "alpaka/onHost/Handle.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
 
 #include <chrono>
@@ -17,32 +18,32 @@ namespace alpaka::onHost
     template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
     struct Device;
 
-    template<typename T_Device, alpaka::concepts::Timing T_Timing = timing::Disabled>
+    template<typename T_Device, alpaka::concepts::EventPolicyList T_EventPolicyList = EventPolicyList<>>
     struct Event;
 
-    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind, alpaka::concepts::Timing T_Timing>
-    struct Event<Device<T_Api, T_DeviceKind>, T_Timing>
+    template<
+        alpaka::concepts::Api T_Api,
+        alpaka::concepts::DeviceKind T_DeviceKind,
+        alpaka::concepts::EventPolicyList T_EventPolicyList>
+    struct Event<Device<T_Api, T_DeviceKind>, T_EventPolicyList>
     {
     private:
         using DeviceInterface = Device<T_Api, T_DeviceKind>;
         using EventHandle = ALPAKA_TYPEOF(
-            internal::MakeEvent::Op<ALPAKA_TYPEOF(*std::declval<DeviceInterface>().get()), T_Timing>{}(
+            internal::MakeEvent::Op<ALPAKA_TYPEOF(*std::declval<DeviceInterface>().get()), T_EventPolicyList>{}(
                 *std::declval<DeviceInterface>().get(),
-                T_Timing{}));
+                std::declval<T_EventPolicyList const&>()));
 
         EventHandle m_event;
+        [[no_unique_address]] T_EventPolicyList m_policies;
 
     public:
         using element_type = typename EventHandle::element_type;
 
         template<typename T_Event>
-        Event(Handle<T_Event>&& event, T_Timing) : m_event{std::forward<Handle<T_Event>>(event)}
-        {
-        }
-
-        template<typename T_Event>
-        Event(Handle<T_Event>&& event) requires std::same_as<T_Timing, timing::Disabled>
-            : Event{std::forward<Handle<T_Event>>(event), timing::disabled}
+        Event(Handle<T_Event>&& event, T_EventPolicyList const& policies)
+            : m_event{std::forward<Handle<T_Event>>(event)}
+            , m_policies{policies}
         {
         }
 
@@ -56,12 +57,17 @@ namespace alpaka::onHost
             return alpaka::internal::getApi(*m_event.get());
         }
 
-        constexpr alpaka::concepts::Timing auto getTiming() const
+        constexpr T_EventPolicyList const& getPolicyList() const
         {
-            return T_Timing{};
+            return m_policies;
         }
 
-        std::string getName() const
+        constexpr alpaka::concepts::Timing auto getTiming() const
+        {
+            return m_policies.getTiming();
+        }
+
+        [[nodiscard]] std::string getName() const
         {
             return alpaka::internal::GetName::Op<std::decay_t<decltype(*m_event.get())>>{}(*m_event.get());
         }
@@ -92,21 +98,16 @@ namespace alpaka::onHost
 
         bool isComplete() const
         {
-            return alpaka::onHost::internal::isEventComplete(*m_event.get());
+            return internal::isEventComplete(*m_event.get());
         }
     };
 
-    template<typename T_Event, alpaka::concepts::Timing T_Timing>
-    Event(Handle<T_Event>&&, T_Timing) -> Event<
+    template<typename T_Event, alpaka::concepts::EventPolicyList T_EventPolicyList>
+    Event(Handle<T_Event>&&, T_EventPolicyList) -> Event<
         Device<
             ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Event>())),
             ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Event>()))>,
-        T_Timing>;
-
-    template<typename T_Event>
-    Event(Handle<T_Event>&&) -> Event<Device<
-        ALPAKA_TYPEOF(alpaka::internal::getApi(std::declval<T_Event>())),
-        ALPAKA_TYPEOF(alpaka::internal::getDeviceKind(std::declval<T_Event>()))>>;
+        T_EventPolicyList>;
 
     /** Return the elapsed time between two timing-enabled queue markers.
      *
@@ -116,10 +117,17 @@ namespace alpaka::onHost
      * not need to be chronologically ordered; the duration is negative if the end
      * marker is reached before the start marker.
      */
-    template<alpaka::concepts::Api T_Api, alpaka::concepts::DeviceKind T_DeviceKind>
+    template<
+        alpaka::concepts::Api T_Api,
+        alpaka::concepts::DeviceKind T_DeviceKind,
+        alpaka::concepts::EventPolicyList T_StartPolicies,
+        alpaka::concepts::EventPolicyList T_EndPolicies>
+    requires(
+        std::same_as<ALPAKA_TYPEOF(T_StartPolicies::getTiming()), timing::Enabled>
+        && std::same_as<ALPAKA_TYPEOF(T_EndPolicies::getTiming()), timing::Enabled>)
     auto getElapsedTime(
-        Event<Device<T_Api, T_DeviceKind>, timing::Enabled> const& start,
-        Event<Device<T_Api, T_DeviceKind>, timing::Enabled> const& end) -> std::chrono::duration<double>
+        Event<Device<T_Api, T_DeviceKind>, T_StartPolicies> const& start,
+        Event<Device<T_Api, T_DeviceKind>, T_EndPolicies> const& end) -> std::chrono::duration<double>
     {
         if(start.getDevice() != end.getDevice())
             throw std::invalid_argument{"Elapsed time requires events from the same device"};

--- a/include/alpaka/onHost/EventPolicyList.hpp
+++ b/include/alpaka/onHost/EventPolicyList.hpp
@@ -1,0 +1,95 @@
+/* Copyright 2026 Tim Hanel
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/onHost/QueuePolicyList.hpp"
+#include "alpaka/tag.hpp"
+#include "alpaka/utility.hpp"
+
+namespace alpaka::trait
+{
+    /** Identifies compile-time event policy tags.
+     *
+     * Specialize this trait with std::true_type to register an application-defined event policy. Every event policy is
+     * also registered as a general policy through IsPolicy.
+     *
+     * @tparam T_Policy Type to inspect.
+     */
+    template<typename T_Policy>
+    struct IsEventPolicy : std::false_type
+    {
+    };
+
+    template<concepts::Timing T_Timing>
+    struct IsEventPolicy<T_Timing> : std::true_type
+    {
+    };
+} // namespace alpaka::trait
+
+namespace alpaka
+{
+    /** Whether a type is registered as a compile-time event policy tag. */
+    template<typename T_Policy>
+    constexpr bool isEventPolicy_v = trait::IsEventPolicy<std::remove_cvref_t<T_Policy>>::value;
+
+    namespace concepts
+    {
+        /** A registered, default-initializable compile-time event policy tag. */
+        template<typename T_Policy>
+        concept EventPolicy = isEventPolicy_v<T_Policy> && std::default_initializable<std::remove_cvref_t<T_Policy>>;
+    } // namespace concepts
+
+    namespace trait
+    {
+        template<concepts::EventPolicy T_Policy>
+        // the requires is in-place since timing already has been defined as IsPolicy under QueuePolicyList.hpp
+        requires(!concepts::QueuePolicy<T_Policy>)
+        struct IsPolicy<T_Policy> : std::true_type
+        {
+        };
+    } // namespace trait
+} // namespace alpaka
+
+namespace alpaka::onHost
+{
+    /** Collection of compile-time policies used to construct an event.
+     *
+     * Policies can be supplied in any order. At most one policy from each category may be present. Timing defaults to
+     * timing::disabled when the timing policy is omitted.
+     *
+     * @tparam T_Policies Event policy tag types contained in the bundle.
+     */
+    template<::alpaka::concepts::EventPolicy... T_Policies>
+    struct EventPolicyList : PolicyList<T_Policies...>
+    {
+        using Base = PolicyList<T_Policies...>;
+
+        /** Construct an event policy bundle.
+         *
+         * @param policies Compile-time event policy tags.
+         */
+        constexpr EventPolicyList(T_Policies... policies) : Base{policies...}
+        {
+        }
+
+        /** Return the selected timing policy, or timing::disabled if none was supplied. */
+        static constexpr alpaka::concepts::Timing auto getTiming()
+        {
+            return Base::search(category::Timing{}, timing::disabled);
+        }
+
+        using Base::hasPolicy;
+    };
+
+    template<typename... T_Policies>
+    EventPolicyList(T_Policies...) -> EventPolicyList<T_Policies...>;
+} // namespace alpaka::onHost
+
+namespace alpaka::concepts
+{
+    /** A specialization of onHost::EventPolicyList. */
+    template<typename T_Policies>
+    concept EventPolicyList = SpecializationOf<T_Policies, onHost::EventPolicyList>;
+} // namespace alpaka::concepts

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -114,13 +114,16 @@ namespace alpaka::onHost
 
         /** Create an event carrying this queue's timing capability.
          *
+         * @param policies Additional event policies.
+         *
          * An event created by a timing-enabled queue can only be enqueued on
          * another timing-enabled queue.
          */
-        auto makeEvent() const
+        template<alpaka::concepts::EventPolicy... T_EventPolicies>
+        requires(!(alpaka::concepts::Timing<T_EventPolicies> || ...))
+        auto makeEvent(T_EventPolicies... policies) const
         {
-            auto device = getDevice();
-            return device.makeEvent(getTiming());
+            return getDevice().makeEvent(EventPolicyList{getTiming(), policies...});
         }
 
         /** Enqueue a kernel functor to a queue.
@@ -239,9 +242,11 @@ namespace alpaka::onHost
          *
          * @param event Event that is to be enqueue in the queue of operations.
          */
-        template<alpaka::concepts::Timing T_EventTiming>
-        requires(std::same_as<T_EventTiming, timing::Disabled> || std::same_as<Timing, timing::Enabled>)
-        void enqueue(Event<Device<T_Api, T_DeviceKind>, T_EventTiming> const& event) const
+        template<alpaka::concepts::EventPolicyList T_EventPolicies>
+        requires(
+            std::same_as<ALPAKA_TYPEOF(T_EventPolicies::getTiming()), timing::Disabled>
+            || std::same_as<Timing, timing::Enabled>)
+        void enqueue(Event<Device<T_Api, T_DeviceKind>, T_EventPolicies> const& event) const
         {
             internal::Enqueue::Event<ALPAKA_TYPEOF(*m_queue.get()), ALPAKA_TYPEOF(*event.get())>{}(
                 *m_queue.get(),
@@ -252,8 +257,8 @@ namespace alpaka::onHost
          *
          * The caller will be blocked until all previously queued operations have been completed.
          */
-        template<alpaka::concepts::Timing T_EventTiming>
-        void waitFor(Event<Device<T_Api, T_DeviceKind>, T_EventTiming> const& event) const
+        template<alpaka::concepts::EventPolicyList T_EventPolicies>
+        void waitFor(Event<Device<T_Api, T_DeviceKind>, T_EventPolicies> const& event) const
         {
             internal::waitFor(*m_queue.get(), *event.get());
         }

--- a/include/alpaka/onHost/concepts.hpp
+++ b/include/alpaka/onHost/concepts.hpp
@@ -23,7 +23,7 @@ namespace alpaka::onHost
         template<typename T>
         concept Device = requires(T device) {
             { alpaka::internal::GetName::Op<T>{}(device) } -> std::convertible_to<std::string>;
-            { internal::MakeEvent::Op<T, timing::Disabled>{}(device, timing::disabled) };
+            { internal::MakeEvent::Op<T, EventPolicyList<>>{}(device, EventPolicyList{}) };
             { internal::GetNativeHandle::Op<T>{}(device) };
             { internal::GetDeviceProperties::Op<T>{}(device) };
         };

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/core/DictTraits.hpp"
 #include "alpaka/core/common.hpp"
 #include "alpaka/onHost/DeviceProperties.hpp"
+#include "alpaka/onHost/EventPolicyList.hpp"
 #include "alpaka/onHost/FrameSpec.hpp"
 #include "alpaka/onHost/Handle.hpp"
 #include "alpaka/onHost/QueuePolicyList.hpp"
@@ -112,12 +113,12 @@ namespace alpaka::onHost
 
         struct MakeEvent
         {
-            template<typename T_Device, alpaka::concepts::Timing T_Timing>
+            template<typename T_Device, alpaka::concepts::EventPolicyList T_EventPolicyList>
             struct Op
             {
-                auto operator()(T_Device& device, T_Timing timing) const
+                auto operator()(T_Device& device, T_EventPolicyList const& policies) const
                 {
-                    return device.makeEvent(timing);
+                    return device.makeEvent(policies);
                 }
             };
         };

--- a/test/unit/event/event.cpp
+++ b/test/unit/event/event.cpp
@@ -49,8 +49,42 @@ static constexpr auto optionalQueueKind =
 static constexpr auto testQueueKinds
     = std::tuple_cat(std::tuple{queueKind::blocking, queueKind::nonBlocking}, optionalQueueKind);
 
+struct TestEventPolicy
+{
+};
+
+template<>
+struct alpaka::trait::IsEventPolicy<TestEventPolicy> : std::true_type
+{
+};
+
+static_assert(alpaka::concepts::EventPolicy<timing::Enabled>);
+static_assert(alpaka::concepts::QueuePolicy<timing::Enabled>);
+static_assert(alpaka::concepts::Policy<timing::Enabled>);
+static_assert(alpaka::concepts::Policy<TestEventPolicy>);
+
+template<typename... T_Policies>
+concept CanInstantiatePolicyList = requires { typename PolicyList<T_Policies...>; };
+
+static_assert(CanInstantiatePolicyList<>);
+static_assert(!CanInstantiatePolicyList<TestEventPolicy, TestEventPolicy>);
+
+constexpr auto defaultEventPolicies = onHost::EventPolicyList{};
+static_assert(alpaka::concepts::EventPolicyList<decltype(defaultEventPolicies)>);
+static_assert(defaultEventPolicies.getTiming() == timing::disabled);
+
+constexpr auto testEventPolicies = onHost::EventPolicyList{timing::enabled, TestEventPolicy{}};
+static_assert(alpaka::concepts::EventPolicyList<decltype(testEventPolicies)>);
+static_assert(!alpaka::concepts::EventPolicyList<TestEventPolicy>);
+static_assert(testEventPolicies.getTiming() == timing::enabled);
+static_assert(testEventPolicies.hasPolicy(TestEventPolicy{}));
+static_assert(!testEventPolicies.hasPolicy(timing::disabled));
+
 template<typename T_Queue, typename T_Event>
 concept CanEnqueueEvent = requires(T_Queue const& queue, T_Event const& event) { queue.enqueue(event); };
+
+template<typename T_Queue, typename... T_Policies>
+concept CanMakeEvent = requires(T_Queue const& queue, T_Policies... policies) { queue.makeEvent(policies...); };
 
 /** This test takes care that kernel in different queues can run concurrent and if we can communicate between host and
  * the device via mapped memory. Even if the concurrent queue test says true it could be that kernels can run under the
@@ -80,7 +114,8 @@ TEMPLATE_LIST_TEST_CASE("event creation and enqueue", "", TestApis)
     onHost::Device device = test::getDeviceOrSkipTest(TestType::makeDict());
 
     onHost::Queue queue = device.makeQueue();
-    onHost::Event ev = device.makeEvent();
+    onHost::Event ev = device.makeEvent(onHost::EventPolicyList{TestEventPolicy{}});
+    CHECK(ev.getPolicyList().hasPolicy(TestEventPolicy{}));
     queue.enqueue(ev);
     onHost::wait(ev);
     CHECK(ev.isComplete() == true);
@@ -107,6 +142,8 @@ TEMPLATE_LIST_TEST_CASE("timing-enabled events measure queued work", "", TestApi
     static_assert(ALPAKA_TYPEOF(start.getTiming()){} == timing::enabled);
     static_assert(ALPAKA_TYPEOF(untimedEvent.getTiming()){} == timing::disabled);
     static_assert(!CanEnqueueEvent<ALPAKA_TYPEOF(untimedQueue), ALPAKA_TYPEOF(start)>);
+    static_assert(!CanMakeEvent<ALPAKA_TYPEOF(queue), timing::Enabled>);
+    static_assert(!CanMakeEvent<ALPAKA_TYPEOF(queue), timing::Disabled>);
 
     queue.enqueue(start);
     queue.enqueue(frameSpec, KernelBundle{EmptyTimingKernel{}});
@@ -174,12 +211,13 @@ TEMPLATE_LIST_TEST_CASE("queue-created timing-enabled events measure queued work
 {
     auto [device, executor] = test::getDeviceExecutorOrSkipTest(TestType::makeDict());
     auto queue = device.makeQueue(queueKind::nonBlocking, timing::enabled);
-    auto start = queue.makeEvent();
+    auto start = queue.makeEvent(TestEventPolicy{});
     auto end = queue.makeEvent();
     onHost::concepts::FrameSpec auto const frameSpec = onHost::getFrameSpec(device, executor, Vec{1u});
 
     static_assert(ALPAKA_TYPEOF(start.getTiming()){} == timing::enabled);
     static_assert(ALPAKA_TYPEOF(end.getTiming()){} == timing::enabled);
+    CHECK(start.getPolicyList().hasPolicy(TestEventPolicy{}));
 
     queue.enqueue(start);
     queue.enqueue(frameSpec, KernelBundle{EmptyTimingKernel{}});
@@ -292,8 +330,8 @@ TEMPLATE_LIST_TEST_CASE("wait for event preserves consumer queue order", "", Tes
     {
         DYNAMIC_SECTION("Ran with the following queueKind: " << alpaka::onHost::getName(queueKind))
         {
-            onHost::Queue producerQueue = device.makeQueue(queueKind::nonBlocking);
-            onHost::Queue consumerQueue = device.makeQueue(queueKind);
+            alpaka::onHost::Queue producerQueue = device.makeQueue(queueKind::nonBlocking);
+            alpaka::onHost::Queue consumerQueue = device.makeQueue(queueKind);
 
             auto produceKernel = TriggerKernel{device};
             onHost::Event event = device.makeEvent();


### PR DESCRIPTION
Extends the current makeEvent() interface with event policies, wrapped in a `EventPolicyList`.
This allows to easily add policies in addition to the current `timing` policy.
This PR is basically a mirrored extension the `QueuePolicyList` introduced in #664.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable event policy lists supporting timing and custom policies.
  - Events can be created with default, individual, or grouped policies.
  - Queue-created events inherit queue timing settings while accepting additional event policies.
  - Event timing can be enabled or disabled independently from queue timing.
  - Event policy information can be queried after creation.

- **Documentation**
  - Updated event timing guidance to explain queue and event policy configuration, shorthand, and inheritance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->