### PR TITLE
fix Github clone issue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,11 @@ stages:
 variables:
   # container version of the generated jobs
   ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION: "4.1"
+  # avoid that GitHub blocks git clone https://github.com/orgs/community/discussions/206581
+  GIT_TERMINAL_PROMPT: "0"
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: "http.https://github.com/.extraheader"
+  GIT_CONFIG_VALUE_0: "Authorization: Basic ${GITHUB_AUTH_BASE64}"
 
 generate:
   stage: generator

--- a/script/ci/configure.sh
+++ b/script/ci/configure.sh
@@ -18,6 +18,16 @@ LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-""}
 load_variable_if_not_exist APCI_CMAKE_BIN_PATH
 load_variable_if_not_exist APCI_CXX_COMPILER
 
+if [[ -z "${GITHUB_AUTH_BASE64:-}" ]]; then
+    echo "ERROR: GITHUB_AUTH_BASE64 is not available in this GitLab job."
+    exit 1
+fi
+# avoid that GitHub blocks git clone calls: see https://github.com/orgs/community/discussions/206581
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0='http.https://github.com/.extraheader'
+export GIT_CONFIG_VALUE_0="Authorization: Basic ${GITHUB_AUTH_BASE64}"
+export GIT_TERMINAL_PROMPT=0
+
 CMAKE_ARGS=(
     -S "${APCI_ALPAKA_ROOT}"
     -B "/build"

--- a/script/job_generator/src/alpaka_bashi/ci_yaml/variables.py
+++ b/script/job_generator/src/alpaka_bashi/ci_yaml/variables.py
@@ -77,6 +77,12 @@ def set_generic_variables(variables: dict[str, Any], combination: bashi.Combinat
     variables["APCI_ONEAPI_TARGET"] = "none"
     variables["APCI_SIMD"] = "DEFAULT"
 
+    # avoid that GitHub blocks git clone calls: see https://github.com/orgs/community/discussions/206581
+    variables["GIT_TERMINAL_PROMPT"] = "0"
+    variables["GIT_CONFIG_COUNT"] = "1"
+    variables["GIT_CONFIG_KEY_0"] = "http.https://github.com/.extraheader"
+    variables["GIT_CONFIG_VALUE_0"] = "Authorization: Basic ${GITHUB_AUTH_BASE64}"
+
     dependencies = ["APCI_OMP", "APCI_TBB"]
     gpu_dependencies = ["APCI_CUDA", "APCI_HIP", "APCI_ONEAPI"]
     sanitizers = ["APCI_SANITIZER_ASAN", "APCI_SANITIZER_TSAN", "APCI_SANITIZER_LSAN", "APCI_SANITIZER_UBSAN"]


### PR DESCRIPTION
The CI has issues to fetch external dependencies due to Github limitations, this PR is adding my access token to avoid blacklisting.

https://github.com/orgs/community/discussions/206581

what I did: 
 - goto github: Useraccount->Settings->Developer Settings->Personal access token->Tokens (classic)
   - create a token (without an expiration date)
   - do **not** give any rights
   - run in you desktop terminal: `printf 'x-access-token:%s' 'YOUR_GITHUB_TOKEN' | base64 -w0`
   - copy the base encoded token withtout ending %
 - in HZDR Gitlab Ci: Settings->CI/CD->Variables add a new variable
    - click: *Visibility:* Mask and hidden
    - add description
    - give it a name (Key)
    - set the value to the base64-encoded token from Github
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved CI pipeline reliability by preventing interactive Git prompts during automated jobs.
- Configured authenticated GitHub access for pipeline operations to reduce blocked repository clone requests.
- Applied these Git settings consistently across generated CI jobs and CI setup scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->