### PR TITLE
Memory pining policies

### DIFF
--- a/docs/snippets/example/250_memoryProperties.cpp
+++ b/docs/snippets/example/250_memoryProperties.cpp
@@ -1,0 +1,88 @@
+/* Copyright 2026 SiPearl
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include "docsTest.hpp"
+
+#include <alpaka/alpaka.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <iostream>
+#include <type_traits>
+#include <vector>
+
+using namespace alpaka;
+
+TEST_CASE("memory allocations", "[docs]")
+{
+    onHost::concepts::Device auto device = onHost::makeHostDevice();
+    {
+        // BEGIN-TUTORIAL-allocBufferDev
+        concepts::Vector auto extents = Vec{2u, 3u};
+        // the allocation is providing a shared buffer which will be
+        // automatically freed if the last handle runs out of a life-time
+        concepts::IBuffer auto devBuffer = onHost::alloc<int>(device, extents, memoryProperty::bestLatency);
+        // END-TUTORIAL-allocBufferDev
+        unused(devBuffer);
+    }
+    {
+        // BEGIN-TUTORIAL-allocBufferMapped
+        concepts::Vector auto extents = Vec{2u, 3u};
+        // allocate memory which lives on the host but is accessible from the compute device too
+        concepts::IBuffer auto devMappedBuffer
+            = onHost::allocMapped<int>(device, extents, memoryProperty::bestBandwidth);
+        // END-TUTORIAL-allocBufferMapped
+        unused(devMappedBuffer);
+    }
+    {
+        // BEGIN-TUTORIAL-allocBufferUnified
+        concepts::Vector auto extents = Vec{2u, 3u};
+        // allocate memory can be accessed from host and device (unified memory),
+        // the real location depends on the native backend e.g. CUDA, OneApi, ...
+        concepts::IBuffer auto devUnifiedBuffer = onHost::allocUnified<int>(device, extents, memoryProperty::locality);
+        // END-TUTORIAL-allocBufferUnified
+        unused(devUnifiedBuffer);
+    }
+}
+
+void callKernel([[maybe_unused]] auto dummyMemory)
+{
+}
+
+TEST_CASE("memory allocations deferred", "[docs]")
+{
+    onHost::concepts::Device auto device = onHost::makeHostDevice();
+    onHost::Queue queue = device.makeQueue();
+    // BEGIN-TUTORIAL-allocBufferDeferred
+    concepts::Vector auto extents = Vec{2u, 3u};
+    {
+        // The allocation is deferred.
+        // It is only allowed to access the memory after the queue processed the allocation task.
+        concepts::IBuffer auto devDeferredBuffer
+            = onHost::allocDeferred<int>(queue, extents, memoryProperty::bestBandwidth);
+        // Call the kernel with the buffer. This is only a dummy call not a real kernel call.
+        callKernel(devDeferredBuffer);
+        // At the end of the scope the buffer will be destroyed, but it could be that the kernel is not finished yet.
+        // This special allocation method take care that the buffer is waiting for the queue before the memory is
+        // freed.
+    }
+    // END-TUTORIAL-allocBufferDeferred
+}
+
+TEST_CASE("memory allocations like", "[docs]")
+{
+    onHost::concepts::Device auto computeDevice = onHost::makeHostDevice();
+    // BEGIN-TUTORIAL-allocLike
+    concepts::Vector auto extents = Vec{2u, 3u};
+    // short notation to allocate memory on the host without a host device as first argument
+    concepts::IBuffer auto hostBuffer = onHost::allocHost<int>(extents, memoryProperty::bestLatency);
+    // inherits value type and extents but does NOT copy the data
+    concepts::IBuffer auto devDoubleBuffer
+        = onHost::allocLike(computeDevice, hostBuffer, memoryProperty::bestBandwidth);
+    // END-TUTORIAL-allocLike
+
+    unused(devDoubleBuffer);
+}

--- a/docs/source/advanced/properties.rst
+++ b/docs/source/advanced/properties.rst
@@ -1,0 +1,27 @@
+Properties
+==========
+
+Memory Properties
+-----------------
+
+The properties in this subsection are available in the namespace ``alpaka::memoryProperty``. They can be applied to all allocation calls: ``alloc``, ``allocHost``, ``allocMapped``, ``allocUnified``, ``allocLike``, ``allocHostLike``, ``allocDeferred`` and ``allocLikeDeferred``.
+
+- ``memoryProperty::bestLatency`` This property selects memory nodes with the lowest access latency for memory pinning
+- ``memoryProperty::bestBandwidth`` This property selects memory nodes with the highest memory bandwidth for memory pinning
+- ``memoryProperty::locality`` This property selects the closest memory nodes for memory pinning
+- ``memoryProperty::defaultProperty`` Equivalent to no property; uses the default alpaka3 behavior
+
+Only one property of this category may be given per allocation call. If none is given, ``memoryProperty::defaultProperty`` is used.
+
+Memory Policy List
+------------------
+
+Allocation properties are collected in an ``alpaka::onHost::MemoryPolicyList``. Properties can either be passed directly to the allocation call or bundled explicitly into a policy list, both forms are equivalent:
+
+.. code-block:: cpp
+
+   auto bufferA = onHost::alloc<int>(device, extents, memoryProperty::bestBandwidth);
+   // is equivalent to
+   auto bufferB = onHost::alloc<int>(device, extents, onHost::MemoryPolicyList{memoryProperty::bestBandwidth});
+
+See :ref:`memory-pinning`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -80,12 +80,14 @@ Individual chapters are based on the information of the chapters before.
    tutorial/warp.rst
    tutorial/kernelFn.rst
    tutorial/vendorInterop.rst
+   tutorial/memoryPinning.rst
 
 .. toctree::
    :caption: Advanced
    :maxdepth: 2
 
    advanced/cmake.rst
+   advanced/properties.rst
    advanced/datastorage.rst
    advanced/benchmark.rst
    advanced/crosscompile.rst

--- a/docs/source/tutorial/memoryPinning.rst
+++ b/docs/source/tutorial/memoryPinning.rst
@@ -1,0 +1,77 @@
+.. _memory-pinning:
+
+Memory Pinning
+==============
+
+On the host, or when CPU devices are used, users can select which kind of memory is allocated. This can be done using allocation properties to select the memory with the best latency, best bandwidth, or best locality.
+
+Memory Allocation Property
+--------------------------
+
+- ``alpaka::memoryProperty::bestLatency`` Selects memory nodes with the best access latency
+- ``alpaka::memoryProperty::bestBandwidth`` Selects memory nodes with the highest memory bandwidth
+- ``alpaka::memoryProperty::locality`` Selects the closest memory nodes
+- ``alpaka::memoryProperty::defaultProperty`` Equivalent to no property; uses the default alpaka3 behavior
+
+These properties bind the memory to the selected nodes. If the memory nodes are full, the allocation fails. They use the MPOL_BIND policy.
+
+When used with other devices, there is no need for a separate code path depending on the device. These memory properties are ignored.
+
+Works with all kinds of allocations:
+
+- Device allocation
+
+  .. literalinclude:: ../../snippets/example/250_memoryProperties.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-allocBufferDev
+    :end-before: END-TUTORIAL-allocBufferDev
+    :dedent:
+
+- Mapped allocation
+
+  .. literalinclude:: ../../snippets/example/250_memoryProperties.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-allocBufferMapped
+    :end-before: END-TUTORIAL-allocBufferMapped
+    :dedent:
+
+- Unified Memory
+
+  .. literalinclude:: ../../snippets/example/250_memoryProperties.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-allocBufferUnified
+    :end-before: END-TUTORIAL-allocBufferUnified
+    :dedent:
+
+- Alloc Like
+
+  .. literalinclude:: ../../snippets/example/250_memoryProperties.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-allocLike
+    :end-before: END-TUTORIAL-allocLike
+    :dedent:
+
+- Deferred Allocation
+
+  .. literalinclude:: ../../snippets/example/250_memoryProperties.cpp
+    :language: cpp
+    :start-after: BEGIN-TUTORIAL-allocBufferDeferred
+    :end-before: END-TUTORIAL-allocBufferDeferred
+    :dedent:
+
+Complete Source File
+--------------------
+
+.. raw:: html
+
+   <details class="full-source">
+   <summary>250_memoryProperties.cpp</summary>
+
+.. filteredliteralinclude:: ../../snippets/example/250_memoryProperties.cpp
+   :language: cpp
+   :linenos:
+
+.. raw:: html
+
+   </details>
+   <br/>

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -46,6 +46,7 @@
 #include "alpaka/onHost/Device.hpp"
 #include "alpaka/onHost/DeviceSelector.hpp"
 #include "alpaka/onHost/EventPolicyList.hpp"
+#include "alpaka/onHost/MemoryPolicyList.hpp"
 #include "alpaka/onHost/Queue.hpp"
 #include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/algo/concurrent.hpp"

--- a/include/alpaka/api/host/Device.hpp
+++ b/include/alpaka/api/host/Device.hpp
@@ -113,10 +113,10 @@ namespace alpaka::onHost
                 internal::hwloc::setThreadAffinity(m_cpuGroupIdx);
             }
 
-            template<typename T>
-            void pinPointer(T* const ptr, size_t bytes)
+            template<typename T, alpaka::concepts::MemoryProperty T_Property>
+            void pinPointer(T* const ptr, size_t bytes, T_Property property)
             {
-                internal::hwloc::pinPointer(ptr, bytes, m_cpuGroupIdx);
+                internal::hwloc::pinPointer(ptr, bytes, property, m_cpuGroupIdx);
             }
 
             bool isNumaAware() const
@@ -225,10 +225,14 @@ namespace alpaka::onHost
 
     namespace internal
     {
-        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct Alloc::Op<T_Type, cpu::Device<T_Platform>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Platform,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct Alloc::Op<T_Type, cpu::Device<T_Platform>, T_Extents, T_Property>
         {
-            auto operator()(cpu::Device<T_Platform>& device, T_Extents const& extents) const
+            auto operator()(cpu::Device<T_Platform>& device, T_Extents const& extents, T_Property property) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 constexpr uint32_t alignment = api::util::simdOptimizedAlignment<T_Type>(
@@ -239,7 +243,7 @@ namespace alpaka::onHost
                 auto deviceDependency = onHost::Device{device.getSharedPtr()};
 
                 T_Type* ptr = reinterpret_cast<T_Type*>(alpaka::core::alignedAlloc(alignment, memSizeInByte));
-                device.pinPointer(ptr, memSizeInByte);
+                device.pinPointer(ptr, memSizeInByte, property);
                 // deviceDependency is captured to keep the device alive until the memory is deleted
                 auto deleter = [ptr, deviceDependency]() { alpaka::core::alignedFree(alignment, ptr); };
 
@@ -263,23 +267,31 @@ namespace alpaka::onHost
             }
         };
 
-        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct AllocUnified::Op<T_Type, cpu::Device<T_Platform>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Platform,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct AllocUnified::Op<T_Type, cpu::Device<T_Platform>, T_Extents, T_Property>
         {
-            auto operator()(cpu::Device<T_Platform>& device, T_Extents const& extents) const
+            auto operator()(cpu::Device<T_Platform>& device, T_Extents const& extents, T_Property property) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
-                return Alloc::Op<T_Type, cpu::Device<T_Platform>, T_Extents>{}(device, extents);
+                return Alloc::Op<T_Type, cpu::Device<T_Platform>, T_Extents, T_Property>{}(device, extents, property);
             }
         };
 
-        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct AllocMapped::Op<T_Type, cpu::Device<T_Platform>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Platform,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct AllocMapped::Op<T_Type, cpu::Device<T_Platform>, T_Extents, T_Property>
         {
-            auto operator()(cpu::Device<T_Platform>& device, T_Extents const& extents) const
+            auto operator()(cpu::Device<T_Platform>& device, T_Extents const& extents, T_Property property) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
-                return Alloc::Op<T_Type, cpu::Device<T_Platform>, T_Extents>{}(device, extents);
+                return Alloc::Op<T_Type, cpu::Device<T_Platform>, T_Extents, T_Property>{}(device, extents, property);
             }
         };
 

--- a/include/alpaka/api/host/OmpCollectiveQueue.hpp
+++ b/include/alpaka/api/host/OmpCollectiveQueue.hpp
@@ -699,10 +699,15 @@ namespace alpaka::onHost
         };
 
         /** OpenMP barrier is used. */
-        template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
-        struct AllocDeferred::Op<T_Type, cpu::OmpCollectiveQueue<T_Device>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Device,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct AllocDeferred::Op<T_Type, cpu::OmpCollectiveQueue<T_Device>, T_Extents, T_Property>
         {
-            auto operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Extents const& extents) const
+            auto operator()(cpu::OmpCollectiveQueue<T_Device>& queue, T_Extents const& extents, T_Property property)
+                const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
 
@@ -710,9 +715,10 @@ namespace alpaka::onHost
                     queue,
                     [&]
                     {
-                        return internal::AllocDeferred::Op<T_Type, cpu::Queue<T_Device>, T_Extents>{}(
+                        return internal::AllocDeferred::Op<T_Type, cpu::Queue<T_Device>, T_Extents, T_Property>{}(
                             *queue.parentQueue,
-                            extents);
+                            extents,
+                            property);
                     });
             }
         };

--- a/include/alpaka/api/host/Queue.hpp
+++ b/include/alpaka/api/host/Queue.hpp
@@ -592,8 +592,12 @@ namespace alpaka::onHost
         /** The code is a copy of the Alloc::Op with the difference that the memory is allocated and freed
          * within a queue
          */
-        template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
-        struct AllocDeferred::Op<T_Type, cpu::Queue<T_Device>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Device,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct AllocDeferred::Op<T_Type, cpu::Queue<T_Device>, T_Extents, T_Property>
         {
             static consteval uint32_t highestPowerOfTwo(uint32_t value)
             {
@@ -605,7 +609,7 @@ namespace alpaka::onHost
                 return result;
             }
 
-            auto operator()(cpu::Queue<T_Device>& queue, T_Extents const& extents) const
+            auto operator()(cpu::Queue<T_Device>& queue, T_Extents const& extents, T_Property property) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
                 auto device = queue.getDevice();
@@ -618,7 +622,7 @@ namespace alpaka::onHost
                 auto queueDependency = queue.getSharedPtr();
 
                 T_Type* ptr = reinterpret_cast<T_Type*>(alpaka::core::alignedAlloc(alignment, memSizeInByte));
-                device->pinPointer(ptr, memSizeInByte);
+                device->pinPointer(ptr, memSizeInByte, property);
 
                 // queueDependency is captured to keep the device alive until the memory is deleted
                 auto deleter = [ptr, queueDep = std::move(queueDependency)]()

--- a/include/alpaka/api/host/hwloc/utility.hpp
+++ b/include/alpaka/api/host/hwloc/utility.hpp
@@ -7,11 +7,15 @@
 #include "alpaka/api/host/hwloc/hwlocConfig.hpp"
 #include "alpaka/api/host/sysInfo.hpp"
 #include "alpaka/core/util.hpp"
+#include "alpaka/onHost/logger/logger.hpp"
+#include "alpaka/tag.hpp"
 #include "alpaka/unused.hpp"
 
 #include <cerrno>
+#include <concepts>
 #include <cstring>
 #include <fstream>
+#include <iostream>
 #include <limits>
 #include <optional>
 #include <sstream>
@@ -346,27 +350,27 @@ namespace alpaka::onHost::internal::hwloc
 #if ALPAKA_HAS_HWLOC
     /** Set the NUMA memory target for the memory range described by ptr and bytes. */
     template<typename T>
-    inline void pinPointerToNumaNode(T* const ptr, size_t bytes, hwloc_obj_t const node)
+    inline void pinPointerToNumaNode(T* const ptr, size_t bytes, hwloc_nodeset_t const nodeset)
     {
         if(ptr == nullptr || bytes == 0u)
             return;
 
-        if(node == nullptr)
-            throw std::runtime_error("NUMA node is null");
-
-        if(node->type != HWLOC_OBJ_NUMANODE)
-            throw std::runtime_error("Memory binding target is not a NUMA node");
-
-        if(node->nodeset == nullptr)
+        if(hwloc_bitmap_iszero(nodeset))
         {
-            throw std::runtime_error("NUMA node has no nodeset");
+            throw std::runtime_error("Nodeset is empty");
         }
 
-        hwloc_nodeset_t nodeset = hwloc_bitmap_dup(node->nodeset);
-        if(nodeset == nullptr)
-        {
-            throw std::bad_alloc();
-        }
+        char* str;
+        hwloc_bitmap_asprintf(&str, nodeset);
+        ALPAKA_LOG_INFO(
+            onHost::logger::memory,
+            [&]()
+            {
+                std::stringstream ss;
+                ss << "pinPointerToNumaNode{ ptr=" << ptr << ", bytes=" << bytes << ", nodeset=" << str << " }";
+                return ss.str();
+            });
+        free(str);
 
         int const rc = hwloc_set_area_membind(
             getTopology(),
@@ -374,9 +378,7 @@ namespace alpaka::onHost::internal::hwloc
             bytes,
             nodeset,
             HWLOC_MEMBIND_BIND,
-            HWLOC_MEMBIND_BYNODESET | HWLOC_MEMBIND_STRICT);
-
-        hwloc_bitmap_free(nodeset);
+            HWLOC_MEMBIND_BYNODESET | HWLOC_MEMBIND_STRICT | HWLOC_MEMBIND_MIGRATE);
 
         if(rc != 0)
         {
@@ -397,38 +399,185 @@ namespace alpaka::onHost::internal::hwloc
     }
 #endif
 
+#if ALPAKA_HAS_HWLOC
+    /** Translate an alpaka memory property tag to the underlying hwloc memory attribute id.
+     *
+     * @tparam T_Property Compile-time memory property tag, must be a placement preference (not
+     * memoryProperty::Default).
+     */
+    template<alpaka::concepts::MemoryProperty T_Property>
+    inline hwloc_memattr_id_t toHwloc(T_Property)
+    {
+        if constexpr(std::same_as<T_Property, memoryProperty::BestBandwidth>)
+            return HWLOC_MEMATTR_ID_BANDWIDTH;
+        else if constexpr(std::same_as<T_Property, memoryProperty::BestLatency>)
+            return HWLOC_MEMATTR_ID_LATENCY;
+        else if constexpr(std::same_as<T_Property, memoryProperty::Locality>)
+            return HWLOC_MEMATTR_ID_LOCALITY;
+        else
+            static_assert(sizeof(T_Property) == 0, "Unknown MemoryProperty");
+    }
+
+    inline hwloc_cpuset_t getInitiatorCpuset(hwloc_topology_t topology, uint32_t cpuDomainIdx)
+    {
+        if(cpuDomainIdx == allDomains)
+        {
+            return hwloc_get_root_obj(topology)->cpuset;
+        }
+
+        hwloc_obj_t cpuDomain = getCpuDomainObj(cpuDomainIdx);
+
+        if(cpuDomain == nullptr)
+        {
+            throw std::runtime_error("Invalid CPU domain");
+        }
+
+        return cpuDomain->cpuset;
+    }
+
+    /** Whether 'value' is preferable to the current 'baseValue' for the requested memory property.
+     *
+     * @tparam T_Property Compile-time memory property tag, must be a placement preference (not
+     * memoryProperty::Default).
+     */
+    template<alpaka::concepts::MemoryProperty T_Property>
+    inline bool isBestValue(hwloc_uint64_t value, hwloc_uint64_t baseValue, T_Property)
+    {
+        if constexpr(std::same_as<T_Property, memoryProperty::BestBandwidth>)
+            return value > baseValue;
+        else if constexpr(std::same_as<T_Property, memoryProperty::BestLatency>)
+            return value < baseValue;
+        else if constexpr(std::same_as<T_Property, memoryProperty::Locality>)
+            return value < baseValue;
+        else
+            static_assert(sizeof(T_Property) == 0, "Property can not be compared");
+    }
+#endif
+
     /** Set the default NUMA memory node for a CPU-domain memory range.
      *
      * @attention This method should be called before the memory is touched, else it may have no effect.
-     *            If a cpuDomainIdx contains more than one numa domain, the first numa domain will be used.
+     *            If a cpuDomainIdx contains more than one numa domain, the first numa domain will be used unless a
+     *            more specific placement policy is requested via `property`.
      *
      * @param ptr pointer address to pin, nullptr is valid input.
      * @param bytes the number of bytes to pin starting from the ptr address.
+     * @param property compile-time memory placement preference, see alpaka::memoryProperty.
      * @param cpuDomainIdx Index of the cpu group.
      */
-    template<typename T>
-    inline void pinPointer(T* const ptr, size_t bytes, uint32_t cpuDomainIdx)
+    template<typename T, alpaka::concepts::MemoryProperty T_Property>
+    inline void pinPointer(T* const ptr, size_t bytes, T_Property property, uint32_t cpuDomainIdx)
     {
 #if ALPAKA_HAS_HWLOC
-        if(cpuDomainIdx == allDomains)
+        if(cpuDomainIdx == allDomains && std::same_as<T_Property, memoryProperty::Default>)
             return;
 
         if(ptr == nullptr || bytes == 0u)
             return;
 
-        std::vector<hwloc_obj_t> const nodes = getMemoryNodes(getCpuDomainObj(cpuDomainIdx));
-        if(nodes.empty())
+        hwloc_topology_t topology = getTopology();
+        hwloc_nodeset_t pinningNodes = hwloc_bitmap_alloc();
+        if(pinningNodes == nullptr)
         {
-            throw std::runtime_error("CPU domain has no associated NUMA memory node");
+            throw std::bad_alloc();
         }
 
-        /** take the first numa domain
-         *
-         * @todo: this should be slectable during onHost::alloc()
-         */
-        pinPointerToNumaNode(ptr, bytes, nodes.front());
+        if constexpr(!std::same_as<T_Property, memoryProperty::Default>)
+        {
+            hwloc_memattr_id_t const attr = toHwloc(property);
+
+            // Domains to evaluate: either the single requested domain, or every domain on the
+            // machine when allDomains is requested. Each domain's memattr data is only valid
+            // when queried with that domain's own cpuset as initiator.
+            std::vector<hwloc_obj_t> const domainsToScan
+                = (cpuDomainIdx == allDomains) ? getCpuDomains()
+                                               : std::vector<hwloc_obj_t>{getCpuDomainObj(cpuDomainIdx)};
+
+            for(hwloc_obj_t domain : domainsToScan)
+            {
+                std::vector<hwloc_obj_t> const domainNodes = getMemoryNodes(domain);
+
+                hwloc_location location{};
+                location.type = HWLOC_LOCATION_TYPE_CPUSET;
+                location.location.cpuset = domain->cpuset;
+
+                hwloc_nodeset_t bestNodes = hwloc_bitmap_alloc();
+                if(bestNodes == nullptr)
+                {
+                    hwloc_bitmap_free(pinningNodes);
+                    throw std::bad_alloc();
+                }
+
+                constexpr auto Min = std::numeric_limits<hwloc_uint64_t>::min();
+                constexpr auto Max = std::numeric_limits<hwloc_uint64_t>::max();
+                hwloc_uint64_t best = isBestValue(Max, Min, property) ? Min : Max;
+
+                for(hwloc_obj_t node : domainNodes)
+                {
+                    hwloc_uint64_t value = 0;
+
+                    int err = hwloc_memattr_get_value(topology, attr, node, &location, 0, &value);
+
+                    if(err != 0 || value == 0)
+                        continue;
+
+                    if(isBestValue(value, best, property))
+                    {
+                        best = value;
+                        hwloc_bitmap_zero(bestNodes);
+                    }
+
+                    if(best == value)
+                    {
+                        hwloc_bitmap_or(bestNodes, bestNodes, node->nodeset);
+                    }
+                }
+
+                // Fall back to this domain's first NUMA node if the attribute wasn't available for it.
+                if(hwloc_bitmap_iszero(bestNodes) && !domainNodes.empty())
+                    hwloc_bitmap_or(bestNodes, bestNodes, domainNodes.front()->nodeset);
+
+                if(!hwloc_bitmap_iszero(bestNodes))
+                {
+                    hwloc_bitmap_or(pinningNodes, pinningNodes, bestNodes);
+                }
+
+                hwloc_bitmap_free(bestNodes);
+            }
+        }
+        else
+        {
+            /** Fallback
+             * Take first numa domain
+             * Only used when device is NumaCPU
+             */
+            // FIXME: - should a warning be added to warn the user when the fallback is used?
+            //        - should the default policy use best locality instead of the first numa?
+            hwloc_obj_t const cpuDomain
+                = (cpuDomainIdx == allDomains) ? hwloc_get_root_obj(topology) : getCpuDomainObj(cpuDomainIdx);
+            std::vector<hwloc_obj_t> const allnodes = getMemoryNodes(cpuDomain);
+            if(!allnodes.empty())
+                hwloc_bitmap_or(pinningNodes, pinningNodes, allnodes.front()->nodeset);
+        }
+
+        if(hwloc_bitmap_iszero(pinningNodes))
+        {
+            hwloc_bitmap_free(pinningNodes);
+            throw std::runtime_error("CPU domain has no associated NUMA memory node");
+        }
+        try
+        {
+            pinPointerToNumaNode(ptr, bytes, pinningNodes);
+        }
+        catch(...)
+        {
+            hwloc_bitmap_free(pinningNodes);
+            throw;
+        }
+
+        hwloc_bitmap_free(pinningNodes);
 #else
-        alpaka::unused(ptr, bytes, cpuDomainIdx);
+        alpaka::unused(ptr, bytes, property, cpuDomainIdx);
         return;
 #endif
     }

--- a/include/alpaka/api/syclGeneric/Device.hpp
+++ b/include/alpaka/api/syclGeneric/Device.hpp
@@ -142,10 +142,17 @@ namespace alpaka::onHost
     namespace internal
     {
 
-        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct Alloc::Op<T_Type, syclGeneric::Device<T_Platform>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Platform,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct Alloc::Op<T_Type, syclGeneric::Device<T_Platform>, T_Extents, T_Property>
         {
-            auto operator()(syclGeneric::Device<T_Platform>& device, T_Extents const& extents) const
+            auto operator()(
+                syclGeneric::Device<T_Platform>& device,
+                T_Extents const& extents,
+                [[maybe_unused]] T_Property property) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 constexpr uint32_t alignment = api::util::simdOptimizedAlignment<T_Type>(
@@ -171,10 +178,17 @@ namespace alpaka::onHost
             }
         };
 
-        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct AllocUnified::Op<T_Type, syclGeneric::Device<T_Platform>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Platform,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct AllocUnified::Op<T_Type, syclGeneric::Device<T_Platform>, T_Extents, T_Property>
         {
-            auto operator()(syclGeneric::Device<T_Platform>& device, T_Extents const& extents) const
+            auto operator()(
+                syclGeneric::Device<T_Platform>& device,
+                T_Extents const& extents,
+                [[maybe_unused]] T_Property property) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 constexpr uint32_t alignment = api::util::simdOptimizedAlignment<T_Type>(
@@ -206,10 +220,17 @@ namespace alpaka::onHost
             }
         };
 
-        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct AllocMapped::Op<T_Type, syclGeneric::Device<T_Platform>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Platform,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct AllocMapped::Op<T_Type, syclGeneric::Device<T_Platform>, T_Extents, T_Property>
         {
-            auto operator()(syclGeneric::Device<T_Platform>& device, T_Extents const& extents) const
+            auto operator()(
+                syclGeneric::Device<T_Platform>& device,
+                T_Extents const& extents,
+                [[maybe_unused]] T_Property property) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 constexpr uint32_t alignment = api::util::simdOptimizedAlignment<T_Type>(

--- a/include/alpaka/api/syclGeneric/Queue.hpp
+++ b/include/alpaka/api/syclGeneric/Queue.hpp
@@ -512,10 +512,17 @@ namespace alpaka::onHost
     /** The code is a copy of the Alloc::Op with the difference that the memory is allocated and freed
      * within a queue
      */
-    template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
-    struct internal::AllocDeferred::Op<T_Type, syclGeneric::Queue<T_Device>, T_Extents>
+    template<
+        typename T_Type,
+        typename T_Device,
+        alpaka::concepts::Vector T_Extents,
+        alpaka::concepts::MemoryProperty T_Property>
+    struct internal::AllocDeferred::Op<T_Type, syclGeneric::Queue<T_Device>, T_Extents, T_Property>
     {
-        auto operator()(syclGeneric::Queue<T_Device>& queue, T_Extents const& extents) const
+        auto operator()(
+            syclGeneric::Queue<T_Device>& queue,
+            T_Extents const& extents,
+            [[maybe_unused]] T_Property property) const
         {
             ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
             auto device = queue.getDevice();

--- a/include/alpaka/api/unifiedCudaHip/Device.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Device.hpp
@@ -180,10 +180,17 @@ namespace alpaka::onHost
 {
     namespace internal
     {
-        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct Alloc::Op<T_Type, unifiedCudaHip::Device<T_Platform>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Platform,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct Alloc::Op<T_Type, unifiedCudaHip::Device<T_Platform>, T_Extents, T_Property>
         {
-            auto operator()(unifiedCudaHip::Device<T_Platform>& device, T_Extents const& extents) const
+            auto operator()(
+                unifiedCudaHip::Device<T_Platform>& device,
+                T_Extents const& extents,
+                [[maybe_unused]] T_Property property) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 using ApiInterface = typename T_Platform::ApiInterface;
@@ -255,10 +262,17 @@ namespace alpaka::onHost
             }
         };
 
-        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct AllocUnified::Op<T_Type, unifiedCudaHip::Device<T_Platform>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Platform,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct AllocUnified::Op<T_Type, unifiedCudaHip::Device<T_Platform>, T_Extents, T_Property>
         {
-            auto operator()(unifiedCudaHip::Device<T_Platform>& device, T_Extents const& extents) const
+            auto operator()(
+                unifiedCudaHip::Device<T_Platform>& device,
+                T_Extents const& extents,
+                [[maybe_unused]] T_Property property) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 using ApiInterface = typename T_Platform::ApiInterface;
@@ -304,10 +318,17 @@ namespace alpaka::onHost
             }
         };
 
-        template<typename T_Type, typename T_Platform, alpaka::concepts::Vector T_Extents>
-        struct AllocMapped::Op<T_Type, unifiedCudaHip::Device<T_Platform>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Platform,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct AllocMapped::Op<T_Type, unifiedCudaHip::Device<T_Platform>, T_Extents, T_Property>
         {
-            auto operator()(unifiedCudaHip::Device<T_Platform>& device, T_Extents const& extents) const
+            auto operator()(
+                unifiedCudaHip::Device<T_Platform>& device,
+                T_Extents const& extents,
+                [[maybe_unused]] T_Property property) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::device);
                 using ApiInterface = typename T_Platform::ApiInterface;

--- a/include/alpaka/api/unifiedCudaHip/Queue.hpp
+++ b/include/alpaka/api/unifiedCudaHip/Queue.hpp
@@ -1025,10 +1025,17 @@ namespace alpaka::onHost
         /** The code is a copy of the Alloc::Op with the difference that the memory is allocated and freed
          * within a queue
          */
-        template<typename T_Type, typename T_Device, alpaka::concepts::Vector T_Extents>
-        struct AllocDeferred::Op<T_Type, unifiedCudaHip::Queue<T_Device>, T_Extents>
+        template<
+            typename T_Type,
+            typename T_Device,
+            alpaka::concepts::Vector T_Extents,
+            alpaka::concepts::MemoryProperty T_Property>
+        struct AllocDeferred::Op<T_Type, unifiedCudaHip::Queue<T_Device>, T_Extents, T_Property>
         {
-            auto operator()(unifiedCudaHip::Queue<T_Device>& queue, T_Extents const& extents) const
+            auto operator()(
+                unifiedCudaHip::Queue<T_Device>& queue,
+                T_Extents const& extents,
+                [[maybe_unused]] T_Property property) const
             {
                 ALPAKA_LOG_FUNCTION(onHost::logger::memory + onHost::logger::queue);
                 using ApiInterface = typename T_Device::ApiInterface;

--- a/include/alpaka/onHost/Device.hpp
+++ b/include/alpaka/onHost/Device.hpp
@@ -8,6 +8,7 @@
 #include "alpaka/interface.hpp"
 #include "alpaka/onHost/Event.hpp"
 #include "alpaka/onHost/EventPolicyList.hpp"
+#include "alpaka/onHost/MemoryPolicyList.hpp"
 #include "alpaka/onHost/Queue.hpp"
 #include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/concepts.hpp"
@@ -207,6 +208,8 @@ namespace alpaka::onHost
      */
     /** Allocate memory on the given device
      *
+     * By default no explicit memory placement preference is used and the backend chooses its default strategy.
+     *
      * @tparam T_Type type of the data elements
      * @param device device handle
      * @param extents number of elements for each dimension
@@ -215,10 +218,48 @@ namespace alpaka::onHost
     template<typename T_Type>
     inline auto alloc(concepts::Device auto const& device, alpaka::concepts::VectorOrScalar auto const& extents)
     {
+        return alloc<T_Type>(device, extents, MemoryPolicyList<>{});
+    }
+
+    /** @copydoc alloc()
+     *
+     * @param firstPolicy First memory allocation policy.
+     * @param policies Additional memory allocation policies.
+     */
+    template<
+        typename T_Type,
+        alpaka::concepts::MemoryPolicy T_FirstPolicy,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto alloc(
+        concepts::Device auto const& device,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        T_FirstPolicy firstPolicy,
+        T_Policies... policies)
+    {
+        return alloc<T_Type>(device, extents, MemoryPolicyList{firstPolicy, policies...});
+    }
+
+    /** @copydoc alloc()
+     *
+     * @param policies Memory allocation policies. Supported policies are:
+     *   - Placement preference:
+     *    - memoryProperty::defaultProperty: no explicit preference, the backend chooses its default strategy.
+     *    - memoryProperty::bestLatency: prefer the memory node with the lowest access latency.
+     *    - memoryProperty::bestBandwidth: prefer the memory node with the highest bandwidth.
+     *    - memoryProperty::locality: prefer the memory node which is most local to the device.
+     */
+    template<typename T_Type, alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto alloc(
+        concepts::Device auto const& device,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        MemoryPolicyList<T_Policies...> const& policies)
+    {
         Vec const extentsVec = extents;
-        return internal::Alloc::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
-            *device.get(),
-            extentsVec);
+        return internal::Alloc::Op<
+            T_Type,
+            std::decay_t<decltype(*device.get())>,
+            ALPAKA_TYPEOF(extentsVec),
+            ALPAKA_TYPEOF(policies.getMemoryProperty())>{}(*device.get(), extentsVec, policies.getMemoryProperty());
     }
 
     /** Allocate memory on the given device with unified virtual memory
@@ -236,10 +277,43 @@ namespace alpaka::onHost
     template<typename T_Type>
     inline auto allocUnified(concepts::Device auto const& device, alpaka::concepts::VectorOrScalar auto const& extents)
     {
+        return allocUnified<T_Type>(device, extents, MemoryPolicyList<>{});
+    }
+
+    /** @copydoc allocUnified()
+     *
+     * @param firstPolicy First memory allocation policy.
+     * @param policies Additional memory allocation policies.
+     */
+    template<
+        typename T_Type,
+        alpaka::concepts::MemoryPolicy T_FirstPolicy,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocUnified(
+        concepts::Device auto const& device,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        T_FirstPolicy firstPolicy,
+        T_Policies... policies)
+    {
+        return allocUnified<T_Type>(device, extents, MemoryPolicyList{firstPolicy, policies...});
+    }
+
+    /** @copydoc allocUnified()
+     *
+     * @param policies Memory allocation policies, see @c alloc() for the supported placement preferences.
+     */
+    template<typename T_Type, alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocUnified(
+        concepts::Device auto const& device,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        MemoryPolicyList<T_Policies...> const& policies)
+    {
         Vec const extentsVec = extents;
-        return internal::AllocUnified::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
-            *device.get(),
-            extentsVec);
+        return internal::AllocUnified::Op<
+            T_Type,
+            std::decay_t<decltype(*device.get())>,
+            ALPAKA_TYPEOF(extentsVec),
+            ALPAKA_TYPEOF(policies.getMemoryProperty())>{}(*device.get(), extentsVec, policies.getMemoryProperty());
     }
 
     /** Allocates unified memory on the device associated with the given queue.
@@ -255,16 +329,49 @@ namespace alpaka::onHost
      * @param queue queue handle
      * @param extents number of elements for each dimension
      */
-    template<typename T_Type, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
+    template<typename T_Type, typename T_Device, alpaka::concepts::QueuePolicyList T_QueuePolicies>
     inline auto allocUnified(
-        Queue<T_Device, T_Policies> const& queue,
+        Queue<T_Device, T_QueuePolicies> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
-        Vec const extentsVec = extents;
-        return internal::AllocUnified::
-            Op<T_Type, std::decay_t<decltype(*queue.getDevice().get())>, ALPAKA_TYPEOF(extentsVec)>{}(
-                *queue.getDevice().get(),
-                extentsVec);
+        return allocUnified<T_Type>(queue.getDevice(), extents, MemoryPolicyList<>{});
+    }
+
+    /** @copydoc allocUnified()
+     *
+     * @param firstPolicy First memory allocation policy.
+     * @param policies Additional memory allocation policies.
+     */
+    template<
+        typename T_Type,
+        typename T_Device,
+        alpaka::concepts::QueuePolicyList T_QueuePolicies,
+        alpaka::concepts::MemoryPolicy T_FirstPolicy,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocUnified(
+        Queue<T_Device, T_QueuePolicies> const& queue,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        T_FirstPolicy firstPolicy,
+        T_Policies... policies)
+    {
+        return allocUnified<T_Type>(queue.getDevice(), extents, MemoryPolicyList{firstPolicy, policies...});
+    }
+
+    /** @copydoc allocUnified()
+     *
+     * @param policies Memory allocation policies, see @c alloc() for the supported placement preferences.
+     */
+    template<
+        typename T_Type,
+        typename T_Device,
+        alpaka::concepts::QueuePolicyList T_QueuePolicies,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocUnified(
+        Queue<T_Device, T_QueuePolicies> const& queue,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        MemoryPolicyList<T_Policies...> const& policies)
+    {
+        return allocUnified<T_Type>(queue.getDevice(), extents, policies);
     }
 
     /** Allocate pinned memory on the host which is mapped into the address space of the device
@@ -280,10 +387,43 @@ namespace alpaka::onHost
     template<typename T_Type>
     inline auto allocMapped(concepts::Device auto const& device, alpaka::concepts::VectorOrScalar auto const& extents)
     {
+        return allocMapped<T_Type>(device, extents, MemoryPolicyList<>{});
+    }
+
+    /** @copydoc allocMapped()
+     *
+     * @param firstPolicy First memory allocation policy.
+     * @param policies Additional memory allocation policies.
+     */
+    template<
+        typename T_Type,
+        alpaka::concepts::MemoryPolicy T_FirstPolicy,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocMapped(
+        concepts::Device auto const& device,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        T_FirstPolicy firstPolicy,
+        T_Policies... policies)
+    {
+        return allocMapped<T_Type>(device, extents, MemoryPolicyList{firstPolicy, policies...});
+    }
+
+    /** @copydoc allocMapped()
+     *
+     * @param policies Memory allocation policies, see @c alloc() for the supported placement preferences.
+     */
+    template<typename T_Type, alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocMapped(
+        concepts::Device auto const& device,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        MemoryPolicyList<T_Policies...> const& policies)
+    {
         Vec const extentsVec = extents;
-        return internal::AllocMapped::Op<T_Type, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
-            *device.get(),
-            extentsVec);
+        return internal::AllocMapped::Op<
+            T_Type,
+            std::decay_t<decltype(*device.get())>,
+            ALPAKA_TYPEOF(extentsVec),
+            ALPAKA_TYPEOF(policies.getMemoryProperty())>{}(*device.get(), extentsVec, policies.getMemoryProperty());
     }
 
     /** Allocate pinned memory on the host which is mapped into the address space of the device
@@ -296,12 +436,49 @@ namespace alpaka::onHost
      * @param queue queue handle
      * @param extents number of elements for each dimension
      */
-    template<typename T_Type, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
+    template<typename T_Type, typename T_Device, alpaka::concepts::QueuePolicyList T_QueuePolicies>
     inline auto allocMapped(
-        Queue<T_Device, T_Policies> const& queue,
+        Queue<T_Device, T_QueuePolicies> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
-        return allocMapped<T_Type>(queue.getDevice(), extents);
+        return allocMapped<T_Type>(queue.getDevice(), extents, MemoryPolicyList<>{});
+    }
+
+    /** @copydoc allocMapped()
+     *
+     * @param firstPolicy First memory allocation policy.
+     * @param policies Additional memory allocation policies.
+     */
+    template<
+        typename T_Type,
+        typename T_Device,
+        alpaka::concepts::QueuePolicyList T_QueuePolicies,
+        alpaka::concepts::MemoryPolicy T_FirstPolicy,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocMapped(
+        Queue<T_Device, T_QueuePolicies> const& queue,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        T_FirstPolicy firstPolicy,
+        T_Policies... policies)
+    {
+        return allocMapped<T_Type>(queue.getDevice(), extents, MemoryPolicyList{firstPolicy, policies...});
+    }
+
+    /** @copydoc allocMapped()
+     *
+     * @param policies Memory allocation policies, see @c alloc() for the supported placement preferences.
+     */
+    template<
+        typename T_Type,
+        typename T_Device,
+        alpaka::concepts::QueuePolicyList T_QueuePolicies,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocMapped(
+        Queue<T_Device, T_QueuePolicies> const& queue,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        MemoryPolicyList<T_Policies...> const& policies)
+    {
+        return allocMapped<T_Type>(queue.getDevice(), extents, policies);
     }
 
     /** Allocate memory on the given device based on a view
@@ -316,7 +493,35 @@ namespace alpaka::onHost
      */
     inline auto allocLike(concepts::Device auto const& device, auto const& view)
     {
-        return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, internal::getExtents(view));
+        return allocLike(device, view, MemoryPolicyList<>{});
+    }
+
+    /** @copydoc allocLike()
+     *
+     * @param firstPolicy First memory allocation policy.
+     * @param policies Additional memory allocation policies.
+     */
+    template<alpaka::concepts::MemoryPolicy T_FirstPolicy, alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocLike(
+        concepts::Device auto const& device,
+        auto const& view,
+        T_FirstPolicy firstPolicy,
+        T_Policies... policies)
+    {
+        return allocLike(device, view, MemoryPolicyList{firstPolicy, policies...});
+    }
+
+    /** @copydoc allocLike()
+     *
+     * @param policies Memory allocation policies, see @c alloc() for the supported placement preferences.
+     */
+    template<alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocLike(
+        concepts::Device auto const& device,
+        auto const& view,
+        MemoryPolicyList<T_Policies...> const& policies)
+    {
+        return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, internal::getExtents(view), policies);
     }
 
     ///@}

--- a/include/alpaka/onHost/MemoryPolicyList.hpp
+++ b/include/alpaka/onHost/MemoryPolicyList.hpp
@@ -1,0 +1,94 @@
+/* Copyright 2026 SiPearl
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/PolicyList.hpp"
+#include "alpaka/tag.hpp"
+#include "alpaka/utility.hpp"
+
+namespace alpaka::trait
+{
+    /** Identifies compile-time memory-allocation policy tags.
+     *
+     * Specialize this trait with std::true_type to register an application-defined memory-allocation policy. Every
+     * memory policy is also registered as a general policy through IsPolicy.
+     *
+     * @tparam T_Policy Type to inspect.
+     */
+    template<typename T_Policy>
+    struct IsMemoryPolicy : std::false_type
+    {
+    };
+
+    template<alpaka::concepts::MemoryProperty T_MemoryProperty>
+    struct IsMemoryPolicy<T_MemoryProperty> : std::true_type
+    {
+    };
+} // namespace alpaka::trait
+
+namespace alpaka
+{
+    /** Whether a type is registered as a compile-time memory-allocation policy tag. */
+    template<typename T_Policy>
+    constexpr bool isMemoryPolicy_v = trait::IsMemoryPolicy<std::remove_cvref_t<T_Policy>>::value;
+
+    namespace concepts
+    {
+        /** A registered, default-initializable compile-time memory-allocation policy tag. */
+        template<typename T_Policy>
+        concept MemoryPolicy = isMemoryPolicy_v<T_Policy> && std::default_initializable<std::remove_cvref_t<T_Policy>>;
+    } // namespace concepts
+
+    namespace trait
+    {
+        template<alpaka::concepts::MemoryPolicy T_Policy>
+        struct IsPolicy<T_Policy> : std::true_type
+        {
+        };
+    } // namespace trait
+} // namespace alpaka
+
+namespace alpaka::onHost
+{
+    /** Collection of compile-time policies used to tweak a memory allocation.
+     *
+     * Policies can be supplied in any order. At most one policy from each category may be present. The memory
+     * property defaults to memoryProperty::defaultProperty when its policy is omitted, which leaves the placement
+     * decision to the backend.
+     *
+     * @tparam T_Policies Memory policy tag types contained in the bundle.
+     */
+    template<alpaka::concepts::MemoryPolicy... T_Policies>
+    struct MemoryPolicyList : PolicyList<T_Policies...>
+    {
+        using Base = PolicyList<T_Policies...>;
+
+        /** Construct a memory policy bundle.
+         *
+         * @param policies Compile-time memory policy tags.
+         */
+        constexpr MemoryPolicyList(T_Policies... policies) : Base{policies...}
+        {
+        }
+
+        /** Return the selected memory property, or memoryProperty::defaultProperty if none was supplied. */
+        static constexpr alpaka::concepts::MemoryProperty auto getMemoryProperty()
+        {
+            return Base::search(category::MemoryProperty{}, memoryProperty::defaultProperty);
+        }
+
+        using Base::hasPolicy;
+    };
+
+    template<typename... T_Policies>
+    MemoryPolicyList(T_Policies...) -> MemoryPolicyList<T_Policies...>;
+} // namespace alpaka::onHost
+
+namespace alpaka::concepts
+{
+    /** A specialization of onHost::MemoryPolicyList. */
+    template<typename T_Policies>
+    concept MemoryPolicyList = SpecializationOf<T_Policies, onHost::MemoryPolicyList>;
+} // namespace alpaka::concepts

--- a/include/alpaka/onHost/Queue.hpp
+++ b/include/alpaka/onHost/Queue.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/executor.hpp"
 #include "alpaka/onHost/Event.hpp"
 #include "alpaka/onHost/FrameSpec.hpp"
+#include "alpaka/onHost/MemoryPolicyList.hpp"
 #include "alpaka/onHost/QueuePolicyList.hpp"
 #include "alpaka/onHost/concepts.hpp"
 #include "alpaka/onHost/internal/interface.hpp"
@@ -471,15 +472,54 @@ namespace alpaka::onHost
      * memory is destroyed. The deallocation is asynchronous performed in the queue which is used for the
      * allocation.
      */
-    template<typename T_Type, typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
+    template<typename T_Type, typename T_Device, alpaka::concepts::QueuePolicyList T_QueuePolicies>
     inline auto allocDeferred(
-        Queue<T_Device, T_Policies> const& queue,
+        Queue<T_Device, T_QueuePolicies> const& queue,
         alpaka::concepts::VectorOrScalar auto const& extents)
     {
+        return allocDeferred<T_Type>(queue, extents, MemoryPolicyList<>{});
+    }
+
+    /** @copydoc allocDeferred()
+     *
+     * @param firstPolicy First memory allocation policy.
+     * @param policies Additional memory allocation policies.
+     */
+    template<
+        typename T_Type,
+        typename T_Device,
+        alpaka::concepts::QueuePolicyList T_QueuePolicies,
+        alpaka::concepts::MemoryPolicy T_FirstPolicy,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocDeferred(
+        Queue<T_Device, T_QueuePolicies> const& queue,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        T_FirstPolicy firstPolicy,
+        T_Policies... policies)
+    {
+        return allocDeferred<T_Type>(queue, extents, MemoryPolicyList{firstPolicy, policies...});
+    }
+
+    /** @copydoc allocDeferred()
+     *
+     * @param policies Memory allocation policies, see @c onHost::alloc() for the supported placement preferences.
+     */
+    template<
+        typename T_Type,
+        typename T_Device,
+        alpaka::concepts::QueuePolicyList T_QueuePolicies,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocDeferred(
+        Queue<T_Device, T_QueuePolicies> const& queue,
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        MemoryPolicyList<T_Policies...> const& policies)
+    {
         Vec const extentsVec = extents;
-        return internal::AllocDeferred::Op<T_Type, std::decay_t<decltype(*queue.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
-            *queue.get(),
-            extentsVec);
+        return internal::AllocDeferred::Op<
+            T_Type,
+            std::decay_t<decltype(*queue.get())>,
+            ALPAKA_TYPEOF(extentsVec),
+            ALPAKA_TYPEOF(policies.getMemoryProperty())>{}(*queue.get(), extentsVec, policies.getMemoryProperty());
     }
 
     /** allocate memory that is accessible after it is processed in the queue
@@ -501,10 +541,48 @@ namespace alpaka::onHost
      * memory is destroyed. The deallocation is asynchronous performed in the queue which is used for the
      * allocation.
      */
-    template<typename T_Device, alpaka::concepts::QueuePolicyList T_Policies>
-    inline auto allocLikeDeferred(Queue<T_Device, T_Policies> const& queue, auto const& view)
+    template<typename T_Device, alpaka::concepts::QueuePolicyList T_QueuePolicies>
+    inline auto allocLikeDeferred(Queue<T_Device, T_QueuePolicies> const& queue, auto const& view)
     {
-        return allocDeferred<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(queue, internal::getExtents(view));
+        return allocLikeDeferred(queue, view, MemoryPolicyList<>{});
+    }
+
+    /** @copydoc allocLikeDeferred()
+     *
+     * @param firstPolicy First memory allocation policy.
+     * @param policies Additional memory allocation policies.
+     */
+    template<
+        typename T_Device,
+        alpaka::concepts::QueuePolicyList T_QueuePolicies,
+        alpaka::concepts::MemoryPolicy T_FirstPolicy,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocLikeDeferred(
+        Queue<T_Device, T_QueuePolicies> const& queue,
+        auto const& view,
+        T_FirstPolicy firstPolicy,
+        T_Policies... policies)
+    {
+        return allocLikeDeferred(queue, view, MemoryPolicyList{firstPolicy, policies...});
+    }
+
+    /** @copydoc allocLikeDeferred()
+     *
+     * @param policies Memory allocation policies, see @c onHost::alloc() for the supported placement preferences.
+     */
+    template<
+        typename T_Device,
+        alpaka::concepts::QueuePolicyList T_QueuePolicies,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocLikeDeferred(
+        Queue<T_Device, T_QueuePolicies> const& queue,
+        auto const& view,
+        MemoryPolicyList<T_Policies...> const& policies)
+    {
+        return allocDeferred<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(
+            queue,
+            internal::getExtents(view),
+            policies);
     }
 
     /** @} */

--- a/include/alpaka/onHost/interface.hpp
+++ b/include/alpaka/onHost/interface.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/api/trait.hpp"
 #include "alpaka/concepts.hpp"
 #include "alpaka/onHost/DeviceSelector.hpp"
+#include "alpaka/onHost/MemoryPolicyList.hpp"
 #include "alpaka/onHost/concepts.hpp"
 #include "alpaka/tag.hpp"
 #include "alpaka/trait.hpp"
@@ -179,7 +180,7 @@ namespace alpaka::onHost
     /** Allocate host memory for a given element type and extents.
      *
      * The allocation is performed on the host controller device
-     * (`api::host` ans `deviceKind::cpu`).
+     * (`api::host` and `deviceKind::cpu`).
      * The returned view owns the allocated memory.
      *
      * @tparam T_ValueType type of the data elements
@@ -189,11 +190,42 @@ namespace alpaka::onHost
     template<typename T_ValueType>
     inline auto allocHost(alpaka::concepts::VectorOrScalar auto const& extents)
     {
+        return allocHost<T_ValueType>(extents, MemoryPolicyList<>{});
+    }
+
+    /** @copydoc allocHost()
+     *
+     * @param firstPolicy First memory allocation policy.
+     * @param policies Additional memory allocation policies.
+     */
+    template<
+        typename T_ValueType,
+        alpaka::concepts::MemoryPolicy T_FirstPolicy,
+        alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocHost(
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        T_FirstPolicy firstPolicy,
+        T_Policies... policies)
+    {
+        return allocHost<T_ValueType>(extents, MemoryPolicyList{firstPolicy, policies...});
+    }
+
+    /** @copydoc allocHost()
+     *
+     * @param policies Memory allocation policies, see @c onHost::alloc() for the supported placement preferences.
+     */
+    template<typename T_ValueType, alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocHost(
+        alpaka::concepts::VectorOrScalar auto const& extents,
+        MemoryPolicyList<T_Policies...> const& policies)
+    {
         auto device = makeHostDevice<T_ValueType>();
         Vec const extentsVec = extents;
-        return internal::Alloc::Op<T_ValueType, std::decay_t<decltype(*device.get())>, ALPAKA_TYPEOF(extentsVec)>{}(
-            *device.get(),
-            extentsVec);
+        return internal::Alloc::Op<
+            T_ValueType,
+            std::decay_t<decltype(*device.get())>,
+            ALPAKA_TYPEOF(extentsVec),
+            ALPAKA_TYPEOF(policies.getMemoryProperty())>{}(*device.get(), extentsVec, policies.getMemoryProperty());
     }
 
     /** Allocate host memory with the same value type and extents as an existing view.
@@ -207,8 +239,29 @@ namespace alpaka::onHost
      */
     inline auto allocHostLike(auto const& view)
     {
+        return allocHostLike(view, MemoryPolicyList<>{});
+    }
+
+    /** @copydoc allocHostLike()
+     *
+     * @param firstPolicy First memory allocation policy.
+     * @param policies Additional memory allocation policies.
+     */
+    template<alpaka::concepts::MemoryPolicy T_FirstPolicy, alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocHostLike(auto const& view, T_FirstPolicy firstPolicy, T_Policies... policies)
+    {
+        return allocHostLike(view, MemoryPolicyList{firstPolicy, policies...});
+    }
+
+    /** @copydoc allocHostLike()
+     *
+     * @param policies Memory allocation policies, see @c onHost::alloc() for the supported placement preferences.
+     */
+    template<alpaka::concepts::MemoryPolicy... T_Policies>
+    inline auto allocHostLike(auto const& view, MemoryPolicyList<T_Policies...> const& policies)
+    {
         auto device = makeHostDevice<ALPAKA_TYPEOF(view)>();
-        return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, internal::getExtents(view));
+        return alloc<alpaka::trait::GetValueType_t<ALPAKA_TYPEOF(view)>>(device, internal::getExtents(view), policies);
     }
 
     /** @} */

--- a/include/alpaka/onHost/internal/interface.hpp
+++ b/include/alpaka/onHost/internal/interface.hpp
@@ -345,37 +345,37 @@ namespace alpaka::onHost
 
         struct Alloc
         {
-            template<typename T_Type, typename T_Any, typename T_Extents>
+            template<typename T_Type, typename T_Any, typename T_Extents, alpaka::concepts::MemoryProperty T_Property>
             struct Op
             {
-                void operator()(T_Any& any, T_Extents const&) const;
+                void operator()(T_Any& any, T_Extents const&, T_Property) const;
             };
         };
 
         struct AllocDeferred
         {
-            template<typename T_Type, typename T_Any, typename T_Extents>
+            template<typename T_Type, typename T_Any, typename T_Extents, alpaka::concepts::MemoryProperty T_Property>
             struct Op
             {
-                void operator()(T_Any& any, T_Extents const&) const;
+                void operator()(T_Any& any, T_Extents const&, T_Property) const;
             };
         };
 
         struct AllocUnified
         {
-            template<typename T_Type, typename T_Any, typename T_Extents>
+            template<typename T_Type, typename T_Any, typename T_Extents, alpaka::concepts::MemoryProperty T_Property>
             struct Op
             {
-                void operator()(T_Any& any, T_Extents const&) const;
+                void operator()(T_Any& any, T_Extents const&, T_Property) const;
             };
         };
 
         struct AllocMapped
         {
-            template<typename T_Type, typename T_Any, typename T_Extents>
+            template<typename T_Type, typename T_Any, typename T_Extents, alpaka::concepts::MemoryProperty T_Property>
             struct Op
             {
-                void operator()(T_Any& any, T_Extents const&) const;
+                void operator()(T_Any& any, T_Extents const&, T_Property) const;
             };
         };
 

--- a/include/alpaka/tag.hpp
+++ b/include/alpaka/tag.hpp
@@ -30,6 +30,13 @@ namespace alpaka
             template<typename T_Policy>
             constexpr bool operator()(T_Policy) const;
         };
+
+        /** Category tag for memory-allocation property policies. */
+        struct MemoryProperty
+        {
+            template<typename T_Policy>
+            constexpr bool operator()(T_Policy) const;
+        };
     } // namespace category
 
     namespace object
@@ -186,6 +193,84 @@ namespace alpaka
 
         constexpr auto disabled = Disabled{};
     } // namespace timing
+
+    namespace memoryProperty
+    {
+        namespace trait
+        {
+            template<typename T_MemoryProperty>
+            struct IsMemoryProperty : std::is_base_of<category::MemoryProperty, T_MemoryProperty>
+            {
+            };
+        } // namespace trait
+
+        template<typename T_MemoryProperty>
+        constexpr bool isMemoryProperty_v = trait::IsMemoryProperty<T_MemoryProperty>::value;
+    } // namespace memoryProperty
+
+    namespace concepts
+    {
+        /** Concept to check if a type selects a memory-allocation placement preference. */
+        template<typename T_MemoryProperty>
+        concept MemoryProperty = memoryProperty::isMemoryProperty_v<T_MemoryProperty>;
+    } // namespace concepts
+
+    namespace memoryProperty
+    {
+        constexpr bool operator==(alpaka::concepts::MemoryProperty auto lhs, alpaka::concepts::MemoryProperty auto rhs)
+        {
+            return std::is_same_v<ALPAKA_TYPEOF(lhs), ALPAKA_TYPEOF(rhs)>;
+        }
+
+        constexpr bool operator!=(alpaka::concepts::MemoryProperty auto lhs, alpaka::concepts::MemoryProperty auto rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        /** No explicit memory placement preference is requested, the backend uses its default strategy. */
+        struct Default : category::MemoryProperty
+        {
+            static std::string getName()
+            {
+                return "Default";
+            }
+        };
+
+        constexpr auto defaultProperty = Default{};
+
+        /** Prefer the memory node which offers the lowest access latency for the allocating CPU domain. */
+        struct BestLatency : category::MemoryProperty
+        {
+            static std::string getName()
+            {
+                return "BestLatency";
+            }
+        };
+
+        constexpr auto bestLatency = BestLatency{};
+
+        /** Prefer the memory node which offers the highest bandwidth for the allocating CPU domain. */
+        struct BestBandwidth : category::MemoryProperty
+        {
+            static std::string getName()
+            {
+                return "BestBandwidth";
+            }
+        };
+
+        constexpr auto bestBandwidth = BestBandwidth{};
+
+        /** Prefer the memory node which is most local to the allocating CPU domain. */
+        struct Locality : category::MemoryProperty
+        {
+            static std::string getName()
+            {
+                return "Locality";
+            }
+        };
+
+        constexpr auto locality = Locality{};
+    } // namespace memoryProperty
 
     namespace deviceKind
     {
@@ -384,6 +469,12 @@ namespace alpaka
         constexpr bool Timing::operator()(T_Policy) const
         {
             return alpaka::concepts::Timing<T_Policy>;
+        }
+
+        template<typename T_Policy>
+        constexpr bool MemoryProperty::operator()(T_Policy) const
+        {
+            return alpaka::concepts::MemoryProperty<T_Policy>;
         }
     } // namespace category
 } // namespace alpaka

--- a/test/unit/mem/alloc.cpp
+++ b/test/unit/mem/alloc.cpp
@@ -12,6 +12,29 @@ using namespace alpaka;
 
 using TestBackends = std::decay_t<decltype(onHost::allBackends(onHost::enabledDeviceSpecs, exec::enabledExecutors))>;
 
+/** Test-only tag verifying that applications can register additional memory allocation policies. */
+struct TestMemoryPolicy
+{
+};
+
+template<>
+struct alpaka::trait::IsMemoryPolicy<TestMemoryPolicy> : std::true_type
+{
+};
+
+static_assert(alpaka::concepts::MemoryPolicy<TestMemoryPolicy>);
+
+constexpr auto defaultMemoryPolicies = onHost::MemoryPolicyList<>{};
+static_assert(alpaka::concepts::MemoryPolicyList<decltype(defaultMemoryPolicies)>);
+static_assert(defaultMemoryPolicies.getMemoryProperty() == memoryProperty::defaultProperty);
+
+constexpr auto testMemoryPolicies = onHost::MemoryPolicyList{memoryProperty::bestBandwidth, TestMemoryPolicy{}};
+static_assert(alpaka::concepts::MemoryPolicyList<decltype(testMemoryPolicies)>);
+static_assert(!alpaka::concepts::MemoryPolicyList<TestMemoryPolicy>);
+static_assert(testMemoryPolicies.getMemoryProperty() == memoryProperty::bestBandwidth);
+static_assert(testMemoryPolicies.hasPolicy(TestMemoryPolicy{}));
+static_assert(!testMemoryPolicies.hasPolicy(memoryProperty::bestLatency));
+
 struct IotaValidate
 {
     ALPAKA_FN_ACC void operator()(auto const& acc, concepts::IMdSpan<int> auto success, concepts::IMdSpan auto in)
@@ -142,6 +165,51 @@ TEMPLATE_LIST_TEST_CASE("alloc zero bytes", "", TestDeviceSpecs)
     CHECK(deviceViewAsync.getExtents() == alpaka::Vec{dataSize});
     [[maybe_unused]] auto unifiedView = onHost::allocUnified<int>(device, dataSize);
     CHECK(unifiedView.getExtents() == alpaka::Vec{dataSize});
+}
+
+TEMPLATE_LIST_TEST_CASE("alloc with memory property", "", TestDeviceSpecs)
+{
+    auto deviceSpec = TestType{};
+
+    auto devSelector = onHost::makeDeviceSelector(deviceSpec);
+    if(!devSelector.isAvailable())
+    {
+        SUCCEED("No device available for " << deviceSpec.getName());
+        return;
+    }
+
+    onHost::Device device = devSelector.makeDevice(0);
+    INFO(deviceSpec.getApi().getName() << " on " << device.getName());
+
+    int dataSize = 42;
+
+    // A single, explicit policy tag.
+    [[maybe_unused]] auto hostBuffer = onHost::allocHost<int>(dataSize, memoryProperty::bestBandwidth);
+    CHECK(hostBuffer.getExtents() == alpaka::Vec{dataSize});
+
+    [[maybe_unused]] auto deviceView = onHost::alloc<int>(device, dataSize, memoryProperty::bestLatency);
+    CHECK(deviceView.getExtents() == alpaka::Vec{dataSize});
+
+    [[maybe_unused]] auto mappedView = onHost::allocMapped<int>(device, dataSize, memoryProperty::locality);
+    CHECK(mappedView.getExtents() == alpaka::Vec{dataSize});
+
+    [[maybe_unused]] auto unifiedView = onHost::allocUnified<int>(device, dataSize, memoryProperty::defaultProperty);
+    CHECK(unifiedView.getExtents() == alpaka::Vec{dataSize});
+
+    [[maybe_unused]] auto likeView = onHost::allocLike(device, deviceView, memoryProperty::bestBandwidth);
+    CHECK(likeView.getExtents() == deviceView.getExtents());
+
+    // An explicit onHost::MemoryPolicyList.
+    [[maybe_unused]] auto explicitPolicyView
+        = onHost::alloc<int>(device, dataSize, onHost::MemoryPolicyList{memoryProperty::bestBandwidth});
+    CHECK(explicitPolicyView.getExtents() == alpaka::Vec{dataSize});
+
+    auto queue = device.makeQueue();
+    [[maybe_unused]] auto deferredView = onHost::allocDeferred<int>(queue, dataSize, memoryProperty::bestBandwidth);
+    CHECK(deferredView.getExtents() == alpaka::Vec{dataSize});
+
+    [[maybe_unused]] auto likeDeferredView = onHost::allocLikeDeferred(queue, deviceView, memoryProperty::locality);
+    CHECK(likeDeferredView.getExtents() == deviceView.getExtents());
 }
 
 /** Evaluates on the host side that all rows start with an address which is a multiple of the alignment of the MdSpan


### PR DESCRIPTION
This pull request implements memory policies, which can be applied to all memory allocation operations.

The policies included in this pull request are, for the moment, only for host devices. It includes:

- ``alpaka::memoryProperty::bestLatency`` selects memory nodes with the best access latency
- ``alpaka::memoryProperty::bestBandwidth``selects memory nodes with the highest memory bandwidth
- ``alpaka::memoryProperty::locality``  selects the closest memory nodes
- ``alpaka::memoryProperty::defaultProperty`` equivalent to no property; uses the default alpaka3 behavior

These properties bind the memory to the selected nodes, using the MPOL_BIND policy. If the memory nodes are full, the allocation fails.

The code has been tested on Intel Sapphire Rapids with HBM; both the host and NumaCPU devices work as intended.

Other properties specific to one, several, or all devices could easily be added later.

One FIXME remains in the code: should the allocation be made non-strict (using MPOL_PREFERRED_MANY), or should a new policy be added that lets the user select non-strict allocation?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added memory allocation properties for selecting latency, bandwidth, locality, or default placement.
  - Allocation APIs now support memory policies across host, mapped, unified, deferred, and “like” allocations.
  - Host allocations can be pinned according to the selected memory preference; unsupported devices safely ignore these preferences.
  - Added support for combining and reusing memory policies through policy lists.

- **Documentation**
  - Added tutorials and advanced reference documentation covering memory pinning and allocation properties.
  - Added examples demonstrating supported allocation methods and policy usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->