### PR TITLE
fix missing pedantic configuration for clang-cuda

### DIFF
--- a/cmake/alpakaCompilePedantic.cmake
+++ b/cmake/alpakaCompilePedantic.cmake
@@ -8,6 +8,9 @@
 #-------------------------------------------------------------------------------
 
 if(TARGET alpaka_target_cuda)
+    alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Wall>")
+    alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Wextra>")
+
     if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
         alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Wreorder>")
         alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--Wdefault-stream-launch>")
@@ -21,11 +24,20 @@ if(TARGET alpaka_target_cuda)
                 "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-pedantic>"
                 "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wno-pedantic>"
         )
-        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Wall>")
-        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Wextra>")
         if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8)
             # avoid `declared with greater visibility than the type of its field` with nvcc 12.8+
             alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Wno-attributes>")
+        endif()
+    elseif(CMAKE_CUDA_COMPILER_ID STREQUAL "Clang")
+        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Wpedantic>")
+        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Werror>")
+
+        # disable warning: 'CUDA version X.Y is only partially supported'
+        alpaka_set_compiler_options(DEVICE target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Wno-unknown-cuda-version>")
+
+        # disable the warning/error: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "22.0")
+            alpaka_set_compiler_options(HOST target alpaka_target_cuda "$<$<COMPILE_LANGUAGE:CUDA>:-Wno-c2y-extensions>")
         endif()
     endif()
 endif()

--- a/docs/snippets/example/230_kernelFn.cpp
+++ b/docs/snippets/example/230_kernelFn.cpp
@@ -57,7 +57,7 @@ namespace tutorial
     template<typename T_DeviceKind>
     ALPAKA_FN_ACC void alpakaFnDispatch(
         VectorAdd::Spec<api::Cuda, T_DeviceKind>,
-        onAcc::concepts::Acc auto const& acc,
+        onAcc::concepts::Acc auto const&,
         concepts::IMdSpan auto out,
         concepts::IDataSource auto const& lhs,
         concepts::IDataSource auto const& rhs)

--- a/include/alpaka/api/cuda/memFence.hpp
+++ b/include/alpaka/api/cuda/memFence.hpp
@@ -237,8 +237,10 @@ namespace alpaka::onAcc::internalCompute
     requires std::same_as<T_Api, api::Cuda>
     struct MemoryFence::Op<T_Api, T_Scope, T_Order>
     {
-        ALPAKA_FN_ACC constexpr void operator()(onAcc::concepts::Acc auto const&, T_Scope const, T_Order const order)
-            const
+        ALPAKA_FN_ACC constexpr void operator()(
+            onAcc::concepts::Acc auto const&,
+            T_Scope const,
+            [[maybe_unused]] T_Order const order) const
         {
             // Host pass is not allowed.
 #    if ALPAKA_ARCH_PTX


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved CUDA compiler diagnostics with stricter warning checks, including enhanced Clang CUDA support.
  * Added compatibility handling for newer CUDA and Clang versions to reduce irrelevant warnings while preserving meaningful errors.

* **Code Quality**
  * Improved readability and portability in CUDA-related examples and memory-fence code without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->